### PR TITLE
fix: add unique image_suffix to all deploy workflows

### DIFF
--- a/.github/workflows/deploy-api.yaml
+++ b/.github/workflows/deploy-api.yaml
@@ -61,6 +61,7 @@ jobs:
           project_id: ${{ vars.NAIS_MANAGEMENT_PROJECT_ID }}
           dockerfile: apps/lumi-api/Dockerfile
           docker_context: apps/lumi-api
+          image_suffix: api
           push_image: ${{ github.event_name == 'push' || github.event_name == 'workflow_dispatch' }}
 
   deploy-dev:

--- a/.github/workflows/deploy-dashboard.yaml
+++ b/.github/workflows/deploy-dashboard.yaml
@@ -159,6 +159,7 @@ jobs:
           project_id: ${{ vars.NAIS_MANAGEMENT_PROJECT_ID }}
           dockerfile: apps/lumi-dashboard/Dockerfile
           docker_context: apps/lumi-dashboard
+          image_suffix: dashboard
 
   deploy-demo:
     name: Deploy to dev-gcp (Demo)

--- a/.github/workflows/deploy-proxy.yaml
+++ b/.github/workflows/deploy-proxy.yaml
@@ -50,6 +50,7 @@ jobs:
           project_id: ${{ vars.NAIS_MANAGEMENT_PROJECT_ID }}
           dockerfile: apps/lumi-submission-proxy/Dockerfile
           docker_context: apps/lumi-submission-proxy
+          image_suffix: submission-proxy
           push_image: ${{ github.event_name == 'push' || github.event_name == 'workflow_dispatch' }}
 
   deploy-dev:


### PR DESCRIPTION
All three deploy workflows used nais/docker-build-push without image_suffix, defaulting to the repo name 'lumi' as image name. When multiple workflows triggered on the same commit (e.g. PR #93), the last to push overwrote earlier images in GAR — causing lumi-api prod pods to run the submission-proxy code.

Image names after fix:
- deploy-api:       lumi-api
- deploy-proxy:     lumi-submission-proxy
- deploy-dashboard: lumi-dashboard (prod), lumi-demo (demo)