### PR TITLE
feat(lumi-survey): support subset validation in useLumiSurvey

### DIFF
--- a/packages/lumi-survey/src/core/__tests__/useLumiSurvey.test.ts
+++ b/packages/lumi-survey/src/core/__tests__/useLumiSurvey.test.ts
@@ -438,4 +438,67 @@ describe("useLumiSurvey", () => {
 
     expect(result.current.answers).not.toHaveProperty("feedback");
   });
+
+  it("submit validates only the provided question subset (branching)", async () => {
+    const submitMock = vi.fn(async (payload: LumiSurveySubmission) => {
+      void payload;
+    });
+    const transport: LumiSurveyTransport = {
+      submit: submitMock,
+    };
+
+    // Survey where Q2 (feedback) is required but would be skipped via branching
+    const { result } = renderHook(() =>
+      useLumiSurvey({
+        surveyId: SURVEY_ID,
+        questions: requiredQuestions,
+        transport,
+      }),
+    );
+
+    // Only answer the rating question
+    await act(() => {
+      result.current.setAnswer("rating", 4);
+    });
+
+    // Without override: should fail because "feedback" is required but unanswered
+    let submission: LumiSurveySubmitResult | undefined;
+    await act(async () => {
+      submission = await result.current.submit();
+    });
+    expect(submission?.ok).toBe(false);
+
+    // With override: pass only the rating question as the visited subset
+    const visitedQuestions = [requiredQuestions[0]]; // only rating
+    await act(async () => {
+      submission = await result.current.submit(visitedQuestions);
+    });
+
+    expect(submission?.ok).toBe(true);
+    expect(submitMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("validate accepts optional question subset", () => {
+    const transport: LumiSurveyTransport = {
+      submit: vi.fn(),
+    };
+
+    const { result } = renderHook(() =>
+      useLumiSurvey({
+        surveyId: SURVEY_ID,
+        questions: requiredQuestions,
+        transport,
+      }),
+    );
+
+    act(() => {
+      result.current.setAnswer("rating", 3);
+    });
+
+    // Without override: should include "feedback" as missing
+    expect(result.current.validate()).toEqual(["feedback"]);
+
+    // With override: only check rating (which is answered)
+    expect(result.current.validate([requiredQuestions[0]])).toEqual([]);
+  });
 });

--- a/packages/lumi-survey/src/core/types.ts
+++ b/packages/lumi-survey/src/core/types.ts
@@ -388,6 +388,11 @@ export interface LumiSurveyEvents {
    * Fired when the dock cannot persist its dismissal flag due to storage restrictions (for example when consent is denied).
    */
   onDismissalPersistFailed?: (cause: unknown) => void;
+  /**
+   * Fired when the current step changes in step mode.
+   * Also fires on initial render (step 0) when step mode is active.
+   */
+  onStepChange?: (currentStep: number, totalSteps: number) => void;
 }
 
 export type LumiSurveyStatus = "idle" | "submitting" | "success" | "error";

--- a/packages/lumi-survey/src/core/useLumiSurvey.ts
+++ b/packages/lumi-survey/src/core/useLumiSurvey.ts
@@ -35,8 +35,10 @@ export interface UseLumiSurveyReturn {
     questionId: string,
     value: LumiSurveyAnswerValue | null | undefined,
   ) => void;
-  submit: () => Promise<LumiSurveySubmitResult>;
-  validate: () => string[];
+  submit: (
+    questionsToValidate?: LumiSurveyQuestion[],
+  ) => Promise<LumiSurveySubmitResult>;
+  validate: (questionsToValidate?: LumiSurveyQuestion[]) => string[];
   reset: () => void;
 }
 
@@ -60,72 +62,80 @@ export function useLumiSurvey(
   const [status, setStatus] = useState<LumiSurveyStatus>("idle");
   const [error, setError] = useState<LumiSurveyError | null>(null);
 
-  const validate = useCallback((): string[] => {
-    return validateAnswers(questions, answers);
-  }, [answers, questions]);
+  const validate = useCallback(
+    (questionsToValidate?: LumiSurveyQuestion[]): string[] => {
+      return validateAnswers(questionsToValidate ?? questions, answers);
+    },
+    [answers, questions],
+  );
 
-  const submit = useCallback(async (): Promise<LumiSurveySubmitResult> => {
-    const missing = validate();
+  const submit = useCallback(
+    async (
+      questionsToValidate?: LumiSurveyQuestion[],
+    ): Promise<LumiSurveySubmitResult> => {
+      const missing = validate(questionsToValidate);
 
-    if (missing.length > 0) {
-      const validationError: LumiSurveyValidationError = {
-        type: "validation",
-        missing,
-      };
-      setStatus("error");
-      setError(validationError);
-      events?.onValidationFailed?.(missing);
-      return { ok: false, error: validationError };
-    }
+      if (missing.length > 0) {
+        const validationError: LumiSurveyValidationError = {
+          type: "validation",
+          missing,
+        };
+        setStatus("error");
+        setError(validationError);
+        events?.onValidationFailed?.(missing);
+        return { ok: false, error: validationError };
+      }
 
-    setStatus("submitting");
-    setError(null);
-
-    const answerSnapshot = cloneAnswers(answers);
-    const submittedAtTimestamp = new Date().toISOString();
-    const submission: LumiSurveySubmission = {
-      surveyId,
-      answers: answerSnapshot,
-      startedAt: startedAtRef.current,
-      submittedAt: submittedAtTimestamp,
-      context: context ? { ...context } : undefined,
-      transportPayload: buildTransportPayload(
-        surveyId,
-        answerSnapshot,
-        questions,
-        surveyType,
-        context,
-        startedAtRef.current,
-        submittedAtTimestamp,
-      ),
-    };
-
-    events?.onSubmitStart?.(submission);
-
-    try {
-      await transport.submit(submission);
-      setStatus("success");
+      setStatus("submitting");
       setError(null);
-      events?.onSubmitSuccess?.(submission);
-      return { ok: true, submission };
-    } catch (cause) {
-      const transportError: LumiSurveyError = { type: "transport", cause };
-      setStatus("error");
-      setError(transportError);
-      events?.onSubmitError?.(cause);
-      return { ok: false, error: transportError };
-    }
-  }, [
-    answers,
-    context,
-    events,
-    questions,
-    startedAtRef,
-    surveyId,
-    surveyType,
-    transport,
-    validate,
-  ]);
+
+      const answerSnapshot = cloneAnswers(answers);
+      const submittedAtTimestamp = new Date().toISOString();
+      const submission: LumiSurveySubmission = {
+        surveyId,
+        answers: answerSnapshot,
+        startedAt: startedAtRef.current,
+        submittedAt: submittedAtTimestamp,
+        context: context ? { ...context } : undefined,
+        transportPayload: buildTransportPayload(
+          surveyId,
+          answerSnapshot,
+          questions,
+          surveyType,
+          context,
+          startedAtRef.current,
+          submittedAtTimestamp,
+        ),
+      };
+
+      events?.onSubmitStart?.(submission);
+
+      try {
+        await transport.submit(submission);
+        setStatus("success");
+        setError(null);
+        events?.onSubmitSuccess?.(submission);
+        return { ok: true, submission };
+      } catch (cause) {
+        const transportError: LumiSurveyError = { type: "transport", cause };
+        setStatus("error");
+        setError(transportError);
+        events?.onSubmitError?.(cause);
+        return { ok: false, error: transportError };
+      }
+    },
+    [
+      answers,
+      context,
+      events,
+      questions,
+      startedAtRef,
+      surveyId,
+      surveyType,
+      transport,
+      validate,
+    ],
+  );
 
   const reset = useCallback(() => {
     resetAnswers();


### PR DESCRIPTION
Allow submit() and validate() to accept an optional subset of questions for validation. This enables step-mode surveys to validate only visited questions, and branching surveys to skip unvisited branches.

Also adds onStepChange event type for step navigation callbacks.

> **Stacked PR 1/5** — base: `main`
>
> Full stack: #116 → #117 → #118 → #119 → #108
