### PR TITLE
fix(survey): respect visibleIf conditions in step navigation

### DIFF
--- a/docs/referanse/events.md
+++ b/docs/referanse/events.md
@@ -24,7 +24,7 @@ Send et `events`-objekt til `LumiSurveyDock`:
     onValidationFailed: (missingQuestionIds) => { /* ... */ },
     onReset: () => { /* ... */ },
     onDismissalPersistFailed: (cause) => { /* ... */ },
-    onStepChange: (currentStep, totalSteps) => { /* ... */ },
+    onStepChange: (visibleStepIndex, totalVisibleSteps) => { /* ... */ },
   }}
 />
 ```
@@ -97,10 +97,10 @@ onDismissalPersistFailed?: (cause: unknown) => void;
 
 ### `onStepChange`
 
-Fyres når brukeren navigerer mellom steg i step-modus.
+Fyres når brukeren navigerer mellom steg i step-modus. Indeksene reflekterer kun synlige spørsmål — skjulte spørsmål (via `visibleIf`) telles ikke med.
 
 ```ts
-onStepChange?: (currentStep: number, totalSteps: number) => void;
+onStepChange?: (visibleStepIndex: number, totalVisibleSteps: number) => void;
 ```
 
 ## Brukseksempler
@@ -157,8 +157,8 @@ import * as amplitude from "@amplitude/analytics-browser";
   transport={transport}
   behavior={{ questionLayout: "steps", showProgress: true }}
   events={{
-    onStepChange: (current, total) => {
-      console.log(`Steg ${current} av ${total}`);
+    onStepChange: (step, total) => {
+      console.log(`Steg ${step + 1} av ${total}`);
     },
     onValidationFailed: (missing) => {
       console.warn("Mangler svar på:", missing);
@@ -179,6 +179,6 @@ interface LumiSurveyEvents {
   onValidationFailed?: (missingQuestionIds: string[]) => void;
   onReset?: () => void;
   onDismissalPersistFailed?: (cause: unknown) => void;
-  onStepChange?: (currentStep: number, totalSteps: number) => void;
+  onStepChange?: (visibleStepIndex: number, totalVisibleSteps: number) => void;
 }
 ```

--- a/packages/lumi-survey/src/components/LumiSurveyDock/LumiSurveyDock.tsx
+++ b/packages/lumi-survey/src/components/LumiSurveyDock/LumiSurveyDock.tsx
@@ -194,9 +194,12 @@ export const LumiSurveyDock = ({
     resetNavigation,
     visitedSteps,
     hasBranching,
+    visibleStepIndex,
+    totalVisibleSteps,
   } = useStepNavigation({
     questions,
     answers,
+    metadata: enrichedContext?.tags,
     forceStepMode,
     onStepChange: forceSinglePage ? undefined : events?.onStepChange,
   });
@@ -243,19 +246,28 @@ export const LumiSurveyDock = ({
     [questions, answers],
   );
 
-  // In step mode with branching, only validate questions the user actually visited.
-  // This prevents validation failures on required questions in unvisited branches.
+  // In step mode with branching, only validate questions the user actually visited
+  // AND that are currently visible. This prevents validation failures on required
+  // questions that became hidden after the user changed an earlier answer.
   const visitedQuestions = useMemo(() => {
     if (isStepMode) {
       const uniqueIndices = [...new Set(visitedSteps)];
-      return uniqueIndices.map((index) => questions[index]).filter(Boolean);
+      const visited = uniqueIndices
+        .map((index) => questions[index])
+        .filter(Boolean);
+      return getVisibleQuestions(visited, answers, enrichedContext?.tags);
     }
-    if (forceSinglePage) {
-      // SinglePage with branching: only validate visible questions
-      return visibleQuestions;
-    }
-    return undefined;
-  }, [isStepMode, forceSinglePage, visitedSteps, questions, visibleQuestions]);
+    // Non-step mode: only validate visible questions (hidden questions are
+    // excluded regardless of whether they were previously visible).
+    return visibleQuestions;
+  }, [
+    isStepMode,
+    visitedSteps,
+    questions,
+    visibleQuestions,
+    answers,
+    enrichedContext?.tags,
+  ]);
 
   const showPersonalDataNotice = useMemo(() => {
     if (!config.showPersonalDataNotice) return false;
@@ -397,7 +409,7 @@ export const LumiSurveyDock = ({
           onQuestionChange={setAnswer}
           stepNavigation={{
             isStepMode,
-            currentStep,
+            currentStep: visibleStepIndex,
             currentStepQuestion,
             canGoBack,
             canGoNext,
@@ -407,7 +419,7 @@ export const LumiSurveyDock = ({
           }}
           progress={{
             showProgress: config.showProgress,
-            totalSteps: questions.length,
+            totalSteps: totalVisibleSteps,
             hasBranching,
           }}
           questionContext={{

--- a/packages/lumi-survey/src/components/LumiSurveyDock/hooks/__tests__/stepNavigationUtils.test.ts
+++ b/packages/lumi-survey/src/components/LumiSurveyDock/hooks/__tests__/stepNavigationUtils.test.ts
@@ -1,0 +1,542 @@
+import { describe, expect, it } from "vitest";
+import type {
+  LumiSurveyAnswerValue,
+  LumiSurveyQuestion,
+} from "../../../../core/types.js";
+import {
+  findLastVisibleInHistory,
+  findNextVisibleIndex,
+  findRedirectTarget,
+  hasReachableQuestionsAfter,
+  isAnswered,
+} from "../stepNavigationUtils.js";
+
+const VISIBLE_IF_QUESTIONS: LumiSurveyQuestion[] = [
+  {
+    id: "q1",
+    type: "singleChoice",
+    prompt: "Steg 1",
+    required: true,
+    options: [
+      { value: "show", label: "Vis" },
+      { value: "show-q3", label: "Vis kun q3" },
+      { value: "hide", label: "Skjul" },
+    ],
+  },
+  {
+    id: "q2",
+    type: "text",
+    prompt: "Steg 2",
+    required: false,
+    maxLength: 500,
+    visibleIf: {
+      field: "ANSWER",
+      questionId: "q1",
+      operator: "EQ",
+      value: "show",
+    },
+  },
+  {
+    id: "q3",
+    type: "text",
+    prompt: "Steg 3",
+    required: false,
+    maxLength: 500,
+    visibleIf: {
+      field: "ANSWER",
+      questionId: "q1",
+      operator: "EQ",
+      value: "show-q3",
+    },
+  },
+  {
+    id: "q4",
+    type: "text",
+    prompt: "Steg 4",
+    required: false,
+    maxLength: 500,
+  },
+];
+
+const ALL_VISIBLE_QUESTIONS: LumiSurveyQuestion[] = [
+  {
+    id: "a1",
+    type: "text",
+    prompt: "A1",
+    required: false,
+    maxLength: 500,
+  },
+  {
+    id: "a2",
+    type: "text",
+    prompt: "A2",
+    required: false,
+    maxLength: 500,
+  },
+  {
+    id: "a3",
+    type: "text",
+    prompt: "A3",
+    required: false,
+    maxLength: 500,
+  },
+];
+
+const METADATA_QUESTIONS: LumiSurveyQuestion[] = [
+  {
+    id: "m1",
+    type: "text",
+    prompt: "M1",
+    required: false,
+    maxLength: 500,
+  },
+  {
+    id: "m2",
+    type: "text",
+    prompt: "M2",
+    required: false,
+    maxLength: 500,
+    visibleIf: {
+      field: "METADATA",
+      key: "showStep2",
+      operator: "EQ",
+      value: true,
+    },
+  },
+];
+
+const ALL_HIDDEN_QUESTIONS: LumiSurveyQuestion[] = [
+  {
+    id: "h1",
+    type: "text",
+    prompt: "Hidden 1",
+    required: false,
+    maxLength: 500,
+    visibleIf: {
+      field: "METADATA",
+      key: "show",
+      operator: "EQ",
+      value: "yes",
+    },
+  },
+  {
+    id: "h2",
+    type: "text",
+    prompt: "Hidden 2",
+    required: false,
+    maxLength: 500,
+    visibleIf: {
+      field: "METADATA",
+      key: "show",
+      operator: "EQ",
+      value: "yes",
+    },
+  },
+];
+
+describe("isAnswered", () => {
+  it.each([
+    { label: "undefined", value: undefined },
+    { label: "null (defensive)", value: null },
+    { label: 'empty string ""', value: "" },
+    { label: '"   " (whitespace-only string)', value: "   " },
+    { label: "empty array []", value: [] },
+  ])("returns false for $label", ({ value }) => {
+    // biome-ignore lint/suspicious/noExplicitAny: testing defensive null handling
+    expect(isAnswered(value as any)).toBe(false);
+  });
+
+  it.each([
+    { label: '"a" (non-empty string)', value: "a" },
+    { label: "0 (NPS-rating)", value: 0 },
+    { label: "5 (numeric value)", value: 5 },
+    { label: '["x", "y"] (multiChoice)', value: ["x", "y"] },
+  ])("returns true for $label", ({ value }) => {
+    expect(isAnswered(value)).toBe(true);
+  });
+});
+
+describe("findNextVisibleIndex", () => {
+  it("returns 0 for all-visible questions starting from index 0", () => {
+    const result = findNextVisibleIndex(
+      ALL_VISIBLE_QUESTIONS,
+      {},
+      undefined,
+      0,
+    );
+    expect(result).toBe(0);
+  });
+
+  it("skips hidden questions and returns the first visible one", () => {
+    const answers: Record<string, LumiSurveyAnswerValue> = { q1: "show-q3" };
+    const result = findNextVisibleIndex(
+      VISIBLE_IF_QUESTIONS,
+      answers,
+      undefined,
+      1,
+    );
+    expect(result).toBe(2);
+  });
+
+  it("returns -1 when no visible questions exist", () => {
+    const result = findNextVisibleIndex(ALL_HIDDEN_QUESTIONS, {}, undefined, 0);
+    expect(result).toBe(-1);
+  });
+
+  it("respects startIndex and scans from that index", () => {
+    const answers: Record<string, LumiSurveyAnswerValue> = { q1: "hide" };
+    const result = findNextVisibleIndex(
+      VISIBLE_IF_QUESTIONS,
+      answers,
+      undefined,
+      2,
+    );
+    expect(result).toBe(3);
+  });
+
+  it("returns -1 when startIndex is beyond array bounds", () => {
+    const result = findNextVisibleIndex(
+      ALL_VISIBLE_QUESTIONS,
+      {},
+      undefined,
+      99,
+    );
+    expect(result).toBe(-1);
+  });
+
+  it("clamps negative startIndex to 0", () => {
+    const result = findNextVisibleIndex(
+      ALL_VISIBLE_QUESTIONS,
+      {},
+      undefined,
+      -5,
+    );
+    expect(result).toBe(0);
+  });
+
+  it("works with METADATA-based visibleIf conditions", () => {
+    const result = findNextVisibleIndex(
+      METADATA_QUESTIONS,
+      {},
+      { showStep2: true },
+      1,
+    );
+    expect(result).toBe(1);
+  });
+});
+
+describe("findLastVisibleInHistory", () => {
+  it("returns the last step in history when all steps are visible", () => {
+    const result = findLastVisibleInHistory(
+      [0, 1, 2],
+      ALL_VISIBLE_QUESTIONS,
+      {},
+      undefined,
+    );
+    expect(result).toEqual({ step: 2, history: [0, 1, 2] });
+  });
+
+  it("skips hidden steps and returns the last visible one with trimmed history", () => {
+    const answers: Record<string, LumiSurveyAnswerValue> = { q1: "show" };
+    const result = findLastVisibleInHistory(
+      [0, 1, 2],
+      VISIBLE_IF_QUESTIONS,
+      answers,
+      undefined,
+    );
+    expect(result).toEqual({ step: 1, history: [0, 1] });
+  });
+
+  it("returns null when no steps in history are visible", () => {
+    const result = findLastVisibleInHistory(
+      [0, 1],
+      ALL_HIDDEN_QUESTIONS,
+      {},
+      undefined,
+    );
+    expect(result).toBeNull();
+  });
+
+  it("returns null for empty history", () => {
+    const result = findLastVisibleInHistory(
+      [],
+      ALL_VISIBLE_QUESTIONS,
+      {},
+      undefined,
+    );
+    expect(result).toBeNull();
+  });
+});
+
+describe("hasReachableQuestionsAfter", () => {
+  it("returns true when a later question has no visibleIf", () => {
+    const result = hasReachableQuestionsAfter(
+      VISIBLE_IF_QUESTIONS,
+      0,
+      "q1",
+      {},
+      undefined,
+    );
+    expect(result).toBe(true);
+  });
+
+  it("returns true when a later question is currently visible", () => {
+    const answers: Record<string, LumiSurveyAnswerValue> = { q1: "show" };
+    const result = hasReachableQuestionsAfter(
+      VISIBLE_IF_QUESTIONS,
+      0,
+      "q1",
+      answers,
+      undefined,
+    );
+    expect(result).toBe(true);
+  });
+
+  it("returns true when a later visibleIf depends on current question", () => {
+    // Isolated fixture: q2 depends on q1, and q1's answer doesn't satisfy q2's
+    // condition yet — but because q2 *references* q1, it's reachable.
+    const questions: LumiSurveyQuestion[] = [
+      {
+        id: "q1",
+        type: "singleChoice",
+        prompt: "Q1",
+        required: false,
+        options: [{ value: "a", label: "A" }],
+      },
+      {
+        id: "q2",
+        type: "text",
+        prompt: "Q2",
+        required: false,
+        maxLength: 500,
+        visibleIf: {
+          field: "ANSWER",
+          questionId: "q1",
+          operator: "EQ",
+          value: "show",
+        },
+      },
+    ];
+
+    const result = hasReachableQuestionsAfter(
+      questions,
+      0,
+      "q1",
+      { q1: "hide" },
+      undefined,
+    );
+    expect(result).toBe(true);
+  });
+
+  it("returns false when all later questions are hidden by unrelated conditions", () => {
+    const questions: LumiSurveyQuestion[] = [
+      {
+        id: "q1",
+        type: "text",
+        prompt: "Q1",
+        required: false,
+        maxLength: 500,
+      },
+      {
+        id: "q2",
+        type: "text",
+        prompt: "Q2",
+        required: false,
+        maxLength: 500,
+        visibleIf: {
+          field: "ANSWER",
+          questionId: "otherQuestion",
+          operator: "EQ",
+          value: "show",
+        },
+      },
+      {
+        id: "q3",
+        type: "text",
+        prompt: "Q3",
+        required: false,
+        maxLength: 500,
+        visibleIf: {
+          field: "METADATA",
+          key: "otherFlag",
+          operator: "EQ",
+          value: true,
+        },
+      },
+    ];
+
+    const result = hasReachableQuestionsAfter(
+      questions,
+      0,
+      "q1",
+      {},
+      { otherFlag: false },
+    );
+    expect(result).toBe(false);
+  });
+
+  it("returns false for the last question", () => {
+    const result = hasReachableQuestionsAfter(
+      ALL_VISIBLE_QUESTIONS,
+      2,
+      "a3",
+      {},
+      undefined,
+    );
+    expect(result).toBe(false);
+  });
+
+  it("returns true for METADATA-based visibleIf that is currently visible", () => {
+    const result = hasReachableQuestionsAfter(
+      METADATA_QUESTIONS,
+      0,
+      "m1",
+      {},
+      { showStep2: true },
+    );
+    expect(result).toBe(true);
+  });
+});
+
+describe("findRedirectTarget", () => {
+  it("returns the next visible forward question when one exists", () => {
+    const answers: Record<string, LumiSurveyAnswerValue> = { q1: "show" };
+    const result = findRedirectTarget(
+      VISIBLE_IF_QUESTIONS,
+      answers,
+      undefined,
+      0,
+      [0],
+    );
+    expect(result).toBe(1);
+  });
+
+  it("falls back to the last visible step in history when nothing is visible forward", () => {
+    const questions: LumiSurveyQuestion[] = [
+      {
+        id: "q1",
+        type: "singleChoice",
+        prompt: "Q1",
+        required: true,
+        options: [{ value: "yes", label: "Yes" }],
+      },
+      {
+        id: "q2",
+        type: "text",
+        prompt: "Q2",
+        required: false,
+        maxLength: 500,
+        visibleIf: {
+          field: "ANSWER",
+          questionId: "q1",
+          operator: "EQ",
+          value: "yes",
+        },
+      },
+      {
+        id: "q3",
+        type: "text",
+        prompt: "Q3",
+        required: false,
+        maxLength: 500,
+        visibleIf: {
+          field: "ANSWER",
+          questionId: "q1",
+          operator: "EQ",
+          value: "no",
+        },
+      },
+    ];
+
+    const result = findRedirectTarget(
+      questions,
+      { q1: "yes" },
+      undefined,
+      2,
+      [0, 1, 2],
+    );
+    expect(result).toBe(1);
+  });
+
+  it("falls back to first visible overall when history has no visible steps", () => {
+    const questions: LumiSurveyQuestion[] = [
+      {
+        id: "q1",
+        type: "text",
+        prompt: "Q1",
+        required: false,
+        maxLength: 500,
+      },
+      {
+        id: "q2",
+        type: "text",
+        prompt: "Q2",
+        required: false,
+        maxLength: 500,
+        visibleIf: {
+          field: "METADATA",
+          key: "showSecond",
+          operator: "EQ",
+          value: true,
+        },
+      },
+    ];
+
+    const result = findRedirectTarget(
+      questions,
+      {},
+      { showSecond: false },
+      1,
+      [1],
+    );
+    expect(result).toBe(0);
+  });
+
+  it("returns -1 when no visible questions exist at all", () => {
+    const result = findRedirectTarget(
+      ALL_HIDDEN_QUESTIONS,
+      {},
+      undefined,
+      0,
+      [0],
+    );
+    expect(result).toBe(-1);
+  });
+
+  it("prefers next visible forward over visible step in history", () => {
+    // Both q1 (in history) and q3 (forward) are visible.
+    // Current step q2 is hidden. Redirect should pick q3 (forward), not q1 (history).
+    const questions: LumiSurveyQuestion[] = [
+      {
+        id: "q1",
+        type: "text",
+        prompt: "Q1",
+        required: false,
+        maxLength: 500,
+      },
+      {
+        id: "q2",
+        type: "text",
+        prompt: "Q2 (hidden)",
+        required: false,
+        maxLength: 500,
+        visibleIf: {
+          field: "METADATA",
+          key: "show",
+          operator: "EQ",
+          value: "yes",
+        },
+      },
+      {
+        id: "q3",
+        type: "text",
+        prompt: "Q3",
+        required: false,
+        maxLength: 500,
+      },
+    ];
+
+    const result = findRedirectTarget(questions, {}, undefined, 1, [0, 1]);
+    expect(result).toBe(2);
+  });
+});

--- a/packages/lumi-survey/src/components/LumiSurveyDock/hooks/__tests__/useStepNavigation.test.ts
+++ b/packages/lumi-survey/src/components/LumiSurveyDock/hooks/__tests__/useStepNavigation.test.ts
@@ -1,33 +1,40 @@
-import { act, renderHook } from "@testing-library/react";
+import { act, renderHook, waitFor } from "@testing-library/react";
 import { describe, expect, it, vi } from "vitest";
-import type { LumiSurveyQuestion } from "../../../../core/types.js";
-import { isAnswered, useStepNavigation } from "../useStepNavigation.js";
+import type { BranchingResult } from "../../../../core/branchingEngine.js";
+import type {
+  LumiSurveyAnswerValue,
+  LumiSurveyQuestion,
+} from "../../../../core/types.js";
+import { useStepNavigation } from "../useStepNavigation.js";
 
-// ============================================
-// isAnswered – pure utility
-// ============================================
-
-describe("isAnswered", () => {
-  it.each([
-    { label: "undefined", value: undefined },
-    { label: "null (defensive)", value: null },
-    { label: 'empty string ""', value: "" },
-    { label: '"   " (whitespace-only string)', value: "   " },
-    { label: "empty array []", value: [] },
-  ])("returns false for $label", ({ value }) => {
-    // biome-ignore lint/suspicious/noExplicitAny: testing defensive null handling
-    expect(isAnswered(value as any)).toBe(false);
-  });
-
-  it.each([
-    { label: '"a" (non-empty string)', value: "a" },
-    { label: "0 (NPS-rating)", value: 0 },
-    { label: "5 (numeric value)", value: 5 },
-    { label: '["x", "y"] (multiChoice)', value: ["x", "y"] },
-  ])("returns true for $label", ({ value }) => {
-    expect(isAnswered(value)).toBe(true);
-  });
-});
+const ALL_HIDDEN_QUESTIONS: LumiSurveyQuestion[] = [
+  {
+    id: "q1",
+    type: "text",
+    prompt: "Hidden 1",
+    required: false,
+    maxLength: 500,
+    visibleIf: {
+      field: "METADATA" as const,
+      key: "show",
+      operator: "EQ" as const,
+      value: "yes",
+    },
+  },
+  {
+    id: "q2",
+    type: "text",
+    prompt: "Hidden 2",
+    required: false,
+    maxLength: 500,
+    visibleIf: {
+      field: "METADATA" as const,
+      key: "show",
+      operator: "EQ" as const,
+      value: "yes",
+    },
+  },
+];
 
 // ============================================
 // Fixtures
@@ -93,6 +100,125 @@ const BRANCHING_QUESTIONS: LumiSurveyQuestion[] = [
     type: "text",
     prompt: "Spørsmål 3",
     required: true,
+    maxLength: 500,
+  },
+];
+
+const VISIBLE_IF_QUESTIONS: LumiSurveyQuestion[] = [
+  {
+    id: "q1",
+    type: "singleChoice",
+    prompt: "Steg 1",
+    required: true,
+    options: [
+      { value: "show", label: "Vis" },
+      { value: "show-q3", label: "Vis kun q3" },
+      { value: "hide", label: "Skjul" },
+    ],
+  },
+  {
+    id: "q2",
+    type: "text",
+    prompt: "Steg 2",
+    required: false,
+    maxLength: 500,
+    visibleIf: {
+      field: "ANSWER",
+      questionId: "q1",
+      operator: "EQ",
+      value: "show",
+    },
+  },
+  {
+    id: "q3",
+    type: "text",
+    prompt: "Steg 3",
+    required: false,
+    maxLength: 500,
+    visibleIf: {
+      field: "ANSWER",
+      questionId: "q1",
+      operator: "EQ",
+      value: "show-q3",
+    },
+  },
+  {
+    id: "q4",
+    type: "text",
+    prompt: "Steg 4",
+    required: false,
+    maxLength: 500,
+  },
+];
+
+const JUMP_TO_VISIBLE_IF_QUESTIONS: LumiSurveyQuestion[] = [
+  {
+    id: "q1",
+    type: "singleChoice",
+    prompt: "Steg 1",
+    required: true,
+    options: [
+      { value: "a", label: "A" },
+      { value: "b", label: "B" },
+    ],
+    logic: [
+      {
+        condition: { field: "ANSWER", operator: "EQ", value: "a" },
+        action: { type: "JUMP_TO", targetId: "q2" },
+      },
+    ],
+  },
+  {
+    id: "q2",
+    type: "text",
+    prompt: "Steg 2",
+    required: false,
+    maxLength: 500,
+    visibleIf: {
+      field: "ANSWER",
+      questionId: "q1",
+      operator: "EQ",
+      value: "visible-q2",
+    },
+  },
+  {
+    id: "q3",
+    type: "text",
+    prompt: "Steg 3",
+    required: false,
+    maxLength: 500,
+  },
+];
+
+const MULTI_CHOICE_VISIBLE_IF_QUESTIONS: LumiSurveyQuestion[] = [
+  {
+    id: "q1",
+    type: "multiChoice",
+    prompt: "Velg flere",
+    required: true,
+    options: [
+      { value: "alpha", label: "Alpha" },
+      { value: "beta", label: "Beta" },
+    ],
+  },
+  {
+    id: "q2",
+    type: "text",
+    prompt: "Vises kun når alpha er valgt",
+    required: false,
+    maxLength: 500,
+    visibleIf: {
+      field: "ANSWER",
+      questionId: "q1",
+      operator: "CONTAINS",
+      value: "alpha",
+    },
+  },
+  {
+    id: "q3",
+    type: "text",
+    prompt: "Fallback",
+    required: false,
     maxLength: 500,
   },
 ];
@@ -574,11 +700,328 @@ describe("useStepNavigation", () => {
     });
   });
 
+  describe("visibleIf in step mode", () => {
+    it("skips one invisible question", () => {
+      const { result } = renderHook(() =>
+        useStepNavigation({
+          questions: VISIBLE_IF_QUESTIONS,
+          answers: { q1: "show-q3" },
+          forceStepMode: true,
+        }),
+      );
+
+      act(() => {
+        result.current.goToNext();
+      });
+
+      expect(result.current.currentQuestion?.id).toBe("q3");
+    });
+
+    it("skips multiple invisible questions in sequence", () => {
+      const { result } = renderHook(() =>
+        useStepNavigation({
+          questions: VISIBLE_IF_QUESTIONS,
+          answers: { q1: "hide" },
+          forceStepMode: true,
+        }),
+      );
+
+      act(() => {
+        result.current.goToNext();
+      });
+
+      expect(result.current.currentStep).toBe(3);
+      expect(result.current.currentQuestion?.id).toBe("q4");
+    });
+
+    it("returns submit signal when all remaining questions are invisible", () => {
+      const { result } = renderHook(() =>
+        useStepNavigation({
+          questions: VISIBLE_IF_QUESTIONS.slice(0, 3),
+          answers: { q1: "hide" },
+          forceStepMode: true,
+        }),
+      );
+
+      act(() => {
+        const navigation = result.current.goToNext();
+        expect(navigation?.nextIndex).toBe(-1);
+      });
+
+      expect(result.current.currentStep).toBe(0);
+    });
+
+    it("scans forward when JUMP_TO targets an invisible question", () => {
+      const { result } = renderHook(() =>
+        useStepNavigation({
+          questions: JUMP_TO_VISIBLE_IF_QUESTIONS,
+          answers: { q1: "a" },
+        }),
+      );
+
+      act(() => {
+        const branchingResult = result.current.goToNext();
+        expect(branchingResult?.triggeredByRule).toBe(true);
+      });
+
+      expect(result.current.currentQuestion?.id).toBe("q3");
+      expect(result.current.currentStep).toBe(2);
+    });
+
+    it("goToNext returns adjusted nextIndex when visibility skips questions", () => {
+      const { result } = renderHook(() =>
+        useStepNavigation({
+          questions: JUMP_TO_VISIBLE_IF_QUESTIONS,
+          answers: { q1: "a" },
+        }),
+      );
+
+      act(() => {
+        const branchingResult: BranchingResult | null =
+          result.current.goToNext();
+        expect(branchingResult?.nextIndex).toBe(2);
+      });
+
+      // JUMP_TO targets q2 (index 1) but q2 is hidden, so actual navigation goes to q3 (index 2)
+      expect(result.current.currentStep).toBe(2);
+    });
+
+    it("sets isLastStep=true when all later steps are invisible", () => {
+      const { result } = renderHook(() =>
+        useStepNavigation({
+          questions: VISIBLE_IF_QUESTIONS.slice(0, 3),
+          answers: { q1: "hide" },
+          forceStepMode: true,
+        }),
+      );
+
+      expect(result.current.isLastStep).toBe(true);
+    });
+
+    it("isLastStep is true for unanswered optional question when all later steps are invisible", () => {
+      const questions: LumiSurveyQuestion[] = [
+        {
+          id: "q1",
+          type: "singleChoice",
+          prompt: "Steg 1",
+          required: true,
+          options: [{ value: "a", label: "A" }],
+        },
+        {
+          id: "q2",
+          type: "text",
+          prompt: "Steg 2 (valgfri)",
+          required: false,
+          maxLength: 500,
+        },
+        {
+          id: "q3",
+          type: "text",
+          prompt: "Steg 3 (skjult)",
+          required: false,
+          maxLength: 500,
+          visibleIf: {
+            field: "ANSWER",
+            questionId: "q1",
+            operator: "EQ",
+            value: "show-q3",
+          },
+        },
+      ];
+
+      const { result } = renderHook(() =>
+        useStepNavigation({
+          questions,
+          answers: { q1: "a" },
+          forceStepMode: true,
+        }),
+      );
+
+      act(() => {
+        result.current.goToNext();
+      });
+
+      expect(result.current.currentQuestion?.id).toBe("q2");
+      expect(result.current.isLastStep).toBe(true);
+    });
+
+    it("isLastStep is false for unanswered question when later step depends on current question", () => {
+      const questions: LumiSurveyQuestion[] = [
+        {
+          id: "rating",
+          type: "singleChoice",
+          prompt: "Hvordan var opplevelsen?",
+          required: false,
+          options: [{ value: "5", label: "5" }],
+        },
+        {
+          id: "feedback",
+          type: "text",
+          prompt: "Hva kan vi forbedre?",
+          required: false,
+          maxLength: 500,
+          visibleIf: {
+            field: "ANSWER",
+            questionId: "rating",
+            operator: "EXISTS",
+          },
+        },
+      ];
+
+      const { result } = renderHook(() =>
+        useStepNavigation({
+          questions,
+          answers: {},
+          forceStepMode: true,
+        }),
+      );
+
+      expect(result.current.currentQuestion?.id).toBe("rating");
+      expect(result.current.isLastStep).toBe(false);
+    });
+
+    it("supports CONTAINS operator for multiChoice visibleIf", () => {
+      const { result } = renderHook(() =>
+        useStepNavigation({
+          questions: MULTI_CHOICE_VISIBLE_IF_QUESTIONS,
+          answers: { q1: ["alpha"] },
+          forceStepMode: true,
+        }),
+      );
+
+      act(() => {
+        result.current.goToNext();
+      });
+
+      expect(result.current.currentQuestion?.id).toBe("q2");
+    });
+
+    it("keeps back navigation safe when visited hidden steps", () => {
+      const { result, rerender } = renderHook(
+        ({ answers }) =>
+          useStepNavigation({
+            questions: VISIBLE_IF_QUESTIONS,
+            answers,
+            forceStepMode: true,
+          }),
+        {
+          initialProps: { answers: { q1: "show", q2: "x", q3: "y" } },
+        },
+      );
+
+      act(() => {
+        result.current.goToNext();
+      });
+      act(() => {
+        result.current.goToNext();
+      });
+      expect(result.current.currentQuestion?.id).toBe("q4");
+
+      rerender({ answers: { q1: "hide", q2: "x", q3: "y" } });
+
+      act(() => {
+        result.current.goToPrevious();
+      });
+
+      expect(result.current.currentQuestion?.id).toBe("q1");
+      expect(result.current.currentStep).toBe(0);
+    });
+
+    it("auto-navigates when current step becomes invisible after answer changes", async () => {
+      const { result, rerender } = renderHook(
+        ({ answers }) =>
+          useStepNavigation({
+            questions: VISIBLE_IF_QUESTIONS,
+            answers,
+            forceStepMode: true,
+          }),
+        {
+          initialProps: { answers: { q1: "show", q2: "text" } },
+        },
+      );
+
+      act(() => {
+        result.current.goToNext();
+      });
+      expect(result.current.currentQuestion?.id).toBe("q2");
+
+      rerender({ answers: { q1: "hide", q2: "text" } });
+
+      await waitFor(() => {
+        expect(result.current.currentQuestion?.id).toBe("q4");
+      });
+    });
+
+    it("auto-navigates to last visited step when current becomes invisible and no later steps visible", async () => {
+      const questions: LumiSurveyQuestion[] = [
+        {
+          id: "q1",
+          type: "singleChoice",
+          prompt: "Steg 1",
+          required: true,
+          options: [
+            { value: "show", label: "Vis" },
+            { value: "hide", label: "Skjul" },
+          ],
+        },
+        {
+          id: "q2",
+          type: "text",
+          prompt: "Steg 2",
+          required: false,
+          maxLength: 500,
+          visibleIf: {
+            field: "ANSWER",
+            questionId: "q1",
+            operator: "EQ",
+            value: "show",
+          },
+        },
+      ];
+
+      const { result, rerender } = renderHook(
+        ({ answers }) =>
+          useStepNavigation({
+            questions,
+            answers,
+            forceStepMode: true,
+          }),
+        {
+          initialProps: {
+            answers: {
+              q1: "show",
+              q2: "text",
+            } as Record<string, LumiSurveyAnswerValue>,
+          },
+        },
+      );
+
+      // Navigate to q2
+      act(() => {
+        result.current.goToNext();
+      });
+      expect(result.current.currentQuestion?.id).toBe("q2");
+
+      // Change answer so q2 becomes hidden, no later steps
+      rerender({
+        answers: { q1: "hide", q2: "text" } as Record<
+          string,
+          LumiSurveyAnswerValue
+        >,
+      });
+
+      await waitFor(() => {
+        // Should fall back to q1 (last visited), not stay on hidden q2
+        expect(result.current.currentQuestion?.id).toBe("q1");
+      });
+    });
+  });
+
   // ------------------------------------------
   // onStepChange callback
   // ------------------------------------------
   describe("onStepChange callback", () => {
-    it("fires onStepChange when step changes in step mode", () => {
+    it("fires onStepChange with visible step index and total visible count", () => {
       const onStepChange = vi.fn();
 
       const { result } = renderHook(() =>
@@ -590,7 +1033,7 @@ describe("useStepNavigation", () => {
         }),
       );
 
-      // Called once on initial render (step 0)
+      // Called once on initial render (visible step 0 of 3)
       expect(onStepChange).toHaveBeenCalledWith(0, 3);
 
       act(() => {
@@ -598,6 +1041,182 @@ describe("useStepNavigation", () => {
       });
 
       expect(onStepChange).toHaveBeenCalledWith(1, 3);
+    });
+
+    it("reports correct visible index when hidden questions are skipped", () => {
+      const onStepChange = vi.fn();
+
+      const { result } = renderHook(() =>
+        useStepNavigation({
+          questions: VISIBLE_IF_QUESTIONS,
+          answers: { q1: "show-q3" },
+          forceStepMode: true,
+          onStepChange,
+        }),
+      );
+
+      // q1 is visible (step 0 of 3 visible: q1, q3, q4)
+      expect(onStepChange).toHaveBeenCalledWith(0, 3);
+
+      act(() => {
+        result.current.goToNext();
+      });
+
+      // Skips q2 (hidden), lands on q3 — visible step 1 of 3
+      expect(onStepChange).toHaveBeenCalledWith(1, 3);
+    });
+
+    it("does not fire onStepChange when no questions are visible", () => {
+      const onStepChange = vi.fn();
+
+      renderHook(() =>
+        useStepNavigation({
+          questions: ALL_HIDDEN_QUESTIONS,
+          answers: {},
+          forceStepMode: true,
+          onStepChange,
+        }),
+      );
+
+      expect(onStepChange).not.toHaveBeenCalled();
+    });
+  });
+
+  // ------------------------------------------
+  // Edge cases: no visible questions
+  // ------------------------------------------
+  describe("no visible questions", () => {
+    it("returns undefined currentQuestion when all questions are hidden", () => {
+      const { result } = renderHook(() =>
+        useStepNavigation({
+          questions: ALL_HIDDEN_QUESTIONS,
+          answers: {},
+          forceStepMode: true,
+        }),
+      );
+
+      expect(result.current.currentQuestion).toBeUndefined();
+      expect(result.current.currentStep).toBe(-1);
+      expect(result.current.canGoNext).toBe(false);
+      expect(result.current.canGoBack).toBe(false);
+      expect(result.current.isLastStep).toBe(false);
+    });
+
+    it("goToNext returns null when all questions are hidden", () => {
+      const { result } = renderHook(() =>
+        useStepNavigation({
+          questions: ALL_HIDDEN_QUESTIONS,
+          answers: {},
+          forceStepMode: true,
+        }),
+      );
+
+      act(() => {
+        expect(result.current.goToNext()).toBeNull();
+      });
+    });
+
+    it("returns undefined currentQuestion for empty questions array", () => {
+      const { result } = renderHook(() =>
+        useStepNavigation({
+          questions: [],
+          answers: {},
+          forceStepMode: true,
+        }),
+      );
+
+      expect(result.current.currentQuestion).toBeUndefined();
+      expect(result.current.currentStep).toBe(-1);
+      expect(result.current.canGoNext).toBe(false);
+    });
+
+    it("recovers from -1 state when questions become visible", async () => {
+      const { result, rerender } = renderHook(
+        ({ metadata }) =>
+          useStepNavigation({
+            questions: ALL_HIDDEN_QUESTIONS,
+            answers: {},
+            metadata,
+            forceStepMode: true,
+          }),
+        { initialProps: { metadata: {} as Record<string, unknown> } },
+      );
+
+      expect(result.current.currentStep).toBe(-1);
+      expect(result.current.currentQuestion).toBeUndefined();
+
+      // Metadata changes to make questions visible
+      rerender({ metadata: { show: "yes" } });
+
+      await waitFor(() => {
+        expect(result.current.currentStep).toBe(0);
+        expect(result.current.currentQuestion?.id).toBe("q1");
+      });
+    });
+
+    it("transitions to -1 when all visible questions become hidden", async () => {
+      const questions: LumiSurveyQuestion[] = [
+        {
+          id: "q1",
+          type: "text",
+          prompt: "Only question",
+          required: false,
+          maxLength: 500,
+          visibleIf: {
+            field: "METADATA" as const,
+            key: "show",
+            operator: "EQ" as const,
+            value: "yes",
+          },
+        },
+      ];
+
+      const { result, rerender } = renderHook(
+        ({ metadata }) =>
+          useStepNavigation({
+            questions,
+            answers: {},
+            metadata,
+            forceStepMode: true,
+          }),
+        {
+          initialProps: {
+            metadata: { show: "yes" } as Record<string, unknown>,
+          },
+        },
+      );
+
+      expect(result.current.currentStep).toBe(0);
+      expect(result.current.currentQuestion?.id).toBe("q1");
+
+      // Metadata changes to hide all questions
+      rerender({ metadata: { show: "no" } });
+
+      await waitFor(() => {
+        expect(result.current.currentStep).toBe(-1);
+        expect(result.current.currentQuestion).toBeUndefined();
+      });
+    });
+  });
+  describe("goToNext guard", () => {
+    it("returns null when required question is unanswered", () => {
+      const { result } = renderHook(() =>
+        useStepNavigation({
+          questions: LINEAR_QUESTIONS,
+          answers: {},
+          forceStepMode: true,
+        }),
+      );
+
+      expect(result.current.currentQuestion?.required).toBe(true);
+      expect(result.current.canGoNext).toBe(false);
+
+      act(() => {
+        expect(result.current.goToNext()).toBeNull();
+      });
+
+      // Should not have moved
+      expect(result.current.currentStep).toBe(0);
     });
   });
 });

--- a/packages/lumi-survey/src/components/LumiSurveyDock/hooks/stepNavigationUtils.ts
+++ b/packages/lumi-survey/src/components/LumiSurveyDock/hooks/stepNavigationUtils.ts
@@ -1,0 +1,120 @@
+import { evaluateVisibility } from "../../../core/evaluateVisibility.js";
+import type {
+  LumiSurveyAnswerValue,
+  LumiSurveyQuestion,
+} from "../../../core/types.js";
+
+/** Check whether a survey answer value is non-empty. */
+export function isAnswered(value: LumiSurveyAnswerValue | undefined): boolean {
+  return (
+    value !== undefined &&
+    value !== null &&
+    (typeof value === "string" ? value.trim() !== "" : true) &&
+    !(Array.isArray(value) && value.length === 0)
+  );
+}
+
+/**
+ * Returns true when at least one question after `currentIndex` is visible now
+ * or could become visible once the current question is answered.
+ *
+ * A later question "may become reachable" if it has no `visibleIf`, if its
+ * visibility depends on the current question (and could therefore change once
+ * answered), or if it already evaluates as visible given current answers.
+ */
+export function hasReachableQuestionsAfter(
+  questions: LumiSurveyQuestion[],
+  currentIndex: number,
+  currentQuestionId: string,
+  answers: Record<string, LumiSurveyAnswerValue>,
+  metadata: Record<string, unknown> | undefined,
+): boolean {
+  return questions.some((question, index) => {
+    if (index <= currentIndex) return false;
+    if (!question.visibleIf) return true;
+    if (
+      question.visibleIf.field !== "METADATA" &&
+      question.visibleIf.questionId === currentQuestionId
+    ) {
+      return true;
+    }
+    return evaluateVisibility(question.visibleIf, answers, metadata);
+  });
+}
+
+/**
+ * Finds the best redirect target when the current step becomes invisible.
+ * Priority: next visible forward → last visible in history → first visible overall.
+ * Returns -1 when no visible question exists at all.
+ */
+export function findRedirectTarget(
+  questions: LumiSurveyQuestion[],
+  answers: Record<string, LumiSurveyAnswerValue>,
+  metadata: Record<string, unknown> | undefined,
+  currentStep: number,
+  visitedSteps: number[],
+): number {
+  // 1. Try the next visible question after the current step
+  const nextVisible = findNextVisibleIndex(
+    questions,
+    answers,
+    metadata,
+    currentStep + 1,
+  );
+  if (nextVisible !== -1) return nextVisible;
+
+  // 2. Fall back to the last visible step the user already visited
+  const historyResult = findLastVisibleInHistory(
+    visitedSteps.slice(0, -1),
+    questions,
+    answers,
+    metadata,
+  );
+  if (historyResult) return historyResult.step;
+
+  // 3. Last resort: scan from the very beginning
+  return findNextVisibleIndex(questions, answers, metadata, 0);
+}
+
+/**
+ * Finds the last visible question index in a visited-steps history.
+ * Searches backward from the end, returning both the step index and
+ * the trimmed history up to (and including) that step.
+ *
+ * Returns `null` when no visible step is found in the history.
+ */
+export function findLastVisibleInHistory(
+  history: number[],
+  questions: LumiSurveyQuestion[],
+  answers: Record<string, LumiSurveyAnswerValue>,
+  metadata: Record<string, unknown> | undefined,
+): { step: number; history: number[] } | null {
+  for (let i = history.length - 1; i >= 0; i--) {
+    const step = history[i];
+    const question = questions[step];
+    if (question && evaluateVisibility(question.visibleIf, answers, metadata)) {
+      return { step, history: history.slice(0, i + 1) };
+    }
+  }
+  return null;
+}
+
+/**
+ * Finds the first visible question index at or after `startIndex`.
+ * Returns -1 when no visible question is found.
+ */
+export function findNextVisibleIndex(
+  questions: LumiSurveyQuestion[],
+  answers: Record<string, LumiSurveyAnswerValue>,
+  metadata: Record<string, unknown> | undefined,
+  startIndex: number,
+): number {
+  for (let index = Math.max(0, startIndex); index < questions.length; index++) {
+    const question = questions[index];
+    if (evaluateVisibility(question.visibleIf, answers, metadata)) {
+      return index;
+    }
+  }
+
+  return -1;
+}

--- a/packages/lumi-survey/src/components/LumiSurveyDock/hooks/useStepNavigation.ts
+++ b/packages/lumi-survey/src/components/LumiSurveyDock/hooks/useStepNavigation.ts
@@ -1,23 +1,29 @@
-import { useCallback, useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import {
   type BranchingResult,
   evaluateBranching,
   surveyHasBranchingLogic,
 } from "../../../core/branchingEngine.js";
+import { evaluateVisibility } from "../../../core/evaluateVisibility.js";
 import type {
   LumiSurveyAnswerValue,
   LumiSurveyQuestion,
 } from "../../../core/types.js";
+import {
+  findLastVisibleInHistory,
+  findNextVisibleIndex,
+  findRedirectTarget,
+  hasReachableQuestionsAfter,
+  isAnswered,
+} from "./stepNavigationUtils.js";
 
-/** Check whether a survey answer value is non-empty. */
-export function isAnswered(value: LumiSurveyAnswerValue | undefined): boolean {
-  return (
-    value !== undefined &&
-    value !== null &&
-    (typeof value === "string" ? value.trim() !== "" : true) &&
-    !(Array.isArray(value) && value.length === 0)
-  );
-}
+export {
+  findLastVisibleInHistory,
+  findNextVisibleIndex,
+  findRedirectTarget,
+  hasReachableQuestionsAfter,
+  isAnswered,
+} from "./stepNavigationUtils.js";
 
 export interface UseStepNavigationOptions {
   questions: LumiSurveyQuestion[];
@@ -25,16 +31,16 @@ export interface UseStepNavigationOptions {
   metadata?: Record<string, unknown>;
   /** If true, forces step mode even without branching logic */
   forceStepMode?: boolean;
-  /** Callback fired when the current step changes */
-  onStepChange?: (currentStep: number, totalSteps: number) => void;
+  /** Callback fired when the visible step changes (receives 0-based visible index and total visible count) */
+  onStepChange?: (visibleStepIndex: number, totalVisibleSteps: number) => void;
 }
 
 export interface UseStepNavigationReturn {
   /** Whether step-based navigation is active (has branching or forceStepMode) */
   isStepMode: boolean;
-  /** Current question index */
+  /** Current question index (-1 when no questions are visible) */
   currentStep: number;
-  /** The current question to display (undefined when the questions array is empty) */
+  /** The current question to display (undefined when no visible questions exist) */
   currentQuestion: LumiSurveyQuestion | undefined;
   /** Whether the user can go back */
   canGoBack: boolean;
@@ -52,6 +58,10 @@ export interface UseStepNavigationReturn {
   hasBranching: boolean;
   /** Array of visited question indices for back navigation */
   visitedSteps: number[];
+  /** 0-based index among currently visible questions (-1 when none visible) */
+  visibleStepIndex: number;
+  /** Total count of currently visible questions */
+  totalVisibleSteps: number;
 }
 
 /**
@@ -76,9 +86,15 @@ export function useStepNavigation(
   );
   const isStepMode = hasBranching || forceStepMode;
 
-  // Navigation state
-  const [currentStep, setCurrentStep] = useState(0);
-  const [visitedSteps, setVisitedSteps] = useState<number[]>([0]);
+  // Navigation state — start on the first visible question (skip any that are
+  // hidden by visibleIf on initial render). Uses -1 when no questions are visible.
+  const [currentStep, setCurrentStep] = useState(() =>
+    findNextVisibleIndex(questions, answers, metadata, 0),
+  );
+  const [visitedSteps, setVisitedSteps] = useState<number[]>(() => {
+    const firstVisible = findNextVisibleIndex(questions, answers, metadata, 0);
+    return firstVisible === -1 ? [] : [firstVisible];
+  });
 
   const currentQuestion = questions[currentStep];
 
@@ -87,9 +103,12 @@ export function useStepNavigation(
   const hasAnsweredCurrent = isAnswered(currentAnswer);
 
   const canGoBack = visitedSteps.length > 1;
-  const canGoNext = hasAnsweredCurrent || !currentQuestion?.required;
+  const canGoNext =
+    !!currentQuestion && (hasAnsweredCurrent || !currentQuestion.required);
 
-  // Shared branching evaluation — used by both isLastStep and goToNext
+  // Shared branching evaluation — used by both isLastStep and goToNext.
+  // Only computed when the current question has been answered, since branching
+  // rules evaluate against the current answer.
   const branchingResult = useMemo(() => {
     if (!currentQuestion || !hasAnsweredCurrent) return null;
     return evaluateBranching(
@@ -108,25 +127,89 @@ export function useStepNavigation(
     hasAnsweredCurrent,
   ]);
 
-  // True when on the last linear step OR branching evaluates to SUBMIT
+  // Determines whether the current step is the last one in the survey path.
+  // Three cases make this true:
+  // 1. Branching explicitly says SUBMIT (nextIndex === -1)
+  // 2. Question is unanswered, and no later questions are reachable (visible
+  //    now, or dependent on the current answer and thus potentially visible)
+  // 3. Question is answered, and no visible questions exist after the
+  //    branching-determined next index
   const isLastStep = useMemo(() => {
     if (!currentQuestion) return false;
-    if (currentStep >= questions.length - 1) return true;
-    if (!branchingResult) return false;
-    return branchingResult.nextIndex === -1;
-  }, [currentQuestion, currentStep, questions.length, branchingResult]);
+    if (branchingResult?.nextIndex === -1) return true;
 
-  // Fire onStepChange when step changes
-  useEffect(() => {
-    if (isStepMode && onStepChange) {
-      onStepChange(currentStep, questions.length);
+    if (!hasAnsweredCurrent) {
+      // When the user hasn't answered yet, we can't evaluate branching rules.
+      // Instead, check if any later question is currently visible OR depends on
+      // this question's answer (meaning it could become visible once answered).
+      return !hasReachableQuestionsAfter(
+        questions,
+        currentStep,
+        currentQuestion.id,
+        answers,
+        metadata,
+      );
     }
-  }, [currentStep, isStepMode, onStepChange, questions.length]);
+
+    // Question is answered — use branching result to determine where we'd go
+    // next, then check if any visible question exists from that point forward.
+    const nextStartIndex = branchingResult
+      ? Math.max(0, branchingResult.nextIndex)
+      : currentStep + 1;
+
+    return (
+      findNextVisibleIndex(questions, answers, metadata, nextStartIndex) === -1
+    );
+  }, [
+    currentQuestion,
+    currentStep,
+    branchingResult,
+    hasAnsweredCurrent,
+    questions,
+    answers,
+    metadata,
+  ]);
+
+  // Compute visible step metrics for progress reporting.
+  // visibleStepIndex is the 0-based position among currently visible questions.
+  const totalVisibleSteps = useMemo(
+    () =>
+      questions.filter((q) =>
+        evaluateVisibility(q.visibleIf, answers, metadata),
+      ).length,
+    [questions, answers, metadata],
+  );
+  const visibleStepIndex = useMemo(() => {
+    if (currentStep < 0) return -1;
+    let count = 0;
+    for (let i = 0; i < currentStep; i++) {
+      if (evaluateVisibility(questions[i].visibleIf, answers, metadata)) {
+        count++;
+      }
+    }
+    return count;
+  }, [currentStep, questions, answers, metadata]);
+
+  // Fire onStepChange when the user actually moves to a different step.
+  // Uses a ref to avoid spurious re-fires when onStepChange reference changes.
+  const prevStepRef = useRef<number | null>(null);
+  const onStepChangeRef = useRef(onStepChange);
+  onStepChangeRef.current = onStepChange;
+
+  useEffect(() => {
+    if (!isStepMode || currentStep < 0) return;
+    if (prevStepRef.current === currentStep) return;
+    prevStepRef.current = currentStep;
+    onStepChangeRef.current?.(visibleStepIndex, totalVisibleSteps);
+  }, [currentStep, isStepMode, visibleStepIndex, totalVisibleSteps]);
 
   const goToNext = useCallback(() => {
     if (!currentQuestion) return null;
+    // Guard: don't advance if the current question is required and unanswered
+    if (currentQuestion.required && !hasAnsweredCurrent) return null;
 
-    // Use pre-computed branching result when available, otherwise evaluate fresh
+    // Evaluate branching rules to get the raw next index. This may point to a
+    // hidden question, so we scan forward to find the first visible one.
     const result =
       branchingResult ??
       evaluateBranching(
@@ -142,47 +225,139 @@ export function useStepNavigation(
       return result;
     }
 
-    // Clamp to valid range
-    const nextIndex = Math.min(
-      Math.max(0, result.nextIndex),
-      questions.length - 1,
+    // Clamp to valid range, then scan for next visible question
+    const nextStartIndex = Math.max(0, result.nextIndex);
+    const nextVisibleIndex = findNextVisibleIndex(
+      questions,
+      answers,
+      metadata,
+      nextStartIndex,
     );
 
-    // Only add to visited if we're going to a new step
-    if (nextIndex !== currentStep) {
-      setCurrentStep(nextIndex);
+    // No visible questions ahead — signal submit to the consumer
+    if (nextVisibleIndex === -1) {
+      return { ...result, nextIndex: -1 };
+    }
+
+    // Navigate and record in history. If we revisit an earlier step (e.g. via
+    // JUMP_TO), truncate history to avoid loops like [0,1,2,1,0,1,2].
+    if (nextVisibleIndex !== currentStep) {
+      setCurrentStep(nextVisibleIndex);
       setVisitedSteps((prev) => {
-        const existingIndex = prev.indexOf(nextIndex);
+        const existingIndex = prev.indexOf(nextVisibleIndex);
         if (existingIndex !== -1) return prev.slice(0, existingIndex + 1);
-        return [...prev, nextIndex];
+        return [...prev, nextVisibleIndex];
       });
     }
 
-    return result;
+    // Return the actual navigation target so the consumer knows where we went
+    return { ...result, nextIndex: nextVisibleIndex };
   }, [
     currentQuestion,
     currentAnswer,
+    hasAnsweredCurrent,
     metadata,
     questions,
     currentStep,
     branchingResult,
+    answers,
   ]);
 
+  // Navigate backward through visited history, skipping any steps that have
+  // become hidden since they were visited (e.g. because the user changed an
+  // earlier answer that affected visibleIf conditions).
   const goToPrevious = useCallback(() => {
     if (visitedSteps.length <= 1) return;
 
-    // Remove current step from history and go to previous
-    const newHistory = visitedSteps.slice(0, -1);
-    const previousStep = newHistory[newHistory.length - 1];
+    // Remove current step and search backward for a still-visible step
+    const previousHistory = visitedSteps.slice(0, -1);
+    const result = findLastVisibleInHistory(
+      previousHistory,
+      questions,
+      answers,
+      metadata,
+    );
 
-    setVisitedSteps(newHistory);
-    setCurrentStep(previousStep);
-  }, [visitedSteps]);
+    if (result) {
+      setVisitedSteps(result.history);
+      setCurrentStep(result.step);
+      return;
+    }
 
+    // No visited steps are visible — fall back to first visible question
+    const firstVisible = findNextVisibleIndex(questions, answers, metadata, 0);
+    if (firstVisible === -1) return;
+    setVisitedSteps([firstVisible]);
+    setCurrentStep(firstVisible);
+  }, [visitedSteps, questions, answers, metadata]);
+
+  // Reset to the beginning — used when the survey definition changes or
+  // the consumer explicitly wants to start over.
   const resetNavigation = useCallback(() => {
-    setCurrentStep(0);
-    setVisitedSteps([0]);
-  }, []);
+    const firstVisible = findNextVisibleIndex(questions, answers, metadata, 0);
+    setCurrentStep(firstVisible);
+    setVisitedSteps(firstVisible === -1 ? [] : [firstVisible]);
+  }, [questions, answers, metadata]);
+
+  // Auto-navigation effect: handles two scenarios:
+  // 1. Current step is -1 (no visible questions) but questions have since become
+  //    visible (e.g. metadata arrived async) → navigate to first visible.
+  // 2. Current step became invisible (e.g. user went back and changed an answer
+  //    that affected a visibleIf condition) → redirect to best available step,
+  //    or fall back to -1 if nothing is visible anymore.
+  useEffect(() => {
+    if (!isStepMode) return;
+
+    // Recovery: no current question — try to find one
+    if (!currentQuestion) {
+      const firstVisible = findNextVisibleIndex(
+        questions,
+        answers,
+        metadata,
+        0,
+      );
+      if (firstVisible === -1) return;
+      setCurrentStep(firstVisible);
+      setVisitedSteps([firstVisible]);
+      return;
+    }
+
+    // Current step is still visible — nothing to do
+    if (evaluateVisibility(currentQuestion.visibleIf, answers, metadata))
+      return;
+
+    const target = findRedirectTarget(
+      questions,
+      answers,
+      metadata,
+      currentStep,
+      visitedSteps,
+    );
+
+    // All questions became hidden — enter no-visible state
+    if (target === -1) {
+      setCurrentStep(-1);
+      setVisitedSteps([]);
+      return;
+    }
+
+    if (target === currentStep) return;
+
+    setCurrentStep(target);
+    setVisitedSteps((prev) => {
+      const existingIndex = prev.indexOf(target);
+      if (existingIndex !== -1) return prev.slice(0, existingIndex + 1);
+      return [...prev, target];
+    });
+  }, [
+    isStepMode,
+    currentQuestion,
+    questions,
+    answers,
+    metadata,
+    currentStep,
+    visitedSteps,
+  ]);
 
   return {
     isStepMode,
@@ -196,5 +371,7 @@ export function useStepNavigation(
     resetNavigation,
     hasBranching,
     visitedSteps,
+    visibleStepIndex,
+    totalVisibleSteps,
   };
 }

--- a/packages/lumi-survey/src/core/__tests__/evaluateVisibility.test.ts
+++ b/packages/lumi-survey/src/core/__tests__/evaluateVisibility.test.ts
@@ -133,6 +133,30 @@ describe("evaluateVisibility", () => {
         evaluateVisibility(condition, { tasks: ["check", "status"] }),
       ).toBe(false);
     });
+
+    it("returns true when string contains substring (case-insensitive)", () => {
+      const condition = {
+        field: "ANSWER" as const,
+        questionId: "feedback",
+        operator: "CONTAINS" as const,
+        value: "good",
+      };
+      expect(
+        evaluateVisibility(condition, { feedback: "Very Good feedback" }),
+      ).toBe(true);
+    });
+
+    it("returns false when string does not contain substring", () => {
+      const condition = {
+        field: "ANSWER" as const,
+        questionId: "feedback",
+        operator: "CONTAINS" as const,
+        value: "bad",
+      };
+      expect(
+        evaluateVisibility(condition, { feedback: "Very Good feedback" }),
+      ).toBe(false);
+    });
   });
 
   describe("with METADATA field", () => {

--- a/packages/lumi-survey/src/core/evaluateVisibility.ts
+++ b/packages/lumi-survey/src/core/evaluateVisibility.ts
@@ -75,11 +75,15 @@ function evaluateOperator(
         actual < expected
       );
     case "CONTAINS":
+      if (typeof actual === "string") {
+        return actual.toLowerCase().includes(String(expected).toLowerCase());
+      }
       return Array.isArray(actual) && actual.includes(expected);
     case "EXISTS":
       return actual !== undefined;
     default:
-      return true;
+      // Unknown operator — fail closed to avoid showing questions by mistake
+      return false;
   }
 }
 

--- a/packages/lumi-survey/src/core/types.ts
+++ b/packages/lumi-survey/src/core/types.ts
@@ -390,9 +390,11 @@ export interface LumiSurveyEvents {
   onDismissalPersistFailed?: (cause: unknown) => void;
   /**
    * Fired when the current step changes in step mode.
-   * Also fires on initial render (step 0) when step mode is active.
+   * Also fires on initial render when step mode is active.
+   * Receives 0-based visible step index and total visible step count
+   * (hidden questions are excluded from both values).
    */
-  onStepChange?: (currentStep: number, totalSteps: number) => void;
+  onStepChange?: (visibleStepIndex: number, totalVisibleSteps: number) => void;
 }
 
 export type LumiSurveyStatus = "idle" | "submitting" | "success" | "error";

--- a/packages/lumi-survey/src/stories/LumiSurveyDock.custom.stories.tsx
+++ b/packages/lumi-survey/src/stories/LumiSurveyDock.custom.stories.tsx
@@ -76,20 +76,6 @@ const CUSTOM_SURVEY: LumiSurveyConfig = {
         },
         { value: "annet", label: "Annet" },
       ],
-      logic: [
-        {
-          condition: {
-            field: "ANSWER",
-            operator: "CONTAINS",
-            value: "annet",
-          },
-          action: { type: "JUMP_TO", targetId: "vanskeligst-annet" },
-        },
-        {
-          condition: { field: "ANSWER", operator: "EXISTS" },
-          action: { type: "JUMP_TO", targetId: "lettere" },
-        },
-      ],
     },
     {
       id: "vanskeligst-annet",
@@ -172,7 +158,7 @@ const meta: Meta<typeof LumiSurveyDock> = {
     docs: {
       description: {
         component:
-          "Tilpasset survey med singleChoice, multiChoice, text og logisk branching. Viser mangfoldet av spørsmålstyper og konfigurasjonsmuligheter.",
+          "Tilpasset survey med singleChoice, multiChoice, text og visibleIf. Viser mangfoldet av spørsmålstyper og konfigurasjonsmuligheter.",
       },
     },
   },
@@ -207,7 +193,7 @@ export const Custom: Story = {
     docs: {
       description: {
         story:
-          "Step-by-step survey uten intro – hopper direkte til første spørsmål. Viser singleChoice, multiChoice, text og logisk branching (velg «Annet» på spørsmål 4).",
+          "Step-by-step survey uten intro – hopper direkte til første spørsmål. Viser singleChoice, multiChoice, text og visibleIf (velg «Annet» på spørsmål 4 for å se oppfølgingsspørsmål).",
       },
     },
   },
@@ -239,7 +225,7 @@ export const MedIntro: Story = {
     docs: {
       description: {
         story:
-          "Samme survey med intro-skjerm, progress bar og logisk branching. Klikk «Start» for å se spørsmålene.",
+          "Samme survey med intro-skjerm, progress bar og visibleIf. Klikk «Start» for å se spørsmålene.",
       },
     },
   },


### PR DESCRIPTION
## Beskrivelse

Fikser en bug der `visibleIf`-betingelser på survey-spørsmål ignoreres fullstendig i step-modus (`questionLayout: "steps"`). Step-navigasjonen (`goToNext`, `goToPrevious`, `isLastStep`, `resetNavigation`) er nå visibility-aware og hopper over usynlige spørsmål.

## Endringer

- **`useStepNavigation.ts`**: Ny `findNextVisibleIndex` helper. `goToNext()` hopper over usynlige spørsmål. `isLastStep` sjekker synlighet (med smart håndtering av midlertidig vs permanent skjulte spørsmål). `goToPrevious()` sjekker synlighet i historikk. Auto-navigering via `useEffect` når current step blir usynlig. Fallback til siste besøkte synlige steg.
- **`LumiSurveyDock.tsx`**: Sender `metadata: enrichedContext?.tags` til `useStepNavigation` hook.
- **`evaluateVisibility.ts`**: CONTAINS-operator støtter nå string (case-insensitive substring) i tillegg til arrays, harmonisert med `branchingEngine.ts`.
- **`useStepNavigation.test.ts`**: 12+ nye tester for visibility-skipping, JUMP_TO til usynlig spørsmål, auto-navigering, CONTAINS multiChoice, isLastStep-presisjon.
- **`evaluateVisibility.test.ts`**: 2 nye tester for string CONTAINS.

## Testresultater

183/183 tester passerer. Lint og typecheck OK. Ingen regresjoner.

## Issue

Closes #142

## Sjekkliste

- [x] Koden kompilerer og linter uten feil
- [x] Endringene er testet (183/183 tester passerer)
- [x] Ingen sensitiv data eksponert (tokens, credentials, PII)