### PR TITLE
ci(dependabot): ignore zod 4 updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -15,6 +15,9 @@ updates:
     cooldown:
       default-days: 7
     open-pull-requests-limit: 10
+    ignore:
+      - dependency-name: "zod"
+        versions: [">=4"]
     groups:
       vitest:
         patterns:


### PR DESCRIPTION
## Beskrivelse

Stopper Zod 4-sporet i repoet nå siden Zod 4 ikke er støttet i lumi ennå.

## Endringer

- .github/dependabot.yml: ignorerer zod-oppdateringer for >=4 i root npm-blokken
- Lukket Dependabot-PR #22 med kommentar om at Zod 4 ikke støttes ennå

## Issue

Ingen issue. Dette er en policy-/repo-opprydding.

## Sjekkliste

- [ ] Koden kompilerer og linter uten feil
- [x] Endringene er testet (manuelt eller automatisk)
- [x] Ingen sensitiv data eksponert (tokens, credentials, PII)

Verifisering:
- pnpm run typecheck ✅
- ruby -e 'require "yaml"; YAML.load_file(".github/dependabot.yml"); puts "dependabot.yml ok"' ✅
- pnpm run lint ⚠️ feiler på eksisterende, ikke-berørte Biome-funn i repoet