### PR TITLE
feat(api): add inbound access for modiapersonoversikt-api

### DIFF
--- a/apps/lumi-api/nais/app/dev.yaml
+++ b/apps/lumi-api/nais/app/dev.yaml
@@ -51,6 +51,8 @@ spec:
         - application: dinesykmeldte
         - application: syfomodiaperson
           namespace: teamsykefravr
+        - application: modiapersonoversikt-api
+          namespace: personoversikt
         - application: lumi-submission-proxy
         - application: oppfolgingsplan-frontend
     outbound:

--- a/apps/lumi-api/nais/app/prod.yaml
+++ b/apps/lumi-api/nais/app/prod.yaml
@@ -51,6 +51,8 @@ spec:
         - application: dinesykmeldte
         - application: syfomodiaperson
           namespace: teamsykefravr
+        - application: modiapersonoversikt-api
+          namespace: personoversikt
         - application: oppfolgingsplan-frontend
     outbound:
       external:


### PR DESCRIPTION
## Beskrivelse

Legger til inbound accessPolicy for `modiapersonoversikt-api` (namespace: `personoversikt`) i både dev-gcp og prod-gcp.

### Endringer

- `apps/lumi-api/nais/app/dev.yaml` — inbound-regel for `modiapersonoversikt-api`
- `apps/lumi-api/nais/app/prod.yaml` — inbound-regel for `modiapersonoversikt-api`

### Verifisering

Ingen kodeendringer — kun NAIS-manifest. Trer i kraft ved neste deploy.

---

Closes #167