### PR TITLE
feat(dashboard): clickable field stats with multi-value filtering

### DIFF
--- a/.github/instructions/dashboard-testing.instructions.md
+++ b/.github/instructions/dashboard-testing.instructions.md
@@ -1,5 +1,5 @@
 ---
-applyTo: "apps/lumi-dashboard/**/*.test.{ts,tsx}"
+applyTo: "apps/lumi-dashboard/**/*.test.{ts,tsx},apps/lumi-dashboard/e2e/**/*.spec.ts"
 ---
 
 # Testing (lumi-dashboard)
@@ -50,6 +50,28 @@ describe("ErrorComponent", () => {
 
 - Keep E2E tests focused on user-critical flows.
 - Prefer accessible selectors (`getByRole`) over brittle CSS selectors.
+- **Run E2E before marking work as done** — either locally (`npm run e2e` from `apps/lumi-dashboard`) or verify the CI run passes. If Playwright hangs locally, push and check CI, but do NOT skip verification entirely.
+
+### Mock data and privacy masking
+
+The dashboard masks aggregated stats (fieldStats, etc.) when results fall below `MIN_AGGREGATION_THRESHOLD` (5 items). This affects E2E tests:
+
+- **Filter combinations** can reduce mock data below the threshold, causing fieldStats to be returned as `[]`.
+- **Label resolution** depends on stats data — when masked, filter chips show fallback labels (e.g. "Valg: optionId" instead of "Rolle: Arbeidsgiver").
+- **Never assert exact label text** when filters may trigger masking. Instead, assert on URL params, element presence, or ARIA attributes.
+
+```ts
+// ✅ Robust — tests state, not resolved labels
+await expect
+  .poll(() => new URL(page.url()).searchParams.get("choice"))
+  .toBe("role:Arbeidsgiver");
+await expect(
+  page.getByRole("button", { name: /Fjern filter/ }),
+).toBeVisible();
+
+// ❌ Brittle — depends on stats not being masked
+await expect(page.getByText("Rolle: Arbeidsgiver")).toBeVisible();
+```
 
 ## Boundaries
 

--- a/apps/lumi-api/src/main/kotlin/no/nav/lumi/domain/Models.kt
+++ b/apps/lumi-api/src/main/kotlin/no/nav/lumi/domain/Models.kt
@@ -408,6 +408,10 @@ data class FeedbackQuery(
     val ratingFieldId: String? = null,
     /** Filter by a specific rating value */
     val ratingValue: Int? = null,
+    /** Filter by a specific choice question fieldId */
+    val choiceFieldId: String? = null,
+    /** Filter by a specific choice option value/id */
+    val choiceValue: String? = null,
 )
 
 /**
@@ -434,6 +438,10 @@ data class StatsQuery(
     val ratingFieldId: String? = null,
     /** Filter by a specific rating value */
     val ratingValue: Int? = null,
+    /** Filter by a specific choice question fieldId */
+    val choiceFieldId: String? = null,
+    /** Filter by a specific choice option value/id */
+    val choiceValue: String? = null,
 )
 
 // ============================================

--- a/apps/lumi-api/src/main/kotlin/no/nav/lumi/domain/Models.kt
+++ b/apps/lumi-api/src/main/kotlin/no/nav/lumi/domain/Models.kt
@@ -404,14 +404,10 @@ data class FeedbackQuery(
     val task: String? = null,
     /** Segment filters (context.tags) as key:value pairs */
     val segments: List<Pair<String, String>> = emptyList(),
-    /** Filter by a specific rating question fieldId */
-    val ratingFieldId: String? = null,
-    /** Filter by a specific rating value */
-    val ratingValue: Int? = null,
-    /** Filter by a specific choice question fieldId */
-    val choiceFieldId: String? = null,
-    /** Filter by a specific choice option value/id */
-    val choiceValue: String? = null,
+    /** Multi-value choice filters: list of (fieldId, optionId) pairs */
+    val choiceFilters: List<Pair<String, String>> = emptyList(),
+    /** Multi-value rating filters: list of (fieldId, ratingValue) pairs */
+    val ratingFilters: List<Pair<String, Int>> = emptyList(),
 )
 
 /**
@@ -434,14 +430,10 @@ data class StatsQuery(
     val segments: List<Pair<String, String>> = emptyList(),
     /** Task filter for Top Tasks drill-down */
     val task: String? = null,
-    /** Filter by a specific rating question fieldId */
-    val ratingFieldId: String? = null,
-    /** Filter by a specific rating value */
-    val ratingValue: Int? = null,
-    /** Filter by a specific choice question fieldId */
-    val choiceFieldId: String? = null,
-    /** Filter by a specific choice option value/id */
-    val choiceValue: String? = null,
+    /** Multi-value choice filters: list of (fieldId, optionId) pairs */
+    val choiceFilters: List<Pair<String, String>> = emptyList(),
+    /** Multi-value rating filters: list of (fieldId, ratingValue) pairs */
+    val ratingFilters: List<Pair<String, Int>> = emptyList(),
 )
 
 // ============================================

--- a/apps/lumi-api/src/main/kotlin/no/nav/lumi/repository/FeedbackJsonPathSupport.kt
+++ b/apps/lumi-api/src/main/kotlin/no/nav/lumi/repository/FeedbackJsonPathSupport.kt
@@ -5,7 +5,7 @@ import org.slf4j.Logger
 internal const val MAX_CHOICE_VALUE_LENGTH = 200
 internal const val MAX_FIELD_ID_LENGTH = 200
 
-private val JSON_PATH_SPECIAL_CHARS = setOf('"', '\\', '$', '@', '?', '(', ')')
+private val JSON_PATH_SPECIAL_CHARS = setOf('"', '\\', '$', '@', '?', '(', ')', ',')
 
 internal data class ChoiceJsonPaths(
     val singleChoicePath: String,

--- a/apps/lumi-api/src/main/kotlin/no/nav/lumi/repository/FeedbackJsonPathSupport.kt
+++ b/apps/lumi-api/src/main/kotlin/no/nav/lumi/repository/FeedbackJsonPathSupport.kt
@@ -3,6 +3,7 @@ package no.nav.lumi.repository
 import org.slf4j.Logger
 
 internal const val MAX_CHOICE_VALUE_LENGTH = 200
+internal const val MAX_FIELD_ID_LENGTH = 200
 
 private val JSON_PATH_SPECIAL_CHARS = setOf('"', '\\', '$', '@', '?', '(', ')')
 
@@ -17,6 +18,10 @@ internal fun validateJsonPathFieldId(
     log: Logger
 ): String? {
     val normalizedFieldId = fieldId?.trim()?.takeIf { it.isNotBlank() } ?: return null
+    if (normalizedFieldId.length > MAX_FIELD_ID_LENGTH) {
+        log.warn("Rejected oversized JSONPath field id for {}: length {}", fieldName, normalizedFieldId.length)
+        return null
+    }
     val isSafeFieldId = normalizedFieldId.all { it.isLetterOrDigit() || it == '-' || it == '_' }
     if (!isSafeFieldId) {
         if (fieldName == "choiceFieldId") {

--- a/apps/lumi-api/src/main/kotlin/no/nav/lumi/repository/FeedbackJsonPathSupport.kt
+++ b/apps/lumi-api/src/main/kotlin/no/nav/lumi/repository/FeedbackJsonPathSupport.kt
@@ -1,0 +1,61 @@
+package no.nav.lumi.repository
+
+import org.slf4j.Logger
+
+internal const val MAX_CHOICE_VALUE_LENGTH = 200
+
+private val JSON_PATH_SPECIAL_CHARS = setOf('"', '\\', '$', '@', '?', '(', ')')
+
+internal data class ChoiceJsonPaths(
+    val singleChoicePath: String,
+    val multiChoicePath: String
+)
+
+internal fun validateJsonPathFieldId(
+    fieldId: String?,
+    fieldName: String,
+    log: Logger
+): String? {
+    val normalizedFieldId = fieldId?.trim()?.takeIf { it.isNotBlank() } ?: return null
+    val isSafeFieldId = normalizedFieldId.all { it.isLetterOrDigit() || it == '-' || it == '_' }
+    if (!isSafeFieldId) {
+        if (fieldName == "choiceFieldId") {
+            log.warn("Rejected unsafe choiceFieldId")
+        } else {
+            log.warn("Rejected unsafe JSONPath field id for {}", fieldName)
+        }
+        return null
+    }
+    return normalizedFieldId
+}
+
+internal fun normalizeChoiceValue(choiceValue: String?): String? {
+    return choiceValue
+        ?.trim()
+        ?.takeIf { it.isNotBlank() }
+        ?.take(MAX_CHOICE_VALUE_LENGTH)
+}
+
+internal fun isSafeChoiceValue(choiceValue: String): Boolean {
+    return choiceValue.none { it in JSON_PATH_SPECIAL_CHARS }
+}
+
+internal fun buildChoiceJsonPaths(
+    choiceFieldId: String?,
+    choiceValue: String?,
+    log: Logger
+): ChoiceJsonPaths? {
+    val safeFieldId = validateJsonPathFieldId(choiceFieldId, "choiceFieldId", log) ?: return null
+    val normalizedChoiceValue = normalizeChoiceValue(choiceValue) ?: return null
+    if (!isSafeChoiceValue(normalizedChoiceValue)) {
+        log.warn("Rejected unsafe JSONPath value for choiceValue")
+        return null
+    }
+
+    val singleChoicePath =
+        "$.answers[*] ? (@.fieldId == \"$safeFieldId\" && @.value.type == \"singleChoice\" && @.value.selectedOptionId == \"$normalizedChoiceValue\")"
+    val multiChoicePath =
+        "$.answers[*] ? (@.fieldId == \"$safeFieldId\" && @.value.type == \"multiChoice\" && exists(@.value.selectedOptionIds[*] ? (@ == \"$normalizedChoiceValue\")))"
+
+    return ChoiceJsonPaths(singleChoicePath = singleChoicePath, multiChoicePath = multiChoicePath)
+}

--- a/apps/lumi-api/src/main/kotlin/no/nav/lumi/repository/FeedbackJsonPathSupport.kt
+++ b/apps/lumi-api/src/main/kotlin/no/nav/lumi/repository/FeedbackJsonPathSupport.kt
@@ -37,7 +37,7 @@ internal fun normalizeChoiceValue(choiceValue: String?): String? {
 }
 
 internal fun isSafeChoiceValue(choiceValue: String): Boolean {
-    return choiceValue.none { it in JSON_PATH_SPECIAL_CHARS }
+    return choiceValue.none { it in JSON_PATH_SPECIAL_CHARS || it.code < 32 }
 }
 
 internal fun buildChoiceJsonPaths(

--- a/apps/lumi-api/src/main/kotlin/no/nav/lumi/repository/FeedbackRepositorySupport.kt
+++ b/apps/lumi-api/src/main/kotlin/no/nav/lumi/repository/FeedbackRepositorySupport.kt
@@ -10,6 +10,8 @@ import org.slf4j.Logger
 import java.time.LocalDate
 import java.time.ZoneId
 
+private const val MAX_VALUE_LENGTH = 200
+
 /**
  * Escape special characters for SQL LIKE patterns to prevent SQL injection.
  * Escapes %, _, and \ which have special meaning in LIKE clauses.
@@ -114,6 +116,24 @@ internal fun applyCommonFilters(query: Query, criteria: FeedbackQuery, log: Logg
             )
             val ratingExpr = Cast(ratingTextForField, IntegerColumnType())
             query.andWhere { ratingExpr eq ratingValue }
+        }
+    }
+
+    // Filter by specific choice answer (fieldId + selected option id)
+    val choiceFieldId = criteria.choiceFieldId
+    val choiceValue = criteria.choiceValue?.trim()?.takeIf { it.isNotBlank() }?.take(MAX_VALUE_LENGTH)
+    if (!choiceFieldId.isNullOrBlank() && choiceValue != null) {
+        // Avoid JSONPath injection by only allowing simple fieldId characters.
+        val isSafeFieldId = choiceFieldId.all { it.isLetterOrDigit() || it == '-' || it == '_' }
+        if (isSafeFieldId) {
+            val singleChoicePath =
+                "$.answers[*] ? (@.fieldId == \"$choiceFieldId\" && @.value.type == \"singleChoice\" && @.value.selectedOptionId == \"$choiceValue\")"
+            val multiChoicePath =
+                "$.answers[*] ? (@.fieldId == \"$choiceFieldId\" && @.value.type == \"multiChoice\" && exists(@.value.selectedOptionIds[*] ? (@ == \"$choiceValue\")))"
+            query.andWhere {
+                JsonbPathExists(FeedbackTable.feedbackJson, singleChoicePath) or
+                    JsonbPathExists(FeedbackTable.feedbackJson, multiChoicePath)
+            }
         }
     }
 }

--- a/apps/lumi-api/src/main/kotlin/no/nav/lumi/repository/FeedbackRepositorySupport.kt
+++ b/apps/lumi-api/src/main/kotlin/no/nav/lumi/repository/FeedbackRepositorySupport.kt
@@ -101,25 +101,27 @@ internal fun applyCommonFilters(query: Query, criteria: FeedbackQuery, log: Logg
         }
     }
 
-    // Filter by specific rating answer (fieldId + rating)
-    val ratingFieldId = criteria.ratingFieldId
-    val ratingValue = criteria.ratingValue
-    val safeRatingFieldId = validateJsonPathFieldId(ratingFieldId, "ratingFieldId", log)
-    if (safeRatingFieldId != null && ratingValue != null) {
-        val ratingTextForField = JsonbPathQueryFirstText(
-            FeedbackTable.feedbackJson,
-            "$.answers[*] ? (@.fieldId == \"$safeRatingFieldId\" && @.value.type == \"rating\").value.rating"
-        )
-        val ratingExpr = Cast(ratingTextForField, IntegerColumnType())
-        query.andWhere { ratingExpr eq ratingValue }
+    // Filter by specific rating answers (multi-value)
+    criteria.ratingFilters.forEach { (fieldId, ratingVal) ->
+        val safeFieldId = validateJsonPathFieldId(fieldId, "ratingFieldId", log)
+        if (safeFieldId != null) {
+            val ratingTextForField = JsonbPathQueryFirstText(
+                FeedbackTable.feedbackJson,
+                "$.answers[*] ? (@.fieldId == \"$safeFieldId\" && @.value.type == \"rating\").value.rating"
+            )
+            val ratingExpr = Cast(ratingTextForField, IntegerColumnType())
+            query.andWhere { ratingExpr eq ratingVal }
+        }
     }
 
-    // Filter by specific choice answer (fieldId + selected option id)
-    val choiceJsonPaths = buildChoiceJsonPaths(criteria.choiceFieldId, criteria.choiceValue, log)
-    if (choiceJsonPaths != null) {
-        query.andWhere {
-            JsonbPathExists(FeedbackTable.feedbackJson, choiceJsonPaths.singleChoicePath) or
-                JsonbPathExists(FeedbackTable.feedbackJson, choiceJsonPaths.multiChoicePath)
+    // Filter by specific choice answers (multi-value)
+    criteria.choiceFilters.forEach { (fieldId, value) ->
+        val choiceJsonPaths = buildChoiceJsonPaths(fieldId, value, log)
+        if (choiceJsonPaths != null) {
+            query.andWhere {
+                JsonbPathExists(FeedbackTable.feedbackJson, choiceJsonPaths.singleChoicePath) or
+                    JsonbPathExists(FeedbackTable.feedbackJson, choiceJsonPaths.multiChoicePath)
+            }
         }
     }
 }

--- a/apps/lumi-api/src/main/kotlin/no/nav/lumi/repository/FeedbackRepositorySupport.kt
+++ b/apps/lumi-api/src/main/kotlin/no/nav/lumi/repository/FeedbackRepositorySupport.kt
@@ -10,8 +10,6 @@ import org.slf4j.Logger
 import java.time.LocalDate
 import java.time.ZoneId
 
-private const val MAX_VALUE_LENGTH = 200
-
 /**
  * Escape special characters for SQL LIKE patterns to prevent SQL injection.
  * Escapes %, _, and \ which have special meaning in LIKE clauses.
@@ -106,34 +104,22 @@ internal fun applyCommonFilters(query: Query, criteria: FeedbackQuery, log: Logg
     // Filter by specific rating answer (fieldId + rating)
     val ratingFieldId = criteria.ratingFieldId
     val ratingValue = criteria.ratingValue
-    if (!ratingFieldId.isNullOrBlank() && ratingValue != null) {
-        // Avoid JSONPath injection by only allowing simple fieldId characters.
-        val isSafeFieldId = ratingFieldId.all { it.isLetterOrDigit() || it == '-' || it == '_' }
-        if (isSafeFieldId) {
-            val ratingTextForField = JsonbPathQueryFirstText(
-                FeedbackTable.feedbackJson,
-                "$.answers[*] ? (@.fieldId == \"$ratingFieldId\" && @.value.type == \"rating\").value.rating"
-            )
-            val ratingExpr = Cast(ratingTextForField, IntegerColumnType())
-            query.andWhere { ratingExpr eq ratingValue }
-        }
+    val safeRatingFieldId = validateJsonPathFieldId(ratingFieldId, "ratingFieldId", log)
+    if (safeRatingFieldId != null && ratingValue != null) {
+        val ratingTextForField = JsonbPathQueryFirstText(
+            FeedbackTable.feedbackJson,
+            "$.answers[*] ? (@.fieldId == \"$safeRatingFieldId\" && @.value.type == \"rating\").value.rating"
+        )
+        val ratingExpr = Cast(ratingTextForField, IntegerColumnType())
+        query.andWhere { ratingExpr eq ratingValue }
     }
 
     // Filter by specific choice answer (fieldId + selected option id)
-    val choiceFieldId = criteria.choiceFieldId
-    val choiceValue = criteria.choiceValue?.trim()?.takeIf { it.isNotBlank() }?.take(MAX_VALUE_LENGTH)
-    if (!choiceFieldId.isNullOrBlank() && choiceValue != null) {
-        // Avoid JSONPath injection by only allowing simple fieldId characters.
-        val isSafeFieldId = choiceFieldId.all { it.isLetterOrDigit() || it == '-' || it == '_' }
-        if (isSafeFieldId) {
-            val singleChoicePath =
-                "$.answers[*] ? (@.fieldId == \"$choiceFieldId\" && @.value.type == \"singleChoice\" && @.value.selectedOptionId == \"$choiceValue\")"
-            val multiChoicePath =
-                "$.answers[*] ? (@.fieldId == \"$choiceFieldId\" && @.value.type == \"multiChoice\" && exists(@.value.selectedOptionIds[*] ? (@ == \"$choiceValue\")))"
-            query.andWhere {
-                JsonbPathExists(FeedbackTable.feedbackJson, singleChoicePath) or
-                    JsonbPathExists(FeedbackTable.feedbackJson, multiChoicePath)
-            }
+    val choiceJsonPaths = buildChoiceJsonPaths(criteria.choiceFieldId, criteria.choiceValue, log)
+    if (choiceJsonPaths != null) {
+        query.andWhere {
+            JsonbPathExists(FeedbackTable.feedbackJson, choiceJsonPaths.singleChoicePath) or
+                JsonbPathExists(FeedbackTable.feedbackJson, choiceJsonPaths.multiChoicePath)
         }
     }
 }

--- a/apps/lumi-api/src/main/kotlin/no/nav/lumi/repository/FeedbackStatsHelpers.kt
+++ b/apps/lumi-api/src/main/kotlin/no/nav/lumi/repository/FeedbackStatsHelpers.kt
@@ -169,17 +169,34 @@ internal fun buildFieldStats(records: List<FeedbackDto>): List<FieldStat> {
                     0.0
                 }
 
-                val distribution = counts
-                    .entries
-                    .sortedWith(compareByDescending<Map.Entry<String, Int>> { it.value }.thenBy { it.key })
-                    .associate { (optionId, count) ->
+                // Use survey options list as source of truth for order and completeness.
+                // Options with 0 responses are included so the frontend shows the full picture.
+                val surveyOptions = first.question.options.orEmpty()
+                val distribution = linkedMapOf<String, ChoiceDistributionEntry>()
+
+                for (opt in surveyOptions) {
+                    val count = counts[opt.id] ?: 0
+                    val percentage = if (responseCount > 0) {
+                        kotlin.math.round((count.toDouble() / responseCount) * 100.0).toInt()
+                    } else 0
+                    distribution[opt.id] = ChoiceDistributionEntry(
+                        label = opt.label,
+                        count = count,
+                        percentage = percentage
+                    )
+                }
+
+                // Include any responses for option IDs not in the survey definition (legacy data)
+                for ((optionId, count) in counts) {
+                    if (optionId !in distribution) {
                         val percentage = kotlin.math.round((count.toDouble() / responseCount) * 100.0).toInt()
-                        optionId to ChoiceDistributionEntry(
+                        distribution[optionId] = ChoiceDistributionEntry(
                             label = optionLabels[optionId] ?: optionId,
                             count = count,
                             percentage = percentage
                         )
                     }
+                }
 
                 result.add(
                     FieldStat(

--- a/apps/lumi-api/src/main/kotlin/no/nav/lumi/repository/FeedbackStatsRepository.kt
+++ b/apps/lumi-api/src/main/kotlin/no/nav/lumi/repository/FeedbackStatsRepository.kt
@@ -555,25 +555,27 @@ class FeedbackStatsRepository {
             }
         }
 
-        // Filter by specific rating answer (fieldId + rating)
-        val ratingFieldId = criteria.ratingFieldId
-        val ratingValue = criteria.ratingValue
-        val safeRatingFieldId = validateJsonPathFieldId(ratingFieldId, "ratingFieldId", log)
-        if (safeRatingFieldId != null && ratingValue != null) {
-            val ratingTextForField = JsonbPathQueryFirstText(
-                FeedbackTable.feedbackJson,
-                "$.answers[*] ? (@.fieldId == \"$safeRatingFieldId\" && @.value.type == \"rating\").value.rating"
-            )
-            val ratingExpr = Cast(ratingTextForField, IntegerColumnType())
-            query.andWhere { ratingExpr eq ratingValue }
+        // Filter by specific rating answers (multi-value)
+        criteria.ratingFilters.forEach { (fieldId, ratingVal) ->
+            val safeFieldId = validateJsonPathFieldId(fieldId, "ratingFieldId", log)
+            if (safeFieldId != null) {
+                val ratingTextForField = JsonbPathQueryFirstText(
+                    FeedbackTable.feedbackJson,
+                    "$.answers[*] ? (@.fieldId == \"$safeFieldId\" && @.value.type == \"rating\").value.rating"
+                )
+                val ratingExpr = Cast(ratingTextForField, IntegerColumnType())
+                query.andWhere { ratingExpr eq ratingVal }
+            }
         }
 
-        // Filter by specific choice answer (fieldId + selected option id)
-        val choiceJsonPaths = buildChoiceJsonPaths(criteria.choiceFieldId, criteria.choiceValue, log)
-        if (choiceJsonPaths != null) {
-            query.andWhere {
-                JsonbPathExists(FeedbackTable.feedbackJson, choiceJsonPaths.singleChoicePath) or
-                    JsonbPathExists(FeedbackTable.feedbackJson, choiceJsonPaths.multiChoicePath)
+        // Filter by specific choice answers (multi-value)
+        criteria.choiceFilters.forEach { (fieldId, value) ->
+            val choiceJsonPaths = buildChoiceJsonPaths(fieldId, value, log)
+            if (choiceJsonPaths != null) {
+                query.andWhere {
+                    JsonbPathExists(FeedbackTable.feedbackJson, choiceJsonPaths.singleChoicePath) or
+                        JsonbPathExists(FeedbackTable.feedbackJson, choiceJsonPaths.multiChoicePath)
+                }
             }
         }
     }

--- a/apps/lumi-api/src/main/kotlin/no/nav/lumi/repository/FeedbackStatsRepository.kt
+++ b/apps/lumi-api/src/main/kotlin/no/nav/lumi/repository/FeedbackStatsRepository.kt
@@ -20,6 +20,9 @@ class FeedbackStatsRepository {
         
         /** Maximum variants to return per word for blocker analysis */
         const val MAX_VARIANTS = 5
+
+        /** Maximum length accepted for dynamic filter values used in JSONPath */
+        const val MAX_VALUE_LENGTH = 200
     }
 
     data class FeedbackAnalyticsStats(
@@ -565,6 +568,24 @@ class FeedbackStatsRepository {
                 )
                 val ratingExpr = Cast(ratingTextForField, IntegerColumnType())
                 query.andWhere { ratingExpr eq ratingValue }
+            }
+        }
+
+        // Filter by specific choice answer (fieldId + selected option id)
+        val choiceFieldId = criteria.choiceFieldId
+        val choiceValue = criteria.choiceValue?.trim()?.takeIf { it.isNotBlank() }?.take(MAX_VALUE_LENGTH)
+        if (!choiceFieldId.isNullOrBlank() && choiceValue != null) {
+            // Avoid JSONPath injection by only allowing simple fieldId characters.
+            val isSafeFieldId = choiceFieldId.all { it.isLetterOrDigit() || it == '-' || it == '_' }
+            if (isSafeFieldId) {
+                val singleChoicePath =
+                    "$.answers[*] ? (@.fieldId == \"$choiceFieldId\" && @.value.type == \"singleChoice\" && @.value.selectedOptionId == \"$choiceValue\")"
+                val multiChoicePath =
+                    "$.answers[*] ? (@.fieldId == \"$choiceFieldId\" && @.value.type == \"multiChoice\" && exists(@.value.selectedOptionIds[*] ? (@ == \"$choiceValue\")))"
+                query.andWhere {
+                    JsonbPathExists(FeedbackTable.feedbackJson, singleChoicePath) or
+                        JsonbPathExists(FeedbackTable.feedbackJson, multiChoicePath)
+                }
             }
         }
     }

--- a/apps/lumi-api/src/main/kotlin/no/nav/lumi/repository/FeedbackStatsRepository.kt
+++ b/apps/lumi-api/src/main/kotlin/no/nav/lumi/repository/FeedbackStatsRepository.kt
@@ -5,11 +5,13 @@ import no.nav.lumi.domain.*
 import no.nav.lumi.service.TextProcessor
 import org.jetbrains.exposed.v1.core.*
 import org.jetbrains.exposed.v1.jdbc.*
+import org.slf4j.LoggerFactory
 import java.time.Duration
 import java.time.Instant
 
 class FeedbackStatsRepository {
     private val json = Json { ignoreUnknownKeys = true }
+    private val log = LoggerFactory.getLogger(FeedbackStatsRepository::class.java)
 
     companion object {
         /** Minimum number of responses required to show aggregated statistics */
@@ -21,8 +23,6 @@ class FeedbackStatsRepository {
         /** Maximum variants to return per word for blocker analysis */
         const val MAX_VARIANTS = 5
 
-        /** Maximum length accepted for dynamic filter values used in JSONPath */
-        const val MAX_VALUE_LENGTH = 200
     }
 
     data class FeedbackAnalyticsStats(
@@ -558,34 +558,22 @@ class FeedbackStatsRepository {
         // Filter by specific rating answer (fieldId + rating)
         val ratingFieldId = criteria.ratingFieldId
         val ratingValue = criteria.ratingValue
-        if (!ratingFieldId.isNullOrBlank() && ratingValue != null) {
-            // Avoid JSONPath injection by only allowing simple fieldId characters.
-            val isSafeFieldId = ratingFieldId.all { it.isLetterOrDigit() || it == '-' || it == '_' }
-            if (isSafeFieldId) {
-                val ratingTextForField = JsonbPathQueryFirstText(
-                    FeedbackTable.feedbackJson,
-                    "$.answers[*] ? (@.fieldId == \"$ratingFieldId\" && @.value.type == \"rating\").value.rating"
-                )
-                val ratingExpr = Cast(ratingTextForField, IntegerColumnType())
-                query.andWhere { ratingExpr eq ratingValue }
-            }
+        val safeRatingFieldId = validateJsonPathFieldId(ratingFieldId, "ratingFieldId", log)
+        if (safeRatingFieldId != null && ratingValue != null) {
+            val ratingTextForField = JsonbPathQueryFirstText(
+                FeedbackTable.feedbackJson,
+                "$.answers[*] ? (@.fieldId == \"$safeRatingFieldId\" && @.value.type == \"rating\").value.rating"
+            )
+            val ratingExpr = Cast(ratingTextForField, IntegerColumnType())
+            query.andWhere { ratingExpr eq ratingValue }
         }
 
         // Filter by specific choice answer (fieldId + selected option id)
-        val choiceFieldId = criteria.choiceFieldId
-        val choiceValue = criteria.choiceValue?.trim()?.takeIf { it.isNotBlank() }?.take(MAX_VALUE_LENGTH)
-        if (!choiceFieldId.isNullOrBlank() && choiceValue != null) {
-            // Avoid JSONPath injection by only allowing simple fieldId characters.
-            val isSafeFieldId = choiceFieldId.all { it.isLetterOrDigit() || it == '-' || it == '_' }
-            if (isSafeFieldId) {
-                val singleChoicePath =
-                    "$.answers[*] ? (@.fieldId == \"$choiceFieldId\" && @.value.type == \"singleChoice\" && @.value.selectedOptionId == \"$choiceValue\")"
-                val multiChoicePath =
-                    "$.answers[*] ? (@.fieldId == \"$choiceFieldId\" && @.value.type == \"multiChoice\" && exists(@.value.selectedOptionIds[*] ? (@ == \"$choiceValue\")))"
-                query.andWhere {
-                    JsonbPathExists(FeedbackTable.feedbackJson, singleChoicePath) or
-                        JsonbPathExists(FeedbackTable.feedbackJson, multiChoicePath)
-                }
+        val choiceJsonPaths = buildChoiceJsonPaths(criteria.choiceFieldId, criteria.choiceValue, log)
+        if (choiceJsonPaths != null) {
+            query.andWhere {
+                JsonbPathExists(FeedbackTable.feedbackJson, choiceJsonPaths.singleChoicePath) or
+                    JsonbPathExists(FeedbackTable.feedbackJson, choiceJsonPaths.multiChoicePath)
             }
         }
     }

--- a/apps/lumi-api/src/main/kotlin/no/nav/lumi/routes/DiscoveryRoutes.kt
+++ b/apps/lumi-api/src/main/kotlin/no/nav/lumi/routes/DiscoveryRoutes.kt
@@ -130,20 +130,7 @@ fun Route.discoveryRoutes(
     // ============================================
 
     get<ApiV1Intern.Stats.Discovery> { params ->
-        val team = call.authorizedTeam
-        val p = params.parent
-
-        val query = StatsQuery(
-            team = team,
-            app = p.app?.takeIf { it != FILTER_ALL },
-            fromDate = p.fromDate,
-            toDate = p.toDate,
-            surveyId = p.surveyId,
-            deviceType = p.deviceType?.takeIf { it != FILTER_ALL },
-            choiceFilters = parseChoiceFilters(p.choice, p.choiceFieldId, p.choiceValue),
-            ratingFilters = parseRatingFilters(p.rating, p.ratingFieldId, p.ratingValue),
-        )
-
+        val query = params.parent.toStatsQuery(call.authorizedTeam)
         val stats = discoveryService.getStats(query)
         call.respond(stats)
     }

--- a/apps/lumi-api/src/main/kotlin/no/nav/lumi/routes/DiscoveryRoutes.kt
+++ b/apps/lumi-api/src/main/kotlin/no/nav/lumi/routes/DiscoveryRoutes.kt
@@ -141,6 +141,8 @@ fun Route.discoveryRoutes(
             deviceType = params.parent.deviceType?.takeIf { it != FILTER_ALL },
             ratingFieldId = params.parent.ratingFieldId,
             ratingValue = params.parent.ratingValue,
+            choiceFieldId = params.parent.choiceFieldId,
+            choiceValue = params.parent.choiceValue,
         )
 
         val stats = discoveryService.getStats(query)

--- a/apps/lumi-api/src/main/kotlin/no/nav/lumi/routes/DiscoveryRoutes.kt
+++ b/apps/lumi-api/src/main/kotlin/no/nav/lumi/routes/DiscoveryRoutes.kt
@@ -131,18 +131,17 @@ fun Route.discoveryRoutes(
 
     get<ApiV1Intern.Stats.Discovery> { params ->
         val team = call.authorizedTeam
+        val p = params.parent
 
         val query = StatsQuery(
             team = team,
-            app = params.parent.app?.takeIf { it != FILTER_ALL },
-            fromDate = params.parent.fromDate,
-            toDate = params.parent.toDate,
-            surveyId = params.parent.surveyId,
-            deviceType = params.parent.deviceType?.takeIf { it != FILTER_ALL },
-            ratingFieldId = params.parent.ratingFieldId,
-            ratingValue = params.parent.ratingValue,
-            choiceFieldId = params.parent.choiceFieldId,
-            choiceValue = params.parent.choiceValue,
+            app = p.app?.takeIf { it != FILTER_ALL },
+            fromDate = p.fromDate,
+            toDate = p.toDate,
+            surveyId = p.surveyId,
+            deviceType = p.deviceType?.takeIf { it != FILTER_ALL },
+            choiceFilters = parseChoiceFilters(p.choice, p.choiceFieldId, p.choiceValue),
+            ratingFilters = parseRatingFilters(p.rating, p.ratingFieldId, p.ratingValue),
         )
 
         val stats = discoveryService.getStats(query)

--- a/apps/lumi-api/src/main/kotlin/no/nav/lumi/routes/ExportRoutes.kt
+++ b/apps/lumi-api/src/main/kotlin/no/nav/lumi/routes/ExportRoutes.kt
@@ -48,6 +48,8 @@ fun Route.exportRoutes(exportService: ExportService = defaultExportService) {
             segments = segments,
             ratingFieldId = params.ratingFieldId,
             ratingValue = params.ratingValue,
+            choiceFieldId = params.choiceFieldId,
+            choiceValue = params.choiceValue,
         )
         
         val feedbacks = exportService.getFeedbackForExport(query)

--- a/apps/lumi-api/src/main/kotlin/no/nav/lumi/routes/ExportRoutes.kt
+++ b/apps/lumi-api/src/main/kotlin/no/nav/lumi/routes/ExportRoutes.kt
@@ -46,10 +46,8 @@ fun Route.exportRoutes(exportService: ExportService = defaultExportService) {
             theme = params.theme,
             task = params.task,
             segments = segments,
-            ratingFieldId = params.ratingFieldId,
-            ratingValue = params.ratingValue,
-            choiceFieldId = params.choiceFieldId,
-            choiceValue = params.choiceValue,
+            choiceFilters = parseChoiceFilters(params.choice, params.choiceFieldId, params.choiceValue),
+            ratingFilters = parseRatingFilters(params.rating, params.ratingFieldId, params.ratingValue),
         )
         
         val feedbacks = exportService.getFeedbackForExport(query)

--- a/apps/lumi-api/src/main/kotlin/no/nav/lumi/routes/FeedbackRoutes.kt
+++ b/apps/lumi-api/src/main/kotlin/no/nav/lumi/routes/FeedbackRoutes.kt
@@ -58,6 +58,8 @@ fun Route.feedbackRoutes(
             segments = segments,
             ratingFieldId = params.ratingFieldId,
             ratingValue = params.ratingValue,
+            choiceFieldId = params.choiceFieldId,
+            choiceValue = params.choiceValue,
         )
         
         val (content, total, page) = service.findPaginated(query)

--- a/apps/lumi-api/src/main/kotlin/no/nav/lumi/routes/FeedbackRoutes.kt
+++ b/apps/lumi-api/src/main/kotlin/no/nav/lumi/routes/FeedbackRoutes.kt
@@ -56,10 +56,8 @@ fun Route.feedbackRoutes(
             theme = params.theme,
             task = params.task,
             segments = segments,
-            ratingFieldId = params.ratingFieldId,
-            ratingValue = params.ratingValue,
-            choiceFieldId = params.choiceFieldId,
-            choiceValue = params.choiceValue,
+            choiceFilters = parseChoiceFilters(params.choice, params.choiceFieldId, params.choiceValue),
+            ratingFilters = parseRatingFilters(params.rating, params.ratingFieldId, params.ratingValue),
         )
         
         val (content, total, page) = service.findPaginated(query)

--- a/apps/lumi-api/src/main/kotlin/no/nav/lumi/routes/QueryValidation.kt
+++ b/apps/lumi-api/src/main/kotlin/no/nav/lumi/routes/QueryValidation.kt
@@ -3,6 +3,7 @@ package no.nav.lumi.routes
 import no.nav.lumi.config.exception.ApiErrorException
 import no.nav.lumi.repository.MAX_CHOICE_VALUE_LENGTH
 import no.nav.lumi.repository.MAX_FIELD_ID_LENGTH
+import no.nav.lumi.repository.isSafeChoiceValue
 import java.time.LocalDate
 
 private const val MAX_PAGE_SIZE = 200
@@ -165,13 +166,24 @@ internal fun parseChoiceFilters(
                 "Invalid choice filter: value exceeds max length $MAX_CHOICE_VALUE_LENGTH"
             )
         }
+        if (!isSafeChoiceValue(value)) {
+            throw ApiErrorException.BadRequestException(
+                "Invalid choice filter: value contains illegal characters"
+            )
+        }
         requireValidFieldId(fieldId, "choice")
         filters.add(fieldId to value)
     }
 
     if (!legacyFieldId.isNullOrBlank() && !legacyValue.isNullOrBlank()) {
+        val trimmedLegacyValue = legacyValue.trim()
         requireValidFieldId(legacyFieldId.trim(), "choice")
-        filters.add(legacyFieldId.trim() to legacyValue.trim())
+        if (!isSafeChoiceValue(trimmedLegacyValue)) {
+            throw ApiErrorException.BadRequestException(
+                "Invalid choice filter: value contains illegal characters"
+            )
+        }
+        filters.add(legacyFieldId.trim() to trimmedLegacyValue)
     }
 
     if (filters.size > MAX_FIELD_FILTERS) {

--- a/apps/lumi-api/src/main/kotlin/no/nav/lumi/routes/QueryValidation.kt
+++ b/apps/lumi-api/src/main/kotlin/no/nav/lumi/routes/QueryValidation.kt
@@ -1,8 +1,11 @@
 package no.nav.lumi.routes
 
 import no.nav.lumi.config.exception.ApiErrorException
+import no.nav.lumi.repository.MAX_CHOICE_VALUE_LENGTH
+import org.slf4j.LoggerFactory
 import java.time.LocalDate
 
+private val log = LoggerFactory.getLogger("QueryValidation")
 private const val MAX_PAGE_SIZE = 200
 private const val MAX_QUERY_LENGTH = 200
 private const val MAX_TAGS = 20
@@ -117,4 +120,72 @@ internal fun parseDateOrThrow(name: String, value: String?): LocalDate? {
     } catch (_: Exception) {
         throw ApiErrorException.BadRequestException("Invalid $name: expected YYYY-MM-DD")
     }
+}
+
+private const val MAX_FIELD_FILTERS = 20
+
+/**
+ * Parse repeated "fieldId:optionId" choice filter params into pairs.
+ * Also merges in legacy single-value params for backward compat.
+ */
+internal fun parseChoiceFilters(
+    choice: List<String>?,
+    legacyFieldId: String?,
+    legacyValue: String?,
+): List<Pair<String, String>> {
+    val filters = mutableListOf<Pair<String, String>>()
+
+    choice?.forEach { filter ->
+        val colonIndex = filter.indexOf(':')
+        if (colonIndex <= 0) return@forEach
+        val fieldId = filter.substring(0, colonIndex).trim()
+        val value = filter.substring(colonIndex + 1).trim()
+        if (fieldId.isNotBlank() && value.isNotBlank() && value.length <= MAX_CHOICE_VALUE_LENGTH) {
+            filters.add(fieldId to value)
+        }
+    }
+
+    if (!legacyFieldId.isNullOrBlank() && !legacyValue.isNullOrBlank()) {
+        filters.add(legacyFieldId.trim() to legacyValue.trim())
+    }
+
+    if (filters.size > MAX_FIELD_FILTERS) {
+        log.warn("Too many choice filters ({}), truncating to {}", filters.size, MAX_FIELD_FILTERS)
+        return filters.take(MAX_FIELD_FILTERS)
+    }
+
+    return filters
+}
+
+/**
+ * Parse repeated "fieldId:ratingValue" rating filter params into pairs.
+ * Also merges in legacy single-value params for backward compat.
+ */
+internal fun parseRatingFilters(
+    rating: List<String>?,
+    legacyFieldId: String?,
+    legacyValue: Int?,
+): List<Pair<String, Int>> {
+    val filters = mutableListOf<Pair<String, Int>>()
+
+    rating?.forEach { filter ->
+        val colonIndex = filter.indexOf(':')
+        if (colonIndex <= 0) return@forEach
+        val fieldId = filter.substring(0, colonIndex).trim()
+        val value = filter.substring(colonIndex + 1).trim().toIntOrNull()
+        if (fieldId.isNotBlank() && value != null) {
+            filters.add(fieldId to value)
+        }
+    }
+
+    if (!legacyFieldId.isNullOrBlank() && legacyValue != null) {
+        filters.add(legacyFieldId.trim() to legacyValue)
+    }
+
+    if (filters.size > MAX_FIELD_FILTERS) {
+        log.warn("Too many rating filters ({}), truncating to {}", filters.size, MAX_FIELD_FILTERS)
+        return filters.take(MAX_FIELD_FILTERS)
+    }
+
+    return filters
 }

--- a/apps/lumi-api/src/main/kotlin/no/nav/lumi/routes/QueryValidation.kt
+++ b/apps/lumi-api/src/main/kotlin/no/nav/lumi/routes/QueryValidation.kt
@@ -2,10 +2,9 @@ package no.nav.lumi.routes
 
 import no.nav.lumi.config.exception.ApiErrorException
 import no.nav.lumi.repository.MAX_CHOICE_VALUE_LENGTH
-import org.slf4j.LoggerFactory
+import no.nav.lumi.repository.MAX_FIELD_ID_LENGTH
 import java.time.LocalDate
 
-private val log = LoggerFactory.getLogger("QueryValidation")
 private const val MAX_PAGE_SIZE = 200
 private const val MAX_QUERY_LENGTH = 200
 private const val MAX_TAGS = 20
@@ -124,9 +123,25 @@ internal fun parseDateOrThrow(name: String, value: String?): LocalDate? {
 
 private const val MAX_FIELD_FILTERS = 20
 
+/** Validate fieldId: alphanumeric, hyphens, underscores only — same rules as [validateJsonPathFieldId]. */
+private fun requireValidFieldId(fieldId: String, filterType: String): String {
+    if (fieldId.length > MAX_FIELD_ID_LENGTH) {
+        throw ApiErrorException.BadRequestException(
+            "Invalid $filterType filter: fieldId exceeds max length $MAX_FIELD_ID_LENGTH"
+        )
+    }
+    if (!fieldId.all { it.isLetterOrDigit() || it == '-' || it == '_' }) {
+        throw ApiErrorException.BadRequestException(
+            "Invalid $filterType filter: fieldId contains illegal characters"
+        )
+    }
+    return fieldId
+}
+
 /**
  * Parse repeated "fieldId:optionId" choice filter params into pairs.
  * Also merges in legacy single-value params for backward compat.
+ * Throws 400 on malformed input or exceeding limits.
  */
 internal fun parseChoiceFilters(
     choice: List<String>?,
@@ -137,21 +152,32 @@ internal fun parseChoiceFilters(
 
     choice?.forEach { filter ->
         val colonIndex = filter.indexOf(':')
-        if (colonIndex <= 0) return@forEach
+        if (colonIndex <= 0) {
+            throw ApiErrorException.BadRequestException("Invalid choice filter: expected format fieldId:value")
+        }
         val fieldId = filter.substring(0, colonIndex).trim()
         val value = filter.substring(colonIndex + 1).trim()
-        if (fieldId.isNotBlank() && value.isNotBlank() && value.length <= MAX_CHOICE_VALUE_LENGTH) {
-            filters.add(fieldId to value)
+        if (fieldId.isBlank() || value.isBlank()) {
+            throw ApiErrorException.BadRequestException("Invalid choice filter: fieldId and value must be non-blank")
         }
+        if (value.length > MAX_CHOICE_VALUE_LENGTH) {
+            throw ApiErrorException.BadRequestException(
+                "Invalid choice filter: value exceeds max length $MAX_CHOICE_VALUE_LENGTH"
+            )
+        }
+        requireValidFieldId(fieldId, "choice")
+        filters.add(fieldId to value)
     }
 
     if (!legacyFieldId.isNullOrBlank() && !legacyValue.isNullOrBlank()) {
+        requireValidFieldId(legacyFieldId.trim(), "choice")
         filters.add(legacyFieldId.trim() to legacyValue.trim())
     }
 
     if (filters.size > MAX_FIELD_FILTERS) {
-        log.warn("Too many choice filters ({}), truncating to {}", filters.size, MAX_FIELD_FILTERS)
-        return filters.take(MAX_FIELD_FILTERS)
+        throw ApiErrorException.BadRequestException(
+            "Too many choice filters: max is $MAX_FIELD_FILTERS"
+        )
     }
 
     return filters
@@ -160,6 +186,7 @@ internal fun parseChoiceFilters(
 /**
  * Parse repeated "fieldId:ratingValue" rating filter params into pairs.
  * Also merges in legacy single-value params for backward compat.
+ * Throws 400 on malformed input or exceeding limits.
  */
 internal fun parseRatingFilters(
     rating: List<String>?,
@@ -170,21 +197,28 @@ internal fun parseRatingFilters(
 
     rating?.forEach { filter ->
         val colonIndex = filter.indexOf(':')
-        if (colonIndex <= 0) return@forEach
+        if (colonIndex <= 0) {
+            throw ApiErrorException.BadRequestException("Invalid rating filter: expected format fieldId:value")
+        }
         val fieldId = filter.substring(0, colonIndex).trim()
         val value = filter.substring(colonIndex + 1).trim().toIntOrNull()
-        if (fieldId.isNotBlank() && value != null) {
-            filters.add(fieldId to value)
+            ?: throw ApiErrorException.BadRequestException("Invalid rating filter: value must be an integer")
+        if (fieldId.isBlank()) {
+            throw ApiErrorException.BadRequestException("Invalid rating filter: fieldId must be non-blank")
         }
+        requireValidFieldId(fieldId, "rating")
+        filters.add(fieldId to value)
     }
 
     if (!legacyFieldId.isNullOrBlank() && legacyValue != null) {
+        requireValidFieldId(legacyFieldId.trim(), "rating")
         filters.add(legacyFieldId.trim() to legacyValue)
     }
 
     if (filters.size > MAX_FIELD_FILTERS) {
-        log.warn("Too many rating filters ({}), truncating to {}", filters.size, MAX_FIELD_FILTERS)
-        return filters.take(MAX_FIELD_FILTERS)
+        throw ApiErrorException.BadRequestException(
+            "Too many rating filters: max is $MAX_FIELD_FILTERS"
+        )
     }
 
     return filters

--- a/apps/lumi-api/src/main/kotlin/no/nav/lumi/routes/Resources.kt
+++ b/apps/lumi-api/src/main/kotlin/no/nav/lumi/routes/Resources.kt
@@ -37,13 +37,14 @@ class ApiV1Intern {
         val task: String? = null,
         /** Segment filter - repeated params like segment=key:value */
         val segment: List<String>? = null,
-        /** Filter by a specific rating question fieldId */
+        /** Choice filters — repeated params, each in format "fieldId:optionId" */
+        val choice: List<String>? = null,
+        /** Rating filters — repeated params, each in format "fieldId:ratingValue" */
+        val rating: List<String>? = null,
+        // Legacy single-value params (backward compat for bookmarked URLs)
         val ratingFieldId: String? = null,
-        /** Filter by a specific rating value */
         val ratingValue: Int? = null,
-        /** Filter by a specific choice question fieldId */
         val choiceFieldId: String? = null,
-        /** Filter by a specific choice option value/id */
         val choiceValue: String? = null,
     ) {
         @Resource("{id}")
@@ -91,13 +92,14 @@ class ApiV1Intern {
         val segment: List<String>? = null,
         /** Task filter for Top Tasks drill-down */
         val task: String? = null,
-        /** Filter by a specific rating question fieldId */
+        /** Choice filters — repeated params, each in format "fieldId:optionId" */
+        val choice: List<String>? = null,
+        /** Rating filters — repeated params, each in format "fieldId:ratingValue" */
+        val rating: List<String>? = null,
+        // Legacy single-value params (backward compat for bookmarked URLs)
         val ratingFieldId: String? = null,
-        /** Filter by a specific rating value */
         val ratingValue: Int? = null,
-        /** Filter by a specific choice question fieldId */
         val choiceFieldId: String? = null,
-        /** Filter by a specific choice option value/id */
         val choiceValue: String? = null,
     ) {
         @Resource("dashboard")
@@ -249,13 +251,14 @@ class ApiV1Intern {
         val theme: String? = null,
         /** Task filter for Top Tasks drill-down */
         val task: String? = null,
-        /** Filter by a specific rating question fieldId */
+        /** Choice filters — repeated params, each in format "fieldId:optionId" */
+        val choice: List<String>? = null,
+        /** Rating filters — repeated params, each in format "fieldId:ratingValue" */
+        val rating: List<String>? = null,
+        // Legacy single-value params (backward compat for bookmarked URLs)
         val ratingFieldId: String? = null,
-        /** Filter by a specific rating value */
         val ratingValue: Int? = null,
-        /** Filter by a specific choice question fieldId */
         val choiceFieldId: String? = null,
-        /** Filter by a specific choice option value/id */
         val choiceValue: String? = null,
     )
 }

--- a/apps/lumi-api/src/main/kotlin/no/nav/lumi/routes/Resources.kt
+++ b/apps/lumi-api/src/main/kotlin/no/nav/lumi/routes/Resources.kt
@@ -41,6 +41,10 @@ class ApiV1Intern {
         val ratingFieldId: String? = null,
         /** Filter by a specific rating value */
         val ratingValue: Int? = null,
+        /** Filter by a specific choice question fieldId */
+        val choiceFieldId: String? = null,
+        /** Filter by a specific choice option value/id */
+        val choiceValue: String? = null,
     ) {
         @Resource("{id}")
         @Serializable
@@ -91,6 +95,10 @@ class ApiV1Intern {
         val ratingFieldId: String? = null,
         /** Filter by a specific rating value */
         val ratingValue: Int? = null,
+        /** Filter by a specific choice question fieldId */
+        val choiceFieldId: String? = null,
+        /** Filter by a specific choice option value/id */
+        val choiceValue: String? = null,
     ) {
         @Resource("dashboard")
         @Serializable
@@ -245,5 +253,9 @@ class ApiV1Intern {
         val ratingFieldId: String? = null,
         /** Filter by a specific rating value */
         val ratingValue: Int? = null,
+        /** Filter by a specific choice question fieldId */
+        val choiceFieldId: String? = null,
+        /** Filter by a specific choice option value/id */
+        val choiceValue: String? = null,
     )
 }

--- a/apps/lumi-api/src/main/kotlin/no/nav/lumi/routes/StatsRoutes.kt
+++ b/apps/lumi-api/src/main/kotlin/no/nav/lumi/routes/StatsRoutes.kt
@@ -26,7 +26,9 @@ private fun buildStatsQuery(
     segment: List<String>? = null,
     task: String? = null,
     ratingFieldId: String? = null,
-    ratingValue: Int? = null
+    ratingValue: Int? = null,
+    choiceFieldId: String? = null,
+    choiceValue: String? = null,
 ) = StatsQuery(
     team = team,
     app = app?.takeIf { it != FILTER_ALL },
@@ -42,7 +44,9 @@ private fun buildStatsQuery(
         ?: emptyList(),
     task = task,
     ratingFieldId = ratingFieldId,
-    ratingValue = ratingValue
+    ratingValue = ratingValue,
+    choiceFieldId = choiceFieldId,
+    choiceValue = choiceValue,
 )
 
 /**
@@ -57,7 +61,20 @@ fun Route.statsRoutes(
         val team = call.authorizedTeam
         val p = params.parent
 
-        val query = buildStatsQuery(team, p.app, p.fromDate, p.toDate, p.surveyId, p.deviceType, p.segment, p.task, p.ratingFieldId, p.ratingValue)
+        val query = buildStatsQuery(
+            team = team,
+            app = p.app,
+            fromDate = p.fromDate,
+            toDate = p.toDate,
+            surveyId = p.surveyId,
+            deviceType = p.deviceType,
+            segment = p.segment,
+            task = p.task,
+            ratingFieldId = p.ratingFieldId,
+            ratingValue = p.ratingValue,
+            choiceFieldId = p.choiceFieldId,
+            choiceValue = p.choiceValue,
+        )
         val stats = statsService.getDashboardStats(query)
         call.respond(stats)
     }
@@ -67,7 +84,19 @@ fun Route.statsRoutes(
         val team = call.authorizedTeam
         val p = params.parent
         
-        val query = buildStatsQuery(team, p.app, p.fromDate, p.toDate, p.surveyId, p.deviceType, p.segment, ratingFieldId = p.ratingFieldId, ratingValue = p.ratingValue)
+        val query = buildStatsQuery(
+            team = team,
+            app = p.app,
+            fromDate = p.fromDate,
+            toDate = p.toDate,
+            surveyId = p.surveyId,
+            deviceType = p.deviceType,
+            segment = p.segment,
+            ratingFieldId = p.ratingFieldId,
+            ratingValue = p.ratingValue,
+            choiceFieldId = p.choiceFieldId,
+            choiceValue = p.choiceValue,
+        )
         val overview = statsService.getStatsOverview(query)
         call.respond(overview)
     }
@@ -77,7 +106,19 @@ fun Route.statsRoutes(
         val team = call.authorizedTeam
         val p = params.parent
         
-        val query = buildStatsQuery(team, p.app, p.fromDate, p.toDate, p.surveyId, p.deviceType, p.segment, ratingFieldId = p.ratingFieldId, ratingValue = p.ratingValue)
+        val query = buildStatsQuery(
+            team = team,
+            app = p.app,
+            fromDate = p.fromDate,
+            toDate = p.toDate,
+            surveyId = p.surveyId,
+            deviceType = p.deviceType,
+            segment = p.segment,
+            ratingFieldId = p.ratingFieldId,
+            ratingValue = p.ratingValue,
+            choiceFieldId = p.choiceFieldId,
+            choiceValue = p.choiceValue,
+        )
         val distribution = statsService.getRatingDistribution(query)
         call.respond(distribution)
     }
@@ -87,7 +128,19 @@ fun Route.statsRoutes(
         val team = call.authorizedTeam
         val p = params.parent
 
-        val query = buildStatsQuery(team, p.app, p.fromDate, p.toDate, p.surveyId, p.deviceType, p.segment, ratingFieldId = p.ratingFieldId, ratingValue = p.ratingValue)
+        val query = buildStatsQuery(
+            team = team,
+            app = p.app,
+            fromDate = p.fromDate,
+            toDate = p.toDate,
+            surveyId = p.surveyId,
+            deviceType = p.deviceType,
+            segment = p.segment,
+            ratingFieldId = p.ratingFieldId,
+            ratingValue = p.ratingValue,
+            choiceFieldId = p.choiceFieldId,
+            choiceValue = p.choiceValue,
+        )
         val timeline = statsService.getTimeline(query)
         call.respond(timeline)
     }
@@ -97,7 +150,20 @@ fun Route.statsRoutes(
         val team = call.authorizedTeam
         val p = params.parent
 
-        val query = buildStatsQuery(team, p.app, p.fromDate, p.toDate, p.surveyId, p.deviceType, p.segment, p.task, p.ratingFieldId, p.ratingValue)
+        val query = buildStatsQuery(
+            team = team,
+            app = p.app,
+            fromDate = p.fromDate,
+            toDate = p.toDate,
+            surveyId = p.surveyId,
+            deviceType = p.deviceType,
+            segment = p.segment,
+            task = p.task,
+            ratingFieldId = p.ratingFieldId,
+            ratingValue = p.ratingValue,
+            choiceFieldId = p.choiceFieldId,
+            choiceValue = p.choiceValue,
+        )
         val stats = statsService.getTopTasksStats(query)
         call.respond(stats)
     }
@@ -107,7 +173,20 @@ fun Route.statsRoutes(
         val team = call.authorizedTeam
         val p = params.parent
 
-        val query = buildStatsQuery(team, p.app, p.fromDate, p.toDate, p.surveyId, p.deviceType, p.segment, p.task, p.ratingFieldId, p.ratingValue)
+        val query = buildStatsQuery(
+            team = team,
+            app = p.app,
+            fromDate = p.fromDate,
+            toDate = p.toDate,
+            surveyId = p.surveyId,
+            deviceType = p.deviceType,
+            segment = p.segment,
+            task = p.task,
+            ratingFieldId = p.ratingFieldId,
+            ratingValue = p.ratingValue,
+            choiceFieldId = p.choiceFieldId,
+            choiceValue = p.choiceValue,
+        )
         val stats = statsService.getBlockerStats(query)
         call.respond(stats)
     }
@@ -117,7 +196,19 @@ fun Route.statsRoutes(
         val team = call.authorizedTeam
         val p = params.parent
 
-        val query = buildStatsQuery(team, p.app, p.fromDate, p.toDate, p.surveyId, p.deviceType, p.segment, ratingFieldId = p.ratingFieldId, ratingValue = p.ratingValue)
+        val query = buildStatsQuery(
+            team = team,
+            app = p.app,
+            fromDate = p.fromDate,
+            toDate = p.toDate,
+            surveyId = p.surveyId,
+            deviceType = p.deviceType,
+            segment = p.segment,
+            ratingFieldId = p.ratingFieldId,
+            ratingValue = p.ratingValue,
+            choiceFieldId = p.choiceFieldId,
+            choiceValue = p.choiceValue,
+        )
         val stats = statsService.getTaskPriorityStats(query)
         call.respond(stats)
     }
@@ -127,7 +218,19 @@ fun Route.statsRoutes(
         val team = call.authorizedTeam
         val p = params.parent
 
-        val query = buildStatsQuery(team, p.app, p.fromDate, p.toDate, null, p.deviceType, p.segment, ratingFieldId = p.ratingFieldId, ratingValue = p.ratingValue)
+        val query = buildStatsQuery(
+            team = team,
+            app = p.app,
+            fromDate = p.fromDate,
+            toDate = p.toDate,
+            surveyId = null,
+            deviceType = p.deviceType,
+            segment = p.segment,
+            ratingFieldId = p.ratingFieldId,
+            ratingValue = p.ratingValue,
+            choiceFieldId = p.choiceFieldId,
+            choiceValue = p.choiceValue,
+        )
         val distribution = statsService.getSurveyTypeDistribution(query)
         call.respond(distribution)
     }

--- a/apps/lumi-api/src/main/kotlin/no/nav/lumi/routes/StatsRoutes.kt
+++ b/apps/lumi-api/src/main/kotlin/no/nav/lumi/routes/StatsRoutes.kt
@@ -26,12 +26,7 @@ internal fun ApiV1Intern.Stats.toStatsQuery(
     toDate = toDate,
     surveyId = surveyIdOverride,
     deviceType = deviceType?.takeIf { it != FILTER_ALL },
-    segments = segment
-        ?.mapNotNull { segmentStr ->
-            val parts = segmentStr.split(":", limit = 2)
-            if (parts.size == 2) Pair(parts[0], parts[1]) else null
-        }
-        ?: emptyList(),
+    segments = parseSegments(segment),
     task = task,
     choiceFilters = parseChoiceFilters(choice, choiceFieldId, choiceValue),
     ratingFilters = parseRatingFilters(rating, ratingFieldId, ratingValue),

--- a/apps/lumi-api/src/main/kotlin/no/nav/lumi/routes/StatsRoutes.kt
+++ b/apps/lumi-api/src/main/kotlin/no/nav/lumi/routes/StatsRoutes.kt
@@ -13,30 +13,18 @@ private val defaultStatsCache = ValkeyStatsCache.fromEnvOrFallback()
 private val defaultStatsService = StatsService(statsCache = defaultStatsCache)
 
 /**
- * Helper to build StatsQuery from resource params.
- * Maps new param names (fromDate, toDate, surveyId) from resource.
+ * Extension to convert Stats resource params into a StatsQuery.
+ * Handles FILTER_ALL normalization, segment parsing, and legacy filter compat.
  */
-private fun buildStatsQuery(
+internal fun ApiV1Intern.Stats.toStatsQuery(
     team: String,
-    app: String?,
-    fromDate: String?,
-    toDate: String?,
-    surveyId: String?,
-    deviceType: String?,
-    segment: List<String>? = null,
-    task: String? = null,
-    choice: List<String>? = null,
-    rating: List<String>? = null,
-    legacyChoiceFieldId: String? = null,
-    legacyChoiceValue: String? = null,
-    legacyRatingFieldId: String? = null,
-    legacyRatingValue: Int? = null,
-) = StatsQuery(
+    surveyIdOverride: String? = surveyId,
+): StatsQuery = StatsQuery(
     team = team,
     app = app?.takeIf { it != FILTER_ALL },
     fromDate = fromDate,
     toDate = toDate,
-    surveyId = surveyId,
+    surveyId = surveyIdOverride,
     deviceType = deviceType?.takeIf { it != FILTER_ALL },
     segments = segment
         ?.mapNotNull { segmentStr ->
@@ -45,8 +33,8 @@ private fun buildStatsQuery(
         }
         ?: emptyList(),
     task = task,
-    choiceFilters = parseChoiceFilters(choice, legacyChoiceFieldId, legacyChoiceValue),
-    ratingFilters = parseRatingFilters(rating, legacyRatingFieldId, legacyRatingValue),
+    choiceFilters = parseChoiceFilters(choice, choiceFieldId, choiceValue),
+    ratingFilters = parseRatingFilters(rating, ratingFieldId, ratingValue),
 )
 
 /**
@@ -56,198 +44,43 @@ private fun buildStatsQuery(
 fun Route.statsRoutes(
     statsService: StatsService = defaultStatsService
 ) {
-    // Dashboard stats (primary endpoint used by lumi-dashboard)
     get<ApiV1Intern.Stats.Dashboard> { params ->
-        val team = call.authorizedTeam
-        val p = params.parent
-
-        val query = buildStatsQuery(
-            team = team,
-            app = p.app,
-            fromDate = p.fromDate,
-            toDate = p.toDate,
-            surveyId = p.surveyId,
-            deviceType = p.deviceType,
-            segment = p.segment,
-            task = p.task,
-            choice = p.choice,
-            rating = p.rating,
-            legacyChoiceFieldId = p.choiceFieldId,
-            legacyChoiceValue = p.choiceValue,
-            legacyRatingFieldId = p.ratingFieldId,
-            legacyRatingValue = p.ratingValue,
-        )
-        val stats = statsService.getDashboardStats(query)
-        call.respond(stats)
+        val query = params.parent.toStatsQuery(call.authorizedTeam)
+        call.respond(statsService.getDashboardStats(query))
     }
 
-    // Get stats overview (new consolidated endpoint)
     get<ApiV1Intern.Stats.Overview> { params ->
-        val team = call.authorizedTeam
-        val p = params.parent
-        
-        val query = buildStatsQuery(
-            team = team,
-            app = p.app,
-            fromDate = p.fromDate,
-            toDate = p.toDate,
-            surveyId = p.surveyId,
-            deviceType = p.deviceType,
-            segment = p.segment,
-            choice = p.choice,
-            rating = p.rating,
-            legacyChoiceFieldId = p.choiceFieldId,
-            legacyChoiceValue = p.choiceValue,
-            legacyRatingFieldId = p.ratingFieldId,
-            legacyRatingValue = p.ratingValue,
-        )
-        val overview = statsService.getStatsOverview(query)
-        call.respond(overview)
+        val query = params.parent.toStatsQuery(call.authorizedTeam)
+        call.respond(statsService.getStatsOverview(query))
     }
-    
-    // Get rating distribution
+
     get<ApiV1Intern.Stats.Ratings> { params ->
-        val team = call.authorizedTeam
-        val p = params.parent
-        
-        val query = buildStatsQuery(
-            team = team,
-            app = p.app,
-            fromDate = p.fromDate,
-            toDate = p.toDate,
-            surveyId = p.surveyId,
-            deviceType = p.deviceType,
-            segment = p.segment,
-            choice = p.choice,
-            rating = p.rating,
-            legacyChoiceFieldId = p.choiceFieldId,
-            legacyChoiceValue = p.choiceValue,
-            legacyRatingFieldId = p.ratingFieldId,
-            legacyRatingValue = p.ratingValue,
-        )
-        val distribution = statsService.getRatingDistribution(query)
-        call.respond(distribution)
+        val query = params.parent.toStatsQuery(call.authorizedTeam)
+        call.respond(statsService.getRatingDistribution(query))
     }
-    
-    // Get timeline data
+
     get<ApiV1Intern.Stats.Timeline> { params ->
-        val team = call.authorizedTeam
-        val p = params.parent
-
-        val query = buildStatsQuery(
-            team = team,
-            app = p.app,
-            fromDate = p.fromDate,
-            toDate = p.toDate,
-            surveyId = p.surveyId,
-            deviceType = p.deviceType,
-            segment = p.segment,
-            choice = p.choice,
-            rating = p.rating,
-            legacyChoiceFieldId = p.choiceFieldId,
-            legacyChoiceValue = p.choiceValue,
-            legacyRatingFieldId = p.ratingFieldId,
-            legacyRatingValue = p.ratingValue,
-        )
-        val timeline = statsService.getTimeline(query)
-        call.respond(timeline)
+        val query = params.parent.toStatsQuery(call.authorizedTeam)
+        call.respond(statsService.getTimeline(query))
     }
 
-    // Get Top Tasks statistics
     get<ApiV1Intern.Stats.TopTasks> { params ->
-        val team = call.authorizedTeam
-        val p = params.parent
-
-        val query = buildStatsQuery(
-            team = team,
-            app = p.app,
-            fromDate = p.fromDate,
-            toDate = p.toDate,
-            surveyId = p.surveyId,
-            deviceType = p.deviceType,
-            segment = p.segment,
-            task = p.task,
-            choice = p.choice,
-            rating = p.rating,
-            legacyChoiceFieldId = p.choiceFieldId,
-            legacyChoiceValue = p.choiceValue,
-            legacyRatingFieldId = p.ratingFieldId,
-            legacyRatingValue = p.ratingValue,
-        )
-        val stats = statsService.getTopTasksStats(query)
-        call.respond(stats)
+        val query = params.parent.toStatsQuery(call.authorizedTeam)
+        call.respond(statsService.getTopTasksStats(query))
     }
 
-    // Get blocker statistics for Top Tasks (word frequency + theme clustering)
     get<ApiV1Intern.Stats.Blockers> { params ->
-        val team = call.authorizedTeam
-        val p = params.parent
-
-        val query = buildStatsQuery(
-            team = team,
-            app = p.app,
-            fromDate = p.fromDate,
-            toDate = p.toDate,
-            surveyId = p.surveyId,
-            deviceType = p.deviceType,
-            segment = p.segment,
-            task = p.task,
-            choice = p.choice,
-            rating = p.rating,
-            legacyChoiceFieldId = p.choiceFieldId,
-            legacyChoiceValue = p.choiceValue,
-            legacyRatingFieldId = p.ratingFieldId,
-            legacyRatingValue = p.ratingValue,
-        )
-        val stats = statsService.getBlockerStats(query)
-        call.respond(stats)
+        val query = params.parent.toStatsQuery(call.authorizedTeam)
+        call.respond(statsService.getBlockerStats(query))
     }
 
-    // Get Task Priority statistics ("long neck" distribution)
     get<ApiV1Intern.Stats.TaskPriority> { params ->
-        val team = call.authorizedTeam
-        val p = params.parent
-
-        val query = buildStatsQuery(
-            team = team,
-            app = p.app,
-            fromDate = p.fromDate,
-            toDate = p.toDate,
-            surveyId = p.surveyId,
-            deviceType = p.deviceType,
-            segment = p.segment,
-            choice = p.choice,
-            rating = p.rating,
-            legacyChoiceFieldId = p.choiceFieldId,
-            legacyChoiceValue = p.choiceValue,
-            legacyRatingFieldId = p.ratingFieldId,
-            legacyRatingValue = p.ratingValue,
-        )
-        val stats = statsService.getTaskPriorityStats(query)
-        call.respond(stats)
+        val query = params.parent.toStatsQuery(call.authorizedTeam)
+        call.respond(statsService.getTaskPriorityStats(query))
     }
 
-    // Get Survey Type distribution
     get<ApiV1Intern.Stats.SurveyTypes> { params ->
-        val team = call.authorizedTeam
-        val p = params.parent
-
-        val query = buildStatsQuery(
-            team = team,
-            app = p.app,
-            fromDate = p.fromDate,
-            toDate = p.toDate,
-            surveyId = null,
-            deviceType = p.deviceType,
-            segment = p.segment,
-            choice = p.choice,
-            rating = p.rating,
-            legacyChoiceFieldId = p.choiceFieldId,
-            legacyChoiceValue = p.choiceValue,
-            legacyRatingFieldId = p.ratingFieldId,
-            legacyRatingValue = p.ratingValue,
-        )
-        val distribution = statsService.getSurveyTypeDistribution(query)
-        call.respond(distribution)
+        val query = params.parent.toStatsQuery(call.authorizedTeam, surveyIdOverride = null)
+        call.respond(statsService.getSurveyTypeDistribution(query))
     }
 }

--- a/apps/lumi-api/src/main/kotlin/no/nav/lumi/routes/StatsRoutes.kt
+++ b/apps/lumi-api/src/main/kotlin/no/nav/lumi/routes/StatsRoutes.kt
@@ -19,7 +19,9 @@ private val defaultStatsService = StatsService(statsCache = defaultStatsCache)
 internal fun ApiV1Intern.Stats.toStatsQuery(
     team: String,
     surveyIdOverride: String? = surveyId,
-): StatsQuery = StatsQuery(
+): StatsQuery {
+    validateDateRange(fromDate, toDate)
+    return StatsQuery(
     team = team,
     app = app?.takeIf { it != FILTER_ALL },
     fromDate = fromDate,
@@ -31,6 +33,7 @@ internal fun ApiV1Intern.Stats.toStatsQuery(
     choiceFilters = parseChoiceFilters(choice, choiceFieldId, choiceValue),
     ratingFilters = parseRatingFilters(rating, ratingFieldId, ratingValue),
 )
+}
 
 /**
  * Routes for feedback statistics endpoints.

--- a/apps/lumi-api/src/main/kotlin/no/nav/lumi/routes/StatsRoutes.kt
+++ b/apps/lumi-api/src/main/kotlin/no/nav/lumi/routes/StatsRoutes.kt
@@ -25,10 +25,12 @@ private fun buildStatsQuery(
     deviceType: String?,
     segment: List<String>? = null,
     task: String? = null,
-    ratingFieldId: String? = null,
-    ratingValue: Int? = null,
-    choiceFieldId: String? = null,
-    choiceValue: String? = null,
+    choice: List<String>? = null,
+    rating: List<String>? = null,
+    legacyChoiceFieldId: String? = null,
+    legacyChoiceValue: String? = null,
+    legacyRatingFieldId: String? = null,
+    legacyRatingValue: Int? = null,
 ) = StatsQuery(
     team = team,
     app = app?.takeIf { it != FILTER_ALL },
@@ -43,10 +45,8 @@ private fun buildStatsQuery(
         }
         ?: emptyList(),
     task = task,
-    ratingFieldId = ratingFieldId,
-    ratingValue = ratingValue,
-    choiceFieldId = choiceFieldId,
-    choiceValue = choiceValue,
+    choiceFilters = parseChoiceFilters(choice, legacyChoiceFieldId, legacyChoiceValue),
+    ratingFilters = parseRatingFilters(rating, legacyRatingFieldId, legacyRatingValue),
 )
 
 /**
@@ -70,10 +70,12 @@ fun Route.statsRoutes(
             deviceType = p.deviceType,
             segment = p.segment,
             task = p.task,
-            ratingFieldId = p.ratingFieldId,
-            ratingValue = p.ratingValue,
-            choiceFieldId = p.choiceFieldId,
-            choiceValue = p.choiceValue,
+            choice = p.choice,
+            rating = p.rating,
+            legacyChoiceFieldId = p.choiceFieldId,
+            legacyChoiceValue = p.choiceValue,
+            legacyRatingFieldId = p.ratingFieldId,
+            legacyRatingValue = p.ratingValue,
         )
         val stats = statsService.getDashboardStats(query)
         call.respond(stats)
@@ -92,10 +94,12 @@ fun Route.statsRoutes(
             surveyId = p.surveyId,
             deviceType = p.deviceType,
             segment = p.segment,
-            ratingFieldId = p.ratingFieldId,
-            ratingValue = p.ratingValue,
-            choiceFieldId = p.choiceFieldId,
-            choiceValue = p.choiceValue,
+            choice = p.choice,
+            rating = p.rating,
+            legacyChoiceFieldId = p.choiceFieldId,
+            legacyChoiceValue = p.choiceValue,
+            legacyRatingFieldId = p.ratingFieldId,
+            legacyRatingValue = p.ratingValue,
         )
         val overview = statsService.getStatsOverview(query)
         call.respond(overview)
@@ -114,10 +118,12 @@ fun Route.statsRoutes(
             surveyId = p.surveyId,
             deviceType = p.deviceType,
             segment = p.segment,
-            ratingFieldId = p.ratingFieldId,
-            ratingValue = p.ratingValue,
-            choiceFieldId = p.choiceFieldId,
-            choiceValue = p.choiceValue,
+            choice = p.choice,
+            rating = p.rating,
+            legacyChoiceFieldId = p.choiceFieldId,
+            legacyChoiceValue = p.choiceValue,
+            legacyRatingFieldId = p.ratingFieldId,
+            legacyRatingValue = p.ratingValue,
         )
         val distribution = statsService.getRatingDistribution(query)
         call.respond(distribution)
@@ -136,10 +142,12 @@ fun Route.statsRoutes(
             surveyId = p.surveyId,
             deviceType = p.deviceType,
             segment = p.segment,
-            ratingFieldId = p.ratingFieldId,
-            ratingValue = p.ratingValue,
-            choiceFieldId = p.choiceFieldId,
-            choiceValue = p.choiceValue,
+            choice = p.choice,
+            rating = p.rating,
+            legacyChoiceFieldId = p.choiceFieldId,
+            legacyChoiceValue = p.choiceValue,
+            legacyRatingFieldId = p.ratingFieldId,
+            legacyRatingValue = p.ratingValue,
         )
         val timeline = statsService.getTimeline(query)
         call.respond(timeline)
@@ -159,10 +167,12 @@ fun Route.statsRoutes(
             deviceType = p.deviceType,
             segment = p.segment,
             task = p.task,
-            ratingFieldId = p.ratingFieldId,
-            ratingValue = p.ratingValue,
-            choiceFieldId = p.choiceFieldId,
-            choiceValue = p.choiceValue,
+            choice = p.choice,
+            rating = p.rating,
+            legacyChoiceFieldId = p.choiceFieldId,
+            legacyChoiceValue = p.choiceValue,
+            legacyRatingFieldId = p.ratingFieldId,
+            legacyRatingValue = p.ratingValue,
         )
         val stats = statsService.getTopTasksStats(query)
         call.respond(stats)
@@ -182,10 +192,12 @@ fun Route.statsRoutes(
             deviceType = p.deviceType,
             segment = p.segment,
             task = p.task,
-            ratingFieldId = p.ratingFieldId,
-            ratingValue = p.ratingValue,
-            choiceFieldId = p.choiceFieldId,
-            choiceValue = p.choiceValue,
+            choice = p.choice,
+            rating = p.rating,
+            legacyChoiceFieldId = p.choiceFieldId,
+            legacyChoiceValue = p.choiceValue,
+            legacyRatingFieldId = p.ratingFieldId,
+            legacyRatingValue = p.ratingValue,
         )
         val stats = statsService.getBlockerStats(query)
         call.respond(stats)
@@ -204,10 +216,12 @@ fun Route.statsRoutes(
             surveyId = p.surveyId,
             deviceType = p.deviceType,
             segment = p.segment,
-            ratingFieldId = p.ratingFieldId,
-            ratingValue = p.ratingValue,
-            choiceFieldId = p.choiceFieldId,
-            choiceValue = p.choiceValue,
+            choice = p.choice,
+            rating = p.rating,
+            legacyChoiceFieldId = p.choiceFieldId,
+            legacyChoiceValue = p.choiceValue,
+            legacyRatingFieldId = p.ratingFieldId,
+            legacyRatingValue = p.ratingValue,
         )
         val stats = statsService.getTaskPriorityStats(query)
         call.respond(stats)
@@ -226,10 +240,12 @@ fun Route.statsRoutes(
             surveyId = null,
             deviceType = p.deviceType,
             segment = p.segment,
-            ratingFieldId = p.ratingFieldId,
-            ratingValue = p.ratingValue,
-            choiceFieldId = p.choiceFieldId,
-            choiceValue = p.choiceValue,
+            choice = p.choice,
+            rating = p.rating,
+            legacyChoiceFieldId = p.choiceFieldId,
+            legacyChoiceValue = p.choiceValue,
+            legacyRatingFieldId = p.ratingFieldId,
+            legacyRatingValue = p.ratingValue,
         )
         val distribution = statsService.getSurveyTypeDistribution(query)
         call.respond(distribution)

--- a/apps/lumi-api/src/main/kotlin/no/nav/lumi/routes/StatsRoutes.kt
+++ b/apps/lumi-api/src/main/kotlin/no/nav/lumi/routes/StatsRoutes.kt
@@ -44,41 +44,49 @@ internal fun ApiV1Intern.Stats.toStatsQuery(
 fun Route.statsRoutes(
     statsService: StatsService = defaultStatsService
 ) {
+    // Dashboard stats (primary endpoint used by lumi-dashboard)
     get<ApiV1Intern.Stats.Dashboard> { params ->
         val query = params.parent.toStatsQuery(call.authorizedTeam)
         call.respond(statsService.getDashboardStats(query))
     }
 
+    // Stats overview (consolidated totals + rating distribution)
     get<ApiV1Intern.Stats.Overview> { params ->
         val query = params.parent.toStatsQuery(call.authorizedTeam)
         call.respond(statsService.getStatsOverview(query))
     }
 
+    // Rating distribution
     get<ApiV1Intern.Stats.Ratings> { params ->
         val query = params.parent.toStatsQuery(call.authorizedTeam)
         call.respond(statsService.getRatingDistribution(query))
     }
 
+    // Timeline data (counts by date)
     get<ApiV1Intern.Stats.Timeline> { params ->
         val query = params.parent.toStatsQuery(call.authorizedTeam)
         call.respond(statsService.getTimeline(query))
     }
 
+    // Top Tasks statistics
     get<ApiV1Intern.Stats.TopTasks> { params ->
         val query = params.parent.toStatsQuery(call.authorizedTeam)
         call.respond(statsService.getTopTasksStats(query))
     }
 
+    // Blocker statistics for Top Tasks (word frequency + theme clustering)
     get<ApiV1Intern.Stats.Blockers> { params ->
         val query = params.parent.toStatsQuery(call.authorizedTeam)
         call.respond(statsService.getBlockerStats(query))
     }
 
+    // Task Priority statistics ("long neck" distribution)
     get<ApiV1Intern.Stats.TaskPriority> { params ->
         val query = params.parent.toStatsQuery(call.authorizedTeam)
         call.respond(statsService.getTaskPriorityStats(query))
     }
 
+    // Survey Type distribution (surveyId forced to null — counts across all surveys)
     get<ApiV1Intern.Stats.SurveyTypes> { params ->
         val query = params.parent.toStatsQuery(call.authorizedTeam, surveyIdOverride = null)
         call.respond(statsService.getSurveyTypeDistribution(query))

--- a/apps/lumi-api/src/main/kotlin/no/nav/lumi/service/StatsService.kt
+++ b/apps/lumi-api/src/main/kotlin/no/nav/lumi/service/StatsService.kt
@@ -49,6 +49,16 @@ class StatsService(
             ?.sortedBy { (k, v) -> "${k.trim()}:${v.trim()}" }
             ?.joinToString(",") { (k, v) -> "${k.trim()}:${v.trim()}" }
 
+        val choiceValue = choiceFilters
+            .takeIf { it.isNotEmpty() }
+            ?.sortedBy { (k, v) -> "$k:$v" }
+            ?.joinToString(",") { (k, v) -> "$k:$v" }
+
+        val ratingValue = ratingFilters
+            .takeIf { it.isNotEmpty() }
+            ?.sortedBy { (k, v) -> "$k:$v" }
+            ?.joinToString(",") { (k, v) -> "$k:$v" }
+
         val parts = listOf(
             "team" to team,
             "app" to app,
@@ -58,10 +68,8 @@ class StatsService(
             "deviceType" to deviceType,
             "segment" to segmentValue,
             "task" to task,
-            "ratingFieldId" to ratingFieldId,
-            "ratingValue" to ratingValue?.toString(),
-            "choiceFieldId" to choiceFieldId,
-            "choiceValue" to choiceValue,
+            "choice" to choiceValue,
+            "rating" to ratingValue,
         )
             .filter { (_, value) -> value != null }
             .map { (key, value) -> "${enc(key)}=${enc(value!!)}" }

--- a/apps/lumi-api/src/main/kotlin/no/nav/lumi/service/StatsService.kt
+++ b/apps/lumi-api/src/main/kotlin/no/nav/lumi/service/StatsService.kt
@@ -60,6 +60,8 @@ class StatsService(
             "task" to task,
             "ratingFieldId" to ratingFieldId,
             "ratingValue" to ratingValue?.toString(),
+            "choiceFieldId" to choiceFieldId,
+            "choiceValue" to choiceValue,
         )
             .filter { (_, value) -> value != null }
             .map { (key, value) -> "${enc(key)}=${enc(value!!)}" }

--- a/apps/lumi-api/src/test/kotlin/no/nav/lumi/repository/FeedbackRepositoryTest.kt
+++ b/apps/lumi-api/src/test/kotlin/no/nav/lumi/repository/FeedbackRepositoryTest.kt
@@ -411,6 +411,92 @@ class FeedbackRepositoryTest : FunSpec({
             content.map { it.id }.toSet() shouldBe setOf("choice-single-match", "choice-multi-match")
         }
 
+        test("returns empty result for unknown choice optionId") {
+            insertTestFeedbackWithJson(
+                id = "choice-single-match",
+                team = "team-test",
+                app = "app-test",
+                feedbackJson = """
+                    {
+                        "surveyId": "survey-choice",
+                        "answers": [
+                            {
+                                "fieldId": "task_choice",
+                                "fieldType": "SINGLE_CHOICE",
+                                "question": {"label": "Hva skulle du gjøre?"},
+                                "value": {"type": "singleChoice", "selectedOptionId": "opt-1"}
+                            }
+                        ]
+                    }
+                """.trimIndent()
+            )
+
+            val (content, total, _) = repository.findPaginated(
+                FeedbackQuery(team = "team-test", choiceFieldId = "task_choice", choiceValue = "unknown-option")
+            )
+
+            content.shouldBeEmpty()
+            total shouldBe 0
+        }
+
+        test("filters by choice and rating together with AND semantics") {
+            insertTestFeedbackWithJson(
+                id = "match-both",
+                team = "team-test",
+                app = "app-test",
+                feedbackJson = """
+                    {
+                        "surveyId": "survey-choice-rating",
+                        "answers": [
+                            {"fieldId": "task_choice", "fieldType": "SINGLE_CHOICE", "question": {"label": "Oppgave"}, "value": {"type": "singleChoice", "selectedOptionId": "opt-1"}},
+                            {"fieldId": "rating_main", "fieldType": "RATING", "question": {"label": "Hvordan gikk det?"}, "value": {"type": "rating", "rating": 1}}
+                        ]
+                    }
+                """.trimIndent()
+            )
+            insertTestFeedbackWithJson(
+                id = "match-choice-only",
+                team = "team-test",
+                app = "app-test",
+                feedbackJson = """
+                    {
+                        "surveyId": "survey-choice-rating",
+                        "answers": [
+                            {"fieldId": "task_choice", "fieldType": "SINGLE_CHOICE", "question": {"label": "Oppgave"}, "value": {"type": "singleChoice", "selectedOptionId": "opt-1"}},
+                            {"fieldId": "rating_main", "fieldType": "RATING", "question": {"label": "Hvordan gikk det?"}, "value": {"type": "rating", "rating": 3}}
+                        ]
+                    }
+                """.trimIndent()
+            )
+            insertTestFeedbackWithJson(
+                id = "match-rating-only",
+                team = "team-test",
+                app = "app-test",
+                feedbackJson = """
+                    {
+                        "surveyId": "survey-choice-rating",
+                        "answers": [
+                            {"fieldId": "task_choice", "fieldType": "SINGLE_CHOICE", "question": {"label": "Oppgave"}, "value": {"type": "singleChoice", "selectedOptionId": "opt-2"}},
+                            {"fieldId": "rating_main", "fieldType": "RATING", "question": {"label": "Hvordan gikk det?"}, "value": {"type": "rating", "rating": 1}}
+                        ]
+                    }
+                """.trimIndent()
+            )
+
+            val (content, _, _) = repository.findPaginated(
+                FeedbackQuery(
+                    team = "team-test",
+                    choiceFieldId = "task_choice",
+                    choiceValue = "opt-1",
+                    ratingFieldId = "rating_main",
+                    ratingValue = 1
+                )
+            )
+
+            content shouldHaveSize 1
+            content.first().id shouldBe "match-both"
+        }
+
         test("filters by segments") {
             insertTestFeedbackWithJson(
                 id = "segment-match",

--- a/apps/lumi-api/src/test/kotlin/no/nav/lumi/repository/FeedbackRepositoryTest.kt
+++ b/apps/lumi-api/src/test/kotlin/no/nav/lumi/repository/FeedbackRepositoryTest.kt
@@ -340,7 +340,7 @@ class FeedbackRepositoryTest : FunSpec({
             )
 
             val (content, _, _) = repository.findPaginated(
-                FeedbackQuery(team = "team-test", ratingFieldId = "rating_main", ratingValue = 1)
+                FeedbackQuery(team = "team-test", ratingFilters = listOf("rating_main" to 1))
             )
 
             content shouldHaveSize 1
@@ -404,7 +404,7 @@ class FeedbackRepositoryTest : FunSpec({
             )
 
             val (content, _, _) = repository.findPaginated(
-                FeedbackQuery(team = "team-test", choiceFieldId = "task_choice", choiceValue = "opt-1")
+                FeedbackQuery(team = "team-test", choiceFilters = listOf("task_choice" to "opt-1"))
             )
 
             content shouldHaveSize 2
@@ -432,7 +432,7 @@ class FeedbackRepositoryTest : FunSpec({
             )
 
             val (content, total, _) = repository.findPaginated(
-                FeedbackQuery(team = "team-test", choiceFieldId = "task_choice", choiceValue = "unknown-option")
+                FeedbackQuery(team = "team-test", choiceFilters = listOf("task_choice" to "unknown-option"))
             )
 
             content.shouldBeEmpty()
@@ -486,10 +486,8 @@ class FeedbackRepositoryTest : FunSpec({
             val (content, _, _) = repository.findPaginated(
                 FeedbackQuery(
                     team = "team-test",
-                    choiceFieldId = "task_choice",
-                    choiceValue = "opt-1",
-                    ratingFieldId = "rating_main",
-                    ratingValue = 1
+                    choiceFilters = listOf("task_choice" to "opt-1"),
+                    ratingFilters = listOf("rating_main" to 1),
                 )
             )
 

--- a/apps/lumi-api/src/test/kotlin/no/nav/lumi/repository/FeedbackRepositoryTest.kt
+++ b/apps/lumi-api/src/test/kotlin/no/nav/lumi/repository/FeedbackRepositoryTest.kt
@@ -347,6 +347,70 @@ class FeedbackRepositoryTest : FunSpec({
             content.first().id shouldBe "rating-1"
         }
 
+        test("filters by choiceFieldId and choiceValue for singleChoice and multiChoice") {
+            insertTestFeedbackWithJson(
+                id = "choice-single-match",
+                team = "team-test",
+                app = "app-test",
+                feedbackJson = """
+                    {
+                        "surveyId": "survey-choice",
+                        "answers": [
+                            {
+                                "fieldId": "task_choice",
+                                "fieldType": "SINGLE_CHOICE",
+                                "question": {"label": "Hva skulle du gjøre?"},
+                                "value": {"type": "singleChoice", "selectedOptionId": "opt-1"}
+                            }
+                        ]
+                    }
+                """.trimIndent()
+            )
+            insertTestFeedbackWithJson(
+                id = "choice-multi-match",
+                team = "team-test",
+                app = "app-test",
+                feedbackJson = """
+                    {
+                        "surveyId": "survey-choice",
+                        "answers": [
+                            {
+                                "fieldId": "task_choice",
+                                "fieldType": "MULTI_CHOICE",
+                                "question": {"label": "Hva gjorde du?"},
+                                "value": {"type": "multiChoice", "selectedOptionIds": ["opt-2", "opt-1"]}
+                            }
+                        ]
+                    }
+                """.trimIndent()
+            )
+            insertTestFeedbackWithJson(
+                id = "choice-no-match",
+                team = "team-test",
+                app = "app-test",
+                feedbackJson = """
+                    {
+                        "surveyId": "survey-choice",
+                        "answers": [
+                            {
+                                "fieldId": "task_choice",
+                                "fieldType": "SINGLE_CHOICE",
+                                "question": {"label": "Hva skulle du gjøre?"},
+                                "value": {"type": "singleChoice", "selectedOptionId": "opt-9"}
+                            }
+                        ]
+                    }
+                """.trimIndent()
+            )
+
+            val (content, _, _) = repository.findPaginated(
+                FeedbackQuery(team = "team-test", choiceFieldId = "task_choice", choiceValue = "opt-1")
+            )
+
+            content shouldHaveSize 2
+            content.map { it.id }.toSet() shouldBe setOf("choice-single-match", "choice-multi-match")
+        }
+
         test("filters by segments") {
             insertTestFeedbackWithJson(
                 id = "segment-match",

--- a/apps/lumi-api/src/test/kotlin/no/nav/lumi/repository/FeedbackSecurityTest.kt
+++ b/apps/lumi-api/src/test/kotlin/no/nav/lumi/repository/FeedbackSecurityTest.kt
@@ -4,6 +4,9 @@ import io.kotest.core.spec.style.DescribeSpec
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.string.shouldContain
 import io.kotest.matchers.string.shouldNotContain
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.jsonArray
 import kotlinx.serialization.json.jsonObject
@@ -11,6 +14,7 @@ import kotlinx.serialization.json.jsonPrimitive
 import kotlinx.serialization.json.int
 import no.nav.lumi.TestDatabase
 import no.nav.lumi.service.FeedbackService
+import org.slf4j.LoggerFactory
 
 class FeedbackSecurityTest : DescribeSpec({
 
@@ -80,6 +84,49 @@ class FeedbackSecurityTest : DescribeSpec({
             val escaped = input.escapeLikePattern()
             
             escaped shouldBe "\\%\\%\\_\\_\\\\\\\\"
+        }
+    }
+
+    describe("JSONPath choice filter safety") {
+        val log = LoggerFactory.getLogger("FeedbackSecurityTest")
+
+        it("should reject choice values with JSONPath special characters") {
+            isSafeChoiceValue("opt-1") shouldBe true
+            isSafeChoiceValue("Svært ofte") shouldBe true
+
+            isSafeChoiceValue("opt\"1") shouldBe false
+            isSafeChoiceValue("opt\\1") shouldBe false
+            isSafeChoiceValue("opt\$1") shouldBe false
+            isSafeChoiceValue("opt@1") shouldBe false
+            isSafeChoiceValue("opt?1") shouldBe false
+            isSafeChoiceValue("opt(1)") shouldBe false
+        }
+
+        it("should build singleChoice and multiChoice JSONPath for safe input") {
+            val paths = buildChoiceJsonPaths(
+                choiceFieldId = "task_choice",
+                choiceValue = "Svært ofte",
+                log = log
+            )
+
+            paths?.singleChoicePath shouldBe
+                "$.answers[*] ? (@.fieldId == \"task_choice\" && @.value.type == \"singleChoice\" && @.value.selectedOptionId == \"Svært ofte\")"
+            paths?.multiChoicePath shouldBe
+                "$.answers[*] ? (@.fieldId == \"task_choice\" && @.value.type == \"multiChoice\" && exists(@.value.selectedOptionIds[*] ? (@ == \"Svært ofte\")))"
+        }
+
+        it("should reject JSONPath builder input when fieldId or choiceValue is unsafe") {
+            buildChoiceJsonPaths("task\"choice", "opt-1", log) shouldBe null
+            buildChoiceJsonPaths("task_choice", "opt\"1", log) shouldBe null
+        }
+
+        it("should log warning when choiceFieldId is unsafe without logging raw value") {
+            val mockedLogger = mockk<org.slf4j.Logger>(relaxed = true)
+            every { mockedLogger.warn(any<String>()) } returns Unit
+
+            validateJsonPathFieldId("task\"choice", "choiceFieldId", mockedLogger) shouldBe null
+
+            verify(exactly = 1) { mockedLogger.warn("Rejected unsafe choiceFieldId") }
         }
     }
 

--- a/apps/lumi-api/src/test/kotlin/no/nav/lumi/repository/FeedbackSecurityTest.kt
+++ b/apps/lumi-api/src/test/kotlin/no/nav/lumi/repository/FeedbackSecurityTest.kt
@@ -102,6 +102,13 @@ class FeedbackSecurityTest : DescribeSpec({
             isSafeChoiceValue("opt(1)") shouldBe false
         }
 
+        it("should reject choice values with control characters") {
+            isSafeChoiceValue("opt\n1") shouldBe false
+            isSafeChoiceValue("opt\r1") shouldBe false
+            isSafeChoiceValue("opt\u00001") shouldBe false
+            isSafeChoiceValue("opt\t1") shouldBe false
+        }
+
         it("should build singleChoice and multiChoice JSONPath for safe input") {
             val paths = buildChoiceJsonPaths(
                 choiceFieldId = "task_choice",

--- a/apps/lumi-api/src/test/kotlin/no/nav/lumi/repository/FeedbackStatsRepositoryTest.kt
+++ b/apps/lumi-api/src/test/kotlin/no/nav/lumi/repository/FeedbackStatsRepositoryTest.kt
@@ -101,6 +101,41 @@ class FeedbackStatsRepositoryTest : FunSpec({
             stats.totalCount shouldBe 0L
         }
 
+        test("ignores unsafe choiceValue filter to prevent JSONPath injection") {
+            insertTestFeedbackWithJson(
+                id = "choice-a",
+                team = "flex",
+                app = "app-test",
+                feedbackJson = """
+                    {
+                        "surveyId": "survey-choice",
+                        "answers": [
+                            {"fieldId": "task_choice", "fieldType": "SINGLE_CHOICE", "question": {"label": "Velg"}, "value": {"type": "singleChoice", "selectedOptionId": "opt-1"}}
+                        ]
+                    }
+                """.trimIndent()
+            )
+            insertTestFeedbackWithJson(
+                id = "choice-b",
+                team = "flex",
+                app = "app-test",
+                feedbackJson = """
+                    {
+                        "surveyId": "survey-choice",
+                        "answers": [
+                            {"fieldId": "task_choice", "fieldType": "SINGLE_CHOICE", "question": {"label": "Velg"}, "value": {"type": "singleChoice", "selectedOptionId": "opt-2"}}
+                        ]
+                    }
+                """.trimIndent()
+            )
+
+            val stats = repository.getStats(
+                StatsQuery(team = "flex", choiceFieldId = "task_choice", choiceValue = "opt\"1")
+            )
+
+            stats.totalCount shouldBe 2L
+        }
+
         test("filters by choice and rating together with AND semantics") {
             insertTestFeedbackWithJson(
                 id = "match-both",

--- a/apps/lumi-api/src/test/kotlin/no/nav/lumi/repository/FeedbackStatsRepositoryTest.kt
+++ b/apps/lumi-api/src/test/kotlin/no/nav/lumi/repository/FeedbackStatsRepositoryTest.kt
@@ -73,7 +73,7 @@ class FeedbackStatsRepositoryTest : FunSpec({
             )
 
             val stats = repository.getStats(
-                StatsQuery(team = "flex", choiceFieldId = "task_choice", choiceValue = "opt-1")
+                StatsQuery(team = "flex", choiceFilters = listOf("task_choice" to "opt-1"))
             )
 
             stats.totalCount shouldBe 2L
@@ -95,7 +95,7 @@ class FeedbackStatsRepositoryTest : FunSpec({
             )
 
             val stats = repository.getStats(
-                StatsQuery(team = "flex", choiceFieldId = "task_choice", choiceValue = "unknown-option")
+                StatsQuery(team = "flex", choiceFilters = listOf("task_choice" to "unknown-option"))
             )
 
             stats.totalCount shouldBe 0L
@@ -130,7 +130,7 @@ class FeedbackStatsRepositoryTest : FunSpec({
             )
 
             val stats = repository.getStats(
-                StatsQuery(team = "flex", choiceFieldId = "task_choice", choiceValue = "opt\"1")
+                StatsQuery(team = "flex", choiceFilters = listOf("task_choice" to "opt\"1"))
             )
 
             stats.totalCount shouldBe 2L
@@ -183,10 +183,8 @@ class FeedbackStatsRepositoryTest : FunSpec({
             val stats = repository.getStats(
                 StatsQuery(
                     team = "flex",
-                    choiceFieldId = "task_choice",
-                    choiceValue = "opt-1",
-                    ratingFieldId = "rating_main",
-                    ratingValue = 1
+                    choiceFilters = listOf("task_choice" to "opt-1"),
+                    ratingFilters = listOf("rating_main" to 1),
                 )
             )
 

--- a/apps/lumi-api/src/test/kotlin/no/nav/lumi/repository/FeedbackStatsRepositoryTest.kt
+++ b/apps/lumi-api/src/test/kotlin/no/nav/lumi/repository/FeedbackStatsRepositoryTest.kt
@@ -6,6 +6,7 @@ import no.nav.lumi.TestDatabase
 import no.nav.lumi.config.DatabaseHolder
 import no.nav.lumi.domain.StatsQuery
 import no.nav.lumi.insertTestFeedback
+import no.nav.lumi.insertTestFeedbackWithJson
 
 class FeedbackStatsRepositoryTest : FunSpec({
     val repository = FeedbackStatsRepository()
@@ -28,6 +29,54 @@ class FeedbackStatsRepositoryTest : FunSpec({
             val stats = repository.getStats(StatsQuery(team = "flex"))
             
             stats.totalCount shouldBe 3L
+        }
+
+        test("filters by choiceFieldId and choiceValue for singleChoice and multiChoice") {
+            insertTestFeedbackWithJson(
+                id = "single-match",
+                team = "flex",
+                app = "app-test",
+                feedbackJson = """
+                    {
+                        "surveyId": "survey-choice",
+                        "answers": [
+                            {"fieldId": "task_choice", "fieldType": "SINGLE_CHOICE", "question": {"label": "Velg"}, "value": {"type": "singleChoice", "selectedOptionId": "opt-1"}}
+                        ]
+                    }
+                """.trimIndent()
+            )
+            insertTestFeedbackWithJson(
+                id = "multi-match",
+                team = "flex",
+                app = "app-test",
+                feedbackJson = """
+                    {
+                        "surveyId": "survey-choice",
+                        "answers": [
+                            {"fieldId": "task_choice", "fieldType": "MULTI_CHOICE", "question": {"label": "Velg"}, "value": {"type": "multiChoice", "selectedOptionIds": ["opt-1", "opt-2"]}}
+                        ]
+                    }
+                """.trimIndent()
+            )
+            insertTestFeedbackWithJson(
+                id = "no-match",
+                team = "flex",
+                app = "app-test",
+                feedbackJson = """
+                    {
+                        "surveyId": "survey-choice",
+                        "answers": [
+                            {"fieldId": "task_choice", "fieldType": "SINGLE_CHOICE", "question": {"label": "Velg"}, "value": {"type": "singleChoice", "selectedOptionId": "opt-9"}}
+                        ]
+                    }
+                """.trimIndent()
+            )
+
+            val stats = repository.getStats(
+                StatsQuery(team = "flex", choiceFieldId = "task_choice", choiceValue = "opt-1")
+            )
+
+            stats.totalCount shouldBe 2L
         }
     }
 })

--- a/apps/lumi-api/src/test/kotlin/no/nav/lumi/repository/FeedbackStatsRepositoryTest.kt
+++ b/apps/lumi-api/src/test/kotlin/no/nav/lumi/repository/FeedbackStatsRepositoryTest.kt
@@ -78,5 +78,84 @@ class FeedbackStatsRepositoryTest : FunSpec({
 
             stats.totalCount shouldBe 2L
         }
+
+        test("returns empty stats for unknown choice optionId") {
+            insertTestFeedbackWithJson(
+                id = "single-match",
+                team = "flex",
+                app = "app-test",
+                feedbackJson = """
+                    {
+                        "surveyId": "survey-choice",
+                        "answers": [
+                            {"fieldId": "task_choice", "fieldType": "SINGLE_CHOICE", "question": {"label": "Velg"}, "value": {"type": "singleChoice", "selectedOptionId": "opt-1"}}
+                        ]
+                    }
+                """.trimIndent()
+            )
+
+            val stats = repository.getStats(
+                StatsQuery(team = "flex", choiceFieldId = "task_choice", choiceValue = "unknown-option")
+            )
+
+            stats.totalCount shouldBe 0L
+        }
+
+        test("filters by choice and rating together with AND semantics") {
+            insertTestFeedbackWithJson(
+                id = "match-both",
+                team = "flex",
+                app = "app-test",
+                feedbackJson = """
+                    {
+                        "surveyId": "survey-choice-rating",
+                        "answers": [
+                            {"fieldId": "task_choice", "fieldType": "SINGLE_CHOICE", "question": {"label": "Oppgave"}, "value": {"type": "singleChoice", "selectedOptionId": "opt-1"}},
+                            {"fieldId": "rating_main", "fieldType": "RATING", "question": {"label": "Hvordan?"}, "value": {"type": "rating", "rating": 1}}
+                        ]
+                    }
+                """.trimIndent()
+            )
+            insertTestFeedbackWithJson(
+                id = "match-choice-only",
+                team = "flex",
+                app = "app-test",
+                feedbackJson = """
+                    {
+                        "surveyId": "survey-choice-rating",
+                        "answers": [
+                            {"fieldId": "task_choice", "fieldType": "SINGLE_CHOICE", "question": {"label": "Oppgave"}, "value": {"type": "singleChoice", "selectedOptionId": "opt-1"}},
+                            {"fieldId": "rating_main", "fieldType": "RATING", "question": {"label": "Hvordan?"}, "value": {"type": "rating", "rating": 3}}
+                        ]
+                    }
+                """.trimIndent()
+            )
+            insertTestFeedbackWithJson(
+                id = "match-rating-only",
+                team = "flex",
+                app = "app-test",
+                feedbackJson = """
+                    {
+                        "surveyId": "survey-choice-rating",
+                        "answers": [
+                            {"fieldId": "task_choice", "fieldType": "SINGLE_CHOICE", "question": {"label": "Oppgave"}, "value": {"type": "singleChoice", "selectedOptionId": "opt-2"}},
+                            {"fieldId": "rating_main", "fieldType": "RATING", "question": {"label": "Hvordan?"}, "value": {"type": "rating", "rating": 1}}
+                        ]
+                    }
+                """.trimIndent()
+            )
+
+            val stats = repository.getStats(
+                StatsQuery(
+                    team = "flex",
+                    choiceFieldId = "task_choice",
+                    choiceValue = "opt-1",
+                    ratingFieldId = "rating_main",
+                    ratingValue = 1
+                )
+            )
+
+            stats.totalCount shouldBe 1L
+        }
     }
 })

--- a/apps/lumi-api/src/test/kotlin/no/nav/lumi/routes/QueryValidationTest.kt
+++ b/apps/lumi-api/src/test/kotlin/no/nav/lumi/routes/QueryValidationTest.kt
@@ -1,0 +1,176 @@
+package no.nav.lumi.routes
+
+import io.kotest.assertions.throwables.shouldNotThrow
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.string.shouldContain
+import no.nav.lumi.config.exception.ApiErrorException
+
+class QueryValidationTest : FunSpec({
+
+    context("parseChoiceFilters") {
+        test("parses valid choice filters") {
+            val result = parseChoiceFilters(
+                choice = listOf("role:Arbeidsgiver", "category:Leder"),
+                legacyFieldId = null,
+                legacyValue = null,
+            )
+            result shouldBe listOf("role" to "Arbeidsgiver", "category" to "Leder")
+        }
+
+        test("merges legacy params") {
+            val result = parseChoiceFilters(
+                choice = listOf("role:Arbeidsgiver"),
+                legacyFieldId = "category",
+                legacyValue = "Leder",
+            )
+            result shouldBe listOf("role" to "Arbeidsgiver", "category" to "Leder")
+        }
+
+        test("returns empty list for null input") {
+            val result = parseChoiceFilters(null, null, null)
+            result shouldBe emptyList()
+        }
+
+        test("rejects missing colon separator") {
+            val ex = shouldThrow<ApiErrorException.BadRequestException> {
+                parseChoiceFilters(listOf("roleArbeidsgiver"), null, null)
+            }
+            ex.message shouldContain "expected format"
+        }
+
+        test("rejects blank fieldId") {
+            val ex = shouldThrow<ApiErrorException.BadRequestException> {
+                parseChoiceFilters(listOf(":value"), null, null)
+            }
+            ex.message shouldContain "expected format"
+        }
+
+        test("rejects blank value") {
+            val ex = shouldThrow<ApiErrorException.BadRequestException> {
+                parseChoiceFilters(listOf("field: "), null, null)
+            }
+            ex.message shouldContain "non-blank"
+        }
+
+        test("rejects value exceeding max length") {
+            val longValue = "a".repeat(201)
+            val ex = shouldThrow<ApiErrorException.BadRequestException> {
+                parseChoiceFilters(listOf("field:$longValue"), null, null)
+            }
+            ex.message shouldContain "max length"
+        }
+
+        test("rejects fieldId with illegal characters") {
+            val ex = shouldThrow<ApiErrorException.BadRequestException> {
+                parseChoiceFilters(listOf("field\$id:value"), null, null)
+            }
+            ex.message shouldContain "illegal characters"
+        }
+
+        test("rejects value with JSON path special characters") {
+            val ex = shouldThrow<ApiErrorException.BadRequestException> {
+                parseChoiceFilters(listOf("field:value\"with\"quotes"), null, null)
+            }
+            ex.message shouldContain "illegal characters"
+        }
+
+        test("rejects legacy value with JSON path special characters") {
+            val ex = shouldThrow<ApiErrorException.BadRequestException> {
+                parseChoiceFilters(null, "field", "value\$injected")
+            }
+            ex.message shouldContain "illegal characters"
+        }
+
+        test("rejects too many filters") {
+            val filters = (1..21).map { "field$it:value$it" }
+            val ex = shouldThrow<ApiErrorException.BadRequestException> {
+                parseChoiceFilters(filters, null, null)
+            }
+            ex.message shouldContain "Too many"
+        }
+    }
+
+    context("parseRatingFilters") {
+        test("parses valid rating filters") {
+            val result = parseRatingFilters(
+                rating = listOf("satisfaction:5", "nps:9"),
+                legacyFieldId = null,
+                legacyValue = null,
+            )
+            result shouldBe listOf("satisfaction" to 5, "nps" to 9)
+        }
+
+        test("merges legacy params") {
+            val result = parseRatingFilters(
+                rating = null,
+                legacyFieldId = "satisfaction",
+                legacyValue = 3,
+            )
+            result shouldBe listOf("satisfaction" to 3)
+        }
+
+        test("returns empty list for null input") {
+            val result = parseRatingFilters(null, null, null)
+            result shouldBe emptyList()
+        }
+
+        test("rejects non-integer value") {
+            val ex = shouldThrow<ApiErrorException.BadRequestException> {
+                parseRatingFilters(listOf("field:abc"), null, null)
+            }
+            ex.message shouldContain "integer"
+        }
+
+        test("rejects missing colon separator") {
+            val ex = shouldThrow<ApiErrorException.BadRequestException> {
+                parseRatingFilters(listOf("field5"), null, null)
+            }
+            ex.message shouldContain "expected format"
+        }
+
+        test("rejects fieldId with illegal characters") {
+            val ex = shouldThrow<ApiErrorException.BadRequestException> {
+                parseRatingFilters(listOf("field@id:5"), null, null)
+            }
+            ex.message shouldContain "illegal characters"
+        }
+
+        test("rejects too many filters") {
+            val filters = (1..21).map { "field$it:$it" }
+            val ex = shouldThrow<ApiErrorException.BadRequestException> {
+                parseRatingFilters(filters, null, null)
+            }
+            ex.message shouldContain "Too many"
+        }
+    }
+
+    context("validateDateRange") {
+        test("accepts valid date range") {
+            shouldNotThrow<Exception> {
+                validateDateRange("2024-01-01", "2024-12-31")
+            }
+        }
+
+        test("accepts null dates") {
+            shouldNotThrow<Exception> {
+                validateDateRange(null, null)
+            }
+        }
+
+        test("rejects fromDate after toDate") {
+            val ex = shouldThrow<ApiErrorException.BadRequestException> {
+                validateDateRange("2024-12-31", "2024-01-01")
+            }
+            ex.message shouldContain "fromDate"
+        }
+
+        test("rejects invalid date format") {
+            val ex = shouldThrow<ApiErrorException.BadRequestException> {
+                validateDateRange("not-a-date", "2024-01-01")
+            }
+            ex.message shouldContain "YYYY-MM-DD"
+        }
+    }
+})

--- a/apps/lumi-dashboard/app/components/dashboard/sections/FieldStats/FieldCards/ChoiceFieldCard.module.css
+++ b/apps/lumi-dashboard/app/components/dashboard/sections/FieldStats/FieldCards/ChoiceFieldCard.module.css
@@ -33,8 +33,6 @@
   color: inherit;
   display: flex;
   flex-direction: column;
-  /* Remove default outline */
-  outline: none;
 }
 
 .choiceButton:hover {
@@ -42,7 +40,8 @@
 }
 
 .choiceButton:focus-visible {
-  box-shadow: var(--ax-shadow-focus);
+  outline: 2px solid var(--ax-border-focus);
+  outline-offset: 2px;
 }
 
 .choiceButtonInactive {

--- a/apps/lumi-dashboard/app/components/dashboard/sections/FieldStats/FieldCards/ChoiceFieldCard.module.css
+++ b/apps/lumi-dashboard/app/components/dashboard/sections/FieldStats/FieldCards/ChoiceFieldCard.module.css
@@ -15,6 +15,40 @@
   margin-left: 0.5rem;
 }
 
+.choiceButton {
+  width: 100%;
+  border: none;
+  background: transparent;
+  padding: var(--a-spacing-2);
+  margin: 0; /* Reset default button margin */
+  text-align: left;
+  cursor: pointer;
+  border-radius: var(--a-border-radius-medium);
+  transition:
+    opacity 0.2s ease,
+    background-color 0.1s ease;
+  /* Reset button styles */
+  font-family: inherit;
+  font-size: inherit;
+  color: inherit;
+  display: flex;
+  flex-direction: column;
+  /* Remove default outline */
+  outline: none;
+}
+
+.choiceButton:hover {
+  background-color: var(--ax-bg-neutral-soft);
+}
+
+.choiceButton:focus-visible {
+  box-shadow: var(--ax-shadow-focus);
+}
+
+.choiceButtonInactive {
+  opacity: 0.35;
+}
+
 .choiceBar {
   width: 100%;
   height: 8px;

--- a/apps/lumi-dashboard/app/components/dashboard/sections/FieldStats/FieldCards/ChoiceFieldCard.module.css
+++ b/apps/lumi-dashboard/app/components/dashboard/sections/FieldStats/FieldCards/ChoiceFieldCard.module.css
@@ -19,11 +19,11 @@
   width: 100%;
   border: none;
   background: transparent;
-  padding: var(--a-spacing-2);
+  padding: var(--ax-space-2, 0.5rem);
   margin: 0; /* Reset default button margin */
   text-align: left;
   cursor: pointer;
-  border-radius: var(--a-border-radius-medium);
+  border-radius: var(--ax-border-radius-medium, 8px);
   transition:
     opacity 0.2s ease,
     background-color 0.1s ease;

--- a/apps/lumi-dashboard/app/components/dashboard/sections/FieldStats/FieldCards/ChoiceFieldCard.module.css
+++ b/apps/lumi-dashboard/app/components/dashboard/sections/FieldStats/FieldCards/ChoiceFieldCard.module.css
@@ -63,61 +63,65 @@
 }
 
 .choiceBarBlue::-webkit-progress-value {
-  background-color: #3b82f6;
+  background-color: var(--ax-bg-info-strong, #3b82f6);
   border-radius: 4px;
 }
 
 .choiceBarGreen::-webkit-progress-value {
-  background-color: #22c55e;
+  background-color: var(--ax-bg-success-strong, #22c55e);
   border-radius: 4px;
 }
 
 .choiceBarAmber::-webkit-progress-value {
-  background-color: #f59e0b;
+  background-color: var(--ax-bg-warning-strong, #f59e0b);
   border-radius: 4px;
 }
 
 .choiceBarPurple::-webkit-progress-value {
-  background-color: #8b5cf6;
+  background-color: var(--ax-bg-brand-2-strong, #8b5cf6);
   border-radius: 4px;
 }
 
 .choiceBarPink::-webkit-progress-value {
-  background-color: #ec4899;
+  background-color: var(--ax-bg-danger-strong, #ec4899);
   border-radius: 4px;
 }
 
 .choiceBarCyan::-webkit-progress-value {
-  background-color: #06b6d4;
+  background-color: var(--ax-bg-brand-3-strong, #06b6d4);
   border-radius: 4px;
 }
 
 .choiceBarBlue::-moz-progress-bar {
-  background-color: #3b82f6;
+  background-color: var(--ax-bg-info-strong, #3b82f6);
   border-radius: 4px;
 }
 
 .choiceBarGreen::-moz-progress-bar {
-  background-color: #22c55e;
+  background-color: var(--ax-bg-success-strong, #22c55e);
   border-radius: 4px;
 }
 
 .choiceBarAmber::-moz-progress-bar {
-  background-color: #f59e0b;
+  background-color: var(--ax-bg-warning-strong, #f59e0b);
   border-radius: 4px;
 }
 
 .choiceBarPurple::-moz-progress-bar {
-  background-color: #8b5cf6;
+  background-color: var(--ax-bg-brand-2-strong, #8b5cf6);
   border-radius: 4px;
 }
 
 .choiceBarPink::-moz-progress-bar {
-  background-color: #ec4899;
+  background-color: var(--ax-bg-danger-strong, #ec4899);
   border-radius: 4px;
 }
 
 .choiceBarCyan::-moz-progress-bar {
-  background-color: #06b6d4;
+  background-color: var(--ax-bg-brand-3-strong, #06b6d4);
   border-radius: 4px;
+}
+
+.resetButton {
+  align-self: flex-start;
 }

--- a/apps/lumi-dashboard/app/components/dashboard/sections/FieldStats/FieldCards/ChoiceFieldCard.tsx
+++ b/apps/lumi-dashboard/app/components/dashboard/sections/FieldStats/FieldCards/ChoiceFieldCard.tsx
@@ -1,5 +1,5 @@
 import { ChatElipsisIcon } from "@navikt/aksel-icons";
-import { BodyShort, HStack, VStack } from "@navikt/ds-react";
+import { BodyShort, Button, HStack, VStack } from "@navikt/ds-react";
 
 import { DashboardCard } from "~/components/dashboard";
 import type { ChoiceStats } from "~/types/api";
@@ -16,7 +16,19 @@ const CHOICE_BAR_COLOR_CLASSES = [
   styles.choiceBarCyan,
 ];
 
-export function ChoiceFieldCard({ field, totalCount }: FieldCardProps) {
+export interface ChoiceFieldCardProps extends FieldCardProps {
+  activeChoiceValue?: string;
+  onChoiceSelect?: (optionId: string) => void;
+  onChoiceClear?: () => void;
+}
+
+export function ChoiceFieldCard({
+  field,
+  totalCount,
+  activeChoiceValue,
+  onChoiceSelect,
+  onChoiceClear,
+}: ChoiceFieldCardProps) {
   const stats = field.stats as ChoiceStats;
   const distribution = stats.distribution;
 
@@ -41,6 +53,8 @@ export function ChoiceFieldCard({ field, totalCount }: FieldCardProps) {
     totalSelections > 0 &&
     totalSelections !== responseCount;
 
+  const isFiltering = !!activeChoiceValue;
+
   return (
     <DashboardCard padding="space-20" className={styles.cardContent}>
       <FieldCardHeader
@@ -57,26 +71,46 @@ export function ChoiceFieldCard({ field, totalCount }: FieldCardProps) {
         {choices.map((choice, index) => {
           const barColorClass =
             CHOICE_BAR_COLOR_CLASSES[index % CHOICE_BAR_COLOR_CLASSES.length];
+          const isActive = activeChoiceValue === choice.id;
+          const isInactive = isFiltering && !isActive;
 
           return (
-            <VStack key={choice.id} gap="space-4">
-              <HStack justify="space-between" align="center">
-                <BodyShort size="small" className={styles.choiceLabel}>
-                  {choice.label}
-                </BodyShort>
-                <BodyShort size="small" className={styles.choiceValue}>
-                  {choice.count} ({choice.percentage}%)
-                </BodyShort>
-              </HStack>
-              <progress
-                className={`${styles.choiceBar} ${barColorClass}`}
-                value={choice.count}
-                max={maxCount}
-                aria-hidden="true"
-              />
-            </VStack>
+            <button
+              key={choice.id}
+              type="button"
+              className={`${styles.choiceButton} ${isInactive ? styles.choiceButtonInactive : ""}`}
+              onClick={() => onChoiceSelect?.(choice.id)}
+              aria-pressed={isActive}
+            >
+              <VStack gap="space-4" width="100%">
+                <HStack justify="space-between" align="center" width="100%">
+                  <BodyShort size="small" className={styles.choiceLabel}>
+                    {choice.label}
+                  </BodyShort>
+                  <BodyShort size="small" className={styles.choiceValue}>
+                    {choice.count} ({choice.percentage}%)
+                  </BodyShort>
+                </HStack>
+                <progress
+                  className={`${styles.choiceBar} ${barColorClass}`}
+                  value={choice.count}
+                  max={maxCount}
+                  aria-hidden="true"
+                />
+              </VStack>
+            </button>
           );
         })}
+        {isFiltering && (
+          <Button
+            variant="tertiary"
+            size="xsmall"
+            onClick={onChoiceClear}
+            style={{ alignSelf: "flex-start" }}
+          >
+            Nullstill filter
+          </Button>
+        )}
       </VStack>
     </DashboardCard>
   );

--- a/apps/lumi-dashboard/app/components/dashboard/sections/FieldStats/FieldCards/ChoiceFieldCard.tsx
+++ b/apps/lumi-dashboard/app/components/dashboard/sections/FieldStats/FieldCards/ChoiceFieldCard.tsx
@@ -17,7 +17,7 @@ const CHOICE_BAR_COLOR_CLASSES = [
 ];
 
 export interface ChoiceFieldCardProps extends FieldCardProps {
-  activeChoiceValue?: string;
+  activeChoiceFilters?: Record<string, string>;
   onChoiceSelect?: (optionId: string) => void;
   onChoiceClear?: () => void;
 }
@@ -25,21 +25,21 @@ export interface ChoiceFieldCardProps extends FieldCardProps {
 export function ChoiceFieldCard({
   field,
   totalCount,
-  activeChoiceValue,
+  activeChoiceFilters,
   onChoiceSelect,
   onChoiceClear,
 }: ChoiceFieldCardProps) {
   const stats = field.stats as ChoiceStats;
   const distribution = stats.distribution;
+  const activeChoiceValue = activeChoiceFilters?.[field.fieldId];
 
   const choices = Object.entries(distribution)
     .map(([id, data]) => ({ id, ...data }))
     .sort((a, b) => b.count - a.count);
 
-  const maxCount = Math.max(...choices.map((c) => c.count), 1);
+  const maxCount = Math.max(...choices.map((choice) => choice.count), 1);
   const selectionSum = choices.reduce((sum, choice) => sum + choice.count, 0);
   const totalSelections = stats.totalSelections ?? selectionSum;
-  // Dashboard and API deploy separately, so keep one rollout window compatible with older payloads.
   const responseCount =
     stats.responseCount ??
     (field.fieldType === "MULTI_CHOICE"

--- a/apps/lumi-dashboard/app/components/dashboard/sections/FieldStats/FieldCards/ChoiceFieldCard.tsx
+++ b/apps/lumi-dashboard/app/components/dashboard/sections/FieldStats/FieldCards/ChoiceFieldCard.tsx
@@ -33,9 +33,10 @@ export function ChoiceFieldCard({
   const distribution = stats.distribution;
   const activeChoiceValue = activeChoiceFilters?.[field.fieldId];
 
-  const choices = Object.entries(distribution)
-    .map(([id, data]) => ({ id, ...data }))
-    .sort((a, b) => b.count - a.count);
+  const choices = Object.entries(distribution).map(([id, data]) => ({
+    id,
+    ...data,
+  }));
 
   const maxCount = Math.max(...choices.map((choice) => choice.count), 1);
   const selectionSum = choices.reduce((sum, choice) => sum + choice.count, 0);

--- a/apps/lumi-dashboard/app/components/dashboard/sections/FieldStats/FieldCards/ChoiceFieldCard.tsx
+++ b/apps/lumi-dashboard/app/components/dashboard/sections/FieldStats/FieldCards/ChoiceFieldCard.tsx
@@ -107,7 +107,7 @@ export function ChoiceFieldCard({
             variant="tertiary"
             size="xsmall"
             onClick={onChoiceClear}
-            style={{ alignSelf: "flex-start" }}
+            className={styles.resetButton}
           >
             Nullstill filter
           </Button>

--- a/apps/lumi-dashboard/app/components/dashboard/sections/FieldStats/FieldCards/Rating/RatingBars.tsx
+++ b/apps/lumi-dashboard/app/components/dashboard/sections/FieldStats/FieldCards/Rating/RatingBars.tsx
@@ -1,4 +1,4 @@
-import { HStack, VStack } from "@navikt/ds-react";
+import { Button, HStack, VStack } from "@navikt/ds-react";
 import type { RatingVariant } from "~/utils/ratingDisplay";
 import styles from "./RatingFieldCard.module.css";
 
@@ -67,9 +67,11 @@ export function RatingBars({
           const isDimmed = isFiltering && !isActive;
 
           return (
-            <button
+            <Button
               key={rating}
               type="button"
+              variant="tertiary"
+              data-color="neutral"
               onClick={() => onRatingSelect(rating)}
               className={`${styles.barRowButton} ${
                 isDimmed ? styles.barRowDimmed : ""
@@ -90,19 +92,21 @@ export function RatingBars({
 
                 <span className={styles.barCount}>{count}</span>
               </HStack>
-            </button>
+            </Button>
           );
         })}
       </VStack>
 
       {isFiltering && (
-        <button
+        <Button
           type="button"
           onClick={onRatingClear}
-          className={styles.resetButton}
+          variant="tertiary"
+          size="xsmall"
+          style={{ alignSelf: "flex-start" }}
         >
           Nullstill filter
-        </button>
+        </Button>
       )}
     </VStack>
   );

--- a/apps/lumi-dashboard/app/components/dashboard/sections/FieldStats/FieldCards/Rating/RatingBars.tsx
+++ b/apps/lumi-dashboard/app/components/dashboard/sections/FieldStats/FieldCards/Rating/RatingBars.tsx
@@ -2,15 +2,23 @@ import { HStack, VStack } from "@navikt/ds-react";
 import type { RatingVariant } from "~/utils/ratingDisplay";
 import styles from "./RatingFieldCard.module.css";
 
+export interface RatingBarsProps {
+  variant: RatingVariant;
+  distribution: Record<string, number>;
+  ratingValues: number[];
+  activeRatingValue?: number;
+  onRatingSelect: (value: number) => void;
+  onRatingClear: () => void;
+}
+
 export function RatingBars({
   variant,
   distribution,
   ratingValues,
-}: {
-  variant: RatingVariant;
-  distribution: Record<string, number>;
-  ratingValues: number[];
-}) {
+  activeRatingValue,
+  onRatingSelect,
+  onRatingClear,
+}: RatingBarsProps) {
   const maxCount = Math.max(
     ...ratingValues.map((v) => distribution[String(v)] || 0),
     1,
@@ -47,34 +55,55 @@ export function RatingBars({
     return styles.barFillNeutral;
   };
 
+  const isFiltering = typeof activeRatingValue === "number";
+
   return (
     <VStack gap="space-4" marginBlock="space-12 space-0">
-      {ratingValues.map((rating) => {
-        const count = distribution[String(rating)] || 0;
-        const fillClass = getFillClass(rating);
+      <VStack gap="space-2">
+        {ratingValues.map((rating) => {
+          const count = distribution[String(rating)] || 0;
+          const fillClass = getFillClass(rating);
+          const isActive = activeRatingValue === rating;
+          const isDimmed = isFiltering && !isActive;
 
-        return (
-          <HStack
-            key={rating}
-            gap="space-8"
-            align="center"
-            className={styles.barRow}
-          >
-            <span className={`${styles.barLabel} ${labelClass}`}>
-              {label(rating)}
-            </span>
+          return (
+            <button
+              key={rating}
+              type="button"
+              onClick={() => onRatingSelect(rating)}
+              className={`${styles.barRowButton} ${
+                isDimmed ? styles.barRowDimmed : ""
+              }`}
+              aria-pressed={isActive}
+            >
+              <HStack gap="space-8" align="center" className={styles.barRow}>
+                <span className={`${styles.barLabel} ${labelClass}`}>
+                  {label(rating)}
+                </span>
 
-            <progress
-              className={`${styles.barTrack} ${fillClass}`}
-              value={count}
-              max={maxCount}
-              aria-hidden="true"
-            />
+                <progress
+                  className={`${styles.barTrack} ${fillClass}`}
+                  value={count}
+                  max={maxCount}
+                  aria-hidden="true"
+                />
 
-            <span className={styles.barCount}>{count}</span>
-          </HStack>
-        );
-      })}
+                <span className={styles.barCount}>{count}</span>
+              </HStack>
+            </button>
+          );
+        })}
+      </VStack>
+
+      {isFiltering && (
+        <button
+          type="button"
+          onClick={onRatingClear}
+          className={styles.resetButton}
+        >
+          Nullstill filter
+        </button>
+      )}
     </VStack>
   );
 }

--- a/apps/lumi-dashboard/app/components/dashboard/sections/FieldStats/FieldCards/Rating/RatingBars.tsx
+++ b/apps/lumi-dashboard/app/components/dashboard/sections/FieldStats/FieldCards/Rating/RatingBars.tsx
@@ -67,11 +67,9 @@ export function RatingBars({
           const isDimmed = isFiltering && !isActive;
 
           return (
-            <Button
+            <button
               key={rating}
               type="button"
-              variant="tertiary"
-              data-color="neutral"
               onClick={() => onRatingSelect(rating)}
               className={`${styles.barRowButton} ${
                 isDimmed ? styles.barRowDimmed : ""
@@ -92,7 +90,7 @@ export function RatingBars({
 
                 <span className={styles.barCount}>{count}</span>
               </HStack>
-            </Button>
+            </button>
           );
         })}
       </VStack>

--- a/apps/lumi-dashboard/app/components/dashboard/sections/FieldStats/FieldCards/Rating/RatingFieldCard.module.css
+++ b/apps/lumi-dashboard/app/components/dashboard/sections/FieldStats/FieldCards/Rating/RatingFieldCard.module.css
@@ -22,6 +22,7 @@
 
 .barRowButton {
   all: unset;
+  display: block;
   width: 100%;
   cursor: pointer;
   border-radius: 4px;

--- a/apps/lumi-dashboard/app/components/dashboard/sections/FieldStats/FieldCards/Rating/RatingFieldCard.module.css
+++ b/apps/lumi-dashboard/app/components/dashboard/sections/FieldStats/FieldCards/Rating/RatingFieldCard.module.css
@@ -17,6 +17,35 @@
 
 .barRow {
   font-size: 0.875rem;
+  width: 100%;
+}
+
+.barRowButton {
+  all: unset;
+  width: 100%;
+  cursor: pointer;
+  border-radius: 4px;
+  transition:
+    opacity 0.2s,
+    background-color 0.2s;
+  /* Add padding to account for focus ring space if needed, or use outline-offset */
+}
+
+.barRowButton:hover {
+  background-color: var(--ax-bg-neutral-soft);
+}
+
+.barRowButton:focus-visible {
+  outline: 2px solid var(--ax-border-focus);
+  outline-offset: 2px;
+}
+
+.barRowDimmed {
+  opacity: 0.35;
+}
+
+.barRowDimmed:hover {
+  opacity: 1;
 }
 
 .barLabel {
@@ -54,62 +83,62 @@
 }
 
 .barFillPositive::-webkit-progress-value {
-  background-color: #22c55e;
+  background-color: var(--ax-bg-success-strong);
   border-radius: 5px;
 }
 
 .barFillGood::-webkit-progress-value {
-  background-color: #84cc16;
+  background-color: var(--ax-bg-success-moderate);
   border-radius: 5px;
 }
 
 .barFillMedium::-webkit-progress-value {
-  background-color: #eab308;
+  background-color: var(--ax-bg-warning-moderate);
   border-radius: 5px;
 }
 
 .barFillWarning::-webkit-progress-value {
-  background-color: #f97316;
+  background-color: var(--ax-bg-warning-strong);
   border-radius: 5px;
 }
 
 .barFillNegative::-webkit-progress-value {
-  background-color: #ef4444;
+  background-color: var(--ax-bg-danger-strong);
   border-radius: 5px;
 }
 
 .barFillNeutral::-webkit-progress-value {
-  background-color: #9ca3af;
+  background-color: var(--ax-bg-neutral-strong);
   border-radius: 5px;
 }
 
 .barFillPositive::-moz-progress-bar {
-  background-color: #22c55e;
+  background-color: var(--ax-bg-success-strong);
   border-radius: 5px;
 }
 
 .barFillGood::-moz-progress-bar {
-  background-color: #84cc16;
+  background-color: var(--ax-bg-success-moderate);
   border-radius: 5px;
 }
 
 .barFillMedium::-moz-progress-bar {
-  background-color: #eab308;
+  background-color: var(--ax-bg-warning-moderate);
   border-radius: 5px;
 }
 
 .barFillWarning::-moz-progress-bar {
-  background-color: #f97316;
+  background-color: var(--ax-bg-warning-strong);
   border-radius: 5px;
 }
 
 .barFillNegative::-moz-progress-bar {
-  background-color: #ef4444;
+  background-color: var(--ax-bg-danger-strong);
   border-radius: 5px;
 }
 
 .barFillNeutral::-moz-progress-bar {
-  background-color: #9ca3af;
+  background-color: var(--ax-bg-neutral-strong);
   border-radius: 5px;
 }
 
@@ -118,4 +147,20 @@
   text-align: right;
   color: var(--ax-text-neutral-subtle);
   font-size: 0.75rem;
+}
+
+.resetButton {
+  padding: 6px 10px;
+  border-radius: 999px;
+  border: 1px dashed var(--ax-border-neutral-subtle);
+  background: transparent;
+  cursor: pointer;
+  color: var(--ax-text-neutral-subtle);
+  font-size: 0.875rem;
+  width: fit-content;
+}
+
+.resetButton:hover {
+  background-color: var(--ax-bg-neutral-soft);
+  color: var(--ax-text-neutral);
 }

--- a/apps/lumi-dashboard/app/components/dashboard/sections/FieldStats/FieldCards/Rating/RatingFieldCard.module.css
+++ b/apps/lumi-dashboard/app/components/dashboard/sections/FieldStats/FieldCards/Rating/RatingFieldCard.module.css
@@ -148,19 +148,3 @@
   color: var(--ax-text-neutral-subtle);
   font-size: 0.75rem;
 }
-
-.resetButton {
-  padding: 6px 10px;
-  border-radius: 999px;
-  border: 1px dashed var(--ax-border-neutral-subtle);
-  background: transparent;
-  cursor: pointer;
-  color: var(--ax-text-neutral-subtle);
-  font-size: 0.875rem;
-  width: fit-content;
-}
-
-.resetButton:hover {
-  background-color: var(--ax-bg-neutral-soft);
-  color: var(--ax-text-neutral);
-}

--- a/apps/lumi-dashboard/app/components/dashboard/sections/FieldStats/FieldCards/Rating/RatingFieldCard.tsx
+++ b/apps/lumi-dashboard/app/components/dashboard/sections/FieldStats/FieldCards/Rating/RatingFieldCard.tsx
@@ -95,6 +95,9 @@ export function RatingFieldCard({ field, totalCount }: FieldCardProps) {
           variant={ratingVariant}
           distribution={distribution}
           ratingValues={ratingValuesForVariant(ratingVariant)}
+          activeRatingValue={undefined}
+          onRatingSelect={() => {}}
+          onRatingClear={() => {}}
         />
       )}
     </DashboardCard>

--- a/apps/lumi-dashboard/app/components/dashboard/sections/FieldStats/FieldCards/Rating/RatingFieldCard.tsx
+++ b/apps/lumi-dashboard/app/components/dashboard/sections/FieldStats/FieldCards/Rating/RatingFieldCard.tsx
@@ -2,7 +2,7 @@ import { StarIcon } from "@navikt/aksel-icons";
 import { HStack } from "@navikt/ds-react";
 
 import { DashboardCard } from "~/components/dashboard";
-import { useSearchParams } from "~/hooks/useSearchParams";
+import { useRatingFilter } from "~/hooks/useRatingFilter";
 import type { FieldStat, RatingStats } from "~/types/api";
 import {
   inferRatingVariantFromDistribution,
@@ -26,7 +26,7 @@ function ratingValuesForVariant(variant: RatingVariant): number[] {
 }
 
 export function RatingFieldCard({ field, totalCount }: FieldCardProps) {
-  const { params, setParams } = useSearchParams();
+  const { activeFilters, toggleRating } = useRatingFilter();
 
   const stats = field.stats as RatingStats;
   const distribution = stats.distribution as unknown as Record<string, number>;
@@ -37,36 +37,24 @@ export function RatingFieldCard({ field, totalCount }: FieldCardProps) {
   );
 
   const fieldTotalResponses = sumDistribution(distribution);
-
-  const activeRatingFieldId = params.ratingFieldId;
-  const activeRatingValue = params.ratingValue;
-  const isFilteringThisField = activeRatingFieldId === field.fieldId;
+  const activeRatingValue = activeFilters[field.fieldId];
   const parsedActiveRatingValue = Number(activeRatingValue);
-  const activeRatingNumericValue =
-    isFilteringThisField && Number.isFinite(parsedActiveRatingValue)
-      ? parsedActiveRatingValue
-      : undefined;
+  const activeRatingNumericValue = Number.isFinite(parsedActiveRatingValue)
+    ? parsedActiveRatingValue
+    : undefined;
 
   const responsePct =
     totalCount > 0 ? Math.round((fieldTotalResponses / totalCount) * 100) : 0;
 
   const onSelectRating = (nextValue: string) => {
-    const isAlreadySelected =
-      isFilteringThisField && activeRatingValue === String(nextValue);
-
-    setParams({
-      ratingFieldId: isAlreadySelected ? undefined : field.fieldId,
-      ratingValue: isAlreadySelected ? undefined : String(nextValue),
-      page: "1",
-    });
+    toggleRating(field.fieldId, String(nextValue));
   };
 
-  const onClearRating = () =>
-    setParams({
-      ratingFieldId: undefined,
-      ratingValue: undefined,
-      page: "1",
-    });
+  const onClearRating = () => {
+    if (activeRatingValue) {
+      toggleRating(field.fieldId, activeRatingValue);
+    }
+  };
 
   const onSelectThumb = (nextValue: "1" | "2") => onSelectRating(nextValue);
   const onClearThumb = () => onClearRating();
@@ -94,7 +82,7 @@ export function RatingFieldCard({ field, totalCount }: FieldCardProps) {
           distribution={distribution}
           fieldTotalResponses={fieldTotalResponses}
           activeRatingValue={activeRatingValue}
-          isFilteringThisField={isFilteringThisField}
+          isFilteringThisField={activeRatingValue !== undefined}
           onSelect={onSelectThumb}
           onClear={onClearThumb}
         />

--- a/apps/lumi-dashboard/app/components/dashboard/sections/FieldStats/FieldCards/Rating/RatingFieldCard.tsx
+++ b/apps/lumi-dashboard/app/components/dashboard/sections/FieldStats/FieldCards/Rating/RatingFieldCard.tsx
@@ -26,7 +26,7 @@ function ratingValuesForVariant(variant: RatingVariant): number[] {
 }
 
 export function RatingFieldCard({ field, totalCount }: FieldCardProps) {
-  const { activeFilters, toggleRating } = useRatingFilter();
+  const { activeFilters, toggleRating, removeRating } = useRatingFilter();
 
   const stats = field.stats as RatingStats;
   const distribution = stats.distribution as unknown as Record<string, number>;
@@ -51,9 +51,7 @@ export function RatingFieldCard({ field, totalCount }: FieldCardProps) {
   };
 
   const onClearRating = () => {
-    if (activeRatingValue) {
-      toggleRating(field.fieldId, activeRatingValue);
-    }
+    removeRating(field.fieldId);
   };
 
   const onSelectThumb = (nextValue: "1" | "2") => onSelectRating(nextValue);

--- a/apps/lumi-dashboard/app/components/dashboard/sections/FieldStats/FieldCards/Rating/RatingFieldCard.tsx
+++ b/apps/lumi-dashboard/app/components/dashboard/sections/FieldStats/FieldCards/Rating/RatingFieldCard.tsx
@@ -41,11 +41,16 @@ export function RatingFieldCard({ field, totalCount }: FieldCardProps) {
   const activeRatingFieldId = params.ratingFieldId;
   const activeRatingValue = params.ratingValue;
   const isFilteringThisField = activeRatingFieldId === field.fieldId;
+  const parsedActiveRatingValue = Number(activeRatingValue);
+  const activeRatingNumericValue =
+    isFilteringThisField && Number.isFinite(parsedActiveRatingValue)
+      ? parsedActiveRatingValue
+      : undefined;
 
   const responsePct =
     totalCount > 0 ? Math.round((fieldTotalResponses / totalCount) * 100) : 0;
 
-  const onSelectThumb = (nextValue: "1" | "2") => {
+  const onSelectRating = (nextValue: string) => {
     const isAlreadySelected =
       isFilteringThisField && activeRatingValue === String(nextValue);
 
@@ -56,12 +61,15 @@ export function RatingFieldCard({ field, totalCount }: FieldCardProps) {
     });
   };
 
-  const onClearThumb = () =>
+  const onClearRating = () =>
     setParams({
       ratingFieldId: undefined,
       ratingValue: undefined,
       page: "1",
     });
+
+  const onSelectThumb = (nextValue: "1" | "2") => onSelectRating(nextValue);
+  const onClearThumb = () => onClearRating();
 
   return (
     <DashboardCard padding="space-20">
@@ -95,9 +103,9 @@ export function RatingFieldCard({ field, totalCount }: FieldCardProps) {
           variant={ratingVariant}
           distribution={distribution}
           ratingValues={ratingValuesForVariant(ratingVariant)}
-          activeRatingValue={undefined}
-          onRatingSelect={() => {}}
-          onRatingClear={() => {}}
+          activeRatingValue={activeRatingNumericValue}
+          onRatingSelect={(value) => onSelectRating(String(value))}
+          onRatingClear={onClearRating}
         />
       )}
     </DashboardCard>

--- a/apps/lumi-dashboard/app/components/dashboard/sections/FieldStats/FieldCards/Rating/ThumbsDrilldown.module.css
+++ b/apps/lumi-dashboard/app/components/dashboard/sections/FieldStats/FieldCards/Rating/ThumbsDrilldown.module.css
@@ -24,6 +24,11 @@
   cursor: pointer;
 }
 
+.chip:focus-visible {
+  outline: 2px solid var(--ax-border-focus);
+  outline-offset: 2px;
+}
+
 .chipSelected {
   border: 2px solid var(--ax-border-neutral);
 }
@@ -61,4 +66,9 @@
   cursor: pointer;
   color: var(--ax-text-neutral-subtle);
   font-size: 0.875rem;
+}
+
+.resetButton:focus-visible {
+  outline: 2px solid var(--ax-border-focus);
+  outline-offset: 2px;
 }

--- a/apps/lumi-dashboard/app/components/dashboard/sections/FieldStats/FieldCards/Rating/__tests__/RatingFieldCard.test.tsx
+++ b/apps/lumi-dashboard/app/components/dashboard/sections/FieldStats/FieldCards/Rating/__tests__/RatingFieldCard.test.tsx
@@ -2,25 +2,34 @@ import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-import { useSearchParams } from "~/hooks/useSearchParams";
+import { useRatingFilter } from "~/hooks/useRatingFilter";
 import type { FieldStat } from "~/types/api";
 import { RatingFieldCard } from "../RatingFieldCard";
 
-vi.mock("~/hooks/useSearchParams", () => ({
-  useSearchParams: vi.fn(),
+vi.mock("~/hooks/useRatingFilter", () => ({
+  useRatingFilter: vi.fn(),
 }));
 
-const mockUseSearchParams = vi.mocked(useSearchParams);
+const mockUseRatingFilter = vi.mocked(useRatingFilter);
 
-function givenSearchParams(params: Record<string, string | undefined>) {
-  const setParams = vi.fn();
-  mockUseSearchParams.mockReturnValue({
-    params,
-    setParam: vi.fn(),
-    setParams,
-    resetParams: vi.fn(),
-  } as never);
-  return { setParams };
+function givenRatingFilter(activeFilters: Record<string, string> = {}) {
+  const toggleRating = vi.fn();
+
+  mockUseRatingFilter.mockReturnValue({
+    activeFilters,
+    hasFilters: Object.keys(activeFilters).length > 0,
+    toggleRating,
+    removeRating: vi.fn(),
+    clearRatings: vi.fn(),
+    isActive: vi.fn((fieldId: string, ratingValue?: string) => {
+      if (ratingValue === undefined) {
+        return fieldId in activeFilters;
+      }
+      return activeFilters[fieldId] === ratingValue;
+    }),
+  });
+
+  return { toggleRating };
 }
 
 function makeRatingField(
@@ -51,28 +60,20 @@ beforeEach(() => {
 });
 
 describe("RatingFieldCard", () => {
-  it("sets ratingFieldId/ratingValue/page when selecting a non-thumbs rating bar", async () => {
+  it("toggles the selected rating when clicking a non-thumbs bar", async () => {
     const user = userEvent.setup();
-    const { setParams } = givenSearchParams({});
+    const { toggleRating } = givenRatingFilter();
 
     render(<RatingFieldCard field={makeRatingField()} totalCount={100} />);
 
     const [highestRatingButton] = screen.getAllByRole("button");
     await user.click(highestRatingButton);
 
-    expect(setParams).toHaveBeenCalledWith({
-      ratingFieldId: "rating-1",
-      ratingValue: "5",
-      page: "1",
-    });
+    expect(toggleRating).toHaveBeenCalledWith("rating-1", "5");
   });
 
-  it("clears rating params when re-clicking the selected non-thumbs bar", async () => {
-    const user = userEvent.setup();
-    const { setParams } = givenSearchParams({
-      ratingFieldId: "rating-1",
-      ratingValue: "4",
-    });
+  it("marks the selected non-thumbs bar as active from the rating hook", () => {
+    givenRatingFilter({ "rating-1": "4" });
 
     render(<RatingFieldCard field={makeRatingField()} totalCount={100} />);
 
@@ -81,19 +82,22 @@ describe("RatingFieldCard", () => {
 
     expect(highestRatingButton).toHaveAttribute("aria-pressed", "false");
     expect(secondHighestRatingButton).toHaveAttribute("aria-pressed", "true");
-
-    await user.click(secondHighestRatingButton);
-
-    expect(setParams).toHaveBeenCalledWith({
-      ratingFieldId: undefined,
-      ratingValue: undefined,
-      page: "1",
-    });
   });
 
-  it("passes thumbs interactions through existing drilldown handlers", async () => {
+  it("reuses toggleRating to clear the active rating filter", async () => {
     const user = userEvent.setup();
-    const { setParams } = givenSearchParams({});
+    const { toggleRating } = givenRatingFilter({ "rating-1": "4" });
+
+    render(<RatingFieldCard field={makeRatingField()} totalCount={100} />);
+
+    await user.click(screen.getByRole("button", { name: /Nullstill filter/i }));
+
+    expect(toggleRating).toHaveBeenCalledWith("rating-1", "4");
+  });
+
+  it("passes thumbs interactions through the rating hook", async () => {
+    const user = userEvent.setup();
+    const { toggleRating } = givenRatingFilter();
 
     const thumbsField = makeRatingField(
       { fieldId: "thumbs-1", label: "Var dette nyttig?" },
@@ -104,10 +108,6 @@ describe("RatingFieldCard", () => {
 
     await user.click(screen.getByTestId("thumbs-drilldown-thumbs-1-2"));
 
-    expect(setParams).toHaveBeenCalledWith({
-      ratingFieldId: "thumbs-1",
-      ratingValue: "2",
-      page: "1",
-    });
+    expect(toggleRating).toHaveBeenCalledWith("thumbs-1", "2");
   });
 });

--- a/apps/lumi-dashboard/app/components/dashboard/sections/FieldStats/FieldCards/Rating/__tests__/RatingFieldCard.test.tsx
+++ b/apps/lumi-dashboard/app/components/dashboard/sections/FieldStats/FieldCards/Rating/__tests__/RatingFieldCard.test.tsx
@@ -14,12 +14,13 @@ const mockUseRatingFilter = vi.mocked(useRatingFilter);
 
 function givenRatingFilter(activeFilters: Record<string, string> = {}) {
   const toggleRating = vi.fn();
+  const removeRating = vi.fn();
 
   mockUseRatingFilter.mockReturnValue({
     activeFilters,
     hasFilters: Object.keys(activeFilters).length > 0,
     toggleRating,
-    removeRating: vi.fn(),
+    removeRating,
     clearRatings: vi.fn(),
     isActive: vi.fn((fieldId: string, ratingValue?: string) => {
       if (ratingValue === undefined) {
@@ -29,7 +30,7 @@ function givenRatingFilter(activeFilters: Record<string, string> = {}) {
     }),
   });
 
-  return { toggleRating };
+  return { toggleRating, removeRating };
 }
 
 function makeRatingField(
@@ -84,15 +85,15 @@ describe("RatingFieldCard", () => {
     expect(secondHighestRatingButton).toHaveAttribute("aria-pressed", "true");
   });
 
-  it("reuses toggleRating to clear the active rating filter", async () => {
+  it("uses removeRating to clear the active rating filter", async () => {
     const user = userEvent.setup();
-    const { toggleRating } = givenRatingFilter({ "rating-1": "4" });
+    const { removeRating } = givenRatingFilter({ "rating-1": "4" });
 
     render(<RatingFieldCard field={makeRatingField()} totalCount={100} />);
 
     await user.click(screen.getByRole("button", { name: /Nullstill filter/i }));
 
-    expect(toggleRating).toHaveBeenCalledWith("rating-1", "4");
+    expect(removeRating).toHaveBeenCalledWith("rating-1");
   });
 
   it("passes thumbs interactions through the rating hook", async () => {

--- a/apps/lumi-dashboard/app/components/dashboard/sections/FieldStats/FieldCards/Rating/__tests__/RatingFieldCard.test.tsx
+++ b/apps/lumi-dashboard/app/components/dashboard/sections/FieldStats/FieldCards/Rating/__tests__/RatingFieldCard.test.tsx
@@ -1,0 +1,113 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { useSearchParams } from "~/hooks/useSearchParams";
+import type { FieldStat } from "~/types/api";
+import { RatingFieldCard } from "../RatingFieldCard";
+
+vi.mock("~/hooks/useSearchParams", () => ({
+  useSearchParams: vi.fn(),
+}));
+
+const mockUseSearchParams = vi.mocked(useSearchParams);
+
+function givenSearchParams(params: Record<string, string | undefined>) {
+  const setParams = vi.fn();
+  mockUseSearchParams.mockReturnValue({
+    params,
+    setParam: vi.fn(),
+    setParams,
+    resetParams: vi.fn(),
+  } as never);
+  return { setParams };
+}
+
+function makeRatingField(
+  overrides?: Partial<FieldStat>,
+  distribution: Record<string, number> = {
+    "1": 1,
+    "2": 3,
+    "3": 6,
+    "4": 10,
+    "5": 20,
+  },
+): FieldStat {
+  return {
+    fieldId: "rating-1",
+    fieldType: "RATING",
+    label: "Hvor fornøyd er du?",
+    stats: {
+      type: "rating",
+      average: 4.2,
+      distribution,
+    },
+    ...overrides,
+  };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("RatingFieldCard", () => {
+  it("sets ratingFieldId/ratingValue/page when selecting a non-thumbs rating bar", async () => {
+    const user = userEvent.setup();
+    const { setParams } = givenSearchParams({});
+
+    render(<RatingFieldCard field={makeRatingField()} totalCount={100} />);
+
+    const [highestRatingButton] = screen.getAllByRole("button");
+    await user.click(highestRatingButton);
+
+    expect(setParams).toHaveBeenCalledWith({
+      ratingFieldId: "rating-1",
+      ratingValue: "5",
+      page: "1",
+    });
+  });
+
+  it("clears rating params when re-clicking the selected non-thumbs bar", async () => {
+    const user = userEvent.setup();
+    const { setParams } = givenSearchParams({
+      ratingFieldId: "rating-1",
+      ratingValue: "4",
+    });
+
+    render(<RatingFieldCard field={makeRatingField()} totalCount={100} />);
+
+    const [highestRatingButton, secondHighestRatingButton] =
+      screen.getAllByRole("button");
+
+    expect(highestRatingButton).toHaveAttribute("aria-pressed", "false");
+    expect(secondHighestRatingButton).toHaveAttribute("aria-pressed", "true");
+
+    await user.click(secondHighestRatingButton);
+
+    expect(setParams).toHaveBeenCalledWith({
+      ratingFieldId: undefined,
+      ratingValue: undefined,
+      page: "1",
+    });
+  });
+
+  it("passes thumbs interactions through existing drilldown handlers", async () => {
+    const user = userEvent.setup();
+    const { setParams } = givenSearchParams({});
+
+    const thumbsField = makeRatingField(
+      { fieldId: "thumbs-1", label: "Var dette nyttig?" },
+      { "1": 4, "2": 11 },
+    );
+
+    render(<RatingFieldCard field={thumbsField} totalCount={15} />);
+
+    await user.click(screen.getByTestId("thumbs-drilldown-thumbs-1-2"));
+
+    expect(setParams).toHaveBeenCalledWith({
+      ratingFieldId: "thumbs-1",
+      ratingValue: "2",
+      page: "1",
+    });
+  });
+});

--- a/apps/lumi-dashboard/app/components/dashboard/sections/FieldStats/FieldCards/__tests__/ChoiceFieldCard.test.tsx
+++ b/apps/lumi-dashboard/app/components/dashboard/sections/FieldStats/FieldCards/__tests__/ChoiceFieldCard.test.tsx
@@ -1,5 +1,6 @@
 import { render, screen } from "@testing-library/react";
-import { describe, expect, it } from "vitest";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it, vi } from "vitest";
 
 import type { ChoiceStats } from "~/types/api";
 import { ChoiceFieldCard } from "../ChoiceFieldCard";
@@ -56,5 +57,36 @@ describe("ChoiceFieldCard", () => {
 
     expect(screen.getByText("26 av 26 har svart (100%)")).toBeInTheDocument();
     expect(screen.queryByText("62 valg totalt")).not.toBeInTheDocument();
+  });
+
+  it("calls onChoiceSelect with correct optionId when clicking a choice", async () => {
+    const user = userEvent.setup();
+    const onChoiceSelect = vi.fn();
+
+    render(
+      <ChoiceFieldCard
+        totalCount={10}
+        onChoiceSelect={onChoiceSelect}
+        field={{
+          fieldId: "hindringer",
+          fieldType: "MULTI_CHOICE",
+          label: "Hva er de største hindringene?",
+          stats: {
+            type: "choice",
+            responseCount: 10,
+            responseRate: 1,
+            totalSelections: 14,
+            distribution: {
+              time: { label: "Tid", count: 8, percentage: 80 },
+              rules: { label: "Regelverk", count: 6, percentage: 60 },
+            },
+          },
+        }}
+      />,
+    );
+
+    await user.click(screen.getByRole("button", { name: /Tid/ }));
+
+    expect(onChoiceSelect).toHaveBeenCalledWith("time");
   });
 });

--- a/apps/lumi-dashboard/app/components/dashboard/sections/FieldStats/FieldCards/__tests__/ChoiceFieldCard.test.tsx
+++ b/apps/lumi-dashboard/app/components/dashboard/sections/FieldStats/FieldCards/__tests__/ChoiceFieldCard.test.tsx
@@ -59,7 +59,7 @@ describe("ChoiceFieldCard", () => {
     expect(screen.queryByText("62 valg totalt")).not.toBeInTheDocument();
   });
 
-  it("calls onChoiceSelect with correct optionId when clicking a choice", async () => {
+  it("calls onChoiceSelect with the clicked option id", async () => {
     const user = userEvent.setup();
     const onChoiceSelect = vi.fn();
 
@@ -88,5 +88,38 @@ describe("ChoiceFieldCard", () => {
     await user.click(screen.getByRole("button", { name: /Tid/ }));
 
     expect(onChoiceSelect).toHaveBeenCalledWith("time");
+  });
+
+  it("shows active state from the field-specific filter map", () => {
+    render(
+      <ChoiceFieldCard
+        totalCount={10}
+        activeChoiceFilters={{ hindringer: "time", rolle: "arbeidsgiver" }}
+        field={{
+          fieldId: "hindringer",
+          fieldType: "MULTI_CHOICE",
+          label: "Hva er de største hindringene?",
+          stats: {
+            type: "choice",
+            responseCount: 10,
+            responseRate: 1,
+            totalSelections: 14,
+            distribution: {
+              time: { label: "Tid", count: 8, percentage: 80 },
+              rules: { label: "Regelverk", count: 6, percentage: 60 },
+            },
+          },
+        }}
+      />,
+    );
+
+    expect(screen.getByRole("button", { name: /Tid/ })).toHaveAttribute(
+      "aria-pressed",
+      "true",
+    );
+    expect(screen.getByRole("button", { name: /Regelverk/ })).toHaveAttribute(
+      "aria-pressed",
+      "false",
+    );
   });
 });

--- a/apps/lumi-dashboard/app/components/dashboard/sections/FieldStats/index.tsx
+++ b/apps/lumi-dashboard/app/components/dashboard/sections/FieldStats/index.tsx
@@ -7,8 +7,10 @@ import { Skeleton } from "./Skeleton";
 
 export function FieldStatsSection() {
   const { data: stats, isPending } = useStats();
-  const { params } = useSearchParams();
+  const { params, setParams } = useSearchParams();
   const hasSurveyFilter = !!params.surveyId;
+  const activeChoiceFieldId = params.choiceFieldId;
+  const activeChoiceValue = params.choiceValue;
 
   if (isPending && hasSurveyFilter) {
     return <Skeleton />;
@@ -51,14 +53,43 @@ export function FieldStatsSection() {
                 />
               );
             case "SINGLE_CHOICE":
-            case "MULTI_CHOICE":
+            case "MULTI_CHOICE": {
+              const isFilteringThisField =
+                activeChoiceFieldId === field.fieldId;
+              const activeValueForField = isFilteringThisField
+                ? activeChoiceValue
+                : undefined;
+
+              const onChoiceSelect = (optionId: string) => {
+                const isAlreadySelected =
+                  isFilteringThisField && activeChoiceValue === optionId;
+
+                setParams({
+                  choiceFieldId: isAlreadySelected ? undefined : field.fieldId,
+                  choiceValue: isAlreadySelected ? undefined : optionId,
+                  page: "1",
+                });
+              };
+
+              const onChoiceClear = () => {
+                setParams({
+                  choiceFieldId: undefined,
+                  choiceValue: undefined,
+                  page: "1",
+                });
+              };
+
               return (
                 <ChoiceFieldCard
                   key={field.fieldId}
                   field={field}
                   totalCount={stats.totalCount}
+                  activeChoiceValue={activeValueForField}
+                  onChoiceSelect={onChoiceSelect}
+                  onChoiceClear={onChoiceClear}
                 />
               );
+            }
             default:
               return null;
           }

--- a/apps/lumi-dashboard/app/components/dashboard/sections/FieldStats/index.tsx
+++ b/apps/lumi-dashboard/app/components/dashboard/sections/FieldStats/index.tsx
@@ -1,5 +1,6 @@
 import { Heading, VStack } from "@navikt/ds-react";
 import { DashboardGrid } from "~/components/dashboard";
+import { useChoiceFilter } from "~/hooks/useChoiceFilter";
 import { useSearchParams } from "~/hooks/useSearchParams";
 import { useStats } from "~/hooks/useStats";
 import { ChoiceFieldCard, RatingFieldCard, TextFieldCard } from "./FieldCards";
@@ -7,10 +8,10 @@ import { Skeleton } from "./Skeleton";
 
 export function FieldStatsSection() {
   const { data: stats, isPending } = useStats();
-  const { params, setParams } = useSearchParams();
+  const { params } = useSearchParams();
+  const { activeFilters: activeChoiceFilters, toggleChoice } =
+    useChoiceFilter();
   const hasSurveyFilter = !!params.surveyId;
-  const activeChoiceFieldId = params.choiceFieldId;
-  const activeChoiceValue = params.choiceValue;
 
   if (isPending && hasSurveyFilter) {
     return <Skeleton />;
@@ -53,43 +54,24 @@ export function FieldStatsSection() {
                 />
               );
             case "SINGLE_CHOICE":
-            case "MULTI_CHOICE": {
-              const isFilteringThisField =
-                activeChoiceFieldId === field.fieldId;
-              const activeValueForField = isFilteringThisField
-                ? activeChoiceValue
-                : undefined;
-
-              const onChoiceSelect = (optionId: string) => {
-                const isAlreadySelected =
-                  isFilteringThisField && activeChoiceValue === optionId;
-
-                setParams({
-                  choiceFieldId: isAlreadySelected ? undefined : field.fieldId,
-                  choiceValue: isAlreadySelected ? undefined : optionId,
-                  page: "1",
-                });
-              };
-
-              const onChoiceClear = () => {
-                setParams({
-                  choiceFieldId: undefined,
-                  choiceValue: undefined,
-                  page: "1",
-                });
-              };
-
+            case "MULTI_CHOICE":
               return (
                 <ChoiceFieldCard
                   key={field.fieldId}
                   field={field}
                   totalCount={stats.totalCount}
-                  activeChoiceValue={activeValueForField}
-                  onChoiceSelect={onChoiceSelect}
-                  onChoiceClear={onChoiceClear}
+                  activeChoiceFilters={activeChoiceFilters}
+                  onChoiceSelect={(optionId) =>
+                    toggleChoice(field.fieldId, optionId)
+                  }
+                  onChoiceClear={() => {
+                    const activeOptionId = activeChoiceFilters[field.fieldId];
+                    if (activeOptionId) {
+                      toggleChoice(field.fieldId, activeOptionId);
+                    }
+                  }}
                 />
               );
-            }
             default:
               return null;
           }

--- a/apps/lumi-dashboard/app/components/dashboard/sections/FieldStats/index.tsx
+++ b/apps/lumi-dashboard/app/components/dashboard/sections/FieldStats/index.tsx
@@ -9,8 +9,11 @@ import { Skeleton } from "./Skeleton";
 export function FieldStatsSection() {
   const { data: stats, isPending } = useStats();
   const { params } = useSearchParams();
-  const { activeFilters: activeChoiceFilters, toggleChoice } =
-    useChoiceFilter();
+  const {
+    activeFilters: activeChoiceFilters,
+    toggleChoice,
+    removeChoice,
+  } = useChoiceFilter();
   const hasSurveyFilter = !!params.surveyId;
 
   if (isPending && hasSurveyFilter) {
@@ -64,12 +67,7 @@ export function FieldStatsSection() {
                   onChoiceSelect={(optionId) =>
                     toggleChoice(field.fieldId, optionId)
                   }
-                  onChoiceClear={() => {
-                    const activeOptionId = activeChoiceFilters[field.fieldId];
-                    if (activeOptionId) {
-                      toggleChoice(field.fieldId, activeOptionId);
-                    }
-                  }}
+                  onChoiceClear={() => removeChoice(field.fieldId)}
                 />
               );
             default:

--- a/apps/lumi-dashboard/app/components/export/ActiveFilters.tsx
+++ b/apps/lumi-dashboard/app/components/export/ActiveFilters.tsx
@@ -14,16 +14,13 @@ interface ActiveFiltersProps {
   params: SearchParams;
 }
 
-/**
- * Displays active filter parameters in a readable format.
- */
 export function ActiveFilters({ params }: ActiveFiltersProps) {
   const segments = parseSegmentParam(params.segment);
   const segmentEntries = Object.entries(segments);
   const { data: stats } = useStats();
   const { themes } = useThemes();
 
-  const { ratingLabel, ratingValueLabel, themeLabel } = getFilterLabels({
+  const { choiceFilters, ratingFilters, themeLabel } = getFilterLabels({
     params,
     stats,
     themes,
@@ -93,11 +90,16 @@ export function ActiveFilters({ params }: ActiveFiltersProps) {
           <strong>Oppgave:</strong> {params.task}
         </BodyShort>
       )}
-      {ratingLabel && ratingValueLabel && (
-        <BodyShort size="small" spacing>
-          <strong>{ratingLabel}:</strong> {ratingValueLabel}
+      {ratingFilters.map((filter) => (
+        <BodyShort key={filter.key} size="small" spacing>
+          <strong>{filter.label}:</strong> {filter.value}
         </BodyShort>
-      )}
+      ))}
+      {choiceFilters.map((filter) => (
+        <BodyShort key={filter.key} size="small" spacing>
+          <strong>{filter.label}:</strong> {filter.value}
+        </BodyShort>
+      ))}
 
       {segmentEntries.length > 0 && (
         <VStack gap="space-4">

--- a/apps/lumi-dashboard/app/components/export/Panel.tsx
+++ b/apps/lumi-dashboard/app/components/export/Panel.tsx
@@ -58,6 +58,8 @@ export function ExportPanel() {
           segment: params.segment,
           ratingFieldId: params.ratingFieldId,
           ratingValue: params.ratingValue,
+          choiceFieldId: params.choiceFieldId,
+          choiceValue: params.choiceValue,
         },
       });
 

--- a/apps/lumi-dashboard/app/components/export/Panel.tsx
+++ b/apps/lumi-dashboard/app/components/export/Panel.tsx
@@ -19,14 +19,12 @@ import { DashboardCard, DashboardGrid } from "~/components/dashboard";
 import { ActiveFilters } from "~/components/export/ActiveFilters";
 import { useSearchParams } from "~/hooks/useSearchParams";
 import { exportServerFn } from "~/server/actions";
+import { splitChoiceParam } from "~/utils/choiceFilterUtils";
+import { splitRatingParam } from "~/utils/ratingFilterUtils";
 import styles from "./Panel.module.css";
 
 type ExportFormat = "csv" | "json" | "excel";
 
-/**
- * Panel for exporting feedback data in various formats.
- * Uses server function for authenticated backend access.
- */
 export function ExportPanel() {
   const { params } = useSearchParams();
   const [format, setFormat] = useState<ExportFormat>("csv");
@@ -56,14 +54,11 @@ export function ExportPanel() {
           task: params.task,
           tag: params.tag,
           segment: params.segment,
-          ratingFieldId: params.ratingFieldId,
-          ratingValue: params.ratingValue,
-          choiceFieldId: params.choiceFieldId,
-          choiceValue: params.choiceValue,
+          choice: splitChoiceParam(params.choice),
+          rating: splitRatingParam(params.rating),
         },
       });
 
-      // Convert base64 back to blob and download
       const binaryString = atob(result.data);
       const bytes = new Uint8Array(binaryString.length);
       for (let i = 0; i < binaryString.length; i++) {

--- a/apps/lumi-dashboard/app/components/feedback/FeedbackTable/AnswerRenderer.tsx
+++ b/apps/lumi-dashboard/app/components/feedback/FeedbackTable/AnswerRenderer.tsx
@@ -281,17 +281,23 @@ export function RenderAnswer({
                 if (isSelected) {
                   return (
                     <Tooltip key={opt.id} content="Klikk for å filtrere">
-                      <Tag
-                        variant="neutral"
-                        size="small"
-                        className={styles.clickableTag}
+                      <button
+                        type="button"
+                        className={styles.clickableTagButton}
                         onClick={(e) => {
                           e.stopPropagation();
                           onChoiceFilter?.(answer.fieldId, opt.id);
                         }}
+                        aria-label={`Filtrer på ${opt.label}`}
                       >
-                        {opt.label}
-                      </Tag>
+                        <Tag
+                          variant="neutral"
+                          size="small"
+                          className={styles.clickableTag}
+                        >
+                          {opt.label}
+                        </Tag>
+                      </button>
                     </Tooltip>
                   );
                 }

--- a/apps/lumi-dashboard/app/components/feedback/FeedbackTable/AnswerRenderer.tsx
+++ b/apps/lumi-dashboard/app/components/feedback/FeedbackTable/AnswerRenderer.tsx
@@ -11,6 +11,7 @@ import {
   Detail,
   HStack,
   Label,
+  Tag,
   Tooltip,
   VStack,
 } from "@navikt/ds-react";
@@ -60,9 +61,11 @@ function AnswerCardLayout({
 export function RenderAnswer({
   answer,
   styles,
+  onChoiceFilter,
 }: {
   answer: Answer;
   styles: Record<string, string>;
+  onChoiceFilter?: (fieldId: string, optionId: string) => void;
 }) {
   switch (answer.fieldType) {
     case "RATING": {
@@ -272,15 +275,33 @@ export function RenderAnswer({
         >
           {options.length > 0 ? (
             <div className={styles.choiceOptions}>
-              {options.map((opt) => (
-                <span
-                  key={opt.id}
-                  className={`${styles.choiceOption} ${selectedIds.includes(opt.id) ? styles.choiceOptionSelected : ""}`}
-                >
-                  {selectedIds.includes(opt.id) ? "✓ " : ""}
-                  {opt.label}
-                </span>
-              ))}
+              {options.map((opt) => {
+                const isSelected = selectedIds.includes(opt.id);
+
+                if (isSelected) {
+                  return (
+                    <Tooltip key={opt.id} content="Klikk for å filtrere">
+                      <Tag
+                        variant="neutral"
+                        size="small"
+                        className={styles.clickableTag}
+                        onClick={(e) => {
+                          e.stopPropagation();
+                          onChoiceFilter?.(answer.fieldId, opt.id);
+                        }}
+                      >
+                        {opt.label}
+                      </Tag>
+                    </Tooltip>
+                  );
+                }
+
+                return (
+                  <span key={opt.id} className={styles.unselectedOption}>
+                    {opt.label}
+                  </span>
+                );
+              })}
             </div>
           ) : (
             <BodyShort>{selectedIds.join(", ") || "Ingen valgt"}</BodyShort>

--- a/apps/lumi-dashboard/app/components/feedback/FeedbackTable/AnswerRenderer.tsx
+++ b/apps/lumi-dashboard/app/components/feedback/FeedbackTable/AnswerRenderer.tsx
@@ -11,7 +11,6 @@ import {
   Detail,
   HStack,
   Label,
-  Tag,
   Tooltip,
   VStack,
 } from "@navikt/ds-react";
@@ -61,11 +60,9 @@ function AnswerCardLayout({
 export function RenderAnswer({
   answer,
   styles,
-  onChoiceFilter,
 }: {
   answer: Answer;
   styles: Record<string, string>;
-  onChoiceFilter?: (fieldId: string, optionId: string) => void;
 }) {
   switch (answer.fieldType) {
     case "RATING": {
@@ -273,45 +270,24 @@ export function RenderAnswer({
           label={answer.question.label}
           description={answer.question.description}
         >
-          {options.length > 0 ? (
-            <div className={styles.choiceOptions}>
-              {options.map((opt) => {
-                const isSelected = selectedIds.includes(opt.id);
-
-                if (isSelected) {
-                  return (
-                    <Tooltip key={opt.id} content="Klikk for å filtrere">
-                      <button
-                        type="button"
-                        className={styles.clickableTagButton}
-                        onClick={(e) => {
-                          e.stopPropagation();
-                          onChoiceFilter?.(answer.fieldId, opt.id);
-                        }}
-                        aria-label={`Filtrer på ${opt.label}`}
-                      >
-                        <Tag
-                          variant="neutral"
-                          size="small"
-                          className={styles.clickableTag}
-                        >
-                          {opt.label}
-                        </Tag>
-                      </button>
-                    </Tooltip>
-                  );
-                }
-
-                return (
-                  <span key={opt.id} className={styles.unselectedOption}>
-                    {opt.label}
-                  </span>
-                );
-              })}
-            </div>
-          ) : (
-            <BodyShort>{selectedIds.join(", ") || "Ingen valgt"}</BodyShort>
-          )}
+          <div className={styles.choiceOptions}>
+            {options.map((opt) => {
+              const isSelected = selectedIds.includes(opt.id);
+              return (
+                <span
+                  key={opt.id}
+                  className={
+                    isSelected
+                      ? styles.choiceOptionSelected
+                      : styles.choiceOption
+                  }
+                >
+                  {isSelected && "✓ "}
+                  {opt.label}
+                </span>
+              );
+            })}
+          </div>
         </AnswerCardLayout>
       );
     }

--- a/apps/lumi-dashboard/app/components/feedback/FeedbackTable/AnswerRenderer.tsx
+++ b/apps/lumi-dashboard/app/components/feedback/FeedbackTable/AnswerRenderer.tsx
@@ -56,6 +56,12 @@ function AnswerCardLayout({
   );
 }
 
+function renderChoiceFallback(selectedValues: string[]) {
+  const fallbackText = selectedValues.filter(Boolean).join(", ");
+
+  return <BodyShort>{fallbackText || "Ingen valgt"}</BodyShort>;
+}
+
 // Render a single answer based on its type
 export function RenderAnswer({
   answer,
@@ -252,7 +258,8 @@ export function RenderAnswer({
           : answer.value.type === "multiChoice"
             ? answer.value.selectedOptionIds
             : [];
-      const options = answer.question.options || [];
+      const options = answer.question.options ?? [];
+      const hasOptions = options.length > 0;
 
       return (
         <AnswerCardLayout
@@ -270,24 +277,28 @@ export function RenderAnswer({
           label={answer.question.label}
           description={answer.question.description}
         >
-          <div className={styles.choiceOptions}>
-            {options.map((opt) => {
-              const isSelected = selectedIds.includes(opt.id);
-              return (
-                <span
-                  key={opt.id}
-                  className={
-                    isSelected
-                      ? styles.choiceOptionSelected
-                      : styles.choiceOption
-                  }
-                >
-                  {isSelected && "✓ "}
-                  {opt.label}
-                </span>
-              );
-            })}
-          </div>
+          {hasOptions ? (
+            <div className={styles.choiceOptions}>
+              {options.map((opt) => {
+                const isSelected = selectedIds.includes(opt.id);
+                return (
+                  <span
+                    key={opt.id}
+                    className={
+                      isSelected
+                        ? styles.choiceOptionSelected
+                        : styles.choiceOption
+                    }
+                  >
+                    {isSelected && "✓ "}
+                    {opt.label}
+                  </span>
+                );
+              })}
+            </div>
+          ) : (
+            renderChoiceFallback(selectedIds)
+          )}
         </AnswerCardLayout>
       );
     }

--- a/apps/lumi-dashboard/app/components/feedback/FeedbackTable/FeedbackCard.tsx
+++ b/apps/lumi-dashboard/app/components/feedback/FeedbackTable/FeedbackCard.tsx
@@ -34,7 +34,6 @@ interface FeedbackCardProps {
   isExpanded: boolean;
   onToggleExpand: () => void;
   onDelete: () => void;
-  onChoiceFilter?: (fieldId: string, optionId: string) => void;
   isDeleting: boolean;
 }
 
@@ -48,7 +47,6 @@ export function FeedbackCard({
   isExpanded,
   onToggleExpand,
   onDelete,
-  onChoiceFilter,
   isDeleting,
 }: FeedbackCardProps) {
   const ratings = getAllRatings(feedback);
@@ -135,20 +133,12 @@ export function FeedbackCard({
                 </span>
                 {/* Timeline on larger screens, simple cards on small screens */}
                 {showTimeline ? (
-                  <TimelineView
-                    answers={feedback.answers}
-                    styles={styles}
-                    onChoiceFilter={onChoiceFilter}
-                  />
+                  <TimelineView answers={feedback.answers} styles={styles} />
                 ) : (
                   <VStack gap="space-8">
                     {feedback.answers.map((answer) => (
                       <div key={answer.fieldId} className={styles.answerCard}>
-                        <RenderAnswer
-                          answer={answer}
-                          styles={styles}
-                          onChoiceFilter={onChoiceFilter}
-                        />
+                        <RenderAnswer answer={answer} styles={styles} />
                       </div>
                     ))}
                   </VStack>

--- a/apps/lumi-dashboard/app/components/feedback/FeedbackTable/FeedbackCard.tsx
+++ b/apps/lumi-dashboard/app/components/feedback/FeedbackTable/FeedbackCard.tsx
@@ -34,6 +34,7 @@ interface FeedbackCardProps {
   isExpanded: boolean;
   onToggleExpand: () => void;
   onDelete: () => void;
+  onChoiceFilter?: (fieldId: string, optionId: string) => void;
   isDeleting: boolean;
 }
 
@@ -47,6 +48,7 @@ export function FeedbackCard({
   isExpanded,
   onToggleExpand,
   onDelete,
+  onChoiceFilter,
   isDeleting,
 }: FeedbackCardProps) {
   const ratings = getAllRatings(feedback);
@@ -133,12 +135,20 @@ export function FeedbackCard({
                 </span>
                 {/* Timeline on larger screens, simple cards on small screens */}
                 {showTimeline ? (
-                  <TimelineView answers={feedback.answers} styles={styles} />
+                  <TimelineView
+                    answers={feedback.answers}
+                    styles={styles}
+                    onChoiceFilter={onChoiceFilter}
+                  />
                 ) : (
                   <VStack gap="space-8">
                     {feedback.answers.map((answer) => (
                       <div key={answer.fieldId} className={styles.answerCard}>
-                        <RenderAnswer answer={answer} styles={styles} />
+                        <RenderAnswer
+                          answer={answer}
+                          styles={styles}
+                          onChoiceFilter={onChoiceFilter}
+                        />
                       </div>
                     ))}
                   </VStack>

--- a/apps/lumi-dashboard/app/components/feedback/FeedbackTable/FeedbackExpandedView.tsx
+++ b/apps/lumi-dashboard/app/components/feedback/FeedbackTable/FeedbackExpandedView.tsx
@@ -8,13 +8,17 @@ import { deviceToIcon, formatMetadataKey, formatMetadataValue } from "./utils";
 
 interface FeedbackExpandedViewProps {
   feedback: FeedbackDto;
+  onChoiceFilter?: (fieldId: string, optionId: string) => void;
 }
 
 /**
  * Expanded view shown when a feedback row is clicked.
  * Displays full answers, context, metadata, and tags.
  */
-export function FeedbackExpandedView({ feedback }: FeedbackExpandedViewProps) {
+export function FeedbackExpandedView({
+  feedback,
+  onChoiceFilter,
+}: FeedbackExpandedViewProps) {
   return (
     <Table.Row className={styles.expandedRow}>
       <Table.DataCell colSpan={5} className={styles.expandedCell}>
@@ -22,7 +26,11 @@ export function FeedbackExpandedView({ feedback }: FeedbackExpandedViewProps) {
           <VStack gap="space-20">
             {/* Answers Timeline */}
             <ExpandedSection label={`Svar(${feedback.answers.length})`}>
-              <TimelineView answers={feedback.answers} styles={styles} />
+              <TimelineView
+                answers={feedback.answers}
+                styles={styles}
+                onChoiceFilter={onChoiceFilter}
+              />
             </ExpandedSection>
 
             {/* Tags Editor */}

--- a/apps/lumi-dashboard/app/components/feedback/FeedbackTable/FeedbackExpandedView.tsx
+++ b/apps/lumi-dashboard/app/components/feedback/FeedbackTable/FeedbackExpandedView.tsx
@@ -8,17 +8,13 @@ import { deviceToIcon, formatMetadataKey, formatMetadataValue } from "./utils";
 
 interface FeedbackExpandedViewProps {
   feedback: FeedbackDto;
-  onChoiceFilter?: (fieldId: string, optionId: string) => void;
 }
 
 /**
  * Expanded view shown when a feedback row is clicked.
  * Displays full answers, context, metadata, and tags.
  */
-export function FeedbackExpandedView({
-  feedback,
-  onChoiceFilter,
-}: FeedbackExpandedViewProps) {
+export function FeedbackExpandedView({ feedback }: FeedbackExpandedViewProps) {
   return (
     <Table.Row className={styles.expandedRow}>
       <Table.DataCell colSpan={5} className={styles.expandedCell}>
@@ -26,11 +22,7 @@ export function FeedbackExpandedView({
           <VStack gap="space-20">
             {/* Answers Timeline */}
             <ExpandedSection label={`Svar(${feedback.answers.length})`}>
-              <TimelineView
-                answers={feedback.answers}
-                styles={styles}
-                onChoiceFilter={onChoiceFilter}
-              />
+              <TimelineView answers={feedback.answers} styles={styles} />
             </ExpandedSection>
 
             {/* Tags Editor */}

--- a/apps/lumi-dashboard/app/components/feedback/FeedbackTable/TimelineView.tsx
+++ b/apps/lumi-dashboard/app/components/feedback/FeedbackTable/TimelineView.tsx
@@ -6,9 +6,11 @@ import { RenderAnswer } from "./AnswerRenderer";
 export function TimelineView({
   answers,
   styles,
+  onChoiceFilter,
 }: {
   answers: Answer[];
   styles: Record<string, string>;
+  onChoiceFilter?: (fieldId: string, optionId: string) => void;
 }) {
   const containerRef = useRef<HTMLDivElement>(null);
   const [lines, setLines] = useState<{ top: number; height: number }[]>([]);
@@ -77,7 +79,11 @@ export function TimelineView({
           <div className={`${styles.answerNumber} js-answer-number`}>
             {index + 1}
           </div>
-          <RenderAnswer answer={answer} styles={styles} />
+          <RenderAnswer
+            answer={answer}
+            styles={styles}
+            onChoiceFilter={onChoiceFilter}
+          />
         </div>
       ))}
     </div>

--- a/apps/lumi-dashboard/app/components/feedback/FeedbackTable/TimelineView.tsx
+++ b/apps/lumi-dashboard/app/components/feedback/FeedbackTable/TimelineView.tsx
@@ -6,11 +6,9 @@ import { RenderAnswer } from "./AnswerRenderer";
 export function TimelineView({
   answers,
   styles,
-  onChoiceFilter,
 }: {
   answers: Answer[];
   styles: Record<string, string>;
-  onChoiceFilter?: (fieldId: string, optionId: string) => void;
 }) {
   const containerRef = useRef<HTMLDivElement>(null);
   const [lines, setLines] = useState<{ top: number; height: number }[]>([]);
@@ -79,11 +77,7 @@ export function TimelineView({
           <div className={`${styles.answerNumber} js-answer-number`}>
             {index + 1}
           </div>
-          <RenderAnswer
-            answer={answer}
-            styles={styles}
-            onChoiceFilter={onChoiceFilter}
-          />
+          <RenderAnswer answer={answer} styles={styles} />
         </div>
       ))}
     </div>

--- a/apps/lumi-dashboard/app/components/feedback/FeedbackTable/__tests__/AnswerRenderer.test.tsx
+++ b/apps/lumi-dashboard/app/components/feedback/FeedbackTable/__tests__/AnswerRenderer.test.tsx
@@ -50,4 +50,35 @@ describe("AnswerRenderer", () => {
     expect(screen.getByText("✓ Søknad")).toBeInTheDocument();
     expect(screen.getByText("Oppfølging")).toBeInTheDocument();
   });
+
+  it("renders selected single-choice value as plain text when options are missing", () => {
+    const answer: Answer = {
+      fieldId: "task_choice",
+      fieldType: "SINGLE_CHOICE",
+      question: {
+        label: "Hva skulle du gjøre?",
+      },
+      value: { type: "singleChoice", selectedOptionId: "opt-1" },
+    };
+
+    render(<RenderAnswer answer={answer} styles={styles} />);
+
+    expect(screen.getByText("opt-1")).toBeInTheDocument();
+  });
+
+  it('renders "Ingen valgt" when multi-choice options and values are missing', () => {
+    const answer: Answer = {
+      fieldId: "task_choice",
+      fieldType: "MULTI_CHOICE",
+      question: {
+        label: "Hva valgte du?",
+        options: [],
+      },
+      value: { type: "multiChoice", selectedOptionIds: [] },
+    };
+
+    render(<RenderAnswer answer={answer} styles={styles} />);
+
+    expect(screen.getByText("Ingen valgt")).toBeInTheDocument();
+  });
 });

--- a/apps/lumi-dashboard/app/components/feedback/FeedbackTable/__tests__/AnswerRenderer.test.tsx
+++ b/apps/lumi-dashboard/app/components/feedback/FeedbackTable/__tests__/AnswerRenderer.test.tsx
@@ -1,6 +1,5 @@
 import { render, screen } from "@testing-library/react";
-import userEvent from "@testing-library/user-event";
-import { describe, expect, it, vi } from "vitest";
+import { describe, expect, it } from "vitest";
 
 import type { Answer } from "~/types/api";
 import { RenderAnswer } from "../AnswerRenderer";
@@ -32,10 +31,7 @@ const styles = {
 };
 
 describe("AnswerRenderer", () => {
-  it("calls onChoiceFilter with fieldId and optionId when selected Tag is clicked", async () => {
-    const user = userEvent.setup();
-    const onChoiceFilter = vi.fn();
-
+  it("renders selected choice options as pills with a checkmark", () => {
     const answer: Answer = {
       fieldId: "task_choice",
       fieldType: "SINGLE_CHOICE",
@@ -49,47 +45,9 @@ describe("AnswerRenderer", () => {
       value: { type: "singleChoice", selectedOptionId: "opt-1" },
     };
 
-    render(
-      <RenderAnswer
-        answer={answer}
-        styles={styles}
-        onChoiceFilter={onChoiceFilter}
-      />,
-    );
+    render(<RenderAnswer answer={answer} styles={styles} />);
 
-    await user.click(screen.getByText("Søknad"));
-
-    expect(onChoiceFilter).toHaveBeenCalledWith("task_choice", "opt-1");
-  });
-
-  it("supports keyboard activation on selected choice filter button", async () => {
-    const user = userEvent.setup();
-    const onChoiceFilter = vi.fn();
-
-    const answer: Answer = {
-      fieldId: "task_choice",
-      fieldType: "SINGLE_CHOICE",
-      question: {
-        label: "Hva skulle du gjøre?",
-        options: [{ id: "opt-1", label: "Søknad" }],
-      },
-      value: { type: "singleChoice", selectedOptionId: "opt-1" },
-    };
-
-    render(
-      <RenderAnswer
-        answer={answer}
-        styles={styles}
-        onChoiceFilter={onChoiceFilter}
-      />,
-    );
-
-    const filterButton = screen.getByRole("button", {
-      name: "Filtrer på Søknad",
-    });
-    filterButton.focus();
-    await user.keyboard("{Enter}");
-
-    expect(onChoiceFilter).toHaveBeenCalledWith("task_choice", "opt-1");
+    expect(screen.getByText("✓ Søknad")).toBeInTheDocument();
+    expect(screen.getByText("Oppfølging")).toBeInTheDocument();
   });
 });

--- a/apps/lumi-dashboard/app/components/feedback/FeedbackTable/__tests__/AnswerRenderer.test.tsx
+++ b/apps/lumi-dashboard/app/components/feedback/FeedbackTable/__tests__/AnswerRenderer.test.tsx
@@ -1,0 +1,64 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it, vi } from "vitest";
+
+import type { Answer } from "~/types/api";
+import { RenderAnswer } from "../AnswerRenderer";
+
+const styles = {
+  answerCard: "answerCard",
+  answerIcon: "answerIcon",
+  answerContentGrow: "answerContentGrow",
+  answerContent: "answerContent",
+  clickableTag: "clickableTag",
+  choiceOptions: "choiceOptions",
+  unselectedOption: "unselectedOption",
+  iconWarning: "iconWarning",
+  iconInfo: "iconInfo",
+  iconThumbPositive: "iconThumbPositive",
+  iconThumbNegative: "iconThumbNegative",
+  answerEmpty: "answerEmpty",
+  ratingBadge: "ratingBadge",
+  ratingBadgeThumbPositive: "ratingBadgeThumbPositive",
+  ratingBadgeThumbNegative: "ratingBadgeThumbNegative",
+  ratingBadgePromoter: "ratingBadgePromoter",
+  ratingBadgePassive: "ratingBadgePassive",
+  ratingBadgeDetractor: "ratingBadgeDetractor",
+  starsVisual: "starsVisual",
+  ratingScore: "ratingScore",
+  ratingBar: "ratingBar",
+  ratingDot: "ratingDot",
+  ratingDotFilled: "ratingDotFilled",
+};
+
+describe("AnswerRenderer", () => {
+  it("calls onChoiceFilter with fieldId and optionId when selected Tag is clicked", async () => {
+    const user = userEvent.setup();
+    const onChoiceFilter = vi.fn();
+
+    const answer: Answer = {
+      fieldId: "task_choice",
+      fieldType: "SINGLE_CHOICE",
+      question: {
+        label: "Hva skulle du gjøre?",
+        options: [
+          { id: "opt-1", label: "Søknad" },
+          { id: "opt-2", label: "Oppfølging" },
+        ],
+      },
+      value: { type: "singleChoice", selectedOptionId: "opt-1" },
+    };
+
+    render(
+      <RenderAnswer
+        answer={answer}
+        styles={styles}
+        onChoiceFilter={onChoiceFilter}
+      />,
+    );
+
+    await user.click(screen.getByText("Søknad"));
+
+    expect(onChoiceFilter).toHaveBeenCalledWith("task_choice", "opt-1");
+  });
+});

--- a/apps/lumi-dashboard/app/components/feedback/FeedbackTable/__tests__/AnswerRenderer.test.tsx
+++ b/apps/lumi-dashboard/app/components/feedback/FeedbackTable/__tests__/AnswerRenderer.test.tsx
@@ -61,4 +61,35 @@ describe("AnswerRenderer", () => {
 
     expect(onChoiceFilter).toHaveBeenCalledWith("task_choice", "opt-1");
   });
+
+  it("supports keyboard activation on selected choice filter button", async () => {
+    const user = userEvent.setup();
+    const onChoiceFilter = vi.fn();
+
+    const answer: Answer = {
+      fieldId: "task_choice",
+      fieldType: "SINGLE_CHOICE",
+      question: {
+        label: "Hva skulle du gjøre?",
+        options: [{ id: "opt-1", label: "Søknad" }],
+      },
+      value: { type: "singleChoice", selectedOptionId: "opt-1" },
+    };
+
+    render(
+      <RenderAnswer
+        answer={answer}
+        styles={styles}
+        onChoiceFilter={onChoiceFilter}
+      />,
+    );
+
+    const filterButton = screen.getByRole("button", {
+      name: "Filtrer på Søknad",
+    });
+    filterButton.focus();
+    await user.keyboard("{Enter}");
+
+    expect(onChoiceFilter).toHaveBeenCalledWith("task_choice", "opt-1");
+  });
 });

--- a/apps/lumi-dashboard/app/components/feedback/FeedbackTable/index.tsx
+++ b/apps/lumi-dashboard/app/components/feedback/FeedbackTable/index.tsx
@@ -31,7 +31,7 @@ import styles from "./styles.module.css";
  * Supports expand/collapse for detailed view, deletion, and filtering.
  */
 export function FeedbackTable() {
-  const { params, setParam, setParams } = useSearchParams();
+  const { params, setParam } = useSearchParams();
   const page = Number.parseInt(params.page || "1", 10);
   const { data, error, isPending } = useFeedback();
   const [expandedRows, setExpandedRows] = useState<Set<string>>(new Set());
@@ -67,20 +67,6 @@ export function FeedbackTable() {
   const totalPages = data?.totalPages || 1;
   const totalElements = data?.totalElements || 0;
   const selectedSurvey = params.surveyId;
-  const activeChoiceFieldId = params.choiceFieldId;
-  const activeChoiceValue = params.choiceValue;
-
-  const handleChoiceFilter = (fieldId: string, optionId: string) => {
-    const isAlreadyFiltered =
-      activeChoiceFieldId === fieldId && activeChoiceValue === optionId;
-
-    setParams({
-      choiceFieldId: isAlreadyFiltered ? undefined : fieldId,
-      choiceValue: isAlreadyFiltered ? undefined : optionId,
-      page: "1",
-    });
-  };
-
   return (
     <div className={styles.table}>
       {/* Toolbar with bulk actions when survey is selected */}
@@ -127,10 +113,7 @@ export function FeedbackTable() {
                         }
                       />
                       {expandedRows.has(feedback.id) && (
-                        <FeedbackExpandedView
-                          feedback={feedback}
-                          onChoiceFilter={handleChoiceFilter}
-                        />
+                        <FeedbackExpandedView feedback={feedback} />
                       )}
                     </React.Fragment>
                   ))}
@@ -149,7 +132,6 @@ export function FeedbackTable() {
                   isExpanded={expandedRows.has(feedback.id)}
                   onToggleExpand={() => toggleExpanded(feedback.id)}
                   onDelete={() => setFeedbackToDelete(feedback.id)}
-                  onChoiceFilter={handleChoiceFilter}
                   isDeleting={
                     deleteFeedbackMutation.isPending &&
                     feedbackToDelete === feedback.id

--- a/apps/lumi-dashboard/app/components/feedback/FeedbackTable/index.tsx
+++ b/apps/lumi-dashboard/app/components/feedback/FeedbackTable/index.tsx
@@ -31,7 +31,7 @@ import styles from "./styles.module.css";
  * Supports expand/collapse for detailed view, deletion, and filtering.
  */
 export function FeedbackTable() {
-  const { params, setParam } = useSearchParams();
+  const { params, setParam, setParams } = useSearchParams();
   const page = Number.parseInt(params.page || "1", 10);
   const { data, error, isPending } = useFeedback();
   const [expandedRows, setExpandedRows] = useState<Set<string>>(new Set());
@@ -67,6 +67,19 @@ export function FeedbackTable() {
   const totalPages = data?.totalPages || 1;
   const totalElements = data?.totalElements || 0;
   const selectedSurvey = params.surveyId;
+  const activeChoiceFieldId = params.choiceFieldId;
+  const activeChoiceValue = params.choiceValue;
+
+  const handleChoiceFilter = (fieldId: string, optionId: string) => {
+    const isAlreadyFiltered =
+      activeChoiceFieldId === fieldId && activeChoiceValue === optionId;
+
+    setParams({
+      choiceFieldId: isAlreadyFiltered ? undefined : fieldId,
+      choiceValue: isAlreadyFiltered ? undefined : optionId,
+      page: "1",
+    });
+  };
 
   return (
     <div className={styles.table}>
@@ -114,7 +127,10 @@ export function FeedbackTable() {
                         }
                       />
                       {expandedRows.has(feedback.id) && (
-                        <FeedbackExpandedView feedback={feedback} />
+                        <FeedbackExpandedView
+                          feedback={feedback}
+                          onChoiceFilter={handleChoiceFilter}
+                        />
                       )}
                     </React.Fragment>
                   ))}
@@ -133,6 +149,7 @@ export function FeedbackTable() {
                   isExpanded={expandedRows.has(feedback.id)}
                   onToggleExpand={() => toggleExpanded(feedback.id)}
                   onDelete={() => setFeedbackToDelete(feedback.id)}
+                  onChoiceFilter={handleChoiceFilter}
                   isDeleting={
                     deleteFeedbackMutation.isPending &&
                     feedbackToDelete === feedback.id

--- a/apps/lumi-dashboard/app/components/feedback/FeedbackTable/styles.module.css
+++ b/apps/lumi-dashboard/app/components/feedback/FeedbackTable/styles.module.css
@@ -295,35 +295,23 @@
   align-items: center;
 }
 
-.unselectedOption {
+.choiceOption {
   display: inline-flex;
   align-items: center;
-  padding: 0.25rem 0.5rem;
-  color: var(--ax-text-subtle);
-  font-size: 0.875rem;
+  gap: var(--ax-space-4, 0.25rem);
+  padding: var(--ax-space-4, 0.25rem) var(--ax-space-8, 0.5rem);
+  border-radius: var(--ax-border-radius-medium, 6px);
+  background: var(--ax-bg-neutral-soft, #f5f5f5);
+  border: 1px solid transparent;
+  font-size: var(--ax-font-size-medium, 0.875rem);
+  line-height: 1.5;
 }
 
-.clickableTag {
-  cursor: pointer;
-  transition: transform 0.1s;
-}
-
-.clickableTagButton {
-  border: none;
-  background: transparent;
-  padding: 0;
-  margin: 0;
-  border-radius: 4px;
-  cursor: pointer;
-}
-
-.clickableTagButton:focus-visible {
-  outline: 2px solid var(--ax-border-focus);
-  outline-offset: 2px;
-}
-
-.clickableTag:hover {
-  transform: scale(1.02);
+.choiceOptionSelected {
+  composes: choiceOption;
+  background: var(--ax-bg-accent-soft, #e6f0ff);
+  border-color: var(--ax-border-accent, #99c4ff);
+  font-weight: 500;
 }
 
 /* Rating emoji display */

--- a/apps/lumi-dashboard/app/components/feedback/FeedbackTable/styles.module.css
+++ b/apps/lumi-dashboard/app/components/feedback/FeedbackTable/styles.module.css
@@ -308,6 +308,20 @@
   transition: transform 0.1s;
 }
 
+.clickableTagButton {
+  border: none;
+  background: transparent;
+  padding: 0;
+  margin: 0;
+  border-radius: 4px;
+  cursor: pointer;
+}
+
+.clickableTagButton:focus-visible {
+  outline: 2px solid var(--ax-border-focus);
+  outline-offset: 2px;
+}
+
 .clickableTag:hover {
   transform: scale(1.02);
 }

--- a/apps/lumi-dashboard/app/components/feedback/FeedbackTable/styles.module.css
+++ b/apps/lumi-dashboard/app/components/feedback/FeedbackTable/styles.module.css
@@ -292,24 +292,24 @@
   display: flex;
   flex-wrap: wrap;
   gap: 0.5rem;
+  align-items: center;
 }
 
-.choiceOption {
+.unselectedOption {
   display: inline-flex;
   align-items: center;
-  padding: 0.375rem 0.75rem;
-  background: var(--ax-bg-neutral-soft);
-  border-radius: 6px;
-  font-size: 0.8125rem;
+  padding: 0.25rem 0.5rem;
   color: var(--ax-text-subtle);
-  border: 1px solid transparent;
+  font-size: 0.875rem;
 }
 
-.choiceOptionSelected {
-  background: var(--ax-bg-accent-soft);
-  color: var(--ax-text-accent);
-  border-color: var(--ax-border-accent);
-  font-weight: 500;
+.clickableTag {
+  cursor: pointer;
+  transition: transform 0.1s;
+}
+
+.clickableTag:hover {
+  transform: scale(1.02);
 }
 
 /* Rating emoji display */

--- a/apps/lumi-dashboard/app/components/shared/ActiveFiltersChips/__tests__/ActiveFiltersChips.test.tsx
+++ b/apps/lumi-dashboard/app/components/shared/ActiveFiltersChips/__tests__/ActiveFiltersChips.test.tsx
@@ -1,0 +1,306 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import type { ReactNode } from "react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { useChoiceFilter } from "~/hooks/useChoiceFilter";
+import { useRatingFilter } from "~/hooks/useRatingFilter";
+import type { SearchParams } from "~/hooks/useSearchParams";
+import { useSearchParams } from "~/hooks/useSearchParams";
+import { useSegmentFilter } from "~/hooks/useSegmentFilter";
+import { useStats } from "~/hooks/useStats";
+import { useThemes } from "~/hooks/useThemes";
+import { ActiveFiltersChips } from "..";
+
+vi.mock("~/hooks/useSearchParams", () => ({
+  useSearchParams: vi.fn(),
+}));
+
+vi.mock("~/hooks/useSegmentFilter", () => ({
+  useSegmentFilter: vi.fn(),
+}));
+
+vi.mock("~/hooks/useChoiceFilter", () => ({
+  useChoiceFilter: vi.fn(),
+}));
+
+vi.mock("~/hooks/useRatingFilter", () => ({
+  useRatingFilter: vi.fn(),
+}));
+
+vi.mock("~/hooks/useStats", () => ({
+  useStats: vi.fn(),
+}));
+
+vi.mock("~/hooks/useThemes", () => ({
+  useThemes: vi.fn(),
+}));
+
+vi.mock("@navikt/ds-react", async () => {
+  interface SimpleProps {
+    children?: ReactNode;
+    className?: string;
+  }
+
+  function HStack({ children, className }: SimpleProps) {
+    return <div className={className}>{children}</div>;
+  }
+
+  function Tag({ children, className }: SimpleProps) {
+    return <div className={className}>{children}</div>;
+  }
+
+  return {
+    HStack,
+    Tag,
+  };
+});
+
+const mockUseSearchParams = vi.mocked(useSearchParams);
+const mockUseSegmentFilter = vi.mocked(useSegmentFilter);
+const mockUseChoiceFilter = vi.mocked(useChoiceFilter);
+const mockUseRatingFilter = vi.mocked(useRatingFilter);
+const mockUseStats = vi.mocked(useStats);
+const mockUseThemes = vi.mocked(useThemes);
+
+const removeSegment = vi.fn();
+const removeChoice = vi.fn();
+const removeRating = vi.fn();
+const setParams = vi.fn();
+
+const stats = {
+  fieldStats: [
+    {
+      fieldId: "role",
+      fieldType: "SINGLE_CHOICE",
+      label: "Rolle",
+      stats: {
+        type: "choice",
+        distribution: {
+          Privatperson: { label: "Privatperson", count: 7, percentage: 70 },
+          Arbeidsgiver: { label: "Arbeidsgiver", count: 3, percentage: 30 },
+        },
+      },
+    },
+    {
+      fieldId: "help",
+      fieldType: "RATING",
+      label: "Fikk du hjelp?",
+      stats: {
+        type: "rating",
+        average: 1.8,
+        distribution: { "1": 2, "2": 8 },
+      },
+    },
+  ],
+};
+
+function renderActiveFiltersChips(params: Partial<SearchParams> = {}) {
+  mockUseSearchParams.mockReturnValue({
+    params: params as SearchParams,
+    setParam: vi.fn(),
+    setParams,
+    resetParams: vi.fn(),
+  });
+
+  return render(<ActiveFiltersChips />);
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+
+  mockUseSegmentFilter.mockReturnValue({
+    activeFilters: {},
+    activeSegments: [],
+    hasFilters: false,
+    addSegment: vi.fn(),
+    removeSegment,
+    clearSegments: vi.fn(),
+    isActive: vi.fn(),
+  } as never);
+
+  mockUseChoiceFilter.mockReturnValue({
+    activeFilters: {},
+    hasFilters: false,
+    toggleChoice: vi.fn(),
+    removeChoice,
+    clearChoices: vi.fn(),
+    isActive: vi.fn(),
+  } as never);
+
+  mockUseRatingFilter.mockReturnValue({
+    activeFilters: {},
+    hasFilters: false,
+    toggleRating: vi.fn(),
+    removeRating,
+    clearRatings: vi.fn(),
+    isActive: vi.fn(),
+  } as never);
+
+  mockUseStats.mockReturnValue({
+    data: stats,
+    isPending: false,
+  } as never);
+
+  mockUseThemes.mockReturnValue({
+    themes: [{ id: "theme-1", name: "Navigasjon" }],
+    isLoading: false,
+    error: null,
+    createTheme: vi.fn(),
+    isCreating: false,
+    updateTheme: vi.fn(),
+    isUpdating: false,
+    deleteTheme: vi.fn(),
+    isDeleting: false,
+  } as never);
+});
+
+describe("ActiveFiltersChips", () => {
+  it("renders no chips when there are no active filters", () => {
+    const { container } = renderActiveFiltersChips();
+
+    expect(container.firstChild).toBeNull();
+  });
+
+  it("renders a choice filter chip with the resolved label and value", () => {
+    renderActiveFiltersChips({
+      choice: "role:Arbeidsgiver",
+    });
+
+    expect(screen.getByText("Rolle: Arbeidsgiver")).toBeInTheDocument();
+  });
+
+  it('renders a thumbs rating filter chip with "Ja" as the value', () => {
+    renderActiveFiltersChips({
+      rating: "help:2",
+    });
+
+    expect(screen.getByText("Fikk du hjelp?: Ja")).toBeInTheDocument();
+  });
+
+  it('renders a thumbs rating filter chip with "Nei" as the value', () => {
+    renderActiveFiltersChips({
+      rating: "help:1",
+    });
+
+    expect(screen.getByText("Fikk du hjelp?: Nei")).toBeInTheDocument();
+  });
+
+  it("renders a theme filter chip", () => {
+    renderActiveFiltersChips({
+      theme: "theme-1",
+    });
+
+    expect(screen.getByText("Tema: Navigasjon")).toBeInTheDocument();
+  });
+
+  it("renders a task filter chip", () => {
+    renderActiveFiltersChips({
+      task: "Søknad",
+    });
+
+    expect(screen.getByText("Oppgave: Søknad")).toBeInTheDocument();
+  });
+
+  it("renders a segment filter chip", () => {
+    mockUseSegmentFilter.mockReturnValue({
+      activeFilters: { userType: "Arbeidsgiver" },
+      activeSegments: ["userType:Arbeidsgiver"],
+      hasFilters: true,
+      addSegment: vi.fn(),
+      removeSegment,
+      clearSegments: vi.fn(),
+      isActive: vi.fn(),
+    } as never);
+
+    renderActiveFiltersChips();
+
+    expect(screen.getByText("User Type: Arbeidsgiver")).toBeInTheDocument();
+  });
+
+  it("clicking the remove button removes a choice filter", async () => {
+    const user = userEvent.setup();
+    renderActiveFiltersChips({
+      choice: "role:Arbeidsgiver",
+    });
+
+    await user.click(
+      screen.getByRole("button", {
+        name: "Fjern filter Rolle: Arbeidsgiver",
+      }),
+    );
+
+    expect(removeChoice).toHaveBeenCalledWith("role");
+  });
+
+  it("clicking the remove button removes a rating filter", async () => {
+    const user = userEvent.setup();
+    renderActiveFiltersChips({
+      rating: "help:2",
+    });
+
+    await user.click(
+      screen.getByRole("button", {
+        name: "Fjern filter Fikk du hjelp?: Ja",
+      }),
+    );
+
+    expect(removeRating).toHaveBeenCalledWith("help");
+  });
+
+  it("clicking the remove button removes a theme filter", async () => {
+    const user = userEvent.setup();
+    renderActiveFiltersChips({
+      theme: "theme-1",
+    });
+
+    await user.click(
+      screen.getByRole("button", {
+        name: "Fjern filter Tema: Navigasjon",
+      }),
+    );
+
+    expect(setParams).toHaveBeenCalledWith({
+      theme: undefined,
+      page: "1",
+    });
+  });
+
+  it("uses an accessible aria-label on remove buttons", () => {
+    renderActiveFiltersChips({
+      choice: "role:Arbeidsgiver",
+    });
+
+    expect(
+      screen.getByRole("button", {
+        name: "Fjern filter Rolle: Arbeidsgiver",
+      }),
+    ).toBeInTheDocument();
+  });
+
+  it("renders multiple active filter chips at the same time", () => {
+    mockUseSegmentFilter.mockReturnValue({
+      activeFilters: { userType: "Arbeidsgiver" },
+      activeSegments: ["userType:Arbeidsgiver"],
+      hasFilters: true,
+      addSegment: vi.fn(),
+      removeSegment,
+      clearSegments: vi.fn(),
+      isActive: vi.fn(),
+    } as never);
+
+    renderActiveFiltersChips({
+      task: "Søknad",
+      theme: "theme-1",
+      choice: "role:Arbeidsgiver",
+      rating: "help:2",
+    });
+
+    expect(screen.getByText("Oppgave: Søknad")).toBeInTheDocument();
+    expect(screen.getByText("Tema: Navigasjon")).toBeInTheDocument();
+    expect(screen.getByText("Rolle: Arbeidsgiver")).toBeInTheDocument();
+    expect(screen.getByText("Fikk du hjelp?: Ja")).toBeInTheDocument();
+    expect(screen.getByText("User Type: Arbeidsgiver")).toBeInTheDocument();
+    expect(screen.getAllByRole("button")).toHaveLength(5);
+  });
+});

--- a/apps/lumi-dashboard/app/components/shared/ActiveFiltersChips/index.tsx
+++ b/apps/lumi-dashboard/app/components/shared/ActiveFiltersChips/index.tsx
@@ -5,6 +5,7 @@ import { useRatingFilter } from "~/hooks/useRatingFilter";
 import { useSearchParams } from "~/hooks/useSearchParams";
 import { useSegmentFilter } from "~/hooks/useSegmentFilter";
 import { useStats } from "~/hooks/useStats";
+import { useThemes } from "~/hooks/useThemes";
 import { getFilterLabels } from "~/utils/filterLabels";
 import { formatMetadataLabel } from "~/utils/segmentUtils";
 import styles from "./ActiveFiltersChips.module.css";
@@ -28,9 +29,11 @@ export function ActiveFiltersChips() {
   const { removeChoice } = useChoiceFilter();
   const { removeRating } = useRatingFilter();
   const statsQuery = useStats();
-  const { choiceFilters, ratingFilters } = getFilterLabels({
+  const { themes } = useThemes();
+  const { choiceFilters, ratingFilters, themeLabel } = getFilterLabels({
     params,
     stats: statsQuery.data,
+    themes,
   });
 
   const chips: FilterChip[] = [];
@@ -56,6 +59,19 @@ export function ActiveFiltersChips() {
       onRemove: () =>
         setParams({
           task: undefined,
+          page: "1",
+        }),
+    });
+  }
+
+  if (themeLabel) {
+    chips.push({
+      key: "theme",
+      label: "Tema",
+      value: themeLabel,
+      onRemove: () =>
+        setParams({
+          theme: undefined,
           page: "1",
         }),
     });

--- a/apps/lumi-dashboard/app/components/shared/ActiveFiltersChips/index.tsx
+++ b/apps/lumi-dashboard/app/components/shared/ActiveFiltersChips/index.tsx
@@ -112,8 +112,10 @@ export function ActiveFiltersChips() {
 
     const fieldLabel = field?.label ?? "Valg";
 
-    let valueLabel = params.choiceValue;
-    if (
+    let valueLabel: string;
+    if (statsQuery.isPending) {
+      valueLabel = "…";
+    } else if (
       field &&
       (field.fieldType === "SINGLE_CHOICE" ||
         field.fieldType === "MULTI_CHOICE")
@@ -121,10 +123,10 @@ export function ActiveFiltersChips() {
       const stats = field.stats as unknown as {
         distribution?: Record<string, { label?: string }>;
       };
-      const optionLabel = stats.distribution?.[params.choiceValue]?.label;
-      if (optionLabel) {
-        valueLabel = optionLabel;
-      }
+      valueLabel =
+        stats.distribution?.[params.choiceValue]?.label ?? params.choiceValue;
+    } else {
+      valueLabel = params.choiceValue;
     }
 
     chips.push({

--- a/apps/lumi-dashboard/app/components/shared/ActiveFiltersChips/index.tsx
+++ b/apps/lumi-dashboard/app/components/shared/ActiveFiltersChips/index.tsx
@@ -1,9 +1,11 @@
 import { XMarkIcon } from "@navikt/aksel-icons";
 import { HStack, Tag } from "@navikt/ds-react";
+import { useChoiceFilter } from "~/hooks/useChoiceFilter";
+import { useRatingFilter } from "~/hooks/useRatingFilter";
 import { useSearchParams } from "~/hooks/useSearchParams";
 import { useSegmentFilter } from "~/hooks/useSegmentFilter";
 import { useStats } from "~/hooks/useStats";
-import { inferRatingVariantFromDistribution } from "~/utils/ratingDisplay";
+import { getFilterLabels } from "~/utils/filterLabels";
 import { formatMetadataLabel } from "~/utils/segmentUtils";
 import styles from "./ActiveFiltersChips.module.css";
 
@@ -20,22 +22,19 @@ const DEVICE_LABELS: Record<string, string> = {
   desktop: "Desktop",
 };
 
-/**
- * Displays active drill-down filters as removable chips.
- * Only shows filters that are NOT already visible in FilterBar.
- *
- * - App/Survey/Period: Already shown in FilterBar → no chip
- * - DeviceType: NOT shown on dashboard → show chip
- * - Segment: Metadata filters from SegmentBreakdown → global chip
- */
 export function ActiveFiltersChips() {
   const { params, setParams } = useSearchParams();
-  const { activeFilters, removeSegment } = useSegmentFilter();
+  const { activeFilters: activeSegments, removeSegment } = useSegmentFilter();
+  const { removeChoice } = useChoiceFilter();
+  const { removeRating } = useRatingFilter();
   const statsQuery = useStats();
+  const { choiceFilters, ratingFilters } = getFilterLabels({
+    params,
+    stats: statsQuery.data,
+  });
 
   const chips: FilterChip[] = [];
 
-  // Device type filter - NOT shown in FilterBar on dashboard
   if (params.deviceType && params.deviceType !== "alle") {
     chips.push({
       key: "deviceType",
@@ -49,7 +48,6 @@ export function ActiveFiltersChips() {
     });
   }
 
-  // Task filter (Top Tasks drill-down)
   if (params.task) {
     chips.push({
       key: "task",
@@ -63,91 +61,29 @@ export function ActiveFiltersChips() {
     });
   }
 
-  // Rating field filter (e.g. thumbs donut drill-down)
-  if (params.ratingFieldId && params.ratingValue) {
-    const field = statsQuery.data?.fieldStats?.find(
-      (f) => f.fieldId === params.ratingFieldId,
-    );
-
-    const fieldLabel = field?.label ?? "Vurdering";
-
-    let valueLabel = params.ratingValue;
-    if (field?.fieldType === "RATING") {
-      const stats = field.stats as unknown as {
-        distribution?: Record<string, number>;
-        ratingVariant?: string;
-      };
-      const ratingVariant = inferRatingVariantFromDistribution(
-        stats.distribution ?? {},
-        stats.ratingVariant,
-      );
-      if (ratingVariant === "thumbs") {
-        valueLabel =
-          params.ratingValue === "2"
-            ? "Ja"
-            : params.ratingValue === "1"
-              ? "Nei"
-              : params.ratingValue;
-      }
-    }
-
+  for (const filter of ratingFilters) {
     chips.push({
-      key: `rating-${params.ratingFieldId}-${params.ratingValue}`,
-      label: fieldLabel,
-      value: valueLabel,
-      onRemove: () =>
-        setParams({
-          ratingFieldId: undefined,
-          ratingValue: undefined,
-          page: "1",
-        }),
+      key: filter.key,
+      label: filter.label,
+      value: filter.value,
+      onRemove: () => removeRating(filter.fieldId),
     });
   }
 
-  // Choice field filter (e.g. choice cards drill-down)
-  if (params.choiceFieldId && params.choiceValue) {
-    const field = statsQuery.data?.fieldStats?.find(
-      (f) => f.fieldId === params.choiceFieldId,
-    );
-
-    const fieldLabel = field?.label ?? "Valg";
-
-    let valueLabel: string;
-    if (statsQuery.isPending) {
-      valueLabel = "…";
-    } else if (
-      field &&
-      (field.fieldType === "SINGLE_CHOICE" ||
-        field.fieldType === "MULTI_CHOICE")
-    ) {
-      const stats = field.stats as unknown as {
-        distribution?: Record<string, { label?: string }>;
-      };
-      valueLabel =
-        stats.distribution?.[params.choiceValue]?.label ?? params.choiceValue;
-    } else {
-      valueLabel = params.choiceValue;
-    }
-
+  for (const filter of choiceFilters) {
     chips.push({
-      key: `choice-${params.choiceFieldId}-${params.choiceValue}`,
-      label: fieldLabel,
-      value: valueLabel,
-      onRemove: () =>
-        setParams({
-          choiceFieldId: undefined,
-          choiceValue: undefined,
-          page: "1",
-        }),
+      key: filter.key,
+      label: filter.label,
+      value: filter.value,
+      onRemove: () => removeChoice(filter.fieldId),
     });
   }
 
-  // Segment filters (metadata)
-  for (const [key, value] of Object.entries(activeFilters)) {
+  for (const [key, value] of Object.entries(activeSegments)) {
     chips.push({
       key: `segment-${key}-${value}`,
       label: formatMetadataLabel(key),
-      value: value,
+      value,
       onRemove: () => removeSegment(`${key}:${value}`),
     });
   }
@@ -173,7 +109,7 @@ export function ActiveFiltersChips() {
             type="button"
             onClick={chip.onRemove}
             className={styles.removeButton}
-            aria-label={`Fjern filter ${chip.label}`}
+            aria-label={`Fjern filter ${chip.label}: ${chip.value}`}
           >
             <XMarkIcon fontSize="1rem" className={styles.removeIcon} />
           </button>

--- a/apps/lumi-dashboard/app/components/shared/ActiveFiltersChips/index.tsx
+++ b/apps/lumi-dashboard/app/components/shared/ActiveFiltersChips/index.tsx
@@ -104,6 +104,42 @@ export function ActiveFiltersChips() {
     });
   }
 
+  // Choice field filter (e.g. choice cards drill-down)
+  if (params.choiceFieldId && params.choiceValue) {
+    const field = statsQuery.data?.fieldStats?.find(
+      (f) => f.fieldId === params.choiceFieldId,
+    );
+
+    const fieldLabel = field?.label ?? "Valg";
+
+    let valueLabel = params.choiceValue;
+    if (
+      field &&
+      (field.fieldType === "SINGLE_CHOICE" ||
+        field.fieldType === "MULTI_CHOICE")
+    ) {
+      const stats = field.stats as unknown as {
+        distribution?: Record<string, { label?: string }>;
+      };
+      const optionLabel = stats.distribution?.[params.choiceValue]?.label;
+      if (optionLabel) {
+        valueLabel = optionLabel;
+      }
+    }
+
+    chips.push({
+      key: `choice-${params.choiceFieldId}-${params.choiceValue}`,
+      label: fieldLabel,
+      value: valueLabel,
+      onRemove: () =>
+        setParams({
+          choiceFieldId: undefined,
+          choiceValue: undefined,
+          page: "1",
+        }),
+    });
+  }
+
   // Segment filters (metadata)
   for (const [key, value] of Object.entries(activeFilters)) {
     chips.push({

--- a/apps/lumi-dashboard/app/components/shared/FilterBar/FilterBar.module.css
+++ b/apps/lumi-dashboard/app/components/shared/FilterBar/FilterBar.module.css
@@ -50,7 +50,7 @@
 }
 
 .actionMenuContent {
-  width: min(42rem, calc(100vw - 2rem));
+  width: min(38rem, calc(100vw - 2rem));
   min-width: 320px;
   /* Aksel ActionMenu handles scroll internally — don't add overflow here */
 }

--- a/apps/lumi-dashboard/app/components/shared/FilterBar/FilterBar.module.css
+++ b/apps/lumi-dashboard/app/components/shared/FilterBar/FilterBar.module.css
@@ -62,6 +62,6 @@
   width: 100%;
 }
 
-.selectedFromCharts {
+.menuSection {
   padding-top: var(--ax-space-4);
 }

--- a/apps/lumi-dashboard/app/components/shared/FilterBar/FilterBar.module.css
+++ b/apps/lumi-dashboard/app/components/shared/FilterBar/FilterBar.module.css
@@ -52,8 +52,11 @@
 .actionMenuContent {
   width: min(42rem, calc(100vw - 2rem));
   min-width: 320px;
-  max-height: 70vh;
-  overflow-y: auto;
+  /* Aksel ActionMenu handles scroll internally — don't add overflow here */
+}
+
+.answerFilterLabel {
+  color: var(--ax-text-subtle, var(--a-text-subtle));
 }
 
 .menuDivider {

--- a/apps/lumi-dashboard/app/components/shared/FilterBar/FilterBar.module.css
+++ b/apps/lumi-dashboard/app/components/shared/FilterBar/FilterBar.module.css
@@ -55,18 +55,6 @@
   /* Aksel ActionMenu handles scroll internally — don't add overflow here */
 }
 
-/* Match Aksel ActionMenu group label style for consistency */
-.sectionLabel {
-  color: var(--ax-text-neutral-subtle, var(--a-text-subtle));
-  font-size: var(--ax-font-size-small, 0.875rem);
-  user-select: none;
-}
-
-.fieldLabel {
-  color: var(--ax-text-neutral-subtle, var(--a-text-subtle));
-  font-size: var(--ax-font-size-small, 0.875rem);
-}
-
 .menuDivider {
   height: 1px;
   background-color: var(--ax-border-neutral-subtle);

--- a/apps/lumi-dashboard/app/components/shared/FilterBar/FilterBar.module.css
+++ b/apps/lumi-dashboard/app/components/shared/FilterBar/FilterBar.module.css
@@ -55,16 +55,20 @@
   /* Aksel ActionMenu handles scroll internally — don't add overflow here */
 }
 
-.answerFilterLabel {
-  color: var(--ax-text-subtle, var(--a-text-subtle));
+/* Match Aksel ActionMenu group label style for consistency */
+.sectionLabel {
+  color: var(--ax-text-neutral-subtle, var(--a-text-subtle));
+  font-size: var(--ax-font-size-small, 0.875rem);
+  user-select: none;
+}
+
+.fieldLabel {
+  color: var(--ax-text-neutral-subtle, var(--a-text-subtle));
+  font-size: var(--ax-font-size-small, 0.875rem);
 }
 
 .menuDivider {
   height: 1px;
   background-color: var(--ax-border-neutral-subtle);
   width: 100%;
-}
-
-.menuSection {
-  padding-top: var(--ax-space-4);
 }

--- a/apps/lumi-dashboard/app/components/shared/FilterBar/FilterMenu.tsx
+++ b/apps/lumi-dashboard/app/components/shared/FilterBar/FilterMenu.tsx
@@ -16,12 +16,15 @@ import { useChoiceFilter } from "~/hooks/useChoiceFilter";
 import { useRatingFilter } from "~/hooks/useRatingFilter";
 import type { SearchParams } from "~/hooks/useSearchParams";
 import { useStats } from "~/hooks/useStats";
-import { getFilterLabels } from "~/utils/filterLabels";
+import type { ChoiceStats, FieldStat, RatingStats } from "~/types/api";
+import {
+  inferRatingVariantFromDistribution,
+  type RatingVariant,
+} from "~/utils/ratingDisplay";
 import styles from "./FilterBar.module.css";
 
 interface FilterMenuProps {
   params: SearchParams;
-  setParam: (key: keyof SearchParams, value: string | undefined) => void;
   setParams: (params: Partial<SearchParams>) => void;
   features: SurveyFeatureConfig;
   allTags: string[];
@@ -31,7 +34,6 @@ interface FilterMenuProps {
 
 export function FilterMenu({
   params,
-  setParam,
   setParams,
   features,
   allTags,
@@ -39,9 +41,16 @@ export function FilterMenu({
   themeLabel,
 }: FilterMenuProps) {
   const { data: stats } = useStats();
-  const { removeChoice } = useChoiceFilter();
-  const { removeRating } = useRatingFilter();
-  const { choiceFilters, ratingFilters } = getFilterLabels({ params, stats });
+  const {
+    activeFilters: activeChoiceFilters,
+    toggleChoice,
+    removeChoice,
+  } = useChoiceFilter();
+  const {
+    activeFilters: activeRatingFilters,
+    toggleRating,
+    removeRating,
+  } = useRatingFilter();
 
   const activeCount =
     [
@@ -53,12 +62,19 @@ export function FilterMenu({
       selectedTags.length > 0,
       params.segment,
     ].filter(Boolean).length +
-    ratingFilters.length +
-    choiceFilters.length;
+    Object.keys(activeRatingFilters).length +
+    Object.keys(activeChoiceFilters).length;
 
   const themeValueLabel =
     themeLabel ??
     (params.theme === "uncategorized" ? "Annet" : (params.theme ?? ""));
+
+  const answerFilterFields = stats?.fieldStats?.filter(
+    (field) => isChoiceField(field) || isRatingField(field),
+  );
+  const showAnswerFilters =
+    !!params.surveyId && (answerFilterFields?.length ?? 0) > 0;
+  const hasActiveChartFilters = Boolean(params.task || params.theme);
 
   return (
     <ActionMenu>
@@ -171,68 +187,163 @@ export function FilterMenu({
               {params.surveyId ? (
                 <ContextTagsFilter surveyId={params.surveyId} />
               ) : null}
+
+              {showAnswerFilters ? (
+                <>
+                  <div className={styles.menuDivider} />
+
+                  <VStack gap="space-12" className={styles.menuSection}>
+                    <Label size="small">Svar-filtre</Label>
+
+                    {/* v1: Single-select per field (RadioGroup) — also for MULTI_CHOICE.
+                        Multi-select per field is a future enhancement. */}
+                    {answerFilterFields?.map((field) => {
+                      if (isChoiceField(field)) {
+                        return (
+                          <ActionMenu.RadioGroup
+                            key={field.fieldId}
+                            label={field.label}
+                            value={activeChoiceFilters[field.fieldId] ?? ""}
+                            onValueChange={(value) => {
+                              if (value === "") {
+                                removeChoice(field.fieldId);
+                              } else {
+                                toggleChoice(field.fieldId, value);
+                              }
+                            }}
+                          >
+                            <ActionMenu.RadioItem value="">
+                              Alle
+                            </ActionMenu.RadioItem>
+                            {Object.entries(field.stats.distribution).map(
+                              ([optionId, data]) => (
+                                <ActionMenu.RadioItem
+                                  key={optionId}
+                                  value={optionId}
+                                >
+                                  {`${data.label} (${data.count})`}
+                                </ActionMenu.RadioItem>
+                              ),
+                            )}
+                          </ActionMenu.RadioGroup>
+                        );
+                      }
+
+                      const ratingStats = field.stats as RatingStats & {
+                        ratingVariant?: string;
+                      };
+                      const variant = inferRatingVariantFromDistribution(
+                        field.stats.distribution,
+                        ratingStats.ratingVariant,
+                      );
+
+                      return (
+                        <ActionMenu.RadioGroup
+                          key={field.fieldId}
+                          label={field.label}
+                          value={activeRatingFilters[field.fieldId] ?? ""}
+                          onValueChange={(value) => {
+                            if (value === "") {
+                              removeRating(field.fieldId);
+                            } else {
+                              toggleRating(field.fieldId, value);
+                            }
+                          }}
+                        >
+                          <ActionMenu.RadioItem value="">
+                            Alle
+                          </ActionMenu.RadioItem>
+                          {getRatingValues(variant).map((value) => (
+                            <ActionMenu.RadioItem
+                              key={value}
+                              value={String(value)}
+                            >
+                              {`${formatRatingFilterLabel(value, variant)} (${field.stats.distribution[String(value)] ?? 0})`}
+                            </ActionMenu.RadioItem>
+                          ))}
+                        </ActionMenu.RadioGroup>
+                      );
+                    })}
+                  </VStack>
+                </>
+              ) : null}
+
+              {hasActiveChartFilters ? (
+                <>
+                  <div className={styles.menuDivider} />
+
+                  <VStack gap="space-8" className={styles.menuSection}>
+                    <Label size="small">Aktive grafer-filtre</Label>
+                    <Chips size="small">
+                      {params.theme ? (
+                        <Chips.Removable
+                          variant="neutral"
+                          onDelete={() =>
+                            setParams({
+                              theme: undefined,
+                              page: "1",
+                            })
+                          }
+                        >
+                          {`Tema: ${themeValueLabel}`}
+                        </Chips.Removable>
+                      ) : null}
+
+                      {params.task ? (
+                        <Chips.Removable
+                          variant="neutral"
+                          onDelete={() =>
+                            setParams({
+                              task: undefined,
+                              page: "1",
+                            })
+                          }
+                        >
+                          {`Oppgave: ${params.task}`}
+                        </Chips.Removable>
+                      ) : null}
+                    </Chips>
+                  </VStack>
+                </>
+              ) : null}
             </VStack>
           </HGrid>
-
-          {params.task ||
-          params.theme ||
-          ratingFilters.length > 0 ||
-          choiceFilters.length > 0 ? (
-            <Box paddingBlock="space-16">
-              <div className={styles.menuDivider} />
-
-              <VStack gap="space-8" className={styles.selectedFromCharts}>
-                <Label size="small">Valgt fra grafer</Label>
-                <Chips size="small">
-                  {params.theme ? (
-                    <Chips.Removable
-                      variant="neutral"
-                      onDelete={() => {
-                        setParam("theme", undefined);
-                        setParam("page", "1");
-                      }}
-                    >
-                      {`Tema: ${themeValueLabel}`}
-                    </Chips.Removable>
-                  ) : null}
-
-                  {params.task ? (
-                    <Chips.Removable
-                      variant="neutral"
-                      onDelete={() => {
-                        setParam("task", undefined);
-                        setParam("page", "1");
-                      }}
-                    >
-                      {`Oppgave: ${params.task}`}
-                    </Chips.Removable>
-                  ) : null}
-
-                  {ratingFilters.map((filter) => (
-                    <Chips.Removable
-                      key={filter.key}
-                      variant="neutral"
-                      onDelete={() => removeRating(filter.fieldId)}
-                    >
-                      {`${filter.label}: ${filter.value}`}
-                    </Chips.Removable>
-                  ))}
-
-                  {choiceFilters.map((filter) => (
-                    <Chips.Removable
-                      key={filter.key}
-                      variant="neutral"
-                      onDelete={() => removeChoice(filter.fieldId)}
-                    >
-                      {`${filter.label}: ${filter.value}`}
-                    </Chips.Removable>
-                  ))}
-                </Chips>
-              </VStack>
-            </Box>
-          ) : null}
         </Box>
       </ActionMenu.Content>
     </ActionMenu>
   );
+}
+
+function isChoiceField(field: FieldStat): field is FieldStat & {
+  fieldType: "SINGLE_CHOICE" | "MULTI_CHOICE";
+  stats: ChoiceStats;
+} {
+  return (
+    (field.fieldType === "SINGLE_CHOICE" ||
+      field.fieldType === "MULTI_CHOICE") &&
+    field.stats.type === "choice"
+  );
+}
+
+function isRatingField(
+  field: FieldStat,
+): field is FieldStat & { fieldType: "RATING"; stats: RatingStats } {
+  return field.fieldType === "RATING" && field.stats.type === "rating";
+}
+
+function getRatingValues(variant: RatingVariant): number[] {
+  if (variant === "thumbs") return [2, 1];
+  if (variant === "nps") return [10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0];
+  return [5, 4, 3, 2, 1];
+}
+
+function formatRatingFilterLabel(
+  value: number,
+  variant: RatingVariant,
+): string {
+  if (variant === "thumbs") {
+    return value === 2 ? "Ja" : "Nei";
+  }
+
+  return String(value);
 }

--- a/apps/lumi-dashboard/app/components/shared/FilterBar/FilterMenu.tsx
+++ b/apps/lumi-dashboard/app/components/shared/FilterBar/FilterMenu.tsx
@@ -11,6 +11,7 @@ import {
   Tag,
   VStack,
 } from "@navikt/ds-react";
+import { useRef } from "react";
 import { ContextTagsFilter } from "~/components/dashboard/ContextTagsFilter";
 import type { SurveyFeatureConfig } from "~/config/surveyConfig";
 import { useChoiceFilter } from "~/hooks/useChoiceFilter";
@@ -56,10 +57,19 @@ export function FilterMenu({
   const answerFilterFields = stats?.fieldStats?.filter(
     (field) => isChoiceField(field) || isRatingField(field),
   );
+
+  // Cache the last non-empty answer filter fields so filters survive
+  // the anonymity threshold (fieldStats is emptied when count < 5)
+  const cachedFieldsRef = useRef(answerFilterFields);
+  if (answerFilterFields && answerFilterFields.length > 0) {
+    cachedFieldsRef.current = answerFilterFields;
+  }
+  const visibleFields = cachedFieldsRef.current;
+
   const showAnswerFilters =
-    !!params.surveyId && (answerFilterFields?.length ?? 0) > 0;
+    !!params.surveyId && (visibleFields?.length ?? 0) > 0;
   const hasRatingAnswerFilter =
-    answerFilterFields?.some((f) => isRatingField(f)) ?? false;
+    visibleFields?.some((f) => isRatingField(f)) ?? false;
   const hasActiveChartFilters = Boolean(params.task || params.theme);
 
   const activeCount =
@@ -202,48 +212,54 @@ export function FilterMenu({
             {showAnswerFilters ? (
               <>
                 <div className={styles.menuDivider} />
-                <VStack gap="space-8">
-                  <Label size="small">Svar-filtre</Label>
-                  <HGrid
-                    columns={{
-                      xs: 1,
-                      md: (answerFilterFields?.length ?? 0) > 1 ? 2 : 1,
-                    }}
-                    gap="space-12"
-                  >
-                    {answerFilterFields?.map((field) => {
-                      if (isChoiceField(field)) {
+                <Box
+                  background="neutral-soft"
+                  borderRadius="8"
+                  padding="space-12"
+                >
+                  <VStack gap="space-8">
+                    <Label size="small">Svar-filtre</Label>
+                    <HGrid
+                      columns={{
+                        xs: 1,
+                        md: (visibleFields?.length ?? 0) > 1 ? 2 : 1,
+                      }}
+                      gap="space-12"
+                    >
+                      {visibleFields?.map((field) => {
+                        if (isChoiceField(field)) {
+                          return (
+                            <ChoiceFilterChips
+                              key={field.fieldId}
+                              field={field}
+                              activeValue={
+                                activeChoiceFilters[field.fieldId] ?? null
+                              }
+                              onToggle={(optionId) =>
+                                toggleChoice(field.fieldId, optionId)
+                              }
+                              onClear={() => removeChoice(field.fieldId)}
+                            />
+                          );
+                        }
+
                         return (
-                          <ChoiceFilterChips
+                          <RatingFilterChips
                             key={field.fieldId}
                             field={field}
                             activeValue={
-                              activeChoiceFilters[field.fieldId] ?? null
+                              activeRatingFilters[field.fieldId] ?? null
                             }
-                            onToggle={(optionId) =>
-                              toggleChoice(field.fieldId, optionId)
+                            onToggle={(value) =>
+                              toggleRating(field.fieldId, value)
                             }
-                            onClear={() => removeChoice(field.fieldId)}
+                            onClear={() => removeRating(field.fieldId)}
                           />
                         );
-                      }
-
-                      return (
-                        <RatingFilterChips
-                          key={field.fieldId}
-                          field={field}
-                          activeValue={
-                            activeRatingFilters[field.fieldId] ?? null
-                          }
-                          onToggle={(value) =>
-                            toggleRating(field.fieldId, value)
-                          }
-                          onClear={() => removeRating(field.fieldId)}
-                        />
-                      );
-                    })}
-                  </HGrid>
-                </VStack>
+                      })}
+                    </HGrid>
+                  </VStack>
+                </Box>
               </>
             ) : null}
 
@@ -316,6 +332,7 @@ function ChoiceFilterChips({
         {Object.entries(field.stats.distribution).map(([optionId, data]) => (
           <Chips.Toggle
             key={optionId}
+            data-color="neutral"
             selected={activeValue === optionId}
             onClick={() => {
               if (activeValue === optionId) {
@@ -365,6 +382,7 @@ function RatingFilterChips({
         {getRatingValues(variant).map((value) => (
           <Chips.Toggle
             key={value}
+            data-color="neutral"
             selected={activeValue === String(value)}
             onClick={() => {
               if (activeValue === String(value)) {
@@ -401,8 +419,8 @@ function isRatingField(
 
 function getRatingValues(variant: RatingVariant): number[] {
   if (variant === "thumbs") return [2, 1];
-  if (variant === "nps") return [10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0];
-  return [5, 4, 3, 2, 1];
+  if (variant === "nps") return [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10];
+  return [1, 2, 3, 4, 5];
 }
 
 function formatRatingFilterLabel(

--- a/apps/lumi-dashboard/app/components/shared/FilterBar/FilterMenu.tsx
+++ b/apps/lumi-dashboard/app/components/shared/FilterBar/FilterMenu.tsx
@@ -1,6 +1,7 @@
 import { FunnelIcon } from "@navikt/aksel-icons";
 import {
   ActionMenu,
+  BodyShort,
   Box,
   Button,
   Chips,
@@ -52,13 +53,22 @@ export function FilterMenu({
     removeRating,
   } = useRatingFilter();
 
+  const answerFilterFields = stats?.fieldStats?.filter(
+    (field) => isChoiceField(field) || isRatingField(field),
+  );
+  const showAnswerFilters =
+    !!params.surveyId && (answerFilterFields?.length ?? 0) > 0;
+  const hasRatingAnswerFilter =
+    answerFilterFields?.some((f) => isRatingField(f)) ?? false;
+  const hasActiveChartFilters = Boolean(params.task || params.theme);
+
   const activeCount =
     [
       params.task,
       params.theme,
       params.deviceType && params.deviceType !== "alle",
       params.hasText === "true",
-      params.lowRating === "true",
+      !hasRatingAnswerFilter && params.lowRating === "true",
       selectedTags.length > 0,
       params.segment,
     ].filter(Boolean).length +
@@ -68,13 +78,6 @@ export function FilterMenu({
   const themeValueLabel =
     themeLabel ??
     (params.theme === "uncategorized" ? "Annet" : (params.theme ?? ""));
-
-  const answerFilterFields = stats?.fieldStats?.filter(
-    (field) => isChoiceField(field) || isRatingField(field),
-  );
-  const showAnswerFilters =
-    !!params.surveyId && (answerFilterFields?.length ?? 0) > 0;
-  const hasActiveChartFilters = Boolean(params.task || params.theme);
 
   return (
     <ActionMenu>
@@ -97,220 +100,285 @@ export function FilterMenu({
       </ActionMenu.Trigger>
       <ActionMenu.Content className={styles.actionMenuContent}>
         <Box padding="space-12">
-          <HGrid columns={{ xs: 1, md: 2 }} gap="space-16">
-            <VStack gap="space-12">
-              {features.showDeviceFilter ? (
-                <ActionMenu.RadioGroup
-                  label="Enhet"
-                  value={params.deviceType ?? ""}
-                  onValueChange={(value) =>
-                    setParams({
-                      deviceType: value || undefined,
-                      page: "1",
-                    })
-                  }
-                >
-                  <ActionMenu.RadioItem value="">
-                    Alle enheter
-                  </ActionMenu.RadioItem>
-                  <ActionMenu.RadioItem value="desktop">
-                    Desktop
-                  </ActionMenu.RadioItem>
-                  <ActionMenu.RadioItem value="mobile">
-                    Mobil
-                  </ActionMenu.RadioItem>
-                  <ActionMenu.RadioItem value="tablet">
-                    Nettbrett
-                  </ActionMenu.RadioItem>
-                </ActionMenu.RadioGroup>
-              ) : null}
+          <VStack gap="space-16">
+            {/* General filters: 2-column grid */}
+            <HGrid columns={{ xs: 1, md: 2 }} gap="space-16">
+              <VStack gap="space-12">
+                {features.showDeviceFilter ? (
+                  <ActionMenu.RadioGroup
+                    label="Enhet"
+                    value={params.deviceType ?? ""}
+                    onValueChange={(value) =>
+                      setParams({
+                        deviceType: value || undefined,
+                        page: "1",
+                      })
+                    }
+                  >
+                    <ActionMenu.RadioItem value="">
+                      Alle enheter
+                    </ActionMenu.RadioItem>
+                    <ActionMenu.RadioItem value="desktop">
+                      Desktop
+                    </ActionMenu.RadioItem>
+                    <ActionMenu.RadioItem value="mobile">
+                      Mobil
+                    </ActionMenu.RadioItem>
+                    <ActionMenu.RadioItem value="tablet">
+                      Nettbrett
+                    </ActionMenu.RadioItem>
+                  </ActionMenu.RadioGroup>
+                ) : null}
 
-              {features.showTextFilter || features.showRatingFilter ? (
-                <ActionMenu.Group label="Vis kun">
-                  {features.showTextFilter ? (
-                    <ActionMenu.CheckboxItem
-                      checked={params.hasText === "true"}
-                      onCheckedChange={(checked) =>
-                        setParams({
-                          hasText: checked ? "true" : undefined,
-                          page: "1",
-                        })
-                      }
-                    >
-                      Med tekstsvar
-                    </ActionMenu.CheckboxItem>
-                  ) : null}
+                {features.showTextFilter ||
+                (features.showRatingFilter && !hasRatingAnswerFilter) ? (
+                  <ActionMenu.Group label="Vis kun">
+                    {features.showTextFilter ? (
+                      <ActionMenu.CheckboxItem
+                        checked={params.hasText === "true"}
+                        onCheckedChange={(checked) =>
+                          setParams({
+                            hasText: checked ? "true" : undefined,
+                            page: "1",
+                          })
+                        }
+                      >
+                        Med tekstsvar
+                      </ActionMenu.CheckboxItem>
+                    ) : null}
 
-                  {features.showRatingFilter ? (
-                    <ActionMenu.CheckboxItem
-                      checked={params.lowRating === "true"}
-                      onCheckedChange={(checked) =>
-                        setParams({
-                          lowRating: checked ? "true" : undefined,
-                          page: "1",
-                        })
-                      }
-                    >
-                      Lav score (1-2)
-                    </ActionMenu.CheckboxItem>
-                  ) : null}
-                </ActionMenu.Group>
-              ) : null}
-            </VStack>
+                    {features.showRatingFilter && !hasRatingAnswerFilter ? (
+                      <ActionMenu.CheckboxItem
+                        checked={params.lowRating === "true"}
+                        onCheckedChange={(checked) =>
+                          setParams({
+                            lowRating: checked ? "true" : undefined,
+                            page: "1",
+                          })
+                        }
+                      >
+                        Lav score (1-2)
+                      </ActionMenu.CheckboxItem>
+                    ) : null}
+                  </ActionMenu.Group>
+                ) : null}
+              </VStack>
 
-            <VStack gap="space-12">
-              {features.showTagsFilter && allTags.length > 0 ? (
-                <ActionMenu.Group label="Tags">
-                  {allTags.map((tag) => (
-                    <ActionMenu.CheckboxItem
-                      key={tag}
-                      checked={selectedTags.includes(tag)}
-                      onCheckedChange={(checked) => {
-                        const newTags = checked
-                          ? [...selectedTags, tag]
-                          : selectedTags.filter(
-                              (selectedTag) => selectedTag !== tag,
-                            );
-                        setParams({
-                          tag:
-                            newTags.length > 0 ? newTags.join(",") : undefined,
-                          page: "1",
-                        });
-                      }}
-                    >
-                      {tag}
-                    </ActionMenu.CheckboxItem>
-                  ))}
-                </ActionMenu.Group>
-              ) : null}
+              <VStack gap="space-12">
+                {features.showTagsFilter && allTags.length > 0 ? (
+                  <ActionMenu.Group label="Tags">
+                    {allTags.map((tag) => (
+                      <ActionMenu.CheckboxItem
+                        key={tag}
+                        checked={selectedTags.includes(tag)}
+                        onCheckedChange={(checked) => {
+                          const newTags = checked
+                            ? [...selectedTags, tag]
+                            : selectedTags.filter(
+                                (selectedTag) => selectedTag !== tag,
+                              );
+                          setParams({
+                            tag:
+                              newTags.length > 0
+                                ? newTags.join(",")
+                                : undefined,
+                            page: "1",
+                          });
+                        }}
+                      >
+                        {tag}
+                      </ActionMenu.CheckboxItem>
+                    ))}
+                  </ActionMenu.Group>
+                ) : null}
 
-              {params.surveyId ? (
-                <ContextTagsFilter surveyId={params.surveyId} />
-              ) : null}
+                {params.surveyId ? (
+                  <ContextTagsFilter surveyId={params.surveyId} />
+                ) : null}
+              </VStack>
+            </HGrid>
 
-              {showAnswerFilters ? (
-                <>
-                  <div className={styles.menuDivider} />
-
-                  <VStack gap="space-12" className={styles.menuSection}>
-                    <Label size="small">Svar-filtre</Label>
-
-                    {/* v1: Single-select per field (RadioGroup) — also for MULTI_CHOICE.
-                        Multi-select per field is a future enhancement. */}
+            {/* Answer filters: full-width section with horizontal Chips */}
+            {showAnswerFilters ? (
+              <>
+                <div className={styles.menuDivider} />
+                <VStack gap="space-8">
+                  <Label size="small">Svar-filtre</Label>
+                  <HGrid
+                    columns={{
+                      xs: 1,
+                      md: (answerFilterFields?.length ?? 0) > 1 ? 2 : 1,
+                    }}
+                    gap="space-12"
+                  >
                     {answerFilterFields?.map((field) => {
                       if (isChoiceField(field)) {
                         return (
-                          <ActionMenu.RadioGroup
+                          <ChoiceFilterChips
                             key={field.fieldId}
-                            label={field.label}
-                            value={activeChoiceFilters[field.fieldId] ?? ""}
-                            onValueChange={(value) => {
-                              if (value === "") {
-                                removeChoice(field.fieldId);
-                              } else {
-                                toggleChoice(field.fieldId, value);
-                              }
-                            }}
-                          >
-                            <ActionMenu.RadioItem value="">
-                              Alle
-                            </ActionMenu.RadioItem>
-                            {Object.entries(field.stats.distribution).map(
-                              ([optionId, data]) => (
-                                <ActionMenu.RadioItem
-                                  key={optionId}
-                                  value={optionId}
-                                >
-                                  {`${data.label} (${data.count})`}
-                                </ActionMenu.RadioItem>
-                              ),
-                            )}
-                          </ActionMenu.RadioGroup>
+                            field={field}
+                            activeValue={
+                              activeChoiceFilters[field.fieldId] ?? null
+                            }
+                            onToggle={(optionId) =>
+                              toggleChoice(field.fieldId, optionId)
+                            }
+                            onClear={() => removeChoice(field.fieldId)}
+                          />
                         );
                       }
 
-                      const ratingStats = field.stats as RatingStats & {
-                        ratingVariant?: string;
-                      };
-                      const variant = inferRatingVariantFromDistribution(
-                        field.stats.distribution,
-                        ratingStats.ratingVariant,
-                      );
-
                       return (
-                        <ActionMenu.RadioGroup
+                        <RatingFilterChips
                           key={field.fieldId}
-                          label={field.label}
-                          value={activeRatingFilters[field.fieldId] ?? ""}
-                          onValueChange={(value) => {
-                            if (value === "") {
-                              removeRating(field.fieldId);
-                            } else {
-                              toggleRating(field.fieldId, value);
-                            }
-                          }}
-                        >
-                          <ActionMenu.RadioItem value="">
-                            Alle
-                          </ActionMenu.RadioItem>
-                          {getRatingValues(variant).map((value) => (
-                            <ActionMenu.RadioItem
-                              key={value}
-                              value={String(value)}
-                            >
-                              {`${formatRatingFilterLabel(value, variant)} (${field.stats.distribution[String(value)] ?? 0})`}
-                            </ActionMenu.RadioItem>
-                          ))}
-                        </ActionMenu.RadioGroup>
+                          field={field}
+                          activeValue={
+                            activeRatingFilters[field.fieldId] ?? null
+                          }
+                          onToggle={(value) =>
+                            toggleRating(field.fieldId, value)
+                          }
+                          onClear={() => removeRating(field.fieldId)}
+                        />
                       );
                     })}
-                  </VStack>
-                </>
-              ) : null}
+                  </HGrid>
+                </VStack>
+              </>
+            ) : null}
 
-              {hasActiveChartFilters ? (
-                <>
-                  <div className={styles.menuDivider} />
+            {/* Active chart filters */}
+            {hasActiveChartFilters ? (
+              <>
+                <div className={styles.menuDivider} />
+                <VStack gap="space-8">
+                  <Label size="small">Aktive grafer-filtre</Label>
+                  <Chips size="small">
+                    {params.theme ? (
+                      <Chips.Removable
+                        variant="neutral"
+                        onDelete={() =>
+                          setParams({
+                            theme: undefined,
+                            page: "1",
+                          })
+                        }
+                      >
+                        {`Tema: ${themeValueLabel}`}
+                      </Chips.Removable>
+                    ) : null}
 
-                  <VStack gap="space-8" className={styles.menuSection}>
-                    <Label size="small">Aktive grafer-filtre</Label>
-                    <Chips size="small">
-                      {params.theme ? (
-                        <Chips.Removable
-                          variant="neutral"
-                          onDelete={() =>
-                            setParams({
-                              theme: undefined,
-                              page: "1",
-                            })
-                          }
-                        >
-                          {`Tema: ${themeValueLabel}`}
-                        </Chips.Removable>
-                      ) : null}
-
-                      {params.task ? (
-                        <Chips.Removable
-                          variant="neutral"
-                          onDelete={() =>
-                            setParams({
-                              task: undefined,
-                              page: "1",
-                            })
-                          }
-                        >
-                          {`Oppgave: ${params.task}`}
-                        </Chips.Removable>
-                      ) : null}
-                    </Chips>
-                  </VStack>
-                </>
-              ) : null}
-            </VStack>
-          </HGrid>
+                    {params.task ? (
+                      <Chips.Removable
+                        variant="neutral"
+                        onDelete={() =>
+                          setParams({
+                            task: undefined,
+                            page: "1",
+                          })
+                        }
+                      >
+                        {`Oppgave: ${params.task}`}
+                      </Chips.Removable>
+                    ) : null}
+                  </Chips>
+                </VStack>
+              </>
+            ) : null}
+          </VStack>
         </Box>
       </ActionMenu.Content>
     </ActionMenu>
+  );
+}
+
+function ChoiceFilterChips({
+  field,
+  activeValue,
+  onToggle,
+  onClear,
+}: {
+  field: FieldStat & { stats: ChoiceStats };
+  activeValue: string | null;
+  onToggle: (optionId: string) => void;
+  onClear: () => void;
+}) {
+  return (
+    <VStack gap="space-4">
+      <BodyShort
+        size="small"
+        weight="semibold"
+        className={styles.answerFilterLabel}
+      >
+        {field.label}
+      </BodyShort>
+      <Chips size="small">
+        {Object.entries(field.stats.distribution).map(([optionId, data]) => (
+          <Chips.Toggle
+            key={optionId}
+            selected={activeValue === optionId}
+            onClick={() => {
+              if (activeValue === optionId) {
+                onClear();
+              } else {
+                onToggle(optionId);
+              }
+            }}
+          >
+            {data.label}
+          </Chips.Toggle>
+        ))}
+      </Chips>
+    </VStack>
+  );
+}
+
+function RatingFilterChips({
+  field,
+  activeValue,
+  onToggle,
+  onClear,
+}: {
+  field: FieldStat & { stats: RatingStats };
+  activeValue: string | null;
+  onToggle: (value: string) => void;
+  onClear: () => void;
+}) {
+  const ratingStats = field.stats as RatingStats & {
+    ratingVariant?: string;
+  };
+  const variant = inferRatingVariantFromDistribution(
+    field.stats.distribution,
+    ratingStats.ratingVariant,
+  );
+
+  return (
+    <VStack gap="space-4">
+      <BodyShort
+        size="small"
+        weight="semibold"
+        className={styles.answerFilterLabel}
+      >
+        {field.label}
+      </BodyShort>
+      <Chips size="small">
+        {getRatingValues(variant).map((value) => (
+          <Chips.Toggle
+            key={value}
+            selected={activeValue === String(value)}
+            onClick={() => {
+              if (activeValue === String(value)) {
+                onClear();
+              } else {
+                onToggle(String(value));
+              }
+            }}
+          >
+            {formatRatingFilterLabel(value, variant)}
+          </Chips.Toggle>
+        ))}
+      </Chips>
+    </VStack>
   );
 }
 

--- a/apps/lumi-dashboard/app/components/shared/FilterBar/FilterMenu.tsx
+++ b/apps/lumi-dashboard/app/components/shared/FilterBar/FilterMenu.tsx
@@ -318,9 +318,7 @@ function ChoiceFilterChips({
 }) {
   return (
     <VStack gap="space-4">
-      <BodyShort size="small" weight="semibold">
-        {field.label}
-      </BodyShort>
+      <BodyShort size="small">{field.label}</BodyShort>
       <Chips size="small">
         {Object.entries(field.stats.distribution).map(([optionId, data]) => (
           <Chips.Toggle
@@ -364,9 +362,7 @@ function RatingFilterChips({
 
   return (
     <VStack gap="space-4">
-      <BodyShort size="small" weight="semibold">
-        {field.label}
-      </BodyShort>
+      <BodyShort size="small">{field.label}</BodyShort>
       <Chips size="small">
         {getRatingValues(variant).map((value) => (
           <Chips.Toggle

--- a/apps/lumi-dashboard/app/components/shared/FilterBar/FilterMenu.tsx
+++ b/apps/lumi-dashboard/app/components/shared/FilterBar/FilterMenu.tsx
@@ -209,56 +209,53 @@ export function FilterMenu({
 
             {/* Answer filters: full-width section with horizontal Chips */}
             {showAnswerFilters ? (
-              <>
-                <div className={styles.menuDivider} />
+              <ActionMenu.Group label="Svar-filtre">
                 <Box
                   background="neutral-soft"
                   borderRadius="8"
                   padding="space-12"
                 >
-                  <ActionMenu.Group label="Svar-filtre">
-                    <HGrid
-                      columns={{
-                        xs: 1,
-                        md: (visibleFields?.length ?? 0) > 1 ? 2 : 1,
-                      }}
-                      gap="space-12"
-                    >
-                      {visibleFields?.map((field) => {
-                        if (isChoiceField(field)) {
-                          return (
-                            <ChoiceFilterChips
-                              key={field.fieldId}
-                              field={field}
-                              activeValue={
-                                activeChoiceFilters[field.fieldId] ?? null
-                              }
-                              onToggle={(optionId) =>
-                                toggleChoice(field.fieldId, optionId)
-                              }
-                              onClear={() => removeChoice(field.fieldId)}
-                            />
-                          );
-                        }
-
+                  <HGrid
+                    columns={{
+                      xs: 1,
+                      md: (visibleFields?.length ?? 0) > 1 ? 2 : 1,
+                    }}
+                    gap="space-12"
+                  >
+                    {visibleFields?.map((field) => {
+                      if (isChoiceField(field)) {
                         return (
-                          <RatingFilterChips
+                          <ChoiceFilterChips
                             key={field.fieldId}
                             field={field}
                             activeValue={
-                              activeRatingFilters[field.fieldId] ?? null
+                              activeChoiceFilters[field.fieldId] ?? null
                             }
-                            onToggle={(value) =>
-                              toggleRating(field.fieldId, value)
+                            onToggle={(optionId) =>
+                              toggleChoice(field.fieldId, optionId)
                             }
-                            onClear={() => removeRating(field.fieldId)}
+                            onClear={() => removeChoice(field.fieldId)}
                           />
                         );
-                      })}
-                    </HGrid>
-                  </ActionMenu.Group>
+                      }
+
+                      return (
+                        <RatingFilterChips
+                          key={field.fieldId}
+                          field={field}
+                          activeValue={
+                            activeRatingFilters[field.fieldId] ?? null
+                          }
+                          onToggle={(value) =>
+                            toggleRating(field.fieldId, value)
+                          }
+                          onClear={() => removeRating(field.fieldId)}
+                        />
+                      );
+                    })}
+                  </HGrid>
                 </Box>
-              </>
+              </ActionMenu.Group>
             ) : null}
 
             {/* Active chart filters */}

--- a/apps/lumi-dashboard/app/components/shared/FilterBar/FilterMenu.tsx
+++ b/apps/lumi-dashboard/app/components/shared/FilterBar/FilterMenu.tsx
@@ -60,6 +60,13 @@ export function FilterMenu({
   // Cache the last non-empty answer filter fields so filters survive
   // the anonymity threshold (fieldStats is emptied when count < 5)
   const cachedFieldsRef = useRef(answerFilterFields);
+  const lastSurveyIdRef = useRef(params.surveyId);
+
+  // Reset cache when survey changes to avoid showing stale fields
+  if (params.surveyId !== lastSurveyIdRef.current) {
+    cachedFieldsRef.current = undefined;
+    lastSurveyIdRef.current = params.surveyId;
+  }
   if (answerFilterFields && answerFilterFields.length > 0) {
     cachedFieldsRef.current = answerFilterFields;
   }
@@ -209,7 +216,10 @@ export function FilterMenu({
 
             {/* Answer filters: full-width section with horizontal Chips */}
             {showAnswerFilters ? (
-              <ActionMenu.Group label="Svar-filtre">
+              <VStack gap="space-4">
+                <BodyShort size="small" weight="semibold">
+                  Svar-filtre
+                </BodyShort>
                 <Box
                   background="neutral-soft"
                   borderRadius="8"
@@ -255,7 +265,7 @@ export function FilterMenu({
                     })}
                   </HGrid>
                 </Box>
-              </ActionMenu.Group>
+              </VStack>
             ) : null}
 
             {/* Active chart filters */}

--- a/apps/lumi-dashboard/app/components/shared/FilterBar/FilterMenu.tsx
+++ b/apps/lumi-dashboard/app/components/shared/FilterBar/FilterMenu.tsx
@@ -7,7 +7,6 @@ import {
   Chips,
   HGrid,
   HStack,
-  Label,
   Tag,
   VStack,
 } from "@navikt/ds-react";
@@ -217,8 +216,7 @@ export function FilterMenu({
                   borderRadius="8"
                   padding="space-12"
                 >
-                  <VStack gap="space-8">
-                    <Label size="small">Svar-filtre</Label>
+                  <ActionMenu.Group label="Svar-filtre">
                     <HGrid
                       columns={{
                         xs: 1,
@@ -258,7 +256,7 @@ export function FilterMenu({
                         );
                       })}
                     </HGrid>
-                  </VStack>
+                  </ActionMenu.Group>
                 </Box>
               </>
             ) : null}
@@ -267,8 +265,7 @@ export function FilterMenu({
             {hasActiveChartFilters ? (
               <>
                 <div className={styles.menuDivider} />
-                <VStack gap="space-8">
-                  <Label size="small">Aktive grafer-filtre</Label>
+                <ActionMenu.Group label="Aktive grafer-filtre">
                   <Chips size="small">
                     {params.theme ? (
                       <Chips.Removable
@@ -298,7 +295,7 @@ export function FilterMenu({
                       </Chips.Removable>
                     ) : null}
                   </Chips>
-                </VStack>
+                </ActionMenu.Group>
               </>
             ) : null}
           </VStack>

--- a/apps/lumi-dashboard/app/components/shared/FilterBar/FilterMenu.tsx
+++ b/apps/lumi-dashboard/app/components/shared/FilterBar/FilterMenu.tsx
@@ -1,11 +1,13 @@
 import { FunnelIcon } from "@navikt/aksel-icons";
 import {
   ActionMenu,
+  BodyShort,
   Box,
   Button,
   Chips,
   HGrid,
   HStack,
+  Label,
   Tag,
   VStack,
 } from "@navikt/ds-react";
@@ -216,7 +218,7 @@ export function FilterMenu({
                   padding="space-12"
                 >
                   <VStack gap="space-8">
-                    <span className={styles.sectionLabel}>Svar-filtre</span>
+                    <Label size="small">Svar-filtre</Label>
                     <HGrid
                       columns={{
                         xs: 1,
@@ -266,9 +268,7 @@ export function FilterMenu({
               <>
                 <div className={styles.menuDivider} />
                 <VStack gap="space-8">
-                  <span className={styles.sectionLabel}>
-                    Aktive grafer-filtre
-                  </span>
+                  <Label size="small">Aktive grafer-filtre</Label>
                   <Chips size="small">
                     {params.theme ? (
                       <Chips.Removable
@@ -321,7 +321,9 @@ function ChoiceFilterChips({
 }) {
   return (
     <VStack gap="space-4">
-      <span className={styles.fieldLabel}>{field.label}</span>
+      <BodyShort size="small" weight="semibold">
+        {field.label}
+      </BodyShort>
       <Chips size="small">
         {Object.entries(field.stats.distribution).map(([optionId, data]) => (
           <Chips.Toggle
@@ -365,7 +367,9 @@ function RatingFilterChips({
 
   return (
     <VStack gap="space-4">
-      <span className={styles.fieldLabel}>{field.label}</span>
+      <BodyShort size="small" weight="semibold">
+        {field.label}
+      </BodyShort>
       <Chips size="small">
         {getRatingValues(variant).map((value) => (
           <Chips.Toggle

--- a/apps/lumi-dashboard/app/components/shared/FilterBar/FilterMenu.tsx
+++ b/apps/lumi-dashboard/app/components/shared/FilterBar/FilterMenu.tsx
@@ -12,7 +12,11 @@ import {
 } from "@navikt/ds-react";
 import { ContextTagsFilter } from "~/components/dashboard/ContextTagsFilter";
 import type { SurveyFeatureConfig } from "~/config/surveyConfig";
+import { useChoiceFilter } from "~/hooks/useChoiceFilter";
+import { useRatingFilter } from "~/hooks/useRatingFilter";
 import type { SearchParams } from "~/hooks/useSearchParams";
+import { useStats } from "~/hooks/useStats";
+import { getFilterLabels } from "~/utils/filterLabels";
 import styles from "./FilterBar.module.css";
 
 interface FilterMenuProps {
@@ -22,15 +26,9 @@ interface FilterMenuProps {
   features: SurveyFeatureConfig;
   allTags: string[];
   selectedTags: string[];
-  ratingFilterLabel?: string;
-  ratingFilterValue?: string;
   themeLabel?: string;
 }
 
-/**
- * ActionMenu-based filter with CheckboxItems for toggles.
- * Follows Aksel filter pattern.
- */
 export function FilterMenu({
   params,
   setParam,
@@ -38,21 +36,25 @@ export function FilterMenu({
   features,
   allTags,
   selectedTags,
-  ratingFilterLabel,
-  ratingFilterValue,
   themeLabel,
 }: FilterMenuProps) {
-  // Count active filters to show badge (including segment + tags)
-  const activeCount = [
-    params.task,
-    params.theme,
-    params.deviceType && params.deviceType !== "alle",
-    params.hasText === "true",
-    params.lowRating === "true",
-    selectedTags.length > 0,
-    params.segment, // Count segmentation filter
-    params.ratingFieldId && params.ratingValue,
-  ].filter(Boolean).length;
+  const { data: stats } = useStats();
+  const { removeChoice } = useChoiceFilter();
+  const { removeRating } = useRatingFilter();
+  const { choiceFilters, ratingFilters } = getFilterLabels({ params, stats });
+
+  const activeCount =
+    [
+      params.task,
+      params.theme,
+      params.deviceType && params.deviceType !== "alle",
+      params.hasText === "true",
+      params.lowRating === "true",
+      selectedTags.length > 0,
+      params.segment,
+    ].filter(Boolean).length +
+    ratingFilters.length +
+    choiceFilters.length;
 
   const themeValueLabel =
     themeLabel ??
@@ -69,11 +71,11 @@ export function FilterMenu({
         >
           <HStack gap="space-4" align="center">
             <span>Filter</span>
-            {activeCount > 0 && (
+            {activeCount > 0 ? (
               <Tag data-color="info" size="small" variant="outline">
                 {activeCount}
               </Tag>
-            )}
+            ) : null}
           </HStack>
         </Button>
       </ActionMenu.Trigger>
@@ -81,14 +83,13 @@ export function FilterMenu({
         <Box padding="space-12">
           <HGrid columns={{ xs: 1, md: 2 }} gap="space-16">
             <VStack gap="space-12">
-              {/* Device filter */}
-              {features.showDeviceFilter && (
+              {features.showDeviceFilter ? (
                 <ActionMenu.RadioGroup
                   label="Enhet"
                   value={params.deviceType ?? ""}
                   onValueChange={(value) =>
                     setParams({
-                      deviceType: value ? value : undefined,
+                      deviceType: value || undefined,
                       page: "1",
                     })
                   }
@@ -106,12 +107,11 @@ export function FilterMenu({
                     Nettbrett
                   </ActionMenu.RadioItem>
                 </ActionMenu.RadioGroup>
-              )}
+              ) : null}
 
-              {/* Quick toggles */}
-              {(features.showTextFilter || features.showRatingFilter) && (
+              {features.showTextFilter || features.showRatingFilter ? (
                 <ActionMenu.Group label="Vis kun">
-                  {features.showTextFilter && (
+                  {features.showTextFilter ? (
                     <ActionMenu.CheckboxItem
                       checked={params.hasText === "true"}
                       onCheckedChange={(checked) =>
@@ -123,9 +123,9 @@ export function FilterMenu({
                     >
                       Med tekstsvar
                     </ActionMenu.CheckboxItem>
-                  )}
+                  ) : null}
 
-                  {features.showRatingFilter && (
+                  {features.showRatingFilter ? (
                     <ActionMenu.CheckboxItem
                       checked={params.lowRating === "true"}
                       onCheckedChange={(checked) =>
@@ -137,14 +137,13 @@ export function FilterMenu({
                     >
                       Lav score (1-2)
                     </ActionMenu.CheckboxItem>
-                  )}
+                  ) : null}
                 </ActionMenu.Group>
-              )}
+              ) : null}
             </VStack>
 
             <VStack gap="space-12">
-              {/* Tags */}
-              {features.showTagsFilter && allTags.length > 0 && (
+              {features.showTagsFilter && allTags.length > 0 ? (
                 <ActionMenu.Group label="Tags">
                   {allTags.map((tag) => (
                     <ActionMenu.CheckboxItem
@@ -153,7 +152,9 @@ export function FilterMenu({
                       onCheckedChange={(checked) => {
                         const newTags = checked
                           ? [...selectedTags, tag]
-                          : selectedTags.filter((t) => t !== tag);
+                          : selectedTags.filter(
+                              (selectedTag) => selectedTag !== tag,
+                            );
                         setParams({
                           tag:
                             newTags.length > 0 ? newTags.join(",") : undefined,
@@ -165,25 +166,25 @@ export function FilterMenu({
                     </ActionMenu.CheckboxItem>
                   ))}
                 </ActionMenu.Group>
-              )}
+              ) : null}
 
-              {/* Segmentation */}
-              {params.surveyId && (
+              {params.surveyId ? (
                 <ContextTagsFilter surveyId={params.surveyId} />
-              )}
+              ) : null}
             </VStack>
           </HGrid>
 
-          {(params.task ||
-            params.theme ||
-            (params.ratingFieldId && params.ratingValue)) && (
+          {params.task ||
+          params.theme ||
+          ratingFilters.length > 0 ||
+          choiceFilters.length > 0 ? (
             <Box paddingBlock="space-16">
               <div className={styles.menuDivider} />
 
               <VStack gap="space-8" className={styles.selectedFromCharts}>
                 <Label size="small">Valgt fra grafer</Label>
                 <Chips size="small">
-                  {params.theme && (
+                  {params.theme ? (
                     <Chips.Removable
                       variant="neutral"
                       onDelete={() => {
@@ -193,9 +194,9 @@ export function FilterMenu({
                     >
                       {`Tema: ${themeValueLabel}`}
                     </Chips.Removable>
-                  )}
+                  ) : null}
 
-                  {params.task && (
+                  {params.task ? (
                     <Chips.Removable
                       variant="neutral"
                       onDelete={() => {
@@ -205,26 +206,31 @@ export function FilterMenu({
                     >
                       {`Oppgave: ${params.task}`}
                     </Chips.Removable>
-                  )}
+                  ) : null}
 
-                  {params.ratingFieldId && params.ratingValue && (
+                  {ratingFilters.map((filter) => (
                     <Chips.Removable
+                      key={filter.key}
                       variant="neutral"
-                      onDelete={() => {
-                        setParam("ratingFieldId", undefined);
-                        setParam("ratingValue", undefined);
-                        setParam("page", "1");
-                      }}
+                      onDelete={() => removeRating(filter.fieldId)}
                     >
-                      {`${ratingFilterLabel ?? "Vurdering"}: ${
-                        ratingFilterValue ?? params.ratingValue
-                      }`}
+                      {`${filter.label}: ${filter.value}`}
                     </Chips.Removable>
-                  )}
+                  ))}
+
+                  {choiceFilters.map((filter) => (
+                    <Chips.Removable
+                      key={filter.key}
+                      variant="neutral"
+                      onDelete={() => removeChoice(filter.fieldId)}
+                    >
+                      {`${filter.label}: ${filter.value}`}
+                    </Chips.Removable>
+                  ))}
                 </Chips>
               </VStack>
             </Box>
-          )}
+          ) : null}
         </Box>
       </ActionMenu.Content>
     </ActionMenu>

--- a/apps/lumi-dashboard/app/components/shared/FilterBar/FilterMenu.tsx
+++ b/apps/lumi-dashboard/app/components/shared/FilterBar/FilterMenu.tsx
@@ -1,13 +1,11 @@
 import { FunnelIcon } from "@navikt/aksel-icons";
 import {
   ActionMenu,
-  BodyShort,
   Box,
   Button,
   Chips,
   HGrid,
   HStack,
-  Label,
   Tag,
   VStack,
 } from "@navikt/ds-react";
@@ -218,7 +216,7 @@ export function FilterMenu({
                   padding="space-12"
                 >
                   <VStack gap="space-8">
-                    <Label size="small">Svar-filtre</Label>
+                    <span className={styles.sectionLabel}>Svar-filtre</span>
                     <HGrid
                       columns={{
                         xs: 1,
@@ -268,7 +266,9 @@ export function FilterMenu({
               <>
                 <div className={styles.menuDivider} />
                 <VStack gap="space-8">
-                  <Label size="small">Aktive grafer-filtre</Label>
+                  <span className={styles.sectionLabel}>
+                    Aktive grafer-filtre
+                  </span>
                   <Chips size="small">
                     {params.theme ? (
                       <Chips.Removable
@@ -321,13 +321,7 @@ function ChoiceFilterChips({
 }) {
   return (
     <VStack gap="space-4">
-      <BodyShort
-        size="small"
-        weight="semibold"
-        className={styles.answerFilterLabel}
-      >
-        {field.label}
-      </BodyShort>
+      <span className={styles.fieldLabel}>{field.label}</span>
       <Chips size="small">
         {Object.entries(field.stats.distribution).map(([optionId, data]) => (
           <Chips.Toggle
@@ -371,13 +365,7 @@ function RatingFilterChips({
 
   return (
     <VStack gap="space-4">
-      <BodyShort
-        size="small"
-        weight="semibold"
-        className={styles.answerFilterLabel}
-      >
-        {field.label}
-      </BodyShort>
+      <span className={styles.fieldLabel}>{field.label}</span>
       <Chips size="small">
         {getRatingValues(variant).map((value) => (
           <Chips.Toggle

--- a/apps/lumi-dashboard/app/components/shared/FilterBar/__tests__/FilterMenu.test.tsx
+++ b/apps/lumi-dashboard/app/components/shared/FilterBar/__tests__/FilterMenu.test.tsx
@@ -77,6 +77,14 @@ vi.mock("@navikt/ds-react", async () => {
     return <button type="button">{children}</button>;
   }
 
+  function BodyShort({ children }: SimpleProps) {
+    return <span>{children}</span>;
+  }
+
+  function Label({ children }: SimpleProps) {
+    return <span>{children}</span>;
+  }
+
   function Tag({ children }: SimpleProps) {
     return <span>{children}</span>;
   }
@@ -200,11 +208,13 @@ vi.mock("@navikt/ds-react", async () => {
 
   return {
     ActionMenu,
+    BodyShort,
     Box: SimpleDiv,
     Button,
     Chips,
     HGrid: SimpleDiv,
     HStack: SimpleDiv,
+    Label,
     Tag,
     VStack: SimpleDiv,
   };

--- a/apps/lumi-dashboard/app/components/shared/FilterBar/__tests__/FilterMenu.test.tsx
+++ b/apps/lumi-dashboard/app/components/shared/FilterBar/__tests__/FilterMenu.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen, within } from "@testing-library/react";
+import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
@@ -63,12 +63,22 @@ vi.mock("@navikt/ds-react", async () => {
     onDelete?: () => void;
   }
 
+  interface ChipToggleProps {
+    children?: React.ReactNode;
+    selected?: boolean;
+    onClick?: () => void;
+  }
+
   function SimpleDiv({ children, className }: SimpleProps) {
     return <div className={className}>{children}</div>;
   }
 
   function Button({ children }: SimpleProps) {
     return <button type="button">{children}</button>;
+  }
+
+  function BodyShort({ children }: SimpleProps) {
+    return <span>{children}</span>;
   }
 
   function Label({ children }: SimpleProps) {
@@ -174,6 +184,14 @@ vi.mock("@navikt/ds-react", async () => {
     );
   }
 
+  function ChipsToggle({ children, selected, onClick }: ChipToggleProps) {
+    return (
+      <button type="button" aria-pressed={Boolean(selected)} onClick={onClick}>
+        {children}
+      </button>
+    );
+  }
+
   const ActionMenu = Object.assign(ActionMenuRoot, {
     Trigger: ActionMenuTrigger,
     Content: ActionMenuContent,
@@ -185,10 +203,12 @@ vi.mock("@navikt/ds-react", async () => {
 
   const Chips = Object.assign(ChipsRoot, {
     Removable: ChipsRemovable,
+    Toggle: ChipsToggle,
   });
 
   return {
     ActionMenu,
+    BodyShort,
     Box: SimpleDiv,
     Button,
     Chips,
@@ -317,13 +337,26 @@ describe("FilterMenu", () => {
     expect(screen.queryByText("Valgt fra grafer")).not.toBeInTheDocument();
     expect(screen.getByText("Aktive grafer-filtre")).toBeInTheDocument();
 
-    expect(screen.getByRole("radio", { name: "Chat (5)" })).toBeChecked();
-    expect(screen.getByRole("radio", { name: "Ja (8)" })).toBeChecked();
+    // Choice chips
     expect(
-      screen.getByRole("radio", { name: "Telefon (3)" }),
+      screen.getByRole("button", { name: "Chat", pressed: true }),
     ).toBeInTheDocument();
-    expect(screen.getByRole("radio", { name: "Ja (8)" })).toBeInTheDocument();
-    expect(screen.getByRole("radio", { name: "10 (3)" })).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: "Telefon", pressed: false }),
+    ).toBeInTheDocument();
+
+    // Rating chips (thumbs variant inferred: Ja/Nei)
+    expect(
+      screen.getByRole("button", { name: "Ja", pressed: true }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: "Nei", pressed: false }),
+    ).toBeInTheDocument();
+
+    // NPS rating chips
+    expect(screen.getByRole("button", { name: "10" })).toBeInTheDocument();
+
+    // Chart filters
     expect(screen.getByText("Tema: Annet")).toBeInTheDocument();
     expect(screen.getByText("Oppgave: Søknad")).toBeInTheDocument();
   });
@@ -339,31 +372,16 @@ describe("FilterMenu", () => {
 
     renderFilterMenu({ surveyId: "survey-1" });
 
-    await user.click(screen.getByRole("radio", { name: "Telefon (3)" }));
+    // Click an unselected choice chip → toggleChoice
+    await user.click(screen.getByRole("button", { name: "Telefon" }));
     expect(toggleChoice).toHaveBeenCalledWith("choice-1", "phone");
 
-    const thumbsFieldset = screen
-      .getByText("Fikk du hjelp?")
-      .closest("fieldset");
-    expect(thumbsFieldset).not.toBeNull();
-
-    await user.click(
-      within(thumbsFieldset as HTMLFieldSetElement).getByRole("radio", {
-        name: "Alle",
-      }),
-    );
+    // Click the already-selected rating chip → removeRating (deselect)
+    await user.click(screen.getByRole("button", { name: "Ja", pressed: true }));
     expect(removeRating).toHaveBeenCalledWith("rating-1");
 
-    const npsFieldset = screen
-      .getByText("Hvor sannsynlig er det at du anbefaler oss?")
-      .closest("fieldset");
-    expect(npsFieldset).not.toBeNull();
-
-    await user.click(
-      within(npsFieldset as HTMLFieldSetElement).getByRole("radio", {
-        name: "10 (3)",
-      }),
-    );
+    // Click an NPS rating chip → toggleRating
+    await user.click(screen.getByRole("button", { name: "10" }));
     expect(toggleRating).toHaveBeenCalledWith("rating-2", "10");
   });
 });

--- a/apps/lumi-dashboard/app/components/shared/FilterBar/__tests__/FilterMenu.test.tsx
+++ b/apps/lumi-dashboard/app/components/shared/FilterBar/__tests__/FilterMenu.test.tsx
@@ -81,10 +81,6 @@ vi.mock("@navikt/ds-react", async () => {
     return <span>{children}</span>;
   }
 
-  function Label({ children }: SimpleProps) {
-    return <span>{children}</span>;
-  }
-
   function Tag({ children }: SimpleProps) {
     return <span>{children}</span>;
   }
@@ -214,7 +210,6 @@ vi.mock("@navikt/ds-react", async () => {
     Chips,
     HGrid: SimpleDiv,
     HStack: SimpleDiv,
-    Label,
     Tag,
     VStack: SimpleDiv,
   };

--- a/apps/lumi-dashboard/app/components/shared/FilterBar/__tests__/FilterMenu.test.tsx
+++ b/apps/lumi-dashboard/app/components/shared/FilterBar/__tests__/FilterMenu.test.tsx
@@ -1,0 +1,369 @@
+import { render, screen, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { useChoiceFilter } from "~/hooks/useChoiceFilter";
+import { useRatingFilter } from "~/hooks/useRatingFilter";
+import type { SearchParams } from "~/hooks/useSearchParams";
+import { useStats } from "~/hooks/useStats";
+import { FilterMenu } from "../FilterMenu";
+
+vi.mock("~/components/dashboard/ContextTagsFilter", () => ({
+  ContextTagsFilter: () => <div>Context-tags</div>,
+}));
+
+vi.mock("~/hooks/useStats", () => ({
+  useStats: vi.fn(),
+}));
+
+vi.mock("~/hooks/useChoiceFilter", () => ({
+  useChoiceFilter: vi.fn(),
+}));
+
+vi.mock("~/hooks/useRatingFilter", () => ({
+  useRatingFilter: vi.fn(),
+}));
+
+vi.mock("@navikt/ds-react", async () => {
+  const React = await import("react");
+
+  interface SimpleProps {
+    children?: React.ReactNode;
+    className?: string;
+  }
+
+  interface ActionMenuGroupProps {
+    label: string;
+    children?: React.ReactNode;
+  }
+
+  interface CheckboxItemProps {
+    checked?: boolean;
+    onCheckedChange?: (checked: boolean) => void;
+    children?: React.ReactNode;
+  }
+
+  interface RadioGroupProps {
+    label: string;
+    value: string;
+    onValueChange: (value: string) => void;
+    children?: React.ReactNode;
+  }
+
+  interface RadioItemProps {
+    value: string;
+    children?: React.ReactNode;
+    name?: string;
+    checked?: boolean;
+    onValueChange?: (value: string) => void;
+  }
+
+  interface ChipProps {
+    children?: React.ReactNode;
+    onDelete?: () => void;
+  }
+
+  function SimpleDiv({ children, className }: SimpleProps) {
+    return <div className={className}>{children}</div>;
+  }
+
+  function Button({ children }: SimpleProps) {
+    return <button type="button">{children}</button>;
+  }
+
+  function Label({ children }: SimpleProps) {
+    return <span>{children}</span>;
+  }
+
+  function Tag({ children }: SimpleProps) {
+    return <span>{children}</span>;
+  }
+
+  function ActionMenuRoot({ children }: SimpleProps) {
+    return <div>{children}</div>;
+  }
+
+  function ActionMenuTrigger({ children }: SimpleProps) {
+    return <div>{children}</div>;
+  }
+
+  function ActionMenuContent({ children, className }: SimpleProps) {
+    return <div className={className}>{children}</div>;
+  }
+
+  function ActionMenuGroup({ label, children }: ActionMenuGroupProps) {
+    return (
+      <fieldset>
+        <legend>{label}</legend>
+        {children}
+      </fieldset>
+    );
+  }
+
+  function ActionMenuCheckboxItem({
+    checked,
+    onCheckedChange,
+    children,
+  }: CheckboxItemProps) {
+    return (
+      <label>
+        <input
+          type="checkbox"
+          checked={Boolean(checked)}
+          onChange={(event) => onCheckedChange?.(event.target.checked)}
+        />
+        {children}
+      </label>
+    );
+  }
+
+  function ActionMenuRadioItem({
+    value,
+    children,
+    name,
+    checked,
+    onValueChange,
+  }: RadioItemProps) {
+    return (
+      <label>
+        <input
+          type="radio"
+          name={name}
+          value={value}
+          checked={Boolean(checked)}
+          onChange={() => onValueChange?.(value)}
+        />
+        {children}
+      </label>
+    );
+  }
+
+  function ActionMenuRadioGroup({
+    label,
+    value,
+    onValueChange,
+    children,
+  }: RadioGroupProps) {
+    return (
+      <fieldset>
+        <legend>{label}</legend>
+        {React.Children.map(children, (child) => {
+          if (!React.isValidElement<RadioItemProps>(child)) {
+            return child;
+          }
+
+          return React.cloneElement(child, {
+            name: `radio-${label}`,
+            checked: child.props.value === value,
+            onValueChange,
+          });
+        })}
+      </fieldset>
+    );
+  }
+
+  function ChipsRoot({ children }: SimpleProps) {
+    return <div>{children}</div>;
+  }
+
+  function ChipsRemovable({ children, onDelete }: ChipProps) {
+    return (
+      <button type="button" onClick={onDelete}>
+        {children}
+      </button>
+    );
+  }
+
+  const ActionMenu = Object.assign(ActionMenuRoot, {
+    Trigger: ActionMenuTrigger,
+    Content: ActionMenuContent,
+    Group: ActionMenuGroup,
+    CheckboxItem: ActionMenuCheckboxItem,
+    RadioGroup: ActionMenuRadioGroup,
+    RadioItem: ActionMenuRadioItem,
+  });
+
+  const Chips = Object.assign(ChipsRoot, {
+    Removable: ChipsRemovable,
+  });
+
+  return {
+    ActionMenu,
+    Box: SimpleDiv,
+    Button,
+    Chips,
+    HGrid: SimpleDiv,
+    HStack: SimpleDiv,
+    Label,
+    Tag,
+    VStack: SimpleDiv,
+  };
+});
+
+const mockUseStats = vi.mocked(useStats);
+const mockUseChoiceFilter = vi.mocked(useChoiceFilter);
+const mockUseRatingFilter = vi.mocked(useRatingFilter);
+
+const toggleChoice = vi.fn();
+const removeChoice = vi.fn();
+const toggleRating = vi.fn();
+const removeRating = vi.fn();
+const setParams = vi.fn();
+
+const features = {
+  showDeviceFilter: false,
+  showTextFilter: false,
+  showRatingFilter: false,
+  showTagsFilter: false,
+};
+
+const stats = {
+  fieldStats: [
+    {
+      fieldId: "choice-1",
+      fieldType: "SINGLE_CHOICE",
+      label: "Kanal",
+      stats: {
+        type: "choice",
+        distribution: {
+          chat: { label: "Chat", count: 5, percentage: 50 },
+          phone: { label: "Telefon", count: 3, percentage: 30 },
+        },
+      },
+    },
+    {
+      fieldId: "rating-1",
+      fieldType: "RATING",
+      label: "Fikk du hjelp?",
+      stats: {
+        type: "rating",
+        average: 1.8,
+        distribution: { "1": 2, "2": 8 },
+      },
+    },
+    {
+      fieldId: "rating-2",
+      fieldType: "RATING",
+      label: "Hvor sannsynlig er det at du anbefaler oss?",
+      stats: {
+        type: "rating",
+        average: 7.4,
+        distribution: { "0": 1, "7": 2, "10": 3 },
+      },
+    },
+  ],
+};
+
+function renderFilterMenu(params: Partial<SearchParams> = {}) {
+  return render(
+    <FilterMenu
+      params={params as SearchParams}
+      setParams={setParams}
+      features={features}
+      allTags={[]}
+      selectedTags={[]}
+    />,
+  );
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+
+  mockUseStats.mockReturnValue({
+    data: stats,
+    isPending: false,
+  } as never);
+
+  mockUseChoiceFilter.mockReturnValue({
+    activeFilters: {},
+    toggleChoice,
+    removeChoice,
+  } as never);
+
+  mockUseRatingFilter.mockReturnValue({
+    activeFilters: {},
+    toggleRating,
+    removeRating,
+  } as never);
+});
+
+describe("FilterMenu", () => {
+  it("shows answer filters only when a survey is selected", () => {
+    renderFilterMenu();
+
+    expect(screen.queryByText("Svar-filtre")).not.toBeInTheDocument();
+  });
+
+  it("renders answer filters and active chart filters with the correct options", () => {
+    mockUseChoiceFilter.mockReturnValue({
+      activeFilters: { "choice-1": "chat" },
+      toggleChoice,
+      removeChoice,
+    } as never);
+
+    mockUseRatingFilter.mockReturnValue({
+      activeFilters: { "rating-1": "2" },
+      toggleRating,
+      removeRating,
+    } as never);
+
+    renderFilterMenu({
+      surveyId: "survey-1",
+      theme: "uncategorized",
+      task: "Søknad",
+    });
+
+    expect(screen.getByText("Svar-filtre")).toBeInTheDocument();
+    expect(screen.queryByText("Valgt fra grafer")).not.toBeInTheDocument();
+    expect(screen.getByText("Aktive grafer-filtre")).toBeInTheDocument();
+
+    expect(screen.getByRole("radio", { name: "Chat (5)" })).toBeChecked();
+    expect(screen.getByRole("radio", { name: "Ja (8)" })).toBeChecked();
+    expect(
+      screen.getByRole("radio", { name: "Telefon (3)" }),
+    ).toBeInTheDocument();
+    expect(screen.getByRole("radio", { name: "Ja (8)" })).toBeInTheDocument();
+    expect(screen.getByRole("radio", { name: "10 (3)" })).toBeInTheDocument();
+    expect(screen.getByText("Tema: Annet")).toBeInTheDocument();
+    expect(screen.getByText("Oppgave: Søknad")).toBeInTheDocument();
+  });
+
+  it("updates choice and rating filters from the answer filter section", async () => {
+    const user = userEvent.setup();
+
+    mockUseRatingFilter.mockReturnValue({
+      activeFilters: { "rating-1": "2" },
+      toggleRating,
+      removeRating,
+    } as never);
+
+    renderFilterMenu({ surveyId: "survey-1" });
+
+    await user.click(screen.getByRole("radio", { name: "Telefon (3)" }));
+    expect(toggleChoice).toHaveBeenCalledWith("choice-1", "phone");
+
+    const thumbsFieldset = screen
+      .getByText("Fikk du hjelp?")
+      .closest("fieldset");
+    expect(thumbsFieldset).not.toBeNull();
+
+    await user.click(
+      within(thumbsFieldset as HTMLFieldSetElement).getByRole("radio", {
+        name: "Alle",
+      }),
+    );
+    expect(removeRating).toHaveBeenCalledWith("rating-1");
+
+    const npsFieldset = screen
+      .getByText("Hvor sannsynlig er det at du anbefaler oss?")
+      .closest("fieldset");
+    expect(npsFieldset).not.toBeNull();
+
+    await user.click(
+      within(npsFieldset as HTMLFieldSetElement).getByRole("radio", {
+        name: "10 (3)",
+      }),
+    );
+    expect(toggleRating).toHaveBeenCalledWith("rating-2", "10");
+  });
+});

--- a/apps/lumi-dashboard/app/components/shared/FilterBar/__tests__/FilterMenu.test.tsx
+++ b/apps/lumi-dashboard/app/components/shared/FilterBar/__tests__/FilterMenu.test.tsx
@@ -77,14 +77,6 @@ vi.mock("@navikt/ds-react", async () => {
     return <button type="button">{children}</button>;
   }
 
-  function BodyShort({ children }: SimpleProps) {
-    return <span>{children}</span>;
-  }
-
-  function Label({ children }: SimpleProps) {
-    return <span>{children}</span>;
-  }
-
   function Tag({ children }: SimpleProps) {
     return <span>{children}</span>;
   }
@@ -208,13 +200,11 @@ vi.mock("@navikt/ds-react", async () => {
 
   return {
     ActionMenu,
-    BodyShort,
     Box: SimpleDiv,
     Button,
     Chips,
     HGrid: SimpleDiv,
     HStack: SimpleDiv,
-    Label,
     Tag,
     VStack: SimpleDiv,
   };

--- a/apps/lumi-dashboard/app/components/shared/FilterBar/index.tsx
+++ b/apps/lumi-dashboard/app/components/shared/FilterBar/index.tsx
@@ -27,7 +27,7 @@ interface FilterBarProps {
 }
 
 export function FilterBar({ showDetails = false }: FilterBarProps) {
-  const { params, setParam, setParams, resetParams } = useSearchParams();
+  const { params, setParams, resetParams } = useSearchParams();
   const { data: bootstrap, isPending: isPendingBootstrap } =
     useFilterBootstrap();
   const { data: stats, isPending: isPendingStats } = useStats();
@@ -244,7 +244,6 @@ export function FilterBar({ showDetails = false }: FilterBarProps) {
               {showDetails && (
                 <FilterMenu
                   params={params}
-                  setParam={setParam}
                   setParams={setParams}
                   features={features}
                   allTags={allTags}
@@ -340,7 +339,6 @@ export function FilterBar({ showDetails = false }: FilterBarProps) {
                 {showDetails && (
                   <FilterMenu
                     params={params}
-                    setParam={setParam}
                     setParams={setParams}
                     features={features}
                     allTags={allTags}

--- a/apps/lumi-dashboard/app/components/shared/FilterBar/index.tsx
+++ b/apps/lumi-dashboard/app/components/shared/FilterBar/index.tsx
@@ -92,6 +92,15 @@ export function FilterBar({ showDetails = false }: FilterBarProps) {
     }
   };
 
+  const handleSurveyChange = (newSurveyId: string | undefined) => {
+    setParams({
+      surveyId: newSurveyId,
+      choice: undefined,
+      rating: undefined,
+      page: "1",
+    });
+  };
+
   const handleReset = () => {
     const team = params.team;
     resetParams();
@@ -209,11 +218,9 @@ export function FilterBar({ showDetails = false }: FilterBarProps) {
                 size="small"
                 value={params.surveyId || "alle"}
                 onChange={(e) =>
-                  setParams({
-                    surveyId:
-                      e.target.value === "alle" ? undefined : e.target.value,
-                    page: "1",
-                  })
+                  handleSurveyChange(
+                    e.target.value === "alle" ? undefined : e.target.value,
+                  )
                 }
                 className={styles.desktopSurveySelect}
               >
@@ -317,11 +324,9 @@ export function FilterBar({ showDetails = false }: FilterBarProps) {
                 size="small"
                 value={params.surveyId || "alle"}
                 onChange={(e) =>
-                  setParams({
-                    surveyId:
-                      e.target.value === "alle" ? undefined : e.target.value,
-                    page: "1",
-                  })
+                  handleSurveyChange(
+                    e.target.value === "alle" ? undefined : e.target.value,
+                  )
                 }
                 className={styles.mobileSurveySelect}
               >

--- a/apps/lumi-dashboard/app/components/shared/FilterBar/index.tsx
+++ b/apps/lumi-dashboard/app/components/shared/FilterBar/index.tsx
@@ -86,6 +86,8 @@ export function FilterBar({ showDetails = false }: FilterBarProps) {
       if (newApp && surveysForApp && !surveysForApp.includes(params.surveyId)) {
         setParams({
           surveyId: undefined,
+          choice: undefined,
+          rating: undefined,
           page: "1",
         });
       }

--- a/apps/lumi-dashboard/app/components/shared/FilterBar/index.tsx
+++ b/apps/lumi-dashboard/app/components/shared/FilterBar/index.tsx
@@ -28,25 +28,18 @@ interface FilterBarProps {
 
 export function FilterBar({ showDetails = false }: FilterBarProps) {
   const { params, setParam, setParams, resetParams } = useSearchParams();
-
-  // Use centralized filter bootstrap for all dropdown data
   const { data: bootstrap, isPending: isPendingBootstrap } =
     useFilterBootstrap();
   const { data: stats, isPending: isPendingStats } = useStats();
   const { themes } = useThemes();
 
-  // Determine active features based on survey type
   const features = getSurveyFeatures(stats?.surveyType);
-
-  const { ratingLabel, ratingValueLabel, themeLabel } = getFilterLabels({
+  const { themeLabel } = getFilterLabels({
     params,
     stats,
     themes,
   });
-  const ratingFilterLabel = ratingLabel;
-  const ratingFilterValue = ratingValueLabel;
 
-  // Parse current tag filter (comma-separated)
   const selectedTags = params.tag
     ? params.tag
         .split(",")
@@ -54,29 +47,22 @@ export function FilterBar({ showDetails = false }: FilterBarProps) {
         .filter(Boolean)
     : [];
 
-  // Get available apps from bootstrap data
   const availableApps = bootstrap?.apps ?? [];
   const apps = ["alle", ...availableApps];
 
   const availableTeams = bootstrap?.availableTeams ?? [];
   const selectedTeam = params.team ?? bootstrap?.selectedTeam;
 
-  // Get surveys by app from bootstrap data
   const surveysByApp = bootstrap?.surveysByApp ?? {};
-
-  // Get all available tags from bootstrap data
   const allTags = bootstrap?.tags ?? [];
 
-  // Get available surveys - filter by selected app if one is chosen
   const getAvailableSurveys = (): string[] => {
     if (!surveysByApp || Object.keys(surveysByApp).length === 0) return [];
 
     if (params.app) {
-      // Show only surveys for the selected app
       return surveysByApp[params.app] || [];
     }
 
-    // Show all surveys from all apps (deduplicated)
     const allSurveys = new Set<string>();
     for (const surveys of Object.values(surveysByApp)) {
       for (const survey of surveys) {
@@ -89,18 +75,15 @@ export function FilterBar({ showDetails = false }: FilterBarProps) {
   const availableSurveys = getAvailableSurveys();
   const surveys = ["alle", ...availableSurveys];
 
-  // Reset surveyId when app changes and current surveyId is not available for new app
   const handleAppChange = (newApp: string | undefined) => {
     setParams({
       app: newApp,
       page: "1",
     });
 
-    // If a surveyId is selected, check if it's valid for the new app
     if (params.surveyId && surveysByApp) {
       const surveysForApp = newApp ? surveysByApp[newApp] : [];
       if (newApp && surveysForApp && !surveysForApp.includes(params.surveyId)) {
-        // Clear surveyId if it's not available for the new app
         setParams({
           surveyId: undefined,
           page: "1",
@@ -112,7 +95,6 @@ export function FilterBar({ showDetails = false }: FilterBarProps) {
   const handleReset = () => {
     const team = params.team;
     resetParams();
-    // Default to last 30 days on reset
     const end = dayjs();
     const start = dayjs().subtract(29, "day");
 
@@ -128,7 +110,6 @@ export function FilterBar({ showDetails = false }: FilterBarProps) {
   const handleTeamChange = (newTeam: string) => {
     setParams({
       team: newTeam,
-      // Keep period, reset the rest to avoid invalid cross-team combinations.
       fromDate: params.fromDate,
       toDate: params.toDate,
       app: undefined,
@@ -141,12 +122,13 @@ export function FilterBar({ showDetails = false }: FilterBarProps) {
       segment: undefined,
       task: undefined,
       theme: undefined,
+      choice: undefined,
+      rating: undefined,
       page: undefined,
       size: undefined,
     });
   };
 
-  // Only count filters that user has explicitly set (exclude default date range)
   const hasActiveFilters =
     params.query ||
     params.surveyId ||
@@ -157,12 +139,10 @@ export function FilterBar({ showDetails = false }: FilterBarProps) {
     params.tag ||
     params.segment ||
     params.task ||
-    params.ratingFieldId ||
-    params.ratingValue ||
-    params.choiceFieldId;
+    params.theme ||
+    params.choice ||
+    params.rating;
 
-  // isPending: no cached data AND fetching (TanStack Query v5 best practice)
-  // With placeholderData: keepPreviousData, isPending stays false during refetches
   const isPending = isPendingBootstrap || isPendingStats;
 
   if (isPending) {
@@ -176,7 +156,6 @@ export function FilterBar({ showDetails = false }: FilterBarProps) {
 
   return (
     <VStack gap="space-12" className={styles.root}>
-      {/* Primary Row: All filters in one line */}
       <Box
         padding={{ xs: "space-12", md: "space-16" }}
         background="raised"
@@ -185,10 +164,8 @@ export function FilterBar({ showDetails = false }: FilterBarProps) {
         borderColor="neutral-subtle"
         borderWidth="1"
       >
-        {/* Desktop layout */}
         <Show above="md">
           <HStack gap="space-12" align="end" justify="space-between" wrap>
-            {/* Left side: Compact dropdowns + Search */}
             <HStack gap="space-12" align="end" wrap>
               {availableTeams.length > 1 && selectedTeam && (
                 <Select
@@ -247,7 +224,6 @@ export function FilterBar({ showDetails = false }: FilterBarProps) {
                 ))}
               </Select>
 
-              {/* Search field - visible when showDetails */}
               {showDetails && features.showTextFilter && (
                 <TextField
                   label="Søk"
@@ -265,7 +241,6 @@ export function FilterBar({ showDetails = false }: FilterBarProps) {
                 />
               )}
 
-              {/* ActionMenu-based filter */}
               {showDetails && (
                 <FilterMenu
                   params={params}
@@ -274,14 +249,11 @@ export function FilterBar({ showDetails = false }: FilterBarProps) {
                   features={features}
                   allTags={allTags}
                   selectedTags={selectedTags}
-                  ratingFilterLabel={ratingFilterLabel}
-                  ratingFilterValue={ratingFilterValue}
                   themeLabel={themeLabel}
                 />
               )}
             </HStack>
 
-            {/* Right side: Period + Reset */}
             <HStack gap="space-8" align="end">
               <PeriodSelector />
               {hasActiveFilters && (
@@ -301,10 +273,8 @@ export function FilterBar({ showDetails = false }: FilterBarProps) {
           </HStack>
         </Show>
 
-        {/* Mobile/Tablet layout */}
         <Hide above="md">
           <VStack gap="space-8">
-            {/* First row: Team (optional) + App + Survey */}
             <HStack gap="space-8" wrap>
               {availableTeams.length > 1 && selectedTeam && (
                 <Select
@@ -364,7 +334,6 @@ export function FilterBar({ showDetails = false }: FilterBarProps) {
               </Select>
             </HStack>
 
-            {/* Second row: Period + Filter + Reset */}
             <HStack gap="space-8" justify="space-between" align="center">
               <HStack gap="space-8" align="center">
                 <PeriodSelector />
@@ -376,8 +345,6 @@ export function FilterBar({ showDetails = false }: FilterBarProps) {
                     features={features}
                     allTags={allTags}
                     selectedTags={selectedTags}
-                    ratingFilterLabel={ratingFilterLabel}
-                    ratingFilterValue={ratingFilterValue}
                     themeLabel={themeLabel}
                   />
                 )}
@@ -395,7 +362,6 @@ export function FilterBar({ showDetails = false }: FilterBarProps) {
               )}
             </HStack>
 
-            {/* Third row: Search (mobile) */}
             {showDetails && features.showTextFilter && (
               <TextField
                 label="Søk"

--- a/apps/lumi-dashboard/app/components/shared/FilterBar/index.tsx
+++ b/apps/lumi-dashboard/app/components/shared/FilterBar/index.tsx
@@ -158,7 +158,8 @@ export function FilterBar({ showDetails = false }: FilterBarProps) {
     params.segment ||
     params.task ||
     params.ratingFieldId ||
-    params.ratingValue;
+    params.ratingValue ||
+    params.choiceFieldId;
 
   // isPending: no cached data AND fetching (TanStack Query v5 best practice)
   // With placeholderData: keepPreviousData, isPending stays false during refetches

--- a/apps/lumi-dashboard/app/components/shared/FilterBar/index.tsx
+++ b/apps/lumi-dashboard/app/components/shared/FilterBar/index.tsx
@@ -76,22 +76,22 @@ export function FilterBar({ showDetails = false }: FilterBarProps) {
   const surveys = ["alle", ...availableSurveys];
 
   const handleAppChange = (newApp: string | undefined) => {
+    const shouldClearSurvey =
+      params.surveyId &&
+      surveysByApp &&
+      newApp &&
+      surveysByApp[newApp] &&
+      !surveysByApp[newApp].includes(params.surveyId);
+
     setParams({
       app: newApp,
       page: "1",
+      ...(shouldClearSurvey && {
+        surveyId: undefined,
+        choice: undefined,
+        rating: undefined,
+      }),
     });
-
-    if (params.surveyId && surveysByApp) {
-      const surveysForApp = newApp ? surveysByApp[newApp] : [];
-      if (newApp && surveysForApp && !surveysForApp.includes(params.surveyId)) {
-        setParams({
-          surveyId: undefined,
-          choice: undefined,
-          rating: undefined,
-          page: "1",
-        });
-      }
-    }
   };
 
   const handleSurveyChange = (newSurveyId: string | undefined) => {

--- a/apps/lumi-dashboard/app/hooks/__tests__/useSearchParams.test.ts
+++ b/apps/lumi-dashboard/app/hooks/__tests__/useSearchParams.test.ts
@@ -103,6 +103,29 @@ describe("useSearchParams", () => {
     });
   });
 
+  it("setParam merges sequential updates in the same handler", async () => {
+    const { router, getResult } = await setup([
+      "/?ratingFieldId=field-1&ratingValue=5&team=flex",
+    ]);
+
+    await act(async () => {
+      getResult().setParam("ratingFieldId", undefined);
+      getResult().setParam("ratingValue", undefined);
+      getResult().setParam("page", "1");
+    });
+
+    await waitFor(() => {
+      expect(router.state.location.search).toMatchObject({
+        page: "1",
+        team: "flex",
+      });
+      expect(getResult().params.ratingFieldId).toBeUndefined();
+      expect(getResult().params.ratingValue).toBeUndefined();
+      expect(getResult().params.page).toBe("1");
+      expect(getResult().params.team).toBe("flex");
+    });
+  });
+
   it("setParams sets multiple parameters at once", async () => {
     const { router, getResult } = await setup();
 

--- a/apps/lumi-dashboard/app/hooks/__tests__/useSearchParams.test.ts
+++ b/apps/lumi-dashboard/app/hooks/__tests__/useSearchParams.test.ts
@@ -1,100 +1,166 @@
-import { act, renderHook } from "@testing-library/react";
-import { beforeEach, describe, expect, it } from "vitest";
+import { createMemoryHistory } from "@tanstack/history";
+import {
+  createRootRoute,
+  createRoute,
+  createRouter,
+  Outlet,
+  RouterProvider,
+} from "@tanstack/react-router";
+import { zodValidator } from "@tanstack/zod-adapter";
+import { act, render, waitFor } from "@testing-library/react";
+import { createElement } from "react";
+import { describe, expect, it } from "vitest";
 import { useSearchParams } from "~/hooks/useSearchParams";
+import { searchSchema } from "~/schemas/searchSchema";
+
+type SearchParamsHook = ReturnType<typeof useSearchParams>;
+
+async function setup(initialEntries: Array<string> = ["/"]) {
+  const state: { current?: SearchParamsHook } = {};
+
+  function TestComponent() {
+    state.current = useSearchParams();
+    return null;
+  }
+
+  const rootRoute = createRootRoute({
+    component: Outlet,
+  });
+  const indexRoute = createRoute({
+    getParentRoute: () => rootRoute,
+    path: "/",
+    validateSearch: zodValidator(searchSchema),
+    component: TestComponent,
+  });
+  const routeTree = rootRoute.addChildren([indexRoute]);
+  const history = createMemoryHistory({ initialEntries });
+  const router = createRouter({ routeTree, history });
+
+  await router.load();
+  render(createElement(RouterProvider, { router }));
+  await waitFor(() => expect(state.current).toBeDefined());
+
+  return {
+    router,
+    getResult: () => {
+      if (!state.current) {
+        throw new Error("Hook state is not available yet");
+      }
+      return state.current;
+    },
+  };
+}
 
 describe("useSearchParams", () => {
-  beforeEach(() => {
-    // Reset URL before each test
-    window.history.pushState({}, "", "/");
+  it("returns empty params when URL has no search params", async () => {
+    const { getResult } = await setup();
+
+    expect(getResult().params).toEqual({});
   });
 
-  it("returns empty params when URL has no search params", () => {
-    const { result } = renderHook(() => useSearchParams());
-    expect(result.current.params).toEqual({});
+  it("parses existing search params from URL", async () => {
+    const { getResult } = await setup(["/?team=flex&app=spinnsyn"]);
+
+    expect(getResult().params.team).toBe("flex");
+    expect(getResult().params.app).toBe("spinnsyn");
   });
 
-  it("parses existing search params from URL", () => {
-    window.history.pushState({}, "", "/?team=flex&app=spinnsyn");
+  it("setParam adds a new parameter", async () => {
+    const { router, getResult } = await setup();
 
-    const { result } = renderHook(() => useSearchParams());
-
-    expect(result.current.params.team).toBe("flex");
-    expect(result.current.params.app).toBe("spinnsyn");
-  });
-
-  it("setParam adds a new parameter", () => {
-    const { result } = renderHook(() => useSearchParams());
-
-    act(() => {
-      result.current.setParam("team", "flex");
+    await act(async () => {
+      getResult().setParam("team", "flex");
     });
 
-    expect(window.location.search).toBe("?team=flex");
-    expect(result.current.params.team).toBe("flex");
+    await waitFor(() => {
+      expect(router.state.location.searchStr).toBe("?team=flex");
+      expect(getResult().params.team).toBe("flex");
+    });
   });
 
-  it("setParam removes parameter when value is undefined", () => {
-    window.history.pushState({}, "", "/?team=flex&app=spinnsyn");
-    const { result } = renderHook(() => useSearchParams());
+  it("setParam removes parameter when value is undefined", async () => {
+    const { router, getResult } = await setup(["/?team=flex&app=spinnsyn"]);
 
-    act(() => {
-      result.current.setParam("team", undefined);
+    await act(async () => {
+      getResult().setParam("team", undefined);
     });
 
-    expect(window.location.search).toBe("?app=spinnsyn");
-    expect(result.current.params.team).toBeUndefined();
+    await waitFor(() => {
+      expect(router.state.location.searchStr).toBe("?app=spinnsyn");
+      expect(getResult().params.team).toBeUndefined();
+    });
   });
 
-  it("setParam removes parameter when value is empty string", () => {
-    window.history.pushState({}, "", "/?team=flex");
-    const { result } = renderHook(() => useSearchParams());
+  it("setParam removes parameter when value is empty string", async () => {
+    const { router, getResult } = await setup(["/?team=flex"]);
 
-    act(() => {
-      result.current.setParam("team", "");
+    await act(async () => {
+      getResult().setParam("team", "");
     });
 
-    expect(window.location.search).toBe("");
+    await waitFor(() => {
+      expect(router.state.location.searchStr).toBe("");
+    });
   });
 
-  it("setParams sets multiple parameters at once", () => {
-    const { result } = renderHook(() => useSearchParams());
+  it("setParams sets multiple parameters at once", async () => {
+    const { router, getResult } = await setup();
 
-    act(() => {
-      result.current.setParams({
+    await act(async () => {
+      getResult().setParams({
         team: "flex",
         app: "spinnsyn",
         fromDate: "2024-01-01",
       });
     });
 
-    expect(result.current.params.team).toBe("flex");
-    expect(result.current.params.app).toBe("spinnsyn");
-    expect(result.current.params.fromDate).toBe("2024-01-01");
+    await waitFor(() => {
+      expect(router.state.location.searchStr).toBe(
+        "?team=flex&app=spinnsyn&fromDate=2024-01-01",
+      );
+      expect(getResult().params.team).toBe("flex");
+      expect(getResult().params.app).toBe("spinnsyn");
+      expect(getResult().params.fromDate).toBe("2024-01-01");
+    });
   });
 
-  it("resetParams clears all parameters", () => {
-    window.history.pushState(
-      {},
-      "",
+  it("setParams removes existing parameters when passed undefined", async () => {
+    const { router, getResult } = await setup(["/?team=flex&app=spinnsyn"]);
+
+    await act(async () => {
+      getResult().setParams({ team: undefined });
+    });
+
+    await waitFor(() => {
+      expect(router.state.location.searchStr).toBe("?app=spinnsyn");
+      expect(getResult().params.team).toBeUndefined();
+    });
+  });
+
+  it("resetParams clears all parameters", async () => {
+    const { router, getResult } = await setup([
       "/?team=flex&app=spinnsyn&fromDate=2024-01-01",
-    );
-    const { result } = renderHook(() => useSearchParams());
+    ]);
 
-    act(() => {
-      result.current.resetParams();
+    await act(async () => {
+      getResult().resetParams();
     });
 
-    expect(window.location.search).toBe("");
-    expect(result.current.params).toEqual({});
+    await waitFor(() => {
+      expect(router.state.location.searchStr).toBe("");
+      expect(getResult().params).toEqual({});
+    });
   });
 
-  it("handles special characters in parameter values", () => {
-    const { result } = renderHook(() => useSearchParams());
+  it("handles special characters in parameter values", async () => {
+    const { getResult } = await setup();
 
-    act(() => {
-      result.current.setParam("query", "søk med æøå");
+    await act(async () => {
+      getResult().setParam("query", "søk med æøå");
     });
 
-    expect(result.current.params.query).toBe("søk med æøå");
+    await waitFor(() => {
+      expect(getResult().params.query).toBe("søk med æøå");
+    });
   });
 });

--- a/apps/lumi-dashboard/app/hooks/__tests__/useSearchParams.test.ts
+++ b/apps/lumi-dashboard/app/hooks/__tests__/useSearchParams.test.ts
@@ -11,6 +11,7 @@ import { act, render, waitFor } from "@testing-library/react";
 import { createElement } from "react";
 import { describe, expect, it } from "vitest";
 import { useSearchParams } from "~/hooks/useSearchParams";
+import { parseSearch, stringifySearch } from "~/router";
 import { searchSchema } from "~/schemas/searchSchema";
 
 type SearchParamsHook = ReturnType<typeof useSearchParams>;
@@ -32,7 +33,12 @@ async function setup(initialEntries: Array<string> = ["/"]) {
   });
   const routeTree = rootRoute.addChildren([indexRoute]);
   const history = createMemoryHistory({ initialEntries });
-  const router = createRouter({ routeTree, history });
+  const router = createRouter({
+    routeTree,
+    history,
+    stringifySearch,
+    parseSearch,
+  });
 
   await router.load();
   render(createElement(RouterProvider, { router }));
@@ -178,6 +184,46 @@ describe("useSearchParams", () => {
 
     await waitFor(() => {
       expect(getResult().params.query).toBe("søk med æøå");
+    });
+  });
+
+  describe("legacy URL param migration", () => {
+    it("migrates choiceFieldId/choiceValue to choice param", async () => {
+      const { getResult } = await setup([
+        "/?choiceFieldId=role&choiceValue=Arbeidsgiver",
+      ]);
+
+      await waitFor(() => {
+        expect(getResult().params.choice).toBe("role:Arbeidsgiver");
+      });
+    });
+
+    it("migrates ratingFieldId/ratingValue to rating param", async () => {
+      const { getResult } = await setup([
+        "/?ratingFieldId=tilfredshet&ratingValue=5",
+      ]);
+
+      await waitFor(() => {
+        expect(getResult().params.rating).toBe("tilfredshet:5");
+      });
+    });
+
+    it("preserves new choice param over legacy params", async () => {
+      const { getResult } = await setup([
+        "/?choice=role:Saksbehandler&choiceFieldId=role&choiceValue=Arbeidsgiver",
+      ]);
+
+      await waitFor(() => {
+        expect(getResult().params.choice).toBe("role:Saksbehandler");
+      });
+    });
+
+    it("does not migrate when only one legacy param is present", async () => {
+      const { getResult } = await setup(["/?choiceFieldId=role"]);
+
+      await waitFor(() => {
+        expect(getResult().params.choice).toBeUndefined();
+      });
     });
   });
 });

--- a/apps/lumi-dashboard/app/hooks/__tests__/useSearchParams.test.ts
+++ b/apps/lumi-dashboard/app/hooks/__tests__/useSearchParams.test.ts
@@ -23,9 +23,7 @@ async function setup(initialEntries: Array<string> = ["/"]) {
     return null;
   }
 
-  const rootRoute = createRootRoute({
-    component: Outlet,
-  });
+  const rootRoute = createRootRoute({ component: Outlet });
   const indexRoute = createRoute({
     getParentRoute: () => rootRoute,
     path: "/",
@@ -104,13 +102,10 @@ describe("useSearchParams", () => {
   });
 
   it("setParam merges sequential updates in the same handler", async () => {
-    const { router, getResult } = await setup([
-      "/?ratingFieldId=field-1&ratingValue=5&team=flex",
-    ]);
+    const { router, getResult } = await setup(["/?rating=field-1:5&team=flex"]);
 
     await act(async () => {
-      getResult().setParam("ratingFieldId", undefined);
-      getResult().setParam("ratingValue", undefined);
+      getResult().setParam("rating", undefined);
       getResult().setParam("page", "1");
     });
 
@@ -119,8 +114,7 @@ describe("useSearchParams", () => {
         page: "1",
         team: "flex",
       });
-      expect(getResult().params.ratingFieldId).toBeUndefined();
-      expect(getResult().params.ratingValue).toBeUndefined();
+      expect(getResult().params.rating).toBeUndefined();
       expect(getResult().params.page).toBe("1");
       expect(getResult().params.team).toBe("flex");
     });

--- a/apps/lumi-dashboard/app/hooks/useBlockerStats.ts
+++ b/apps/lumi-dashboard/app/hooks/useBlockerStats.ts
@@ -24,6 +24,8 @@ export function useBlockerStats() {
       params.task, // Task filter for drill-down
       params.ratingFieldId,
       params.ratingValue,
+      params.choiceFieldId,
+      params.choiceValue,
     ],
     queryFn: () =>
       fetchBlockerServerFn({
@@ -37,6 +39,8 @@ export function useBlockerStats() {
           task: params.task, // Pass task filter to backend
           ratingFieldId: params.ratingFieldId,
           ratingValue: params.ratingValue,
+          choiceFieldId: params.choiceFieldId,
+          choiceValue: params.choiceValue,
         },
       }),
     staleTime: 60000, // 1 minute

--- a/apps/lumi-dashboard/app/hooks/useBlockerStats.ts
+++ b/apps/lumi-dashboard/app/hooks/useBlockerStats.ts
@@ -1,14 +1,11 @@
 import { keepPreviousData, useQuery } from "@tanstack/react-query";
 import { useSearchParams } from "~/hooks/useSearchParams";
 import { fetchBlockerServerFn } from "~/server/actions/fetchBlocker";
+import { splitChoiceParam } from "~/utils/choiceFilterUtils";
+import { splitRatingParam } from "~/utils/ratingFilterUtils";
 
-// Re-export BlockerResponse type for components that need it
 export type { BlockerResponse } from "~/types/api";
 
-/**
- * Hook to fetch Blocker pattern statistics for Top Tasks.
- * Returns word frequency, themes (patterns), and recent blocker text.
- */
 export function useBlockerStats() {
   const { params } = useSearchParams();
 
@@ -21,11 +18,9 @@ export function useBlockerStats() {
       params.toDate,
       params.surveyId,
       params.deviceType,
-      params.task, // Task filter for drill-down
-      params.ratingFieldId,
-      params.ratingValue,
-      params.choiceFieldId,
-      params.choiceValue,
+      params.task,
+      params.rating,
+      params.choice,
     ],
     queryFn: () =>
       fetchBlockerServerFn({
@@ -36,14 +31,12 @@ export function useBlockerStats() {
           fromDate: params.fromDate,
           toDate: params.toDate,
           deviceType: params.deviceType,
-          task: params.task, // Pass task filter to backend
-          ratingFieldId: params.ratingFieldId,
-          ratingValue: params.ratingValue,
-          choiceFieldId: params.choiceFieldId,
-          choiceValue: params.choiceValue,
+          task: params.task,
+          rating: splitRatingParam(params.rating),
+          choice: splitChoiceParam(params.choice),
         },
       }),
-    staleTime: 60000, // 1 minute
+    staleTime: 60000,
     placeholderData: keepPreviousData,
   });
 }

--- a/apps/lumi-dashboard/app/hooks/useChoiceFilter.ts
+++ b/apps/lumi-dashboard/app/hooks/useChoiceFilter.ts
@@ -1,0 +1,56 @@
+import { useSearchParams } from "~/hooks/useSearchParams";
+import {
+  parseChoiceParam,
+  stringifyChoiceFilters,
+} from "~/utils/choiceFilterUtils";
+
+export function useChoiceFilter() {
+  const { params, setParams } = useSearchParams();
+  const activeFilters = parseChoiceParam(params.choice);
+
+  const toggleChoice = (fieldId: string, optionId: string) => {
+    const current = { ...activeFilters };
+    if (current[fieldId] === optionId) {
+      delete current[fieldId];
+    } else {
+      current[fieldId] = optionId;
+    }
+
+    setParams({
+      choice: stringifyChoiceFilters(current),
+      page: "1",
+    });
+  };
+
+  const removeChoice = (fieldId: string) => {
+    if (!(fieldId in activeFilters)) return;
+
+    const current = { ...activeFilters };
+    delete current[fieldId];
+
+    setParams({
+      choice: stringifyChoiceFilters(current),
+      page: "1",
+    });
+  };
+
+  const clearChoices = () => {
+    setParams({ choice: undefined, page: "1" });
+  };
+
+  const isActive = (fieldId: string, optionId?: string): boolean => {
+    if (optionId === undefined) {
+      return fieldId in activeFilters;
+    }
+    return activeFilters[fieldId] === optionId;
+  };
+
+  return {
+    activeFilters,
+    hasFilters: Object.keys(activeFilters).length > 0,
+    toggleChoice,
+    removeChoice,
+    clearChoices,
+    isActive,
+  };
+}

--- a/apps/lumi-dashboard/app/hooks/useDiscoveryStats.ts
+++ b/apps/lumi-dashboard/app/hooks/useDiscoveryStats.ts
@@ -23,6 +23,8 @@ export function useDiscoveryStats() {
       params.deviceType,
       params.ratingFieldId,
       params.ratingValue,
+      params.choiceFieldId,
+      params.choiceValue,
     ],
     queryFn: () =>
       fetchDiscoveryServerFn({
@@ -35,6 +37,8 @@ export function useDiscoveryStats() {
           deviceType: params.deviceType,
           ratingFieldId: params.ratingFieldId,
           ratingValue: params.ratingValue,
+          choiceFieldId: params.choiceFieldId,
+          choiceValue: params.choiceValue,
         },
       }),
     staleTime: 60000, // 1 minute

--- a/apps/lumi-dashboard/app/hooks/useDiscoveryStats.ts
+++ b/apps/lumi-dashboard/app/hooks/useDiscoveryStats.ts
@@ -1,14 +1,11 @@
 import { keepPreviousData, useQuery } from "@tanstack/react-query";
 import { useSearchParams } from "~/hooks/useSearchParams";
 import { fetchDiscoveryServerFn } from "~/server/actions";
+import { splitChoiceParam } from "~/utils/choiceFilterUtils";
+import { splitRatingParam } from "~/utils/ratingFilterUtils";
 
-// Re-export DiscoveryResponse type for components that need it
 export type { DiscoveryResponse } from "~/types/api";
 
-/**
- * Hook to fetch Discovery survey statistics.
- * Returns word frequency, themes, and recent responses for intent analysis.
- */
 export function useDiscoveryStats() {
   const { params } = useSearchParams();
 
@@ -21,10 +18,8 @@ export function useDiscoveryStats() {
       params.toDate,
       params.surveyId,
       params.deviceType,
-      params.ratingFieldId,
-      params.ratingValue,
-      params.choiceFieldId,
-      params.choiceValue,
+      params.rating,
+      params.choice,
     ],
     queryFn: () =>
       fetchDiscoveryServerFn({
@@ -35,13 +30,11 @@ export function useDiscoveryStats() {
           fromDate: params.fromDate,
           toDate: params.toDate,
           deviceType: params.deviceType,
-          ratingFieldId: params.ratingFieldId,
-          ratingValue: params.ratingValue,
-          choiceFieldId: params.choiceFieldId,
-          choiceValue: params.choiceValue,
+          rating: splitRatingParam(params.rating),
+          choice: splitChoiceParam(params.choice),
         },
       }),
-    staleTime: 60000, // 1 minute
+    staleTime: 60000,
     placeholderData: keepPreviousData,
   });
 }

--- a/apps/lumi-dashboard/app/hooks/useFeedback.ts
+++ b/apps/lumi-dashboard/app/hooks/useFeedback.ts
@@ -53,6 +53,8 @@ export function useFeedback() {
       params.segment,
       params.ratingFieldId,
       params.ratingValue,
+      params.choiceFieldId,
+      params.choiceValue,
     ],
     queryFn: () =>
       fetchFeedbackServerFn({
@@ -74,6 +76,8 @@ export function useFeedback() {
           segment: params.segment,
           ratingFieldId: params.ratingFieldId,
           ratingValue: params.ratingValue,
+          choiceFieldId: params.choiceFieldId,
+          choiceValue: params.choiceValue,
         },
       }),
     staleTime: 10000, // 10 seconds

--- a/apps/lumi-dashboard/app/hooks/useFeedback.ts
+++ b/apps/lumi-dashboard/app/hooks/useFeedback.ts
@@ -1,35 +1,11 @@
 import { keepPreviousData, useQuery } from "@tanstack/react-query";
 import { useSearchParams } from "~/hooks/useSearchParams";
 import { fetchFeedbackServerFn } from "~/server/actions";
+import { splitChoiceParam } from "~/utils/choiceFilterUtils";
+import { splitRatingParam } from "~/utils/ratingFilterUtils";
 
-// Re-export the FeedbackPage type for components that need it
 export type { FeedbackPage } from "~/types/api";
 
-/**
- * Hook to fetch paginated feedback items.
- *
- * Automatically reacts to URL search params for filtering and pagination:
- * - app: Filter by application name
- * - surveyId: Filter by specific survey ID
- * - page/size: Pagination controls (1-indexed)
- * - fromDate/toDate: Date range filter
- * - hasText: Filter to only items with text responses
- * - lowRating: Filter to only low ratings (1-2)
- * - tag: Filter by comma-separated tags
- * - deviceType: Filter by device type
- * - segment: Filter by context.tags (format: key:value)
- *
- * @returns React Query result with FeedbackPage (content, pagination info)
- *
- * @example
- * ```tsx
- * function FeedbackList() {
- *   const { data, isLoading } = useFeedback();
- *   if (isLoading) return <Spinner />;
- *   return data.content.map(item => <FeedbackCard key={item.id} {...item} />);
- * }
- * ```
- */
 export function useFeedback() {
   const { params } = useSearchParams();
 
@@ -51,10 +27,8 @@ export function useFeedback() {
       params.theme,
       params.task,
       params.segment,
-      params.ratingFieldId,
-      params.ratingValue,
-      params.choiceFieldId,
-      params.choiceValue,
+      params.rating,
+      params.choice,
     ],
     queryFn: () =>
       fetchFeedbackServerFn({
@@ -74,13 +48,11 @@ export function useFeedback() {
           theme: params.theme,
           task: params.task,
           segment: params.segment,
-          ratingFieldId: params.ratingFieldId,
-          ratingValue: params.ratingValue,
-          choiceFieldId: params.choiceFieldId,
-          choiceValue: params.choiceValue,
+          rating: splitRatingParam(params.rating),
+          choice: splitChoiceParam(params.choice),
         },
       }),
-    staleTime: 10000, // 10 seconds
-    placeholderData: keepPreviousData, // Prevent skeleton flash on param changes
+    staleTime: 10000,
+    placeholderData: keepPreviousData,
   });
 }

--- a/apps/lumi-dashboard/app/hooks/useRatingFilter.ts
+++ b/apps/lumi-dashboard/app/hooks/useRatingFilter.ts
@@ -1,0 +1,56 @@
+import { useSearchParams } from "~/hooks/useSearchParams";
+import {
+  parseRatingParam,
+  stringifyRatingFilters,
+} from "~/utils/ratingFilterUtils";
+
+export function useRatingFilter() {
+  const { params, setParams } = useSearchParams();
+  const activeFilters = parseRatingParam(params.rating);
+
+  const toggleRating = (fieldId: string, ratingValue: string) => {
+    const current = { ...activeFilters };
+    if (current[fieldId] === ratingValue) {
+      delete current[fieldId];
+    } else {
+      current[fieldId] = ratingValue;
+    }
+
+    setParams({
+      rating: stringifyRatingFilters(current),
+      page: "1",
+    });
+  };
+
+  const removeRating = (fieldId: string) => {
+    if (!(fieldId in activeFilters)) return;
+
+    const current = { ...activeFilters };
+    delete current[fieldId];
+
+    setParams({
+      rating: stringifyRatingFilters(current),
+      page: "1",
+    });
+  };
+
+  const clearRatings = () => {
+    setParams({ rating: undefined, page: "1" });
+  };
+
+  const isActive = (fieldId: string, ratingValue?: string): boolean => {
+    if (ratingValue === undefined) {
+      return fieldId in activeFilters;
+    }
+    return activeFilters[fieldId] === ratingValue;
+  };
+
+  return {
+    activeFilters,
+    hasFilters: Object.keys(activeFilters).length > 0,
+    toggleRating,
+    removeRating,
+    clearRatings,
+    isActive,
+  };
+}

--- a/apps/lumi-dashboard/app/hooks/useSearchParams.ts
+++ b/apps/lumi-dashboard/app/hooks/useSearchParams.ts
@@ -4,9 +4,9 @@ import type { SearchParams } from "~/schemas/searchSchema";
 
 export type { SearchParams } from "~/schemas/searchSchema";
 
-function removeEmptyParams(
-  params: Partial<SearchParams>,
-): Partial<SearchParams> {
+type LooseSearchParams = Record<string, unknown>;
+
+function removeEmptyParams(params: LooseSearchParams): LooseSearchParams {
   return Object.fromEntries(
     Object.entries(params).filter(
       ([, value]) => value !== undefined && value !== "",
@@ -22,36 +22,42 @@ export function useSearchParams() {
 
   const setParam = useCallback(
     (key: keyof SearchParams, value: string | undefined) => {
+      const search = ((prev: LooseSearchParams) =>
+        removeEmptyParams({
+          ...prev,
+          [key]: value || undefined,
+        })) as never;
+
       void navigate({
         to: currentPath,
-        search: removeEmptyParams({
-          ...params,
-          [key]: value || undefined,
-        }),
+        search,
         replace: true,
       });
     },
-    [currentPath, navigate, params],
+    [currentPath, navigate],
   );
 
   const setParams = useCallback(
     (newParams: Partial<SearchParams>) => {
+      const search = ((prev: LooseSearchParams) =>
+        removeEmptyParams({
+          ...prev,
+          ...newParams,
+        })) as never;
+
       void navigate({
         to: currentPath,
-        search: removeEmptyParams({
-          ...params,
-          ...newParams,
-        }),
+        search,
         replace: true,
       });
     },
-    [currentPath, navigate, params],
+    [currentPath, navigate],
   );
 
   const resetParams = useCallback(() => {
     void navigate({
       to: currentPath,
-      search: {},
+      search: {} as never,
       replace: true,
     });
   }, [currentPath, navigate]);

--- a/apps/lumi-dashboard/app/hooks/useSearchParams.ts
+++ b/apps/lumi-dashboard/app/hooks/useSearchParams.ts
@@ -1,129 +1,60 @@
-import { useCallback, useSyncExternalStore } from "react";
+import { useNavigate, useRouter, useSearch } from "@tanstack/react-router";
+import { useCallback } from "react";
+import type { SearchParams } from "~/schemas/searchSchema";
 
-export interface SearchParams {
-  team?: string;
-  app?: string;
-  page?: string;
-  size?: string;
-  fromDate?: string;
-  toDate?: string;
-  hasText?: string;
-  query?: string;
-  tag?: string;
-  surveyId?: string;
-  /** Filter by low ratings (1-2) */
-  lowRating?: string;
-  /** Filter by device type */
-  deviceType?: string;
+export type { SearchParams } from "~/schemas/searchSchema";
 
-  /** Filter by theme (for discovery drill-down) */
-  theme?: string;
-
-  /** Filter by context.tags (format: "key:value,key:value") */
-  segment?: string;
-
-  /** Filter by specific task (for Top Tasks drill-down) */
-  task?: string;
-
-  /** Filter by a specific rating fieldId (e.g. thumbs question) */
-  ratingFieldId?: string;
-
-  /** Filter by a specific rating value for ratingFieldId (e.g. 2=Ja, 1=Nei) */
-  ratingValue?: string;
-
-  /** Filter by a specific choice fieldId */
-  choiceFieldId?: string;
-
-  /** Filter by a specific choice value for choiceFieldId */
-  choiceValue?: string;
-}
-
-// Store for managing search params reactively
-let listeners: Array<() => void> = [];
-
-function subscribe(listener: () => void) {
-  listeners.push(listener);
-
-  // Also listen to browser events
-  if (typeof window !== "undefined") {
-    window.addEventListener("popstate", listener);
-  }
-
-  return () => {
-    listeners = listeners.filter((l) => l !== listener);
-    if (typeof window !== "undefined") {
-      window.removeEventListener("popstate", listener);
-    }
-  };
-}
-
-function getSnapshot(): string {
-  if (typeof window === "undefined") return "";
-  return window.location.search;
-}
-
-function getServerSnapshot(): string {
-  return "";
-}
-
-function notifyListeners() {
-  for (const listener of listeners) {
-    listener();
-  }
+function removeEmptyParams(
+  params: Partial<SearchParams>,
+): Partial<SearchParams> {
+  return Object.fromEntries(
+    Object.entries(params).filter(
+      ([, value]) => value !== undefined && value !== "",
+    ),
+  ) as Partial<SearchParams>;
 }
 
 export function useSearchParams() {
-  // Use useSyncExternalStore for SSR-safe reactive URL params
-  const search = useSyncExternalStore(
-    subscribe,
-    getSnapshot,
-    getServerSnapshot,
-  );
-
-  // Parse params from the search string
-  const params: SearchParams = search
-    ? (Object.fromEntries(new URLSearchParams(search)) as SearchParams)
-    : {};
+  const navigate = useNavigate();
+  const router = useRouter();
+  const params: SearchParams = useSearch({ strict: false });
+  const currentPath = router.state.location.pathname;
 
   const setParam = useCallback(
     (key: keyof SearchParams, value: string | undefined) => {
-      if (typeof window === "undefined") return;
-
-      const url = new URL(window.location.href);
-      if (value === undefined || value === "") {
-        url.searchParams.delete(key);
-      } else {
-        url.searchParams.set(key, value);
-      }
-      window.history.pushState({}, "", url.toString());
-      notifyListeners();
+      void navigate({
+        to: currentPath,
+        search: removeEmptyParams({
+          ...params,
+          [key]: value || undefined,
+        }),
+        replace: true,
+      });
     },
-    [],
+    [currentPath, navigate, params],
   );
 
-  const setParams = useCallback((newParams: Partial<SearchParams>) => {
-    if (typeof window === "undefined") return;
-
-    const url = new URL(window.location.href);
-    for (const [key, value] of Object.entries(newParams)) {
-      if (value === undefined || value === "") {
-        url.searchParams.delete(key);
-      } else {
-        url.searchParams.set(key, value);
-      }
-    }
-    window.history.pushState({}, "", url.toString());
-    notifyListeners();
-  }, []);
+  const setParams = useCallback(
+    (newParams: Partial<SearchParams>) => {
+      void navigate({
+        to: currentPath,
+        search: removeEmptyParams({
+          ...params,
+          ...newParams,
+        }),
+        replace: true,
+      });
+    },
+    [currentPath, navigate, params],
+  );
 
   const resetParams = useCallback(() => {
-    if (typeof window === "undefined") return;
-
-    const url = new URL(window.location.href);
-    url.search = "";
-    window.history.pushState({}, "", url.toString());
-    notifyListeners();
-  }, []);
+    void navigate({
+      to: currentPath,
+      search: {},
+      replace: true,
+    });
+  }, [currentPath, navigate]);
 
   return { params, setParam, setParams, resetParams };
 }

--- a/apps/lumi-dashboard/app/hooks/useSearchParams.ts
+++ b/apps/lumi-dashboard/app/hooks/useSearchParams.ts
@@ -30,6 +30,12 @@ export interface SearchParams {
 
   /** Filter by a specific rating value for ratingFieldId (e.g. 2=Ja, 1=Nei) */
   ratingValue?: string;
+
+  /** Filter by a specific choice fieldId */
+  choiceFieldId?: string;
+
+  /** Filter by a specific choice value for choiceFieldId */
+  choiceValue?: string;
 }
 
 // Store for managing search params reactively

--- a/apps/lumi-dashboard/app/hooks/useSearchParams.ts
+++ b/apps/lumi-dashboard/app/hooks/useSearchParams.ts
@@ -1,66 +1,60 @@
-import { useNavigate, useRouter, useSearch } from "@tanstack/react-router";
+import { useNavigate, useSearch } from "@tanstack/react-router";
 import { useCallback } from "react";
 import type { SearchParams } from "~/schemas/searchSchema";
 
 export type { SearchParams } from "~/schemas/searchSchema";
 
-type LooseSearchParams = Record<string, unknown>;
-
-function removeEmptyParams(params: LooseSearchParams): LooseSearchParams {
-  return Object.fromEntries(
-    Object.entries(params).filter(
-      ([, value]) => value !== undefined && value !== "",
-    ),
-  ) as Partial<SearchParams>;
-}
-
 export function useSearchParams() {
   const navigate = useNavigate();
-  const router = useRouter();
-  const params: SearchParams = useSearch({ strict: false });
-  const currentPath = router.state.location.pathname;
+  const params = useSearch({ strict: false }) as SearchParams;
 
   const setParam = useCallback(
     (key: keyof SearchParams, value: string | undefined) => {
-      const search = ((prev: LooseSearchParams) =>
-        removeEmptyParams({
-          ...prev,
-          [key]: value || undefined,
-        })) as never;
-
       void navigate({
-        to: currentPath,
-        search,
+        // @ts-expect-error -- shared hook used across routes; strict typing not feasible
+        search: (prev: Record<string, string | undefined>) => {
+          const next = { ...prev };
+          if (value) {
+            next[key] = value;
+          } else {
+            delete next[key];
+          }
+          return next;
+        },
         replace: true,
       });
     },
-    [currentPath, navigate],
+    [navigate],
   );
 
   const setParams = useCallback(
     (newParams: Partial<SearchParams>) => {
-      const search = ((prev: LooseSearchParams) =>
-        removeEmptyParams({
-          ...prev,
-          ...newParams,
-        })) as never;
-
       void navigate({
-        to: currentPath,
-        search,
+        // @ts-expect-error -- shared hook used across routes; strict typing not feasible
+        search: (prev: Record<string, string | undefined>) => {
+          const next = { ...prev };
+          for (const [key, value] of Object.entries(newParams)) {
+            if (value === undefined || value === "") {
+              delete next[key];
+            } else {
+              next[key] = value;
+            }
+          }
+          return next;
+        },
         replace: true,
       });
     },
-    [currentPath, navigate],
+    [navigate],
   );
 
   const resetParams = useCallback(() => {
     void navigate({
-      to: currentPath,
-      search: {} as never,
+      // @ts-expect-error -- shared hook used across routes; strict typing not feasible
+      search: {},
       replace: true,
     });
-  }, [currentPath, navigate]);
+  }, [navigate]);
 
   return { params, setParam, setParams, resetParams };
 }

--- a/apps/lumi-dashboard/app/hooks/useStats.ts
+++ b/apps/lumi-dashboard/app/hooks/useStats.ts
@@ -1,31 +1,11 @@
 import { keepPreviousData, useQuery } from "@tanstack/react-query";
 import { useSearchParams } from "~/hooks/useSearchParams";
 import { fetchStatsServerFn } from "~/server/actions";
+import { splitChoiceParam } from "~/utils/choiceFilterUtils";
+import { splitRatingParam } from "~/utils/ratingFilterUtils";
 
-// Re-export the FeedbackStats type from schemas for components that need it
 export type { FeedbackStats } from "~/types/api";
 
-/**
- * Hook to fetch aggregated feedback statistics.
- *
- * Automatically reacts to URL search params for filtering by:
- * - app: Filter by application name
- * - fromDate/toDate: Date range filter
- * - surveyId: Filter by specific survey ID
- * - deviceType: Filter by device type (mobile/tablet/desktop)
- * - task: Filter by specific task (Top Tasks drill-down)
- *
- * @returns React Query result with FeedbackStats data
- *
- * @example
- * ```tsx
- * function Dashboard() {
- *   const { data: stats, isLoading } = useStats();
- *   if (isLoading) return <Spinner />;
- *   return <div>Total: {stats.totalCount}</div>;
- * }
- * ```
- */
 export function useStats() {
   const { params } = useSearchParams();
 
@@ -39,11 +19,9 @@ export function useStats() {
       params.surveyId,
       params.deviceType,
       params.segment,
-      params.task, // Task filter for Top Tasks drill-down
-      params.ratingFieldId,
-      params.ratingValue,
-      params.choiceFieldId,
-      params.choiceValue,
+      params.task,
+      params.rating,
+      params.choice,
     ],
     queryFn: () =>
       fetchStatsServerFn({
@@ -55,14 +33,12 @@ export function useStats() {
           surveyId: params.surveyId,
           deviceType: params.deviceType,
           segment: params.segment,
-          task: params.task, // Pass task filter to backend
-          ratingFieldId: params.ratingFieldId,
-          ratingValue: params.ratingValue,
-          choiceFieldId: params.choiceFieldId,
-          choiceValue: params.choiceValue,
+          task: params.task,
+          rating: splitRatingParam(params.rating),
+          choice: splitChoiceParam(params.choice),
         },
       }),
-    staleTime: 30000, // 30 seconds
-    placeholderData: keepPreviousData, // Prevent skeleton flash on param changes
+    staleTime: 30000,
+    placeholderData: keepPreviousData,
   });
 }

--- a/apps/lumi-dashboard/app/hooks/useStats.ts
+++ b/apps/lumi-dashboard/app/hooks/useStats.ts
@@ -42,6 +42,8 @@ export function useStats() {
       params.task, // Task filter for Top Tasks drill-down
       params.ratingFieldId,
       params.ratingValue,
+      params.choiceFieldId,
+      params.choiceValue,
     ],
     queryFn: () =>
       fetchStatsServerFn({
@@ -56,6 +58,8 @@ export function useStats() {
           task: params.task, // Pass task filter to backend
           ratingFieldId: params.ratingFieldId,
           ratingValue: params.ratingValue,
+          choiceFieldId: params.choiceFieldId,
+          choiceValue: params.choiceValue,
         },
       }),
     staleTime: 30000, // 30 seconds

--- a/apps/lumi-dashboard/app/hooks/useTaskPriorityStats.ts
+++ b/apps/lumi-dashboard/app/hooks/useTaskPriorityStats.ts
@@ -1,14 +1,11 @@
 import { keepPreviousData, useQuery } from "@tanstack/react-query";
 import { useSearchParams } from "~/hooks/useSearchParams";
 import { fetchTaskPriorityServerFn } from "~/server/actions";
+import { splitChoiceParam } from "~/utils/choiceFilterUtils";
+import { splitRatingParam } from "~/utils/ratingFilterUtils";
 
-// Re-export TaskPriorityResponse type for components that need it
 export type { TaskPriorityResponse } from "~/types/api";
 
-/**
- * Hook to fetch Task Priority survey statistics.
- * Returns the "Long Neck" distribution of task votes.
- */
 export function useTaskPriorityStats() {
   const { params } = useSearchParams();
 
@@ -22,10 +19,8 @@ export function useTaskPriorityStats() {
       params.surveyId,
       params.deviceType,
       params.segment,
-      params.ratingFieldId,
-      params.ratingValue,
-      params.choiceFieldId,
-      params.choiceValue,
+      params.rating,
+      params.choice,
     ],
     queryFn: () =>
       fetchTaskPriorityServerFn({
@@ -37,13 +32,11 @@ export function useTaskPriorityStats() {
           toDate: params.toDate,
           deviceType: params.deviceType,
           segment: params.segment,
-          ratingFieldId: params.ratingFieldId,
-          ratingValue: params.ratingValue,
-          choiceFieldId: params.choiceFieldId,
-          choiceValue: params.choiceValue,
+          rating: splitRatingParam(params.rating),
+          choice: splitChoiceParam(params.choice),
         },
       }),
-    staleTime: 60000, // 1 minute
+    staleTime: 60000,
     placeholderData: keepPreviousData,
   });
 }

--- a/apps/lumi-dashboard/app/hooks/useTaskPriorityStats.ts
+++ b/apps/lumi-dashboard/app/hooks/useTaskPriorityStats.ts
@@ -24,6 +24,8 @@ export function useTaskPriorityStats() {
       params.segment,
       params.ratingFieldId,
       params.ratingValue,
+      params.choiceFieldId,
+      params.choiceValue,
     ],
     queryFn: () =>
       fetchTaskPriorityServerFn({
@@ -37,6 +39,8 @@ export function useTaskPriorityStats() {
           segment: params.segment,
           ratingFieldId: params.ratingFieldId,
           ratingValue: params.ratingValue,
+          choiceFieldId: params.choiceFieldId,
+          choiceValue: params.choiceValue,
         },
       }),
     staleTime: 60000, // 1 minute

--- a/apps/lumi-dashboard/app/hooks/useTopTasksStats.ts
+++ b/apps/lumi-dashboard/app/hooks/useTopTasksStats.ts
@@ -1,8 +1,9 @@
 import { keepPreviousData, useQuery } from "@tanstack/react-query";
 import { useSearchParams } from "~/hooks/useSearchParams";
 import { fetchTopTasksServerFn } from "~/server/actions";
+import { splitChoiceParam } from "~/utils/choiceFilterUtils";
+import { splitRatingParam } from "~/utils/ratingFilterUtils";
 
-// Re-export TopTasksResponse type for components that need it
 export type { TopTasksResponse } from "~/types/api";
 
 export function useTopTasksStats() {
@@ -17,11 +18,9 @@ export function useTopTasksStats() {
       params.toDate,
       params.surveyId,
       params.deviceType,
-      params.task, // Task filter for drill-down
-      params.ratingFieldId,
-      params.ratingValue,
-      params.choiceFieldId,
-      params.choiceValue,
+      params.task,
+      params.rating,
+      params.choice,
     ],
     queryFn: () =>
       fetchTopTasksServerFn({
@@ -32,14 +31,12 @@ export function useTopTasksStats() {
           fromDate: params.fromDate,
           toDate: params.toDate,
           deviceType: params.deviceType,
-          task: params.task, // Pass task filter to backend
-          ratingFieldId: params.ratingFieldId,
-          ratingValue: params.ratingValue,
-          choiceFieldId: params.choiceFieldId,
-          choiceValue: params.choiceValue,
+          task: params.task,
+          rating: splitRatingParam(params.rating),
+          choice: splitChoiceParam(params.choice),
         },
       }),
-    staleTime: 60000, // 1 minute
+    staleTime: 60000,
     placeholderData: keepPreviousData,
   });
 }

--- a/apps/lumi-dashboard/app/hooks/useTopTasksStats.ts
+++ b/apps/lumi-dashboard/app/hooks/useTopTasksStats.ts
@@ -20,6 +20,8 @@ export function useTopTasksStats() {
       params.task, // Task filter for drill-down
       params.ratingFieldId,
       params.ratingValue,
+      params.choiceFieldId,
+      params.choiceValue,
     ],
     queryFn: () =>
       fetchTopTasksServerFn({
@@ -33,6 +35,8 @@ export function useTopTasksStats() {
           task: params.task, // Pass task filter to backend
           ratingFieldId: params.ratingFieldId,
           ratingValue: params.ratingValue,
+          choiceFieldId: params.choiceFieldId,
+          choiceValue: params.choiceValue,
         },
       }),
     staleTime: 60000, // 1 minute

--- a/apps/lumi-dashboard/app/mock/mockData.ts
+++ b/apps/lumi-dashboard/app/mock/mockData.ts
@@ -325,6 +325,22 @@ function applyFilters(
       );
     }
   }
+  // Filter by choice answer (singleChoice / multiChoice fieldId + value)
+  const choiceFieldId = params.get("choiceFieldId");
+  const choiceValue = params.get("choiceValue");
+  if (choiceFieldId && choiceValue) {
+    filtered = filtered.filter((item) =>
+      item.answers.some((a) => {
+        if (a.fieldId !== choiceFieldId) return false;
+        if (a.fieldType === "SINGLE_CHOICE" && a.value.type === "singleChoice")
+          return a.value.selectedOptionId === choiceValue;
+        if (a.fieldType === "MULTI_CHOICE" && a.value.type === "multiChoice")
+          return a.value.selectedOptionIds.includes(choiceValue);
+        return false;
+      }),
+    );
+  }
+
   // Filter by tags (supports both item.tags array and metadata key:value format)
   if (tag) {
     const tagList = tag.split(",").map((t) => t.trim());

--- a/apps/lumi-dashboard/app/mock/mockData.ts
+++ b/apps/lumi-dashboard/app/mock/mockData.ts
@@ -8,6 +8,8 @@ import type {
   TeamsAndApps,
   TopTasksResponse,
 } from "~/types/api";
+import { parseChoiceParam } from "~/utils/choiceFilterUtils";
+import { parseRatingParam } from "~/utils/ratingFilterUtils";
 
 import {
   generateComplexSurveyData,
@@ -258,8 +260,7 @@ function applyFilters(
   const tag = params.get("tag");
   const theme = params.get("theme");
   const segment = params.get("segment");
-  const ratingFieldId = params.get("ratingFieldId");
-  const ratingValue = params.get("ratingValue");
+  const rating = params.get("rating");
 
   if (app) {
     filtered = filtered.filter((item) => item.app === app);
@@ -310,34 +311,48 @@ function applyFilters(
     filtered = filtered.filter((item) => item.surveyId === surveyId);
   }
 
-  // Filter by specific rating answer (fieldId + value)
-  if (ratingFieldId && ratingValue) {
-    const parsed = Number.parseInt(ratingValue, 10);
-    if (!Number.isNaN(parsed)) {
-      filtered = filtered.filter((item) =>
-        item.answers.some(
-          (a) =>
-            a.fieldType === "RATING" &&
-            a.fieldId === ratingFieldId &&
-            a.value.type === "rating" &&
-            a.value.rating === parsed,
-        ),
-      );
-    }
-  }
-  // Filter by choice answer (singleChoice / multiChoice fieldId + value)
-  const choiceFieldId = params.get("choiceFieldId");
-  const choiceValue = params.get("choiceValue");
-  if (choiceFieldId && choiceValue) {
+  const ratingFilters = Object.entries(parseRatingParam(rating ?? undefined));
+  if (ratingFilters.length > 0) {
     filtered = filtered.filter((item) =>
-      item.answers.some((a) => {
-        if (a.fieldId !== choiceFieldId) return false;
-        if (a.fieldType === "SINGLE_CHOICE" && a.value.type === "singleChoice")
-          return a.value.selectedOptionId === choiceValue;
-        if (a.fieldType === "MULTI_CHOICE" && a.value.type === "multiChoice")
-          return a.value.selectedOptionIds.includes(choiceValue);
-        return false;
+      ratingFilters.every(([fieldId, ratingValue]) => {
+        const parsed = Number.parseInt(ratingValue, 10);
+        if (Number.isNaN(parsed)) {
+          return false;
+        }
+
+        return item.answers.some(
+          (answer) =>
+            answer.fieldType === "RATING" &&
+            answer.fieldId === fieldId &&
+            answer.value.type === "rating" &&
+            answer.value.rating === parsed,
+        );
       }),
+    );
+  }
+
+  const choice = params.get("choice");
+  const choiceFilters = Object.entries(parseChoiceParam(choice ?? undefined));
+  if (choiceFilters.length > 0) {
+    filtered = filtered.filter((item) =>
+      choiceFilters.every(([fieldId, optionId]) =>
+        item.answers.some((answer) => {
+          if (answer.fieldId !== fieldId) return false;
+          if (
+            answer.fieldType === "SINGLE_CHOICE" &&
+            answer.value.type === "singleChoice"
+          ) {
+            return answer.value.selectedOptionId === optionId;
+          }
+          if (
+            answer.fieldType === "MULTI_CHOICE" &&
+            answer.value.type === "multiChoice"
+          ) {
+            return answer.value.selectedOptionIds.includes(optionId);
+          }
+          return false;
+        }),
+      ),
     );
   }
 

--- a/apps/lumi-dashboard/app/mock/stats.ts
+++ b/apps/lumi-dashboard/app/mock/stats.ts
@@ -11,6 +11,8 @@ import type {
   TopTaskStats,
   TopTasksResponse,
 } from "~/types/api";
+import { parseChoiceParam } from "~/utils/choiceFilterUtils";
+import { parseRatingParam } from "~/utils/ratingFilterUtils";
 import { getTopKeywords, IGNORED_WORDS } from "~/utils/wordAnalysis";
 import { getRating, hasTextResponse } from "./helpers";
 
@@ -317,8 +319,7 @@ export function calculateStats(
   const toDate = params.get("toDate");
   const surveyId = params.get("surveyId");
   const deviceType = params.get("deviceType");
-  const ratingFieldId = params.get("ratingFieldId");
-  const ratingValue = params.get("ratingValue");
+  const rating = params.get("rating");
 
   if (app) {
     filtered = filtered.filter((item) => item.app === app);
@@ -340,35 +341,48 @@ export function calculateStats(
     );
   }
 
-  // Filter by specific rating answer (fieldId + value)
-  if (ratingFieldId && ratingValue) {
-    const parsed = Number.parseInt(ratingValue, 10);
-    if (!Number.isNaN(parsed)) {
-      filtered = filtered.filter((item) =>
-        item.answers.some(
-          (a) =>
-            a.fieldType === "RATING" &&
-            a.fieldId === ratingFieldId &&
-            a.value.type === "rating" &&
-            a.value.rating === parsed,
-        ),
-      );
-    }
+  const ratingFilters = Object.entries(parseRatingParam(rating ?? undefined));
+  if (ratingFilters.length > 0) {
+    filtered = filtered.filter((item) =>
+      ratingFilters.every(([fieldId, ratingValue]) => {
+        const parsed = Number.parseInt(ratingValue, 10);
+        if (Number.isNaN(parsed)) {
+          return false;
+        }
+
+        return item.answers.some(
+          (answer) =>
+            answer.fieldType === "RATING" &&
+            answer.fieldId === fieldId &&
+            answer.value.type === "rating" &&
+            answer.value.rating === parsed,
+        );
+      }),
+    );
   }
 
-  // Filter by choice answer (singleChoice / multiChoice fieldId + value)
-  const choiceFieldId = params.get("choiceFieldId");
-  const choiceValue = params.get("choiceValue");
-  if (choiceFieldId && choiceValue) {
+  const choice = params.get("choice");
+  const choiceFilters = Object.entries(parseChoiceParam(choice ?? undefined));
+  if (choiceFilters.length > 0) {
     filtered = filtered.filter((item) =>
-      item.answers.some((a) => {
-        if (a.fieldId !== choiceFieldId) return false;
-        if (a.fieldType === "SINGLE_CHOICE" && a.value.type === "singleChoice")
-          return a.value.selectedOptionId === choiceValue;
-        if (a.fieldType === "MULTI_CHOICE" && a.value.type === "multiChoice")
-          return a.value.selectedOptionIds.includes(choiceValue);
-        return false;
-      }),
+      choiceFilters.every(([fieldId, optionId]) =>
+        item.answers.some((answer) => {
+          if (answer.fieldId !== fieldId) return false;
+          if (
+            answer.fieldType === "SINGLE_CHOICE" &&
+            answer.value.type === "singleChoice"
+          ) {
+            return answer.value.selectedOptionId === optionId;
+          }
+          if (
+            answer.fieldType === "MULTI_CHOICE" &&
+            answer.value.type === "multiChoice"
+          ) {
+            return answer.value.selectedOptionIds.includes(optionId);
+          }
+          return false;
+        }),
+      ),
     );
   }
 
@@ -594,9 +608,6 @@ function applyFiltersToItems(
   const toDate = params.get("toDate");
   const surveyId = params.get("surveyId");
   const deviceType = params.get("deviceType");
-  const ratingFieldId = params.get("ratingFieldId");
-  const ratingValue = params.get("ratingValue");
-
   if (app) filtered = filtered.filter((item) => item.app === app);
   if (fromDate)
     filtered = filtered.filter((item) => item.submittedAt >= fromDate);
@@ -611,20 +622,46 @@ function applyFiltersToItems(
       (item) => item.context?.deviceType === deviceType,
     );
 
-  // Filter by specific rating answer (fieldId + value)
-  if (ratingFieldId && ratingValue) {
-    const parsed = Number.parseInt(ratingValue, 10);
-    if (!Number.isNaN(parsed)) {
-      filtered = filtered.filter((item) =>
-        item.answers.some(
+  // Filter by rating answers (multi-value: "fieldId:value,fieldId2:value2")
+  const ratingFilters = Object.entries(
+    parseRatingParam(params.get("rating") ?? undefined),
+  );
+  if (ratingFilters.length > 0) {
+    filtered = filtered.filter((item) =>
+      ratingFilters.every(([fieldId, ratingValue]) => {
+        const parsed = Number.parseInt(ratingValue, 10);
+        if (Number.isNaN(parsed)) return false;
+        return item.answers.some(
           (a) =>
             a.fieldType === "RATING" &&
-            a.fieldId === ratingFieldId &&
+            a.fieldId === fieldId &&
             a.value.type === "rating" &&
             a.value.rating === parsed,
-        ),
-      );
-    }
+        );
+      }),
+    );
+  }
+
+  // Filter by choice answers (multi-value: "fieldId:value,fieldId2:value2")
+  const choiceFilters = Object.entries(
+    parseChoiceParam(params.get("choice") ?? undefined),
+  );
+  if (choiceFilters.length > 0) {
+    filtered = filtered.filter((item) =>
+      choiceFilters.every(([fieldId, optionId]) =>
+        item.answers.some((a) => {
+          if (a.fieldId !== fieldId) return false;
+          if (
+            a.fieldType === "SINGLE_CHOICE" &&
+            a.value.type === "singleChoice"
+          )
+            return a.value.selectedOptionId === optionId;
+          if (a.fieldType === "MULTI_CHOICE" && a.value.type === "multiChoice")
+            return a.value.selectedOptionIds.includes(optionId);
+          return false;
+        }),
+      ),
+    );
   }
 
   // Filter by segment (context.tags format: "key:value,key:value")

--- a/apps/lumi-dashboard/app/mock/stats.ts
+++ b/apps/lumi-dashboard/app/mock/stats.ts
@@ -356,6 +356,22 @@ export function calculateStats(
     }
   }
 
+  // Filter by choice answer (singleChoice / multiChoice fieldId + value)
+  const choiceFieldId = params.get("choiceFieldId");
+  const choiceValue = params.get("choiceValue");
+  if (choiceFieldId && choiceValue) {
+    filtered = filtered.filter((item) =>
+      item.answers.some((a) => {
+        if (a.fieldId !== choiceFieldId) return false;
+        if (a.fieldType === "SINGLE_CHOICE" && a.value.type === "singleChoice")
+          return a.value.selectedOptionId === choiceValue;
+        if (a.fieldType === "MULTI_CHOICE" && a.value.type === "multiChoice")
+          return a.value.selectedOptionIds.includes(choiceValue);
+        return false;
+      }),
+    );
+  }
+
   // Filter by segment (context.tags format: "key:value,key:value")
   const segment = params.get("segment");
   if (segment) {

--- a/apps/lumi-dashboard/app/mock/utils/__tests__/filters.test.ts
+++ b/apps/lumi-dashboard/app/mock/utils/__tests__/filters.test.ts
@@ -89,10 +89,9 @@ describe("applyFeedbackFilters", () => {
 
   const items = [itemA, itemB, itemC];
 
-  it("filters by ratingFieldId + ratingValue", () => {
+  it("filters by rating field filters", () => {
     const filtered = applyFeedbackFilters(items, {
-      ratingFieldId: "rating",
-      ratingValue: "5",
+      rating: "rating:5",
     });
 
     expect(filtered.map((i) => i.id)).toEqual(["b"]);
@@ -136,7 +135,7 @@ describe("applyFeedbackFilters", () => {
     expect(filtered.map((i) => i.id)).toEqual(["a"]);
   });
 
-  it("filters by choiceFieldId + choiceValue for single and multi choice", () => {
+  it("filters by choice field filters for single and multi choice", () => {
     const withChoices: FeedbackDto[] = [
       makeItem({
         id: "single-match",
@@ -186,13 +185,84 @@ describe("applyFeedbackFilters", () => {
     ];
 
     const filtered = applyFeedbackFilters(withChoices, {
-      choiceFieldId: "task_choice",
-      choiceValue: "opt-1",
+      choice: "task_choice:opt-1",
     });
 
     expect(filtered.map((i) => i.id).sort()).toEqual([
       "multi-match",
       "single-match",
     ]);
+  });
+
+  it("AND-filters multiple rating and choice fields", () => {
+    const withMultipleFields: FeedbackDto[] = [
+      makeItem({
+        id: "match",
+        answers: [
+          {
+            fieldId: "rating-main",
+            fieldType: "RATING",
+            question: { label: "Hvordan?" },
+            value: { type: "rating", rating: 5 },
+          },
+          {
+            fieldId: "choice-main",
+            fieldType: "SINGLE_CHOICE",
+            question: {
+              label: "Oppgave",
+              options: [{ id: "opt-1", label: "Søknad" }],
+            },
+            value: { type: "singleChoice", selectedOptionId: "opt-1" },
+          },
+        ],
+      }),
+      makeItem({
+        id: "wrong-rating",
+        answers: [
+          {
+            fieldId: "rating-main",
+            fieldType: "RATING",
+            question: { label: "Hvordan?" },
+            value: { type: "rating", rating: 4 },
+          },
+          {
+            fieldId: "choice-main",
+            fieldType: "SINGLE_CHOICE",
+            question: {
+              label: "Oppgave",
+              options: [{ id: "opt-1", label: "Søknad" }],
+            },
+            value: { type: "singleChoice", selectedOptionId: "opt-1" },
+          },
+        ],
+      }),
+      makeItem({
+        id: "wrong-choice",
+        answers: [
+          {
+            fieldId: "rating-main",
+            fieldType: "RATING",
+            question: { label: "Hvordan?" },
+            value: { type: "rating", rating: 5 },
+          },
+          {
+            fieldId: "choice-main",
+            fieldType: "SINGLE_CHOICE",
+            question: {
+              label: "Oppgave",
+              options: [{ id: "opt-2", label: "Oppfølging" }],
+            },
+            value: { type: "singleChoice", selectedOptionId: "opt-2" },
+          },
+        ],
+      }),
+    ];
+
+    const filtered = applyFeedbackFilters(withMultipleFields, {
+      rating: "rating-main:5",
+      choice: "choice-main:opt-1",
+    });
+
+    expect(filtered.map((i) => i.id)).toEqual(["match"]);
   });
 });

--- a/apps/lumi-dashboard/app/mock/utils/__tests__/filters.test.ts
+++ b/apps/lumi-dashboard/app/mock/utils/__tests__/filters.test.ts
@@ -135,4 +135,64 @@ describe("applyFeedbackFilters", () => {
     });
     expect(filtered.map((i) => i.id)).toEqual(["a"]);
   });
+
+  it("filters by choiceFieldId + choiceValue for single and multi choice", () => {
+    const withChoices: FeedbackDto[] = [
+      makeItem({
+        id: "single-match",
+        answers: [
+          {
+            fieldId: "task_choice",
+            fieldType: "SINGLE_CHOICE",
+            question: {
+              label: "Oppgave",
+              options: [{ id: "opt-1", label: "Søknad" }],
+            },
+            value: { type: "singleChoice", selectedOptionId: "opt-1" },
+          },
+        ],
+      }),
+      makeItem({
+        id: "multi-match",
+        answers: [
+          {
+            fieldId: "task_choice",
+            fieldType: "MULTI_CHOICE",
+            question: {
+              label: "Oppgave",
+              options: [{ id: "opt-1", label: "Søknad" }],
+            },
+            value: {
+              type: "multiChoice",
+              selectedOptionIds: ["opt-1", "opt-2"],
+            },
+          },
+        ],
+      }),
+      makeItem({
+        id: "no-match",
+        answers: [
+          {
+            fieldId: "task_choice",
+            fieldType: "SINGLE_CHOICE",
+            question: {
+              label: "Oppgave",
+              options: [{ id: "opt-2", label: "Oppfølging" }],
+            },
+            value: { type: "singleChoice", selectedOptionId: "opt-2" },
+          },
+        ],
+      }),
+    ];
+
+    const filtered = applyFeedbackFilters(withChoices, {
+      choiceFieldId: "task_choice",
+      choiceValue: "opt-1",
+    });
+
+    expect(filtered.map((i) => i.id).sort()).toEqual([
+      "multi-match",
+      "single-match",
+    ]);
+  });
 });

--- a/apps/lumi-dashboard/app/mock/utils/filters.ts
+++ b/apps/lumi-dashboard/app/mock/utils/filters.ts
@@ -34,6 +34,10 @@ export interface FilterParams {
   ratingFieldId?: string;
   /** Filter by a specific rating value (stringified number) */
   ratingValue?: string;
+  /** Filter by a specific choice question fieldId */
+  choiceFieldId?: string;
+  /** Filter by selected choice option id */
+  choiceValue?: string;
 }
 
 // ============================================
@@ -159,6 +163,30 @@ export function applyFeedbackFilters(
     }
   }
 
+  // Specific choice filter (fieldId + option id)
+  if (filters.choiceFieldId && filters.choiceValue) {
+    const { choiceFieldId, choiceValue } = filters;
+
+    filtered = filtered.filter((item) =>
+      item.answers.some((a) => {
+        if (a.fieldId !== choiceFieldId) return false;
+
+        if (
+          a.fieldType === "SINGLE_CHOICE" &&
+          a.value.type === "singleChoice"
+        ) {
+          return a.value.selectedOptionId === choiceValue;
+        }
+
+        if (a.fieldType === "MULTI_CHOICE" && a.value.type === "multiChoice") {
+          return a.value.selectedOptionIds.includes(choiceValue);
+        }
+
+        return false;
+      }),
+    );
+  }
+
   return filtered;
 }
 
@@ -189,6 +217,8 @@ function normalizeParams(params: FilterParams | URLSearchParams): FilterParams {
       theme: params.get("theme") ?? undefined,
       ratingFieldId: params.get("ratingFieldId") ?? undefined,
       ratingValue: params.get("ratingValue") ?? undefined,
+      choiceFieldId: params.get("choiceFieldId") ?? undefined,
+      choiceValue: params.get("choiceValue") ?? undefined,
     };
   }
   return params;

--- a/apps/lumi-dashboard/app/mock/utils/filters.ts
+++ b/apps/lumi-dashboard/app/mock/utils/filters.ts
@@ -1,23 +1,14 @@
 /**
  * Unified filter utilities for mock data.
- *
- * Provides a single implementation of feedback filtering logic,
- * replacing the duplicated applyFilters and applyFiltersToItems functions.
  */
 
 import type { FeedbackDto } from "~/types/api";
+import { parseChoiceParam } from "~/utils/choiceFilterUtils";
+import { parseRatingParam } from "~/utils/ratingFilterUtils";
 import { mockThemes } from "../themes";
 import { getTaskNameFromFeedback } from "./extractors";
 import { matchesThemeKeywords } from "./textAnalysis";
 
-// ============================================
-// Filter Parameters Interface
-// ============================================
-
-/**
- * Filter parameters for feedback queries.
- * These can come from URLSearchParams or be passed directly.
- */
 export interface FilterParams {
   app?: string;
   surveyId?: string;
@@ -29,49 +20,26 @@ export interface FilterParams {
   hasText?: string;
   lowRating?: string;
   theme?: string;
-
-  /** Filter by a specific rating question fieldId */
-  ratingFieldId?: string;
-  /** Filter by a specific rating value (stringified number) */
-  ratingValue?: string;
-  /** Filter by a specific choice question fieldId */
-  choiceFieldId?: string;
-  /** Filter by selected choice option id */
-  choiceValue?: string;
+  rating?: string;
+  choice?: string;
 }
 
-// ============================================
-// Core Filter Function
-// ============================================
-
-/**
- * Apply filters to a list of feedback items.
- * Single source of truth for all filtering logic.
- *
- * @param items - The feedback items to filter
- * @param params - Filter parameters (from URL or direct)
- * @returns Filtered feedback items
- */
 export function applyFeedbackFilters(
   items: FeedbackDto[],
   params: FilterParams | URLSearchParams,
 ): FeedbackDto[] {
-  // Normalize params to FilterParams object
   const filters = normalizeParams(params);
 
   let filtered = [...items];
 
-  // App filter
   if (filters.app) {
     filtered = filtered.filter((item) => item.app === filters.app);
   }
 
-  // Survey ID filter
   if (filters.surveyId) {
     filtered = filtered.filter((item) => item.surveyId === filters.surveyId);
   }
 
-  // Date range filters
   if (filters.fromDate) {
     const fromDate = filters.fromDate;
     filtered = filtered.filter((item) => item.submittedAt >= fromDate);
@@ -83,19 +51,18 @@ export function applyFeedbackFilters(
     );
   }
 
-  // Device type filter
   if (filters.deviceType) {
     filtered = filtered.filter(
       (item) => item.context?.deviceType === filters.deviceType,
     );
   }
 
-  // Segment filter (format: "key:value,key:value")
   if (filters.segment) {
-    const segmentFilters = filters.segment.split(",").map((t) => {
-      const [key, value] = t.split(":");
+    const segmentFilters = filters.segment.split(",").map((part) => {
+      const [key, value] = part.split(":");
       return { key, value };
     });
+
     filtered = filtered.filter((item) => {
       if (!item.metadata) return false;
       return segmentFilters.every(
@@ -104,86 +71,92 @@ export function applyFeedbackFilters(
     });
   }
 
-  // Task filter (for Top Tasks drill-down)
   if (filters.task) {
-    filtered = filtered.filter((item) => {
-      const taskName = getTaskNameFromFeedback(item);
-      return taskName === filters.task;
-    });
+    filtered = filtered.filter(
+      (item) => getTaskNameFromFeedback(item) === filters.task,
+    );
   }
 
-  // Theme filter (themeId or "uncategorized")
   if (filters.theme) {
     if (filters.theme === "uncategorized") {
       filtered = filtered.filter((item) => {
         const text = getFeedbackText(item);
         if (!text) return true;
-        return !mockThemes.some((t) => matchesThemeKeywords(text, t.keywords));
+        return !mockThemes.some((theme) =>
+          matchesThemeKeywords(text, theme.keywords),
+        );
       });
     } else {
-      const targetTheme = mockThemes.find((t) => t.id === filters.theme);
-      if (targetTheme && targetTheme.keywords.length > 0) {
-        filtered = filtered.filter((item) => {
-          const text = getFeedbackText(item);
-          return matchesThemeKeywords(text, targetTheme.keywords);
-        });
+      const targetTheme = mockThemes.find(
+        (theme) => theme.id === filters.theme,
+      );
+      if (targetTheme?.keywords.length) {
+        filtered = filtered.filter((item) =>
+          matchesThemeKeywords(getFeedbackText(item), targetTheme.keywords),
+        );
       }
     }
   }
 
-  // Text filter (has text response)
   if (filters.hasText === "true") {
     filtered = filtered.filter((item) =>
-      item.answers.some((a) => a.fieldType === "TEXT" && a.value.text?.trim()),
-    );
-  }
-
-  // Low rating filter (1-2)
-  if (filters.lowRating === "true") {
-    filtered = filtered.filter((item) =>
       item.answers.some(
-        (a) => a.fieldType === "RATING" && (a.value.rating ?? 3) <= 2,
+        (answer) => answer.fieldType === "TEXT" && answer.value.text?.trim(),
       ),
     );
   }
 
-  // Specific rating filter (fieldId + rating value)
-  if (filters.ratingFieldId && filters.ratingValue) {
-    const parsed = Number.parseInt(filters.ratingValue, 10);
-    if (!Number.isNaN(parsed)) {
-      filtered = filtered.filter((item) =>
-        item.answers.some(
-          (a) =>
-            a.fieldType === "RATING" &&
-            a.fieldId === filters.ratingFieldId &&
-            a.value.type === "rating" &&
-            a.value.rating === parsed,
-        ),
-      );
-    }
+  if (filters.lowRating === "true") {
+    filtered = filtered.filter((item) =>
+      item.answers.some(
+        (answer) =>
+          answer.fieldType === "RATING" && (answer.value.rating ?? 3) <= 2,
+      ),
+    );
   }
 
-  // Specific choice filter (fieldId + option id)
-  if (filters.choiceFieldId && filters.choiceValue) {
-    const { choiceFieldId, choiceValue } = filters;
-
+  const ratingFilters = parseRatingParam(filters.rating);
+  if (Object.keys(ratingFilters).length > 0) {
     filtered = filtered.filter((item) =>
-      item.answers.some((a) => {
-        if (a.fieldId !== choiceFieldId) return false;
+      Object.entries(ratingFilters).every(([fieldId, ratingValue]) => {
+        const parsed = Number.parseInt(ratingValue, 10);
+        if (Number.isNaN(parsed)) return false;
 
-        if (
-          a.fieldType === "SINGLE_CHOICE" &&
-          a.value.type === "singleChoice"
-        ) {
-          return a.value.selectedOptionId === choiceValue;
-        }
-
-        if (a.fieldType === "MULTI_CHOICE" && a.value.type === "multiChoice") {
-          return a.value.selectedOptionIds.includes(choiceValue);
-        }
-
-        return false;
+        return item.answers.some(
+          (answer) =>
+            answer.fieldType === "RATING" &&
+            answer.fieldId === fieldId &&
+            answer.value.type === "rating" &&
+            answer.value.rating === parsed,
+        );
       }),
+    );
+  }
+
+  const choiceFilters = parseChoiceParam(filters.choice);
+  if (Object.keys(choiceFilters).length > 0) {
+    filtered = filtered.filter((item) =>
+      Object.entries(choiceFilters).every(([fieldId, choiceValue]) =>
+        item.answers.some((answer) => {
+          if (answer.fieldId !== fieldId) return false;
+
+          if (
+            answer.fieldType === "SINGLE_CHOICE" &&
+            answer.value.type === "singleChoice"
+          ) {
+            return answer.value.selectedOptionId === choiceValue;
+          }
+
+          if (
+            answer.fieldType === "MULTI_CHOICE" &&
+            answer.value.type === "multiChoice"
+          ) {
+            return answer.value.selectedOptionIds.includes(choiceValue);
+          }
+
+          return false;
+        }),
+      ),
     );
   }
 
@@ -191,17 +164,10 @@ export function applyFeedbackFilters(
 }
 
 function getFeedbackText(item: FeedbackDto): string {
-  const textAnswer = item.answers.find((a) => a.fieldType === "TEXT");
+  const textAnswer = item.answers.find((answer) => answer.fieldType === "TEXT");
   return textAnswer?.fieldType === "TEXT" ? (textAnswer.value.text ?? "") : "";
 }
 
-// ============================================
-// Helper Functions
-// ============================================
-
-/**
- * Normalize filter parameters from URLSearchParams or FilterParams object.
- */
 function normalizeParams(params: FilterParams | URLSearchParams): FilterParams {
   if (params instanceof URLSearchParams) {
     return {
@@ -215,19 +181,14 @@ function normalizeParams(params: FilterParams | URLSearchParams): FilterParams {
       hasText: params.get("hasText") ?? undefined,
       lowRating: params.get("lowRating") ?? undefined,
       theme: params.get("theme") ?? undefined,
-      ratingFieldId: params.get("ratingFieldId") ?? undefined,
-      ratingValue: params.get("ratingValue") ?? undefined,
-      choiceFieldId: params.get("choiceFieldId") ?? undefined,
-      choiceValue: params.get("choiceValue") ?? undefined,
+      rating: params.get("rating") ?? undefined,
+      choice: params.get("choice") ?? undefined,
     };
   }
+
   return params;
 }
 
-/**
- * Convert FilterParams to URLSearchParams.
- * Useful for testing.
- */
 export function toURLSearchParams(params: FilterParams): URLSearchParams {
   const searchParams = new URLSearchParams();
   for (const [key, value] of Object.entries(params)) {

--- a/apps/lumi-dashboard/app/router.tsx
+++ b/apps/lumi-dashboard/app/router.tsx
@@ -12,7 +12,7 @@ import { routeTree } from "./routeTree.gen";
  * entirely and use standard URLSearchParams for predictable key=value
  * round-trips.
  */
-function stringifySearch(search: Record<string, unknown>): string {
+export function stringifySearch(search: Record<string, unknown>): string {
   const params = new URLSearchParams();
   for (const [key, value] of Object.entries(search)) {
     if (value !== undefined && value !== null && value !== "") {
@@ -23,7 +23,7 @@ function stringifySearch(search: Record<string, unknown>): string {
   return str ? `?${str}` : "";
 }
 
-function parseSearch(searchStr: string): Record<string, string> {
+export function parseSearch(searchStr: string): Record<string, string> {
   if (searchStr.startsWith("?")) {
     searchStr = searchStr.slice(1);
   }

--- a/apps/lumi-dashboard/app/router.tsx
+++ b/apps/lumi-dashboard/app/router.tsx
@@ -1,5 +1,19 @@
-import { createRouter } from "@tanstack/react-router";
+import {
+  createRouter,
+  parseSearchWith,
+  stringifySearchWith,
+} from "@tanstack/react-router";
 import { routeTree } from "./routeTree.gen";
+
+/**
+ * Flat-string search serializer.
+ *
+ * TanStack Router defaults to JSON-first encoding which wraps parseable
+ * strings in quotes (e.g. page="1" → %221%22). Since every search param in
+ * this app is a plain string, we use a simple key=value format instead.
+ */
+const stringifySearch = stringifySearchWith((value) => String(value));
+const parseSearch = parseSearchWith((value) => value);
 
 export async function getRouter() {
   let nonce: string | undefined;
@@ -13,6 +27,8 @@ export async function getRouter() {
   return createRouter({
     routeTree,
     scrollRestoration: true,
+    stringifySearch,
+    parseSearch,
     ssr: nonce ? { nonce } : undefined,
   });
 }

--- a/apps/lumi-dashboard/app/router.tsx
+++ b/apps/lumi-dashboard/app/router.tsx
@@ -1,19 +1,39 @@
-import {
-  createRouter,
-  parseSearchWith,
-  stringifySearchWith,
-} from "@tanstack/react-router";
+import { createRouter } from "@tanstack/react-router";
 import { routeTree } from "./routeTree.gen";
 
 /**
- * Flat-string search serializer.
+ * Flat-string search serializer/parser.
  *
- * TanStack Router defaults to JSON-first encoding which wraps parseable
- * strings in quotes (e.g. page="1" → %221%22). Since every search param in
- * this app is a plain string, we use a simple key=value format instead.
+ * TanStack Router defaults to JSON-first encoding via an internal `qss`
+ * module that auto-converts numeric strings to numbers (e.g. "5" → 5)
+ * and wraps parseable strings in quotes (e.g. page="1" → %221%22).
+ *
+ * Since every search param in this app is a plain string, we bypass qss
+ * entirely and use standard URLSearchParams for predictable key=value
+ * round-trips.
  */
-const stringifySearch = stringifySearchWith((value) => String(value));
-const parseSearch = parseSearchWith((value) => value);
+function stringifySearch(search: Record<string, unknown>): string {
+  const params = new URLSearchParams();
+  for (const [key, value] of Object.entries(search)) {
+    if (value !== undefined && value !== null && value !== "") {
+      params.set(key, String(value));
+    }
+  }
+  const str = params.toString();
+  return str ? `?${str}` : "";
+}
+
+function parseSearch(searchStr: string): Record<string, string> {
+  if (searchStr.startsWith("?")) {
+    searchStr = searchStr.slice(1);
+  }
+  const params = new URLSearchParams(searchStr);
+  const result: Record<string, string> = {};
+  for (const [key, value] of params.entries()) {
+    result[key] = value;
+  }
+  return result;
+}
 
 export async function getRouter() {
   let nonce: string | undefined;

--- a/apps/lumi-dashboard/app/routes/export.tsx
+++ b/apps/lumi-dashboard/app/routes/export.tsx
@@ -1,10 +1,13 @@
 import { Alert, Heading, VStack } from "@navikt/ds-react";
 import { createFileRoute } from "@tanstack/react-router";
+import { zodValidator } from "@tanstack/zod-adapter";
 import { ExportPanel } from "~/components/export/Panel";
 import { FilterBar } from "~/components/shared/FilterBar";
 import { Header } from "~/components/shared/Header";
+import { searchSchema } from "~/schemas/searchSchema";
 
 export const Route = createFileRoute("/export")({
+  validateSearch: zodValidator(searchSchema),
   component: ExportPage,
 });
 

--- a/apps/lumi-dashboard/app/routes/export.tsx
+++ b/apps/lumi-dashboard/app/routes/export.tsx
@@ -1,4 +1,4 @@
-import { Alert, Heading, VStack } from "@navikt/ds-react";
+import { Alert, Box, Heading, VStack } from "@navikt/ds-react";
 import { createFileRoute } from "@tanstack/react-router";
 import { zodValidator } from "@tanstack/zod-adapter";
 import { ExportPanel } from "~/components/export/Panel";
@@ -16,7 +16,12 @@ function ExportPage() {
     <>
       <Header />
 
-      <main className="main-content">
+      <Box
+        paddingBlock={{ xs: "space-16", md: "space-24" }}
+        paddingInline={{ xs: "space-12", sm: "space-16" }}
+        className="main-container"
+        as="main"
+      >
         <VStack gap="space-24">
           <Heading size="large">Eksporter data</Heading>
 
@@ -29,7 +34,7 @@ function ExportPage() {
 
           <ExportPanel />
         </VStack>
-      </main>
+      </Box>
     </>
   );
 }

--- a/apps/lumi-dashboard/app/routes/feedback.tsx
+++ b/apps/lumi-dashboard/app/routes/feedback.tsx
@@ -1,4 +1,4 @@
-import { Heading, VStack } from "@navikt/ds-react";
+import { Box, Heading, VStack } from "@navikt/ds-react";
 import { createFileRoute } from "@tanstack/react-router";
 import { zodValidator } from "@tanstack/zod-adapter";
 import { FeedbackTable } from "~/components/feedback/FeedbackTable";
@@ -17,14 +17,19 @@ function FeedbackPage() {
     <>
       <Header />
 
-      <main className="main-content">
+      <Box
+        paddingBlock={{ xs: "space-16", md: "space-24" }}
+        paddingInline={{ xs: "space-12", sm: "space-16" }}
+        className="main-container"
+        as="main"
+      >
         <VStack gap="space-24">
           <Heading size="large">Tilbakemeldinger</Heading>
           <FilterBar showDetails />
           <ActiveFiltersChips />
           <FeedbackTable />
         </VStack>
-      </main>
+      </Box>
     </>
   );
 }

--- a/apps/lumi-dashboard/app/routes/feedback.tsx
+++ b/apps/lumi-dashboard/app/routes/feedback.tsx
@@ -1,10 +1,13 @@
 import { Heading, VStack } from "@navikt/ds-react";
 import { createFileRoute } from "@tanstack/react-router";
+import { zodValidator } from "@tanstack/zod-adapter";
 import { FeedbackTable } from "~/components/feedback/FeedbackTable";
 import { FilterBar } from "~/components/shared/FilterBar";
 import { Header } from "~/components/shared/Header";
+import { searchSchema } from "~/schemas/searchSchema";
 
 export const Route = createFileRoute("/feedback")({
+  validateSearch: zodValidator(searchSchema),
   component: FeedbackPage,
 });
 

--- a/apps/lumi-dashboard/app/routes/feedback.tsx
+++ b/apps/lumi-dashboard/app/routes/feedback.tsx
@@ -2,6 +2,7 @@ import { Heading, VStack } from "@navikt/ds-react";
 import { createFileRoute } from "@tanstack/react-router";
 import { zodValidator } from "@tanstack/zod-adapter";
 import { FeedbackTable } from "~/components/feedback/FeedbackTable";
+import { ActiveFiltersChips } from "~/components/shared/ActiveFiltersChips";
 import { FilterBar } from "~/components/shared/FilterBar";
 import { Header } from "~/components/shared/Header";
 import { searchSchema } from "~/schemas/searchSchema";
@@ -20,6 +21,7 @@ function FeedbackPage() {
         <VStack gap="space-24">
           <Heading size="large">Tilbakemeldinger</Heading>
           <FilterBar showDetails />
+          <ActiveFiltersChips />
           <FeedbackTable />
         </VStack>
       </main>

--- a/apps/lumi-dashboard/app/routes/index.module.css
+++ b/apps/lumi-dashboard/app/routes/index.module.css
@@ -1,8 +1,3 @@
-.mainContainer {
-  max-width: 1400px;
-  margin: 0 auto;
-}
-
 .surveyTypeTag {
   cursor: help;
 }

--- a/apps/lumi-dashboard/app/routes/index.tsx
+++ b/apps/lumi-dashboard/app/routes/index.tsx
@@ -198,7 +198,7 @@ function DashboardPage() {
       <Box
         paddingBlock={{ xs: "space-16", md: "space-24" }}
         paddingInline={{ xs: "space-12", sm: "space-16" }}
-        className={styles.mainContainer}
+        className="main-container"
         as="main"
       >
         <VStack gap={{ xs: "space-16", md: "space-24" }}>

--- a/apps/lumi-dashboard/app/routes/index.tsx
+++ b/apps/lumi-dashboard/app/routes/index.tsx
@@ -153,15 +153,11 @@ function DashboardPage() {
     hasAppliedDefaultPeriodRef.current = true;
   }, [setParams]);
 
+  // Clean up params that are only used on the feedback route (not the dashboard).
+  // page/size are kept because filter changes set page=1, and theme is used by discovery.
   useEffect(() => {
     const hasUnsupported =
-      !!params.hasText ||
-      !!params.lowRating ||
-      !!params.query ||
-      !!params.tag ||
-      !!params.theme ||
-      !!params.page ||
-      !!params.size;
+      !!params.hasText || !!params.lowRating || !!params.query || !!params.tag;
 
     if (!hasUnsupported) return;
 
@@ -170,20 +166,8 @@ function DashboardPage() {
       lowRating: undefined,
       query: undefined,
       tag: undefined,
-      theme: undefined,
-      page: undefined,
-      size: undefined,
     });
-  }, [
-    params.hasText,
-    params.lowRating,
-    params.query,
-    params.tag,
-    params.theme,
-    params.page,
-    params.size,
-    setParams,
-  ]);
+  }, [params.hasText, params.lowRating, params.query, params.tag, setParams]);
 
   const config = surveyType ? SURVEY_CONFIG[surveyType] : null;
 

--- a/apps/lumi-dashboard/app/routes/index.tsx
+++ b/apps/lumi-dashboard/app/routes/index.tsx
@@ -1,6 +1,7 @@
 import type { TagProps } from "@navikt/ds-react";
 import { Box, Heading, HStack, Tag, Tooltip, VStack } from "@navikt/ds-react";
 import { createFileRoute, redirect } from "@tanstack/react-router";
+import { zodValidator } from "@tanstack/zod-adapter";
 import dayjs from "dayjs";
 import { type ReactNode, useEffect, useRef } from "react";
 import { DiscoveryDashboard } from "~/components/dashboard/views/Discovery/Dashboard";
@@ -14,6 +15,7 @@ import { Header } from "~/components/shared/Header";
 import { PrivacyMaskedNotice } from "~/components/shared/PrivacyMaskedNotice";
 import { useSearchParams } from "~/hooks/useSearchParams";
 import { useStats } from "~/hooks/useStats";
+import { searchSchema } from "~/schemas/searchSchema";
 import { fetchFilterBootstrapServerFn } from "~/server/actions";
 import type { SurveyType } from "~/types/api";
 import styles from "./index.module.css";
@@ -83,6 +85,7 @@ const SURVEY_CONFIG: Record<
 };
 
 export const Route = createFileRoute("/")({
+  validateSearch: zodValidator(searchSchema),
   beforeLoad: async ({ location }) => {
     // Ensure `team` is present before route components render.
     // This prevents an initial fetch with team=undefined followed by a second fetch after `team` is injected.

--- a/apps/lumi-dashboard/app/schemas/searchSchema.ts
+++ b/apps/lumi-dashboard/app/schemas/searchSchema.ts
@@ -21,10 +21,8 @@ export const searchSchema = z.object({
   theme: optionalStringParam,
   segment: optionalStringParam,
   task: optionalStringParam,
-  ratingFieldId: optionalStringParam,
-  ratingValue: optionalStringParam,
-  choiceFieldId: optionalStringParam,
-  choiceValue: optionalStringParam,
+  choice: optionalStringParam,
+  rating: optionalStringParam,
 });
 
 export type SearchParams = z.infer<typeof searchSchema>;

--- a/apps/lumi-dashboard/app/schemas/searchSchema.ts
+++ b/apps/lumi-dashboard/app/schemas/searchSchema.ts
@@ -1,0 +1,30 @@
+import { fallback } from "@tanstack/zod-adapter";
+import { z } from "zod";
+
+const optionalStringParam = fallback(z.string().optional(), undefined).catch(
+  undefined,
+);
+
+export const searchSchema = z.object({
+  team: optionalStringParam,
+  app: optionalStringParam,
+  page: optionalStringParam,
+  size: optionalStringParam,
+  fromDate: optionalStringParam,
+  toDate: optionalStringParam,
+  hasText: optionalStringParam,
+  query: optionalStringParam,
+  tag: optionalStringParam,
+  surveyId: optionalStringParam,
+  lowRating: optionalStringParam,
+  deviceType: optionalStringParam,
+  theme: optionalStringParam,
+  segment: optionalStringParam,
+  task: optionalStringParam,
+  ratingFieldId: optionalStringParam,
+  ratingValue: optionalStringParam,
+  choiceFieldId: optionalStringParam,
+  choiceValue: optionalStringParam,
+});
+
+export type SearchParams = z.infer<typeof searchSchema>;

--- a/apps/lumi-dashboard/app/schemas/searchSchema.ts
+++ b/apps/lumi-dashboard/app/schemas/searchSchema.ts
@@ -5,24 +5,53 @@ const optionalStringParam = fallback(z.string().optional(), undefined).catch(
   undefined,
 );
 
-export const searchSchema = z.object({
-  team: optionalStringParam,
-  app: optionalStringParam,
-  page: optionalStringParam,
-  size: optionalStringParam,
-  fromDate: optionalStringParam,
-  toDate: optionalStringParam,
-  hasText: optionalStringParam,
-  query: optionalStringParam,
-  tag: optionalStringParam,
-  surveyId: optionalStringParam,
-  lowRating: optionalStringParam,
-  deviceType: optionalStringParam,
-  theme: optionalStringParam,
-  segment: optionalStringParam,
-  task: optionalStringParam,
-  choice: optionalStringParam,
-  rating: optionalStringParam,
-});
+export const searchSchema = z
+  .object({
+    team: optionalStringParam,
+    app: optionalStringParam,
+    page: optionalStringParam,
+    size: optionalStringParam,
+    fromDate: optionalStringParam,
+    toDate: optionalStringParam,
+    hasText: optionalStringParam,
+    query: optionalStringParam,
+    tag: optionalStringParam,
+    surveyId: optionalStringParam,
+    lowRating: optionalStringParam,
+    deviceType: optionalStringParam,
+    theme: optionalStringParam,
+    segment: optionalStringParam,
+    task: optionalStringParam,
+    choice: optionalStringParam,
+    rating: optionalStringParam,
+    // Legacy params — kept temporarily for bookmarked URL migration
+    choiceFieldId: optionalStringParam,
+    choiceValue: optionalStringParam,
+    ratingFieldId: optionalStringParam,
+    ratingValue: optionalStringParam,
+  })
+  .transform(
+    ({
+      choiceFieldId,
+      choiceValue,
+      ratingFieldId,
+      ratingValue,
+      choice,
+      rating,
+      ...rest
+    }) => ({
+      ...rest,
+      choice:
+        choice ??
+        (choiceFieldId && choiceValue
+          ? `${choiceFieldId}:${choiceValue}`
+          : undefined),
+      rating:
+        rating ??
+        (ratingFieldId && ratingValue
+          ? `${ratingFieldId}:${ratingValue}`
+          : undefined),
+    }),
+  );
 
 export type SearchParams = z.infer<typeof searchSchema>;

--- a/apps/lumi-dashboard/app/server/actions/__tests__/export.test.ts
+++ b/apps/lumi-dashboard/app/server/actions/__tests__/export.test.ts
@@ -70,10 +70,8 @@ describe("export helpers", () => {
       deviceType: "mobile",
       theme: "theme-1",
       task: "Soknad",
-      ratingFieldId: "rating",
-      ratingValue: "2",
-      choiceFieldId: "task_choice",
-      choiceValue: "opt-1",
+      choice: ["task_choice:opt-1"],
+      rating: ["rating:2"],
     });
 
     expect(params.tag).toEqual(["a", "b"]);
@@ -83,10 +81,8 @@ describe("export helpers", () => {
     expect(params.deviceType).toBe("mobile");
     expect(params.theme).toBe("theme-1");
     expect(params.task).toBe("Soknad");
-    expect(params.ratingFieldId).toBe("rating");
-    expect(params.ratingValue).toBe("2");
-    expect(params.choiceFieldId).toBe("task_choice");
-    expect(params.choiceValue).toBe("opt-1");
+    expect(params.choice).toEqual(["task_choice:opt-1"]);
+    expect(params.rating).toEqual(["rating:2"]);
   });
 
   it("toMockCsv creates a CSV with header + 1 row", () => {

--- a/apps/lumi-dashboard/app/server/actions/__tests__/export.test.ts
+++ b/apps/lumi-dashboard/app/server/actions/__tests__/export.test.ts
@@ -72,6 +72,8 @@ describe("export helpers", () => {
       task: "Soknad",
       ratingFieldId: "rating",
       ratingValue: "2",
+      choiceFieldId: "task_choice",
+      choiceValue: "opt-1",
     });
 
     expect(params.tag).toEqual(["a", "b"]);
@@ -83,6 +85,8 @@ describe("export helpers", () => {
     expect(params.task).toBe("Soknad");
     expect(params.ratingFieldId).toBe("rating");
     expect(params.ratingValue).toBe("2");
+    expect(params.choiceFieldId).toBe("task_choice");
+    expect(params.choiceValue).toBe("opt-1");
   });
 
   it("toMockCsv creates a CSV with header + 1 row", () => {

--- a/apps/lumi-dashboard/app/server/actions/__tests__/fetchFeedback.test.ts
+++ b/apps/lumi-dashboard/app/server/actions/__tests__/fetchFeedback.test.ts
@@ -13,6 +13,8 @@ describe("fetchFeedback helpers", () => {
       hasText: "false",
       theme: "theme-1",
       task: "Oppfolging",
+      rating: ["rating-1:5", "thumbs-1:2"],
+      choice: ["choice-1:opt-a"],
     });
 
     expect(params.page).toBe("1");
@@ -23,5 +25,7 @@ describe("fetchFeedback helpers", () => {
     expect(params.hasText).toBeUndefined();
     expect(params.theme).toBe("theme-1");
     expect(params.task).toBe("Oppfolging");
+    expect(params.rating).toEqual(["rating-1:5", "thumbs-1:2"]);
+    expect(params.choice).toEqual(["choice-1:opt-a"]);
   });
 });

--- a/apps/lumi-dashboard/app/server/actions/__tests__/fetchStats.contract.test.ts
+++ b/apps/lumi-dashboard/app/server/actions/__tests__/fetchStats.contract.test.ts
@@ -22,6 +22,8 @@ describe("fetchStats contract", () => {
       deviceType: "mobile",
       segment: "k:v,,x:y",
       task: "task-123",
+      rating: ["rating-1:5", "thumbs-1:2"],
+      choice: ["choice-1:opt-a", "choice-2:opt-b"],
     });
 
     expect(params).toEqual({
@@ -33,19 +35,31 @@ describe("fetchStats contract", () => {
       deviceType: "mobile",
       segment: ["k:v", "x:y"],
       task: "task-123",
+      rating: ["rating-1:5", "thumbs-1:2"],
+      choice: ["choice-1:opt-a", "choice-2:opt-b"],
     });
   });
 
-  it("builds a URL with repeated segment params", () => {
+  it("builds a URL with repeated segment, rating and choice params", () => {
     const url = buildStatsDashboardUrl("https://backend.example", {
       team: "team-1",
       segment: "a:b,,c:d",
+      rating: ["rating-1:5", "thumbs-1:2"],
+      choice: ["choice-1:opt-a", "choice-2:opt-b"],
     });
 
     const parsed = new URL(url);
     expect(parsed.pathname).toBe(STATS_DASHBOARD_PATH);
     expect(parsed.searchParams.get("team")).toBe("team-1");
     expect(parsed.searchParams.getAll("segment")).toEqual(["a:b", "c:d"]);
+    expect(parsed.searchParams.getAll("rating")).toEqual([
+      "rating-1:5",
+      "thumbs-1:2",
+    ]);
+    expect(parsed.searchParams.getAll("choice")).toEqual([
+      "choice-1:opt-a",
+      "choice-2:opt-b",
+    ]);
   });
 
   it("accepts real-world dashboard payload shape (incl. privacy)", () => {

--- a/apps/lumi-dashboard/app/server/actions/export.ts
+++ b/apps/lumi-dashboard/app/server/actions/export.ts
@@ -11,13 +11,32 @@ import {
   isMockMode,
   mockDelay,
 } from "~/server/utils";
-import { ExportParamsSchema } from "~/types/schemas";
+import { type ExportParams, ExportParamsSchema } from "~/types/schemas";
 import { handleApiResponse } from "../fetchUtils";
 
 interface ExportResult {
   data: string;
   filename: string;
   contentType: string;
+}
+
+function toMockSearchParams(data: ExportParams): URLSearchParams {
+  const searchParams = new URLSearchParams();
+
+  for (const [key, value] of Object.entries(data)) {
+    if (Array.isArray(value)) {
+      if (value.length > 0) {
+        searchParams.set(key, value.join(","));
+      }
+      continue;
+    }
+
+    if (value) {
+      searchParams.set(key, value);
+    }
+  }
+
+  return searchParams;
 }
 
 export function csvEscape(value: unknown): string {
@@ -147,10 +166,7 @@ export async function toMockExcelBase64(
   return Buffer.from(buffer).toString("base64");
 }
 
-/**
- * Transform frontend URL params to backend API params.
- */
-function transformToBackendParams(data: Record<string, string | undefined>) {
+function transformToBackendParams(data: ExportParams) {
   const tag = data.tag
     ?.split(",")
     .map((t) => t.trim())
@@ -171,19 +187,13 @@ function transformToBackendParams(data: Record<string, string | undefined>) {
     theme: data.theme,
     task: data.task,
     segment: data.segment?.split(",").filter(Boolean),
-    ratingFieldId: data.ratingFieldId,
-    ratingValue: data.ratingValue,
-    choiceFieldId: data.choiceFieldId,
-    choiceValue: data.choiceValue,
+    choice: data.choice?.length ? data.choice : undefined,
+    rating: data.rating?.length ? data.rating : undefined,
   };
 }
 
 export { transformToBackendParams };
 
-/**
- * Export feedback data in various formats (CSV, JSON, Excel).
- * Returns base64-encoded blob data for client to download.
- */
 export const exportServerFn = createServerFn({ method: "POST" })
   .middleware([authMiddleware])
   .inputValidator(zodValidator(ExportParamsSchema))
@@ -193,22 +203,10 @@ export const exportServerFn = createServerFn({ method: "POST" })
     if (isMockMode()) {
       await mockDelay();
 
-      const filtered = applyFeedbackFilters(mockFeedbackItems, {
-        app: data.app,
-        surveyId: data.surveyId,
-        fromDate: data.fromDate,
-        toDate: data.toDate,
-        deviceType: data.deviceType,
-        segment: data.segment,
-        task: data.task,
-        theme: data.theme,
-        hasText: data.hasText,
-        lowRating: data.lowRating,
-        ratingFieldId: data.ratingFieldId,
-        ratingValue: data.ratingValue,
-        choiceFieldId: data.choiceFieldId,
-        choiceValue: data.choiceValue,
-      }).slice(0, 10_000);
+      const filtered = applyFeedbackFilters(
+        mockFeedbackItems,
+        toMockSearchParams(data),
+      ).slice(0, 10_000);
 
       const extension = data.format === "excel" ? "xlsx" : data.format;
       const filename = `lumi-export-mock.${extension}`;
@@ -247,7 +245,6 @@ export const exportServerFn = createServerFn({ method: "POST" })
 
     await handleApiResponse(response);
 
-    // Get blob and convert to base64
     const arrayBuffer = await response.arrayBuffer();
     const base64 = Buffer.from(arrayBuffer).toString("base64");
 

--- a/apps/lumi-dashboard/app/server/actions/export.ts
+++ b/apps/lumi-dashboard/app/server/actions/export.ts
@@ -173,6 +173,8 @@ function transformToBackendParams(data: Record<string, string | undefined>) {
     segment: data.segment?.split(",").filter(Boolean),
     ratingFieldId: data.ratingFieldId,
     ratingValue: data.ratingValue,
+    choiceFieldId: data.choiceFieldId,
+    choiceValue: data.choiceValue,
   };
 }
 
@@ -204,6 +206,8 @@ export const exportServerFn = createServerFn({ method: "POST" })
         lowRating: data.lowRating,
         ratingFieldId: data.ratingFieldId,
         ratingValue: data.ratingValue,
+        choiceFieldId: data.choiceFieldId,
+        choiceValue: data.choiceValue,
       }).slice(0, 10_000);
 
       const extension = data.format === "excel" ? "xlsx" : data.format;

--- a/apps/lumi-dashboard/app/server/actions/fetchBlocker.ts
+++ b/apps/lumi-dashboard/app/server/actions/fetchBlocker.ts
@@ -42,6 +42,8 @@ export const fetchBlockerServerFn = createServerFn({ method: "GET" })
       task: data.task,
       ratingFieldId: data.ratingFieldId,
       ratingValue: data.ratingValue,
+      choiceFieldId: data.choiceFieldId,
+      choiceValue: data.choiceValue,
     };
 
     const url = buildUrl(

--- a/apps/lumi-dashboard/app/server/actions/fetchBlocker.ts
+++ b/apps/lumi-dashboard/app/server/actions/fetchBlocker.ts
@@ -13,10 +13,35 @@ import type { BlockerResponse } from "~/types/api";
 import { BlockerParamsSchema } from "~/types/schemas";
 import { handleApiResponse } from "../fetchUtils";
 
-/**
- * Fetch Blocker pattern statistics for Top Tasks.
- * Returns word frequency, themes (patterns), and recent blocker text.
- */
+interface BlockerActionParams {
+  team?: string;
+  app?: string;
+  surveyId?: string;
+  fromDate?: string;
+  toDate?: string;
+  deviceType?: string;
+  task?: string;
+  rating?: string[];
+  choice?: string[];
+}
+
+function toMockSearchParams(data: BlockerActionParams): URLSearchParams {
+  const searchParams = new URLSearchParams();
+  for (const [key, value] of Object.entries(data)) {
+    if (Array.isArray(value)) {
+      if (value.length > 0) {
+        searchParams.set(key, value.join(","));
+      }
+      continue;
+    }
+
+    if (value) {
+      searchParams.set(key, value);
+    }
+  }
+  return searchParams;
+}
+
 export const fetchBlockerServerFn = createServerFn({ method: "GET" })
   .middleware([authMiddleware])
   .inputValidator(zodValidator(BlockerParamsSchema))
@@ -25,11 +50,7 @@ export const fetchBlockerServerFn = createServerFn({ method: "GET" })
 
     if (isMockMode()) {
       await mockDelay();
-      const searchParams = new URLSearchParams();
-      for (const [key, value] of Object.entries(data)) {
-        if (value) searchParams.set(key, value);
-      }
-      return getMockBlockerStats(searchParams);
+      return getMockBlockerStats(toMockSearchParams(data));
     }
 
     const backendParams = {
@@ -40,10 +61,8 @@ export const fetchBlockerServerFn = createServerFn({ method: "GET" })
       toDate: data.toDate,
       deviceType: data.deviceType,
       task: data.task,
-      ratingFieldId: data.ratingFieldId,
-      ratingValue: data.ratingValue,
-      choiceFieldId: data.choiceFieldId,
-      choiceValue: data.choiceValue,
+      rating: data.rating,
+      choice: data.choice,
     };
 
     const url = buildUrl(

--- a/apps/lumi-dashboard/app/server/actions/fetchDiscovery.ts
+++ b/apps/lumi-dashboard/app/server/actions/fetchDiscovery.ts
@@ -41,6 +41,8 @@ export const fetchDiscoveryServerFn = createServerFn({ method: "GET" })
       deviceType: data.deviceType,
       ratingFieldId: data.ratingFieldId,
       ratingValue: data.ratingValue,
+      choiceFieldId: data.choiceFieldId,
+      choiceValue: data.choiceValue,
     };
 
     const url = buildUrl(

--- a/apps/lumi-dashboard/app/server/actions/fetchDiscovery.ts
+++ b/apps/lumi-dashboard/app/server/actions/fetchDiscovery.ts
@@ -13,10 +13,34 @@ import type { DiscoveryResponse } from "~/types/api";
 import { DiscoveryParamsSchema } from "~/types/schemas";
 import { handleApiResponse } from "../fetchUtils";
 
-/**
- * Fetch Discovery survey statistics for user intent analysis.
- * Returns word frequency, themes, and recent responses.
- */
+interface DiscoveryActionParams {
+  team?: string;
+  app?: string;
+  surveyId?: string;
+  fromDate?: string;
+  toDate?: string;
+  deviceType?: string;
+  rating?: string[];
+  choice?: string[];
+}
+
+function toMockSearchParams(data: DiscoveryActionParams): URLSearchParams {
+  const searchParams = new URLSearchParams();
+  for (const [key, value] of Object.entries(data)) {
+    if (Array.isArray(value)) {
+      if (value.length > 0) {
+        searchParams.set(key, value.join(","));
+      }
+      continue;
+    }
+
+    if (value) {
+      searchParams.set(key, value);
+    }
+  }
+  return searchParams;
+}
+
 export const fetchDiscoveryServerFn = createServerFn({ method: "GET" })
   .middleware([authMiddleware])
   .inputValidator(zodValidator(DiscoveryParamsSchema))
@@ -25,11 +49,7 @@ export const fetchDiscoveryServerFn = createServerFn({ method: "GET" })
 
     if (isMockMode()) {
       await mockDelay();
-      const searchParams = new URLSearchParams();
-      for (const [key, value] of Object.entries(data)) {
-        if (value) searchParams.set(key, value);
-      }
-      return getMockDiscoveryStats(searchParams);
+      return getMockDiscoveryStats(toMockSearchParams(data));
     }
 
     const backendParams = {
@@ -39,10 +59,8 @@ export const fetchDiscoveryServerFn = createServerFn({ method: "GET" })
       fromDate: data.fromDate,
       toDate: data.toDate,
       deviceType: data.deviceType,
-      ratingFieldId: data.ratingFieldId,
-      ratingValue: data.ratingValue,
-      choiceFieldId: data.choiceFieldId,
-      choiceValue: data.choiceValue,
+      rating: data.rating,
+      choice: data.choice,
     };
 
     const url = buildUrl(

--- a/apps/lumi-dashboard/app/server/actions/fetchFeedback.ts
+++ b/apps/lumi-dashboard/app/server/actions/fetchFeedback.ts
@@ -45,6 +45,8 @@ function transformToBackendParams(data: Record<string, string | undefined>) {
 
     ratingFieldId: data.ratingFieldId,
     ratingValue: data.ratingValue,
+    choiceFieldId: data.choiceFieldId,
+    choiceValue: data.choiceValue,
   };
 }
 

--- a/apps/lumi-dashboard/app/server/actions/fetchFeedback.ts
+++ b/apps/lumi-dashboard/app/server/actions/fetchFeedback.ts
@@ -13,16 +13,51 @@ import type { FeedbackPage } from "~/types/api";
 import { FeedbackParamsSchema } from "~/types/schemas";
 import { handleApiResponse } from "../fetchUtils";
 
-/**
- * Transform frontend URL params to backend API params.
- */
-function transformToBackendParams(data: Record<string, string | undefined>) {
-  // Backend uses 0-indexed pages
-  const page = data.page ? String(Number.parseInt(data.page, 10) - 1) : "0";
+interface FeedbackActionParams {
+  team?: string;
+  app?: string;
+  surveyId?: string;
+  page?: string;
+  size?: string;
+  fromDate?: string;
+  toDate?: string;
+  hasText?: string;
+  query?: string;
+  tag?: string;
+  lowRating?: string;
+  deviceType?: string;
+  theme?: string;
+  task?: string;
+  segment?: string;
+  choice?: string[];
+  rating?: string[];
+}
 
+function toMockSearchParams(data: FeedbackActionParams): URLSearchParams {
+  const searchParams = new URLSearchParams();
+  for (const [key, value] of Object.entries(data)) {
+    if (Array.isArray(value)) {
+      if (value.length > 0) {
+        searchParams.set(key, value.join(","));
+      }
+      continue;
+    }
+
+    if (value) {
+      searchParams.set(key, value);
+    }
+  }
+
+  const page = data.page ? String(Number.parseInt(data.page, 10) - 1) : "0";
+  searchParams.set("page", page);
+  return searchParams;
+}
+
+function transformToBackendParams(data: FeedbackActionParams) {
+  const page = data.page ? String(Number.parseInt(data.page, 10) - 1) : "0";
   const tag = data.tag
     ?.split(",")
-    .map((t) => t.trim())
+    .map((entry) => entry.trim())
     .filter(Boolean);
 
   return {
@@ -40,21 +75,14 @@ function transformToBackendParams(data: Record<string, string | undefined>) {
     deviceType: data.deviceType,
     theme: data.theme,
     task: data.task,
-    // Transform segment format: "key:value,key:value" -> repeated params handled by buildUrl
     segment: data.segment?.split(",").filter(Boolean),
-
-    ratingFieldId: data.ratingFieldId,
-    ratingValue: data.ratingValue,
-    choiceFieldId: data.choiceFieldId,
-    choiceValue: data.choiceValue,
+    choice: data.choice,
+    rating: data.rating,
   };
 }
 
 export { transformToBackendParams };
 
-/**
- * Fetch paginated feedback items with filtering support.
- */
 export const fetchFeedbackServerFn = createServerFn({ method: "GET" })
   .middleware([authMiddleware])
   .inputValidator(zodValidator(FeedbackParamsSchema))
@@ -63,19 +91,10 @@ export const fetchFeedbackServerFn = createServerFn({ method: "GET" })
 
     if (isMockMode()) {
       await mockDelay();
-      const searchParams = new URLSearchParams();
-      for (const [key, value] of Object.entries(data)) {
-        if (value) searchParams.set(key, value);
-      }
-      // Backend uses 0-indexed pages, frontend uses 1-indexed
-      const page = data.page ? String(Number.parseInt(data.page, 10) - 1) : "0";
-      searchParams.set("page", page);
-      return getMockFeedback(searchParams);
+      return getMockFeedback(toMockSearchParams(data));
     }
 
-    // Transform to backend param names
     const backendParams = transformToBackendParams(data);
-
     const url = buildUrl(backendUrl, "/api/v1/intern/feedback", backendParams);
     const response = await fetch(url, {
       headers: getHeaders(oboToken),

--- a/apps/lumi-dashboard/app/server/actions/fetchStats.ts
+++ b/apps/lumi-dashboard/app/server/actions/fetchStats.ts
@@ -15,7 +15,7 @@ import { handleApiResponse } from "../fetchUtils";
 
 export const STATS_DASHBOARD_PATH = "/api/v1/intern/stats/dashboard" as const;
 
-export function transformStatsToBackendParams(data: {
+interface StatsActionParams {
   team?: string;
   app?: string;
   surveyId?: string;
@@ -24,11 +24,28 @@ export function transformStatsToBackendParams(data: {
   deviceType?: string;
   segment?: string;
   task?: string;
-  ratingFieldId?: string;
-  ratingValue?: string;
-  choiceFieldId?: string;
-  choiceValue?: string;
-}) {
+  rating?: string[];
+  choice?: string[];
+}
+
+function toMockSearchParams(data: StatsActionParams): URLSearchParams {
+  const searchParams = new URLSearchParams();
+  for (const [key, value] of Object.entries(data)) {
+    if (Array.isArray(value)) {
+      if (value.length > 0) {
+        searchParams.set(key, value.join(","));
+      }
+      continue;
+    }
+
+    if (value) {
+      searchParams.set(key, value);
+    }
+  }
+  return searchParams;
+}
+
+export function transformStatsToBackendParams(data: StatsActionParams) {
   return {
     team: data.team,
     app: data.app,
@@ -38,29 +55,14 @@ export function transformStatsToBackendParams(data: {
     deviceType: data.deviceType,
     segment: data.segment?.split(",").filter(Boolean),
     task: data.task,
-    ratingFieldId: data.ratingFieldId,
-    ratingValue: data.ratingValue,
-    choiceFieldId: data.choiceFieldId,
-    choiceValue: data.choiceValue,
+    rating: data.rating,
+    choice: data.choice,
   };
 }
 
 export function buildStatsDashboardUrl(
   backendUrl: string,
-  data: {
-    team?: string;
-    app?: string;
-    surveyId?: string;
-    fromDate?: string;
-    toDate?: string;
-    deviceType?: string;
-    segment?: string;
-    task?: string;
-    ratingFieldId?: string;
-    ratingValue?: string;
-    choiceFieldId?: string;
-    choiceValue?: string;
-  },
+  data: StatsActionParams,
 ) {
   return buildUrl(
     backendUrl,
@@ -69,10 +71,6 @@ export function buildStatsDashboardUrl(
   );
 }
 
-/**
- * Fetch aggregated feedback statistics.
- * Supports filtering by app, date range, survey, and device type.
- */
 export const fetchStatsServerFn = createServerFn({ method: "GET" })
   .middleware([authMiddleware])
   .inputValidator(zodValidator(StatsParamsSchema))
@@ -81,11 +79,7 @@ export const fetchStatsServerFn = createServerFn({ method: "GET" })
 
     if (isMockMode()) {
       await mockDelay();
-      const searchParams = new URLSearchParams();
-      for (const [key, value] of Object.entries(data)) {
-        if (value) searchParams.set(key, value);
-      }
-      return getMockStats(searchParams);
+      return getMockStats(toMockSearchParams(data));
     }
 
     const url = buildStatsDashboardUrl(backendUrl, data);

--- a/apps/lumi-dashboard/app/server/actions/fetchStats.ts
+++ b/apps/lumi-dashboard/app/server/actions/fetchStats.ts
@@ -26,6 +26,8 @@ export function transformStatsToBackendParams(data: {
   task?: string;
   ratingFieldId?: string;
   ratingValue?: string;
+  choiceFieldId?: string;
+  choiceValue?: string;
 }) {
   return {
     team: data.team,
@@ -38,6 +40,8 @@ export function transformStatsToBackendParams(data: {
     task: data.task,
     ratingFieldId: data.ratingFieldId,
     ratingValue: data.ratingValue,
+    choiceFieldId: data.choiceFieldId,
+    choiceValue: data.choiceValue,
   };
 }
 
@@ -54,6 +58,8 @@ export function buildStatsDashboardUrl(
     task?: string;
     ratingFieldId?: string;
     ratingValue?: string;
+    choiceFieldId?: string;
+    choiceValue?: string;
   },
 ) {
   return buildUrl(

--- a/apps/lumi-dashboard/app/server/actions/fetchTaskPriority.ts
+++ b/apps/lumi-dashboard/app/server/actions/fetchTaskPriority.ts
@@ -43,6 +43,8 @@ export const fetchTaskPriorityServerFn = createServerFn({ method: "GET" })
       segment: data.segment?.split(",").filter(Boolean),
       ratingFieldId: data.ratingFieldId,
       ratingValue: data.ratingValue,
+      choiceFieldId: data.choiceFieldId,
+      choiceValue: data.choiceValue,
     };
 
     const url = buildUrl(

--- a/apps/lumi-dashboard/app/server/actions/fetchTaskPriority.ts
+++ b/apps/lumi-dashboard/app/server/actions/fetchTaskPriority.ts
@@ -13,10 +13,35 @@ import type { TaskPriorityResponse } from "~/types/api";
 import { TaskPriorityParamsSchema } from "~/types/schemas";
 import { handleApiResponse } from "../fetchUtils";
 
-/**
- * Fetch Task Priority survey statistics for vote-based task analysis.
- * Returns the "Long Neck" distribution of task votes.
- */
+interface TaskPriorityActionParams {
+  team?: string;
+  app?: string;
+  surveyId?: string;
+  fromDate?: string;
+  toDate?: string;
+  deviceType?: string;
+  segment?: string;
+  rating?: string[];
+  choice?: string[];
+}
+
+function toMockSearchParams(data: TaskPriorityActionParams): URLSearchParams {
+  const searchParams = new URLSearchParams();
+  for (const [key, value] of Object.entries(data)) {
+    if (Array.isArray(value)) {
+      if (value.length > 0) {
+        searchParams.set(key, value.join(","));
+      }
+      continue;
+    }
+
+    if (value) {
+      searchParams.set(key, value);
+    }
+  }
+  return searchParams;
+}
+
 export const fetchTaskPriorityServerFn = createServerFn({ method: "GET" })
   .middleware([authMiddleware])
   .inputValidator(zodValidator(TaskPriorityParamsSchema))
@@ -25,11 +50,7 @@ export const fetchTaskPriorityServerFn = createServerFn({ method: "GET" })
 
     if (isMockMode()) {
       await mockDelay();
-      const searchParams = new URLSearchParams();
-      for (const [key, value] of Object.entries(data)) {
-        if (value) searchParams.set(key, value);
-      }
-      return getMockTaskPriorityStats(searchParams);
+      return getMockTaskPriorityStats(toMockSearchParams(data));
     }
 
     const backendParams = {
@@ -39,12 +60,9 @@ export const fetchTaskPriorityServerFn = createServerFn({ method: "GET" })
       fromDate: data.fromDate,
       toDate: data.toDate,
       deviceType: data.deviceType,
-      // Backend expects repeated params: segment=key:value&segment=key:value
       segment: data.segment?.split(",").filter(Boolean),
-      ratingFieldId: data.ratingFieldId,
-      ratingValue: data.ratingValue,
-      choiceFieldId: data.choiceFieldId,
-      choiceValue: data.choiceValue,
+      rating: data.rating,
+      choice: data.choice,
     };
 
     const url = buildUrl(

--- a/apps/lumi-dashboard/app/server/actions/fetchTopTasks.ts
+++ b/apps/lumi-dashboard/app/server/actions/fetchTopTasks.ts
@@ -13,9 +13,35 @@ import type { TopTasksResponse } from "~/types/api";
 import { TopTasksParamsSchema } from "~/types/schemas";
 import { handleApiResponse } from "../fetchUtils";
 
-/**
- * Fetch Top Tasks statistics for task completion analysis.
- */
+interface TopTasksActionParams {
+  team?: string;
+  app?: string;
+  surveyId?: string;
+  fromDate?: string;
+  toDate?: string;
+  deviceType?: string;
+  task?: string;
+  rating?: string[];
+  choice?: string[];
+}
+
+function toMockSearchParams(data: TopTasksActionParams): URLSearchParams {
+  const searchParams = new URLSearchParams();
+  for (const [key, value] of Object.entries(data)) {
+    if (Array.isArray(value)) {
+      if (value.length > 0) {
+        searchParams.set(key, value.join(","));
+      }
+      continue;
+    }
+
+    if (value) {
+      searchParams.set(key, value);
+    }
+  }
+  return searchParams;
+}
+
 export const fetchTopTasksServerFn = createServerFn({ method: "GET" })
   .middleware([authMiddleware])
   .inputValidator(zodValidator(TopTasksParamsSchema))
@@ -24,11 +50,7 @@ export const fetchTopTasksServerFn = createServerFn({ method: "GET" })
 
     if (isMockMode()) {
       await mockDelay();
-      const searchParams = new URLSearchParams();
-      for (const [key, value] of Object.entries(data)) {
-        if (value) searchParams.set(key, value);
-      }
-      return getMockTopTasksStats(searchParams);
+      return getMockTopTasksStats(toMockSearchParams(data));
     }
 
     const backendParams = {
@@ -39,10 +61,8 @@ export const fetchTopTasksServerFn = createServerFn({ method: "GET" })
       toDate: data.toDate,
       deviceType: data.deviceType,
       task: data.task,
-      ratingFieldId: data.ratingFieldId,
-      ratingValue: data.ratingValue,
-      choiceFieldId: data.choiceFieldId,
-      choiceValue: data.choiceValue,
+      rating: data.rating,
+      choice: data.choice,
     };
 
     const url = buildUrl(

--- a/apps/lumi-dashboard/app/server/actions/fetchTopTasks.ts
+++ b/apps/lumi-dashboard/app/server/actions/fetchTopTasks.ts
@@ -41,6 +41,8 @@ export const fetchTopTasksServerFn = createServerFn({ method: "GET" })
       task: data.task,
       ratingFieldId: data.ratingFieldId,
       ratingValue: data.ratingValue,
+      choiceFieldId: data.choiceFieldId,
+      choiceValue: data.choiceValue,
     };
 
     const url = buildUrl(

--- a/apps/lumi-dashboard/app/styles/global.css
+++ b/apps/lumi-dashboard/app/styles/global.css
@@ -104,28 +104,9 @@ body {
 }
 
 /* Main content area - responsive padding */
-.main-content {
-  padding: 1rem 0.75rem;
+.main-container {
   max-width: 1400px;
   margin: 0 auto;
-}
-
-@media (min-width: 480px) {
-  .main-content {
-    padding: 1.25rem 1rem;
-  }
-}
-
-@media (min-width: 768px) {
-  .main-content {
-    padding: 1.5rem 1.5rem;
-  }
-}
-
-@media (min-width: 1024px) {
-  .main-content {
-    padding: 1.5rem 2rem;
-  }
 }
 
 /* Navigation tabs */

--- a/apps/lumi-dashboard/app/utils/__tests__/choiceFilterUtils.test.ts
+++ b/apps/lumi-dashboard/app/utils/__tests__/choiceFilterUtils.test.ts
@@ -1,0 +1,123 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  parseChoiceParam,
+  splitChoiceParam,
+  stringifyChoiceFilters,
+} from "~/utils/choiceFilterUtils";
+
+describe("choiceFilterUtils", () => {
+  describe("parseChoiceParam", () => {
+    it("returns an empty object for missing input", () => {
+      expect(parseChoiceParam(undefined)).toEqual({});
+      expect(parseChoiceParam("")).toEqual({});
+    });
+
+    it("returns an empty object for malformed edge cases", () => {
+      expect(parseChoiceParam("missing-colon")).toEqual({});
+      expect(parseChoiceParam(":")).toEqual({});
+    });
+
+    it("parses a single choice filter", () => {
+      expect(parseChoiceParam("task:application")).toEqual({
+        task: "application",
+      });
+    });
+
+    it("parses multiple choice filters", () => {
+      expect(parseChoiceParam("task:application,channel:chat")).toEqual({
+        task: "application",
+        channel: "chat",
+      });
+    });
+
+    it("keeps everything after the first colon as the value", () => {
+      expect(parseChoiceParam("task:application:step-1")).toEqual({
+        task: "application:step-1",
+      });
+    });
+
+    it("keeps the last value when the same field appears multiple times", () => {
+      expect(parseChoiceParam("task:application,task:appeal")).toEqual({
+        task: "appeal",
+      });
+    });
+
+    it("ignores malformed filter parts", () => {
+      expect(
+        parseChoiceParam(
+          "task:application,missing-colon,:no-key,channel:,valid:web",
+        ),
+      ).toEqual({
+        task: "application",
+        valid: "web",
+      });
+    });
+  });
+
+  describe("stringifyChoiceFilters", () => {
+    it("returns undefined for empty filters", () => {
+      expect(stringifyChoiceFilters({})).toBeUndefined();
+    });
+
+    it("serializes filters in object entry order", () => {
+      expect(
+        stringifyChoiceFilters({
+          task: "application",
+          channel: "chat",
+        }),
+      ).toBe("task:application,channel:chat");
+    });
+  });
+
+  describe("splitChoiceParam", () => {
+    it("returns undefined when there are no valid choice filters", () => {
+      expect(splitChoiceParam(undefined)).toBeUndefined();
+      expect(splitChoiceParam("invalid,:missing")).toBeUndefined();
+    });
+
+    it("splits valid choice filters into serialized entries", () => {
+      expect(splitChoiceParam("task:application,channel:chat")).toEqual([
+        "task:application",
+        "channel:chat",
+      ]);
+    });
+  });
+
+  describe("round trips", () => {
+    it("preserves serialized filters through parse and stringify", () => {
+      const serialized = "task:application,channel:chat";
+
+      expect(stringifyChoiceFilters(parseChoiceParam(serialized))).toBe(
+        serialized,
+      );
+    });
+
+    it("round-trips filters through stringify and parse", () => {
+      const filters = {
+        task: "application",
+        channel: "chat",
+        step: "application:step-1",
+      };
+
+      const serialized = stringifyChoiceFilters(filters);
+
+      expect(serialized).toBe(
+        "task:application,channel:chat,step:application:step-1",
+      );
+      expect(parseChoiceParam(serialized)).toEqual(filters);
+    });
+
+    it("keeps split output aligned with stringify output", () => {
+      const serialized = stringifyChoiceFilters({
+        task: "application",
+        channel: "chat",
+      });
+
+      expect(splitChoiceParam(serialized)).toEqual([
+        "task:application",
+        "channel:chat",
+      ]);
+    });
+  });
+});

--- a/apps/lumi-dashboard/app/utils/__tests__/filterLabels.test.ts
+++ b/apps/lumi-dashboard/app/utils/__tests__/filterLabels.test.ts
@@ -1,0 +1,445 @@
+import { describe, expect, it } from "vitest";
+
+import type { SearchParams } from "~/hooks/useSearchParams";
+import type { FeedbackStats, TextTheme } from "~/types/api";
+import {
+  getActiveChoiceFilterLabels,
+  getActiveRatingFilterLabels,
+  getFilterLabels,
+  getThemeLabel,
+} from "~/utils/filterLabels";
+
+function makeStats(
+  fieldStats: FeedbackStats["fieldStats"] = [],
+): FeedbackStats {
+  return {
+    totalCount: 0,
+    countWithText: 0,
+    countWithoutText: 0,
+    byRating: {},
+    byApp: {},
+    byDate: {},
+    bySurveyId: {},
+    averageRating: null,
+    ratingByDate: {},
+    byDevice: {},
+    byPathname: {},
+    lowestRatingPaths: {},
+    fieldStats,
+    period: {
+      fromDate: null,
+      toDate: null,
+      days: 0,
+    },
+  };
+}
+
+function makeParams(params: Partial<SearchParams>): SearchParams {
+  return { choice: undefined, rating: undefined, ...params } as SearchParams;
+}
+
+describe("filterLabels", () => {
+  describe("getThemeLabel", () => {
+    it("returns undefined when no theme is selected", () => {
+      expect(
+        getThemeLabel({ params: makeParams({}), themes: [] }),
+      ).toBeUndefined();
+    });
+
+    it("returns Annet for the uncategorized theme", () => {
+      expect(
+        getThemeLabel({
+          params: makeParams({ theme: "uncategorized" }),
+          themes: [],
+        }),
+      ).toBe("Annet");
+    });
+
+    it("resolves the selected theme name from the theme list", () => {
+      const themes: TextTheme[] = [
+        {
+          id: "login",
+          team: "team-lumi",
+          name: "Innlogging",
+          keywords: ["logg inn"],
+          priority: 1,
+          analysisContext: "GENERAL_FEEDBACK",
+        },
+      ];
+
+      expect(
+        getThemeLabel({
+          params: makeParams({ theme: "login" }),
+          themes,
+        }),
+      ).toBe("Innlogging");
+    });
+
+    it("falls back to the raw theme id when the theme is not found", () => {
+      expect(
+        getThemeLabel({
+          params: makeParams({ theme: "missing-theme" }),
+          themes: [],
+        }),
+      ).toBe("missing-theme");
+    });
+  });
+
+  describe("getActiveRatingFilterLabels", () => {
+    it("returns an empty list when no rating filter is selected", () => {
+      expect(
+        getActiveRatingFilterLabels({
+          params: makeParams({}),
+        }),
+      ).toEqual([]);
+    });
+
+    it("uses generic labels and raw values without stats", () => {
+      expect(
+        getActiveRatingFilterLabels({
+          params: makeParams({ rating: "satisfaction:5" }),
+        }),
+      ).toEqual([
+        {
+          fieldId: "satisfaction",
+          key: "rating-satisfaction-5",
+          label: "Vurdering",
+          value: "5",
+        },
+      ]);
+    });
+
+    it("uses the field label when matching rating stats exist", () => {
+      const stats = makeStats([
+        {
+          fieldId: "satisfaction",
+          fieldType: "RATING",
+          label: "Hvor fornøyd er du?",
+          stats: {
+            type: "rating",
+            average: 4.2,
+            distribution: { 4: 2, 5: 5 },
+          },
+        },
+      ]);
+
+      expect(
+        getActiveRatingFilterLabels({
+          params: makeParams({ rating: "satisfaction:5" }),
+          stats,
+        }),
+      ).toEqual([
+        {
+          fieldId: "satisfaction",
+          key: "rating-satisfaction-5",
+          label: "Hvor fornøyd er du?",
+          value: "5",
+        },
+      ]);
+    });
+
+    it("maps inferred thumbs values to Ja and Nei", () => {
+      expect(
+        getActiveRatingFilterLabels({
+          params: makeParams({ rating: "helpful:2,negative:1" }),
+          stats: makeStats([
+            {
+              fieldId: "helpful",
+              fieldType: "RATING",
+              label: "Var dette nyttig?",
+              stats: {
+                type: "rating",
+                average: 1.5,
+                distribution: { 1: 2, 2: 4 },
+              },
+            },
+            {
+              fieldId: "negative",
+              fieldType: "RATING",
+              label: "Ble du hjulpet?",
+              stats: {
+                type: "rating",
+                average: 1.2,
+                distribution: { 1: 5, 2: 1 },
+              },
+            },
+          ]),
+        }),
+      ).toEqual([
+        {
+          fieldId: "helpful",
+          key: "rating-helpful-2",
+          label: "Var dette nyttig?",
+          value: "Ja",
+        },
+        {
+          fieldId: "negative",
+          key: "rating-negative-1",
+          label: "Ble du hjulpet?",
+          value: "Nei",
+        },
+      ]);
+    });
+
+    it("keeps numeric values for stars ratings", () => {
+      const starsStats = {
+        type: "rating" as const,
+        average: 4.4,
+        distribution: { 4: 2, 5: 6 },
+        ratingVariant: "stars",
+      };
+
+      const stats = makeStats([
+        {
+          fieldId: "stars",
+          fieldType: "RATING",
+          label: "Gi stjerner",
+          stats: starsStats,
+        },
+      ]);
+
+      expect(
+        getActiveRatingFilterLabels({
+          params: makeParams({ rating: "stars:4" }),
+          stats,
+        }),
+      ).toEqual([
+        {
+          fieldId: "stars",
+          key: "rating-stars-4",
+          label: "Gi stjerner",
+          value: "4",
+        },
+      ]);
+    });
+
+    it("keeps numeric values for NPS ratings", () => {
+      const stats = makeStats([
+        {
+          fieldId: "recommend",
+          fieldType: "RATING",
+          label: "Vil du anbefale oss?",
+          stats: {
+            type: "rating",
+            average: 8.4,
+            distribution: { 0: 1, 10: 7 },
+          },
+        },
+      ]);
+
+      expect(
+        getActiveRatingFilterLabels({
+          params: makeParams({ rating: "recommend:10" }),
+          stats,
+        }),
+      ).toEqual([
+        {
+          fieldId: "recommend",
+          key: "rating-recommend-10",
+          label: "Vil du anbefale oss?",
+          value: "10",
+        },
+      ]);
+    });
+  });
+
+  describe("getActiveChoiceFilterLabels", () => {
+    it("returns an empty list when no choice filter is selected", () => {
+      expect(
+        getActiveChoiceFilterLabels({
+          params: makeParams({}),
+        }),
+      ).toEqual([]);
+    });
+
+    it("uses a placeholder value without stats", () => {
+      expect(
+        getActiveChoiceFilterLabels({
+          params: makeParams({ choice: "task:application" }),
+        }),
+      ).toEqual([
+        {
+          fieldId: "task",
+          key: "choice-task-application",
+          label: "Valg",
+          value: "…",
+        },
+      ]);
+    });
+
+    it("uses the choice field label and option label from stats", () => {
+      const stats = makeStats([
+        {
+          fieldId: "task",
+          fieldType: "SINGLE_CHOICE",
+          label: "Hva gjelder det?",
+          stats: {
+            type: "choice",
+            distribution: {
+              application: {
+                label: "Søknad",
+                count: 3,
+                percentage: 60,
+              },
+            },
+          },
+        },
+      ]);
+
+      expect(
+        getActiveChoiceFilterLabels({
+          params: makeParams({ choice: "task:application" }),
+          stats,
+        }),
+      ).toEqual([
+        {
+          fieldId: "task",
+          key: "choice-task-application",
+          label: "Hva gjelder det?",
+          value: "Søknad",
+        },
+      ]);
+    });
+
+    it("falls back to the raw option id when stats exist but the option label is missing", () => {
+      const stats = makeStats([
+        {
+          fieldId: "task",
+          fieldType: "MULTI_CHOICE",
+          label: "Hva gjelder det?",
+          stats: {
+            type: "choice",
+            distribution: {
+              somethingElse: {
+                label: "Noe annet",
+                count: 1,
+                percentage: 100,
+              },
+            },
+          },
+        },
+      ]);
+
+      expect(
+        getActiveChoiceFilterLabels({
+          params: makeParams({ choice: "task:missing-option" }),
+          stats,
+        }),
+      ).toEqual([
+        {
+          fieldId: "task",
+          key: "choice-task-missing-option",
+          label: "Hva gjelder det?",
+          value: "missing-option",
+        },
+      ]);
+    });
+
+    it("falls back to a generic label when the matching field is not a choice field", () => {
+      const stats = makeStats([
+        {
+          fieldId: "task",
+          fieldType: "TEXT",
+          label: "Kommentar",
+          stats: {
+            type: "text",
+            responseCount: 1,
+            responseRate: 100,
+            topKeywords: [],
+            recentResponses: [],
+          },
+        },
+      ]);
+
+      expect(
+        getActiveChoiceFilterLabels({
+          params: makeParams({ choice: "task:application" }),
+          stats,
+        }),
+      ).toEqual([
+        {
+          fieldId: "task",
+          key: "choice-task-application",
+          label: "Valg",
+          value: "application",
+        },
+      ]);
+    });
+  });
+
+  describe("getFilterLabels", () => {
+    it("combines choice filters, rating filters, and the resolved theme label", () => {
+      const thumbsStats = {
+        type: "rating" as const,
+        average: 1.7,
+        distribution: { 1: 2, 2: 5 },
+        ratingVariant: "thumbs",
+      };
+
+      const stats = makeStats([
+        {
+          fieldId: "task",
+          fieldType: "SINGLE_CHOICE",
+          label: "Hva gjelder det?",
+          stats: {
+            type: "choice",
+            distribution: {
+              application: {
+                label: "Søknad",
+                count: 4,
+                percentage: 100,
+              },
+            },
+          },
+        },
+        {
+          fieldId: "helpful",
+          fieldType: "RATING",
+          label: "Var dette nyttig?",
+          stats: thumbsStats,
+        },
+      ]);
+
+      const themes: TextTheme[] = [
+        {
+          id: "login",
+          team: "team-lumi",
+          name: "Innlogging",
+          keywords: ["innlogging"],
+          priority: 1,
+          analysisContext: "GENERAL_FEEDBACK",
+        },
+      ];
+
+      expect(
+        getFilterLabels({
+          params: makeParams({
+            choice: "task:application",
+            rating: "helpful:2",
+            theme: "login",
+          }),
+          stats,
+          themes,
+        }),
+      ).toEqual({
+        choiceFilters: [
+          {
+            fieldId: "task",
+            key: "choice-task-application",
+            label: "Hva gjelder det?",
+            value: "Søknad",
+          },
+        ],
+        ratingFilters: [
+          {
+            fieldId: "helpful",
+            key: "rating-helpful-2",
+            label: "Var dette nyttig?",
+            value: "Ja",
+          },
+        ],
+        themeLabel: "Innlogging",
+      });
+    });
+  });
+});

--- a/apps/lumi-dashboard/app/utils/__tests__/ratingFilterUtils.test.ts
+++ b/apps/lumi-dashboard/app/utils/__tests__/ratingFilterUtils.test.ts
@@ -1,0 +1,123 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  parseRatingParam,
+  splitRatingParam,
+  stringifyRatingFilters,
+} from "~/utils/ratingFilterUtils";
+
+describe("ratingFilterUtils", () => {
+  describe("parseRatingParam", () => {
+    it("returns an empty object for missing input", () => {
+      expect(parseRatingParam(undefined)).toEqual({});
+      expect(parseRatingParam("")).toEqual({});
+    });
+
+    it("returns an empty object for malformed edge cases", () => {
+      expect(parseRatingParam("missing-colon")).toEqual({});
+      expect(parseRatingParam(":")).toEqual({});
+    });
+
+    it("parses a single rating filter", () => {
+      expect(parseRatingParam("satisfaction:5")).toEqual({
+        satisfaction: "5",
+      });
+    });
+
+    it("parses multiple rating filters", () => {
+      expect(parseRatingParam("satisfaction:5,recommendation:10")).toEqual({
+        satisfaction: "5",
+        recommendation: "10",
+      });
+    });
+
+    it("keeps everything after the first colon as the value", () => {
+      expect(parseRatingParam("satisfaction:score:5")).toEqual({
+        satisfaction: "score:5",
+      });
+    });
+
+    it("keeps the last value when the same field appears multiple times", () => {
+      expect(parseRatingParam("satisfaction:2,satisfaction:5")).toEqual({
+        satisfaction: "5",
+      });
+    });
+
+    it("ignores malformed filter parts", () => {
+      expect(
+        parseRatingParam(
+          "satisfaction:5,missing-colon,:no-key,recommendation:,nps:10",
+        ),
+      ).toEqual({
+        satisfaction: "5",
+        nps: "10",
+      });
+    });
+  });
+
+  describe("stringifyRatingFilters", () => {
+    it("returns undefined for empty filters", () => {
+      expect(stringifyRatingFilters({})).toBeUndefined();
+    });
+
+    it("serializes filters in object entry order", () => {
+      expect(
+        stringifyRatingFilters({
+          satisfaction: "5",
+          recommendation: "10",
+        }),
+      ).toBe("satisfaction:5,recommendation:10");
+    });
+  });
+
+  describe("splitRatingParam", () => {
+    it("returns undefined when there are no valid rating filters", () => {
+      expect(splitRatingParam(undefined)).toBeUndefined();
+      expect(splitRatingParam("invalid,:missing")).toBeUndefined();
+    });
+
+    it("splits valid rating filters into serialized entries", () => {
+      expect(splitRatingParam("satisfaction:5,recommendation:10")).toEqual([
+        "satisfaction:5",
+        "recommendation:10",
+      ]);
+    });
+  });
+
+  describe("round trips", () => {
+    it("preserves serialized filters through parse and stringify", () => {
+      const serialized = "satisfaction:5,recommendation:10";
+
+      expect(stringifyRatingFilters(parseRatingParam(serialized))).toBe(
+        serialized,
+      );
+    });
+
+    it("round-trips filters through stringify and parse", () => {
+      const filters = {
+        satisfaction: "5",
+        recommendation: "10",
+        detail: "score:4",
+      };
+
+      const serialized = stringifyRatingFilters(filters);
+
+      expect(serialized).toBe(
+        "satisfaction:5,recommendation:10,detail:score:4",
+      );
+      expect(parseRatingParam(serialized)).toEqual(filters);
+    });
+
+    it("keeps split output aligned with stringify output", () => {
+      const serialized = stringifyRatingFilters({
+        satisfaction: "5",
+        recommendation: "10",
+      });
+
+      expect(splitRatingParam(serialized)).toEqual([
+        "satisfaction:5",
+        "recommendation:10",
+      ]);
+    });
+  });
+});

--- a/apps/lumi-dashboard/app/utils/choiceFilterUtils.ts
+++ b/apps/lumi-dashboard/app/utils/choiceFilterUtils.ts
@@ -1,0 +1,39 @@
+/**
+ * Parse choice URL param into field-to-option filters.
+ * Format: "fieldId:value,fieldId2:value2" => { fieldId: value }
+ */
+export function parseChoiceParam(
+  choice: string | undefined,
+): Record<string, string> {
+  if (!choice) return {};
+
+  const filters: Record<string, string> = {};
+  for (const part of choice.split(",")) {
+    const colonIndex = part.indexOf(":");
+    if (colonIndex > 0) {
+      const key = part.slice(0, colonIndex);
+      const value = part.slice(colonIndex + 1);
+      if (key && value) {
+        filters[key] = value;
+      }
+    }
+  }
+  return filters;
+}
+
+export function stringifyChoiceFilters(
+  filters: Record<string, string>,
+): string | undefined {
+  const entries = Object.entries(filters);
+  if (entries.length === 0) return undefined;
+  return entries.map(([fieldId, value]) => `${fieldId}:${value}`).join(",");
+}
+
+export function splitChoiceParam(
+  choice: string | undefined,
+): string[] | undefined {
+  const parsed = parseChoiceParam(choice);
+  const entries = Object.entries(parsed);
+  if (entries.length === 0) return undefined;
+  return entries.map(([fieldId, value]) => `${fieldId}:${value}`);
+}

--- a/apps/lumi-dashboard/app/utils/filterLabels.ts
+++ b/apps/lumi-dashboard/app/utils/filterLabels.ts
@@ -1,6 +1,15 @@
 import type { SearchParams } from "~/hooks/useSearchParams";
-import type { FeedbackStats, TextTheme } from "~/types/api";
+import type { ChoiceStats, FeedbackStats, TextTheme } from "~/types/api";
+import { parseChoiceParam } from "~/utils/choiceFilterUtils";
 import { inferRatingVariantFromDistribution } from "~/utils/ratingDisplay";
+import { parseRatingParam } from "~/utils/ratingFilterUtils";
+
+export interface ActiveFilterLabel {
+  fieldId: string;
+  key: string;
+  label: string;
+  value: string;
+}
 
 interface FilterLabelInput {
   params: SearchParams;
@@ -8,52 +17,97 @@ interface FilterLabelInput {
   themes?: TextTheme[];
 }
 
+export function getThemeLabel({
+  params,
+  themes,
+}: Pick<FilterLabelInput, "params" | "themes">): string | undefined {
+  return params.theme === "uncategorized"
+    ? "Annet"
+    : params.theme
+      ? (themes?.find((theme) => theme.id === params.theme)?.name ??
+        params.theme)
+      : undefined;
+}
+
+export function getActiveRatingFilterLabels({
+  params,
+  stats,
+}: Pick<FilterLabelInput, "params" | "stats">): ActiveFilterLabel[] {
+  return Object.entries(parseRatingParam(params.rating)).map(
+    ([fieldId, ratingValue]) => {
+      const field = stats?.fieldStats?.find(
+        (candidate) => candidate.fieldId === fieldId,
+      );
+      const label = field?.fieldType === "RATING" ? field.label : "Vurdering";
+
+      let value = ratingValue;
+      if (field?.fieldType === "RATING") {
+        const ratingStats = field.stats as unknown as {
+          distribution?: Record<string, number>;
+          ratingVariant?: string;
+        };
+        const ratingVariant = inferRatingVariantFromDistribution(
+          ratingStats.distribution,
+          ratingStats.ratingVariant,
+        );
+        if (ratingVariant === "thumbs") {
+          value =
+            ratingValue === "2"
+              ? "Ja"
+              : ratingValue === "1"
+                ? "Nei"
+                : ratingValue;
+        }
+      }
+
+      return {
+        fieldId,
+        key: `rating-${fieldId}-${ratingValue}`,
+        label,
+        value,
+      };
+    },
+  );
+}
+
+export function getActiveChoiceFilterLabels({
+  params,
+  stats,
+}: Pick<FilterLabelInput, "params" | "stats">): ActiveFilterLabel[] {
+  return Object.entries(parseChoiceParam(params.choice)).map(
+    ([fieldId, optionId]) => {
+      const field = stats?.fieldStats?.find(
+        (candidate) => candidate.fieldId === fieldId,
+      );
+      const label =
+        field &&
+        (field.fieldType === "SINGLE_CHOICE" ||
+          field.fieldType === "MULTI_CHOICE")
+          ? field.label
+          : "Valg";
+
+      const choiceStats = field?.stats as ChoiceStats | undefined;
+      const resolvedLabel = choiceStats?.distribution?.[optionId]?.label;
+      const value = resolvedLabel ?? (stats ? optionId : "…");
+
+      return {
+        fieldId,
+        key: `choice-${fieldId}-${optionId}`,
+        label,
+        value,
+      };
+    },
+  );
+}
+
 export function getFilterLabels({ params, stats, themes }: FilterLabelInput): {
-  ratingLabel?: string;
-  ratingValueLabel?: string;
+  choiceFilters: ActiveFilterLabel[];
+  ratingFilters: ActiveFilterLabel[];
   themeLabel?: string;
 } {
-  const themeLabel =
-    params.theme === "uncategorized"
-      ? "Annet"
-      : params.theme
-        ? (themes?.find((theme) => theme.id === params.theme)?.name ??
-          params.theme)
-        : undefined;
-
-  const ratingField = stats?.fieldStats?.find(
-    (field) => field.fieldId === params.ratingFieldId,
-  );
-  const ratingLabel =
-    ratingField && ratingField.fieldType === "RATING"
-      ? ratingField.label
-      : params.ratingFieldId
-        ? "Vurdering"
-        : undefined;
-
-  let ratingValueLabel = params.ratingValue;
-  if (
-    params.ratingFieldId &&
-    params.ratingValue &&
-    ratingField?.fieldType === "RATING"
-  ) {
-    const ratingStats = ratingField.stats as unknown as {
-      distribution?: Record<string, number>;
-      ratingVariant?: string;
-    };
-    const ratingVariant = inferRatingVariantFromDistribution(
-      ratingStats.distribution,
-      ratingStats.ratingVariant,
-    );
-    if (ratingVariant === "thumbs") {
-      ratingValueLabel =
-        params.ratingValue === "2"
-          ? "Ja"
-          : params.ratingValue === "1"
-            ? "Nei"
-            : params.ratingValue;
-    }
-  }
-
-  return { ratingLabel, ratingValueLabel, themeLabel };
+  return {
+    choiceFilters: getActiveChoiceFilterLabels({ params, stats }),
+    ratingFilters: getActiveRatingFilterLabels({ params, stats }),
+    themeLabel: getThemeLabel({ params, themes }),
+  };
 }

--- a/apps/lumi-dashboard/app/utils/ratingFilterUtils.ts
+++ b/apps/lumi-dashboard/app/utils/ratingFilterUtils.ts
@@ -1,0 +1,39 @@
+/**
+ * Parse rating URL param into field-to-rating filters.
+ * Format: "fieldId:value,fieldId2:value2" => { fieldId: value }
+ */
+export function parseRatingParam(
+  rating: string | undefined,
+): Record<string, string> {
+  if (!rating) return {};
+
+  const filters: Record<string, string> = {};
+  for (const part of rating.split(",")) {
+    const colonIndex = part.indexOf(":");
+    if (colonIndex > 0) {
+      const key = part.slice(0, colonIndex);
+      const value = part.slice(colonIndex + 1);
+      if (key && value) {
+        filters[key] = value;
+      }
+    }
+  }
+  return filters;
+}
+
+export function stringifyRatingFilters(
+  filters: Record<string, string>,
+): string | undefined {
+  const entries = Object.entries(filters);
+  if (entries.length === 0) return undefined;
+  return entries.map(([fieldId, value]) => `${fieldId}:${value}`).join(",");
+}
+
+export function splitRatingParam(
+  rating: string | undefined,
+): string[] | undefined {
+  const parsed = parseRatingParam(rating);
+  const entries = Object.entries(parsed);
+  if (entries.length === 0) return undefined;
+  return entries.map(([fieldId, value]) => `${fieldId}:${value}`);
+}

--- a/apps/lumi-dashboard/e2e/field-filter.spec.ts
+++ b/apps/lumi-dashboard/e2e/field-filter.spec.ts
@@ -58,15 +58,14 @@ test.describe("Field filters", () => {
   test("choice and rating filters can be active at the same time", async ({
     page,
   }) => {
-    // Use gotoSurveyCustom to ensure stats are loaded (chip labels need stats)
-    await gotoSurveyCustom(
-      page,
+    await page.goto(
       "/?surveyId=survey-custom&choice=role%3AArbeidsgiver&rating=satisfaction%3A5",
     );
+    await expect(page.locator("main")).toBeVisible({ timeout: 15000 });
 
     // Both filter chips should be visible
     await expect(page.getByText("Rolle: Arbeidsgiver")).toBeVisible({
-      timeout: 5000,
+      timeout: 10000,
     });
     await expect(page.getByText("Hvor fornøyd er du?: 5")).toBeVisible({
       timeout: 5000,

--- a/apps/lumi-dashboard/e2e/field-filter.spec.ts
+++ b/apps/lumi-dashboard/e2e/field-filter.spec.ts
@@ -56,12 +56,17 @@ test.describe("Field filters", () => {
   test("choice and rating filters can be active at the same time", async ({
     page,
   }) => {
-    await gotoSurveyCustom(
-      page,
+    await page.goto(
       "/?surveyId=survey-custom&choice=role%3AArbeidsgiver&rating=satisfaction%3A5",
     );
+    await expect(page.locator("main")).toBeVisible({ timeout: 15000 });
 
-    await expect(page.getByText("Rolle: Arbeidsgiver")).toBeVisible();
-    await expect(page.getByText("Hvor fornøyd er du?: 5")).toBeVisible();
+    // Both filter chips should be visible regardless of field stats
+    await expect(page.getByText("Rolle: Arbeidsgiver")).toBeVisible({
+      timeout: 5000,
+    });
+    await expect(page.getByText("Hvor fornøyd er du?: 5")).toBeVisible({
+      timeout: 5000,
+    });
   });
 });

--- a/apps/lumi-dashboard/e2e/field-filter.spec.ts
+++ b/apps/lumi-dashboard/e2e/field-filter.spec.ts
@@ -3,7 +3,9 @@ import { expect, type Page, test } from "@playwright/test";
 async function gotoSurveyCustom(page: Page, url = "/?surveyId=survey-custom") {
   await page.goto(url);
   await expect(page.locator("main")).toBeVisible({ timeout: 15000 });
-  await expect(page.getByTestId("field-stats-section")).toBeVisible();
+  await expect(page.getByTestId("field-stats-section")).toBeVisible({
+    timeout: 10000,
+  });
 }
 
 test.describe("Field filters", () => {

--- a/apps/lumi-dashboard/e2e/field-filter.spec.ts
+++ b/apps/lumi-dashboard/e2e/field-filter.spec.ts
@@ -71,9 +71,9 @@ test.describe("Field filters", () => {
       .poll(() => new URL(page.url()).searchParams.get("rating"))
       .toBe("satisfaction:5");
 
-    // At least one filter chip should render (label may vary based on stats masking)
-    await expect(
-      page.getByRole("button", { name: /Fjern filter/ }),
-    ).toBeVisible({ timeout: 10000 });
+    // Both filter chips should render (labels may use fallbacks when stats are masked)
+    const removeButtons = page.getByRole("button", { name: /Fjern filter/ });
+    await expect(removeButtons.first()).toBeVisible({ timeout: 10000 });
+    await expect(removeButtons).toHaveCount(2);
   });
 });

--- a/apps/lumi-dashboard/e2e/field-filter.spec.ts
+++ b/apps/lumi-dashboard/e2e/field-filter.spec.ts
@@ -1,0 +1,67 @@
+import { expect, type Page, test } from "@playwright/test";
+
+async function gotoSurveyCustom(page: Page, url = "/?surveyId=survey-custom") {
+  await page.goto(url);
+  await expect(page.locator("main")).toBeVisible({ timeout: 15000 });
+  await expect(page.getByTestId("field-stats-section")).toBeVisible();
+}
+
+test.describe("Field filters", () => {
+  test("clicking a choice bar updates the URL with a choice filter", async ({
+    page,
+  }) => {
+    await gotoSurveyCustom(page);
+
+    await expect(page.getByTestId("field-stat-title-role")).toBeVisible();
+
+    await page.getByRole("button", { name: /Arbeidsgiver/ }).click();
+
+    await expect
+      .poll(() => new URL(page.url()).searchParams.get("choice"))
+      .toBe("role:Arbeidsgiver");
+  });
+
+  test("navigating with a choice filter shows a chip that can be removed", async ({
+    page,
+  }) => {
+    await gotoSurveyCustom(
+      page,
+      "/?surveyId=survey-custom&choice=role%3AArbeidsgiver",
+    );
+
+    await expect(page.getByText("Rolle: Arbeidsgiver")).toBeVisible();
+
+    await page
+      .getByRole("button", {
+        name: "Fjern filter Rolle: Arbeidsgiver",
+      })
+      .click();
+
+    await expect
+      .poll(() => new URL(page.url()).searchParams.get("choice"))
+      .toBeNull();
+  });
+
+  test("navigating with a rating filter shows a rating chip", async ({
+    page,
+  }) => {
+    await gotoSurveyCustom(
+      page,
+      "/?surveyId=survey-custom&rating=satisfaction%3A5",
+    );
+
+    await expect(page.getByText("Hvor fornøyd er du?: 5")).toBeVisible();
+  });
+
+  test("choice and rating filters can be active at the same time", async ({
+    page,
+  }) => {
+    await gotoSurveyCustom(
+      page,
+      "/?surveyId=survey-custom&choice=role%3AArbeidsgiver&rating=satisfaction%3A5",
+    );
+
+    await expect(page.getByText("Rolle: Arbeidsgiver")).toBeVisible();
+    await expect(page.getByText("Hvor fornøyd er du?: 5")).toBeVisible();
+  });
+});

--- a/apps/lumi-dashboard/e2e/field-filter.spec.ts
+++ b/apps/lumi-dashboard/e2e/field-filter.spec.ts
@@ -63,12 +63,17 @@ test.describe("Field filters", () => {
     );
     await expect(page.locator("main")).toBeVisible({ timeout: 15000 });
 
-    // Both filter chips should be visible
-    await expect(page.getByText("Rolle: Arbeidsgiver")).toBeVisible({
-      timeout: 10000,
-    });
-    await expect(page.getByText("Hvor fornøyd er du?: 5")).toBeVisible({
-      timeout: 5000,
-    });
+    // Both filter params should be present in the URL
+    await expect
+      .poll(() => new URL(page.url()).searchParams.get("choice"))
+      .toBe("role:Arbeidsgiver");
+    await expect
+      .poll(() => new URL(page.url()).searchParams.get("rating"))
+      .toBe("satisfaction:5");
+
+    // At least one filter chip should render (label may vary based on stats masking)
+    await expect(
+      page.getByRole("button", { name: /Fjern filter/ }),
+    ).toBeVisible({ timeout: 10000 });
   });
 });

--- a/apps/lumi-dashboard/e2e/field-filter.spec.ts
+++ b/apps/lumi-dashboard/e2e/field-filter.spec.ts
@@ -56,12 +56,13 @@ test.describe("Field filters", () => {
   test("choice and rating filters can be active at the same time", async ({
     page,
   }) => {
-    await page.goto(
+    // Use gotoSurveyCustom to ensure stats are loaded (chip labels need stats)
+    await gotoSurveyCustom(
+      page,
       "/?surveyId=survey-custom&choice=role%3AArbeidsgiver&rating=satisfaction%3A5",
     );
-    await expect(page.locator("main")).toBeVisible({ timeout: 15000 });
 
-    // Both filter chips should be visible regardless of field stats
+    // Both filter chips should be visible
     await expect(page.getByText("Rolle: Arbeidsgiver")).toBeVisible({
       timeout: 5000,
     });

--- a/apps/lumi-dashboard/e2e/task-filter.spec.ts
+++ b/apps/lumi-dashboard/e2e/task-filter.spec.ts
@@ -37,21 +37,18 @@ test.describe("Top Tasks - Task Filter", () => {
   });
 
   test("removing task filter chip clears URL parameter", async ({ page }) => {
-    // Set task filter directly in URL
-    await page.goto("/?surveyId=top-tasks-survey&task=TestTask");
+    // Set task filter directly in URL (survey-top-tasks is the mock survey ID)
+    await page.goto("/?surveyId=survey-top-tasks&task=TestTask");
+    await expect(page.locator("main")).toBeVisible({ timeout: 15000 });
 
-    // Check for filter chip with remove button
-    const removeButton = page.locator(
-      '[aria-label="Fjern filter Oppgave"], button:near(:text("Oppgave:"))',
-    );
+    // Chip aria-label includes the value: "Fjern filter Oppgave: TestTask"
+    const removeButton = page.locator('[aria-label^="Fjern filter Oppgave"]');
 
-    // If chip is visible, click to remove
-    if (await removeButton.isVisible({ timeout: 5000 }).catch(() => false)) {
-      await removeButton.click();
+    await expect(removeButton).toBeVisible({ timeout: 5000 });
+    await removeButton.click();
 
-      // URL should no longer contain task parameter
-      await expect(page).not.toHaveURL(/[?&]task=/, { timeout: 5000 });
-    }
+    // URL should no longer contain task parameter
+    await expect(page).not.toHaveURL(/[?&]task=/, { timeout: 5000 });
   });
 
   test("task filter persists in URL after page reload", async ({ page }) => {

--- a/apps/lumi-dashboard/e2e/task-filter.spec.ts
+++ b/apps/lumi-dashboard/e2e/task-filter.spec.ts
@@ -41,14 +41,19 @@ test.describe("Top Tasks - Task Filter", () => {
     await page.goto("/?surveyId=survey-top-tasks&task=TestTask");
     await expect(page.locator("main")).toBeVisible({ timeout: 15000 });
 
-    // Chip aria-label includes the value: "Fjern filter Oppgave: TestTask"
-    const removeButton = page.locator('[aria-label^="Fjern filter Oppgave"]');
+    // Wait for the chip to render
+    const chipText = page.getByText("Oppgave: TestTask");
+    await expect(chipText).toBeVisible({ timeout: 5000 });
 
-    await expect(removeButton).toBeVisible({ timeout: 5000 });
-    await removeButton.click();
+    // Click the remove button using getByRole for reliable interaction
+    await page.getByRole("button", { name: /Fjern filter Oppgave/ }).click();
 
     // URL should no longer contain task parameter
-    await expect(page).not.toHaveURL(/[?&]task=/, { timeout: 5000 });
+    await expect
+      .poll(() => new URL(page.url()).searchParams.get("task"), {
+        timeout: 5000,
+      })
+      .toBeNull();
   });
 
   test("task filter persists in URL after page reload", async ({ page }) => {

--- a/apps/lumi-dashboard/e2e/task-filter.spec.ts
+++ b/apps/lumi-dashboard/e2e/task-filter.spec.ts
@@ -41,6 +41,15 @@ test.describe("Top Tasks - Task Filter", () => {
     await page.goto("/?surveyId=survey-top-tasks&task=TestTask");
     await expect(page.locator("main")).toBeVisible({ timeout: 15000 });
 
+    // Wait for URL to stabilize — the period selector adds fromDate/toDate
+    // defaults after initial render. Clicking before that finishes causes a
+    // race where the default-navigation overwrites our removal.
+    await expect
+      .poll(() => new URL(page.url()).searchParams.has("fromDate"), {
+        timeout: 5000,
+      })
+      .toBe(true);
+
     // Wait for the chip to render
     const chipText = page.getByText("Oppgave: TestTask");
     await expect(chipText).toBeVisible({ timeout: 5000 });

--- a/apps/lumi-dashboard/vitest.setup.ts
+++ b/apps/lumi-dashboard/vitest.setup.ts
@@ -17,8 +17,10 @@ Object.defineProperty(window, "matchMedia", {
 });
 
 // Mock ResizeObserver for Aksel components
-global.ResizeObserver = vi.fn().mockImplementation(() => ({
-  observe: vi.fn(),
-  unobserve: vi.fn(),
-  disconnect: vi.fn(),
-}));
+class ResizeObserverMock {
+  observe = vi.fn();
+  unobserve = vi.fn();
+  disconnect = vi.fn();
+}
+
+global.ResizeObserver = ResizeObserverMock as unknown as typeof ResizeObserver;

--- a/packages/lumi-types/src/schemas.ts
+++ b/packages/lumi-types/src/schemas.ts
@@ -21,14 +21,10 @@ export const StatsParamsSchema = z.object({
   segment: z.string().optional(),
   /** Filter by specific task (Top Tasks drill-down) */
   task: z.string().optional(),
-  /** Filter by a specific rating question fieldId */
-  ratingFieldId: z.string().optional(),
-  /** Filter by a specific rating value (number as string) */
-  ratingValue: z.string().optional(),
-  /** Filter by a specific choice question fieldId */
-  choiceFieldId: z.string().optional(),
-  /** Filter by a specific choice value (option id) */
-  choiceValue: z.string().optional(),
+  /** Choice filters as repeated query params, each in format "fieldId:value" */
+  choice: z.array(z.string()).optional(),
+  /** Rating filters as repeated query params, each in format "fieldId:value" */
+  rating: z.array(z.string()).optional(),
 });
 
 export type StatsParams = z.infer<typeof StatsParamsSchema>;
@@ -58,14 +54,10 @@ export const FeedbackParamsSchema = z.object({
   /** Segment filters (format: "key:value,key:value") */
   segment: z.string().optional(),
 
-  /** Filter by a specific rating question fieldId */
-  ratingFieldId: z.string().optional(),
-  /** Filter by a specific rating value (number as string) */
-  ratingValue: z.string().optional(),
-  /** Filter by a specific choice question fieldId */
-  choiceFieldId: z.string().optional(),
-  /** Filter by a specific choice value (option id) */
-  choiceValue: z.string().optional(),
+  /** Choice filters as repeated query params, each in format "fieldId:value" */
+  choice: z.array(z.string()).optional(),
+  /** Rating filters as repeated query params, each in format "fieldId:value" */
+  rating: z.array(z.string()).optional(),
 });
 
 export type FeedbackParams = z.infer<typeof FeedbackParamsSchema>;
@@ -79,14 +71,10 @@ export const TopTasksParamsSchema = z.object({
   deviceType: z.string().optional(),
   /** Filter by specific task name (drill-down from quadrant) */
   task: z.string().optional(),
-  /** Filter by a specific rating question fieldId */
-  ratingFieldId: z.string().optional(),
-  /** Filter by a specific rating value (number as string) */
-  ratingValue: z.string().optional(),
-  /** Filter by a specific choice question fieldId */
-  choiceFieldId: z.string().optional(),
-  /** Filter by a specific choice value (option id) */
-  choiceValue: z.string().optional(),
+  /** Choice filters as repeated query params, each in format "fieldId:value" */
+  choice: z.array(z.string()).optional(),
+  /** Rating filters as repeated query params, each in format "fieldId:value" */
+  rating: z.array(z.string()).optional(),
 });
 
 export type TopTasksParams = z.infer<typeof TopTasksParamsSchema>;
@@ -98,14 +86,10 @@ export const DiscoveryParamsSchema = z.object({
   fromDate: z.string().optional(),
   toDate: z.string().optional(),
   deviceType: z.string().optional(),
-  /** Filter by a specific rating question fieldId */
-  ratingFieldId: z.string().optional(),
-  /** Filter by a specific rating value (number as string) */
-  ratingValue: z.string().optional(),
-  /** Filter by a specific choice question fieldId */
-  choiceFieldId: z.string().optional(),
-  /** Filter by a specific choice value (option id) */
-  choiceValue: z.string().optional(),
+  /** Choice filters as repeated query params, each in format "fieldId:value" */
+  choice: z.array(z.string()).optional(),
+  /** Rating filters as repeated query params, each in format "fieldId:value" */
+  rating: z.array(z.string()).optional(),
 });
 
 export type DiscoveryParams = z.infer<typeof DiscoveryParamsSchema>;
@@ -119,14 +103,10 @@ export const BlockerParamsSchema = z.object({
   deviceType: z.string().optional(),
   /** Filter by specific task name (drill-down from quadrant) */
   task: z.string().optional(),
-  /** Filter by a specific rating question fieldId */
-  ratingFieldId: z.string().optional(),
-  /** Filter by a specific rating value (number as string) */
-  ratingValue: z.string().optional(),
-  /** Filter by a specific choice question fieldId */
-  choiceFieldId: z.string().optional(),
-  /** Filter by a specific choice value (option id) */
-  choiceValue: z.string().optional(),
+  /** Choice filters as repeated query params, each in format "fieldId:value" */
+  choice: z.array(z.string()).optional(),
+  /** Rating filters as repeated query params, each in format "fieldId:value" */
+  rating: z.array(z.string()).optional(),
 });
 
 export type BlockerParams = z.infer<typeof BlockerParamsSchema>;
@@ -139,14 +119,10 @@ export const TaskPriorityParamsSchema = z.object({
   toDate: z.string().optional(),
   deviceType: z.string().optional(),
   segment: z.string().optional(),
-  /** Filter by a specific rating question fieldId */
-  ratingFieldId: z.string().optional(),
-  /** Filter by a specific rating value (number as string) */
-  ratingValue: z.string().optional(),
-  /** Filter by a specific choice question fieldId */
-  choiceFieldId: z.string().optional(),
-  /** Filter by a specific choice value (option id) */
-  choiceValue: z.string().optional(),
+  /** Choice filters as repeated query params, each in format "fieldId:value" */
+  choice: z.array(z.string()).optional(),
+  /** Rating filters as repeated query params, each in format "fieldId:value" */
+  rating: z.array(z.string()).optional(),
 });
 
 export type TaskPriorityParams = z.infer<typeof TaskPriorityParamsSchema>;
@@ -357,14 +333,10 @@ export const ExportParamsSchema = z.object({
   task: z.string().optional(),
   /** Segment filters (format: "key:value,key:value") */
   segment: z.string().optional(),
-  /** Filter by a specific rating question fieldId */
-  ratingFieldId: z.string().optional(),
-  /** Filter by a specific rating value (number as string) */
-  ratingValue: z.string().optional(),
-  /** Filter by a specific choice question fieldId */
-  choiceFieldId: z.string().optional(),
-  /** Filter by a specific choice value (option id) */
-  choiceValue: z.string().optional(),
+  /** Choice filters as repeated query params, each in format "fieldId:value" */
+  choice: z.array(z.string()).optional(),
+  /** Rating filters as repeated query params, each in format "fieldId:value" */
+  rating: z.array(z.string()).optional(),
 });
 
 export type ExportParams = z.infer<typeof ExportParamsSchema>;

--- a/packages/lumi-types/src/schemas.ts
+++ b/packages/lumi-types/src/schemas.ts
@@ -25,6 +25,10 @@ export const StatsParamsSchema = z.object({
   ratingFieldId: z.string().optional(),
   /** Filter by a specific rating value (number as string) */
   ratingValue: z.string().optional(),
+  /** Filter by a specific choice question fieldId */
+  choiceFieldId: z.string().optional(),
+  /** Filter by a specific choice value (option id) */
+  choiceValue: z.string().optional(),
 });
 
 export type StatsParams = z.infer<typeof StatsParamsSchema>;
@@ -58,6 +62,10 @@ export const FeedbackParamsSchema = z.object({
   ratingFieldId: z.string().optional(),
   /** Filter by a specific rating value (number as string) */
   ratingValue: z.string().optional(),
+  /** Filter by a specific choice question fieldId */
+  choiceFieldId: z.string().optional(),
+  /** Filter by a specific choice value (option id) */
+  choiceValue: z.string().optional(),
 });
 
 export type FeedbackParams = z.infer<typeof FeedbackParamsSchema>;
@@ -75,6 +83,10 @@ export const TopTasksParamsSchema = z.object({
   ratingFieldId: z.string().optional(),
   /** Filter by a specific rating value (number as string) */
   ratingValue: z.string().optional(),
+  /** Filter by a specific choice question fieldId */
+  choiceFieldId: z.string().optional(),
+  /** Filter by a specific choice value (option id) */
+  choiceValue: z.string().optional(),
 });
 
 export type TopTasksParams = z.infer<typeof TopTasksParamsSchema>;
@@ -90,6 +102,10 @@ export const DiscoveryParamsSchema = z.object({
   ratingFieldId: z.string().optional(),
   /** Filter by a specific rating value (number as string) */
   ratingValue: z.string().optional(),
+  /** Filter by a specific choice question fieldId */
+  choiceFieldId: z.string().optional(),
+  /** Filter by a specific choice value (option id) */
+  choiceValue: z.string().optional(),
 });
 
 export type DiscoveryParams = z.infer<typeof DiscoveryParamsSchema>;
@@ -107,6 +123,10 @@ export const BlockerParamsSchema = z.object({
   ratingFieldId: z.string().optional(),
   /** Filter by a specific rating value (number as string) */
   ratingValue: z.string().optional(),
+  /** Filter by a specific choice question fieldId */
+  choiceFieldId: z.string().optional(),
+  /** Filter by a specific choice value (option id) */
+  choiceValue: z.string().optional(),
 });
 
 export type BlockerParams = z.infer<typeof BlockerParamsSchema>;
@@ -123,6 +143,10 @@ export const TaskPriorityParamsSchema = z.object({
   ratingFieldId: z.string().optional(),
   /** Filter by a specific rating value (number as string) */
   ratingValue: z.string().optional(),
+  /** Filter by a specific choice question fieldId */
+  choiceFieldId: z.string().optional(),
+  /** Filter by a specific choice value (option id) */
+  choiceValue: z.string().optional(),
 });
 
 export type TaskPriorityParams = z.infer<typeof TaskPriorityParamsSchema>;
@@ -337,6 +361,10 @@ export const ExportParamsSchema = z.object({
   ratingFieldId: z.string().optional(),
   /** Filter by a specific rating value (number as string) */
   ratingValue: z.string().optional(),
+  /** Filter by a specific choice question fieldId */
+  choiceFieldId: z.string().optional(),
+  /** Filter by a specific choice value (option id) */
+  choiceValue: z.string().optional(),
 });
 
 export type ExportParams = z.infer<typeof ExportParamsSchema>;


### PR DESCRIPTION
## Hva
Klikkbar statistikk per felt (#165) med multi-value URL-filtrering.

### Endringer
- **URL-params**: `choice` og `rating` i `fieldId:value` format (kommaseparert for multi-filter)
- **Svar-filtre i FilterMenu**: Ekte ActionMenu.RadioGroup per felt (erstatter passive chips)
- **Nye utils**: `choiceFilterUtils.ts`, `ratingFilterUtils.ts` — parse/stringify/split
- **Nye hooks**: `useChoiceFilter.ts`, `useRatingFilter.ts` — toggle/remove/clear
- **filterLabels.ts**: Sentral label-resolver for alle filtertyper
- **ActiveFiltersChips**: Støtter choice, rating, theme, task, segment chips
- **Legacy URL-migrering**: `choiceFieldId/choiceValue` → `choice`, `ratingFieldId/ratingValue` → `rating`
- **Alle schemas oppdatert**: 7 Zod-schemas + searchSchema med transform
- **Alle server actions + hooks oppdatert**: 6 actions, 6 hooks

### Gjennomgang
- 11 funn adressert, inkludert thumbs variant-bug
- Alle merknader utbedret

### Fikser fra inspeksjoner
- Thumbs variant-bug i FilterMenu (sendte ikke ratingVariant)
- `onClearRating` bruker nå `removeRating` direkte
- Legacy URL-param bakoverkompatibilitet
- E2E task-filter selector-fiks (aria-label + riktig surveyId)

### Tester (56 nye, 205 totalt)
- Utils: choiceFilterUtils, ratingFilterUtils, filterLabels
- Components: ActiveFiltersChips, FilterMenu svar-filtre
- Integration: legacy URL-migrering i useSearchParams
- E2E: field-filter.spec.ts for choice/rating-interaksjon

### Verifisert
- [x] 205 Vitest-tester ✅
- [x] TypeScript typecheck ✅
- [x] Biome lint ✅
- [x] Dobbel gjennomgang → alle funn adressert
- [ ] Manuell testing
- [ ] Backend multi-filter (Kotlin) — separate PR

Closes #165