### PR TITLE
build(deps): upgrade biome to 2.4.10

### DIFF
--- a/apps/lumi-dashboard/app/components/dashboard/views/TopTasks/TimelineChart.tsx
+++ b/apps/lumi-dashboard/app/components/dashboard/views/TopTasks/TimelineChart.tsx
@@ -111,7 +111,7 @@ export function TopTasksTimelineChart() {
         />
         <Tooltip
           content={({ active, payload }) => {
-            if (active && payload && payload.length) {
+            if (active && payload?.length) {
               const d = payload[0].payload;
               return (
                 <div

--- a/apps/lumi-dashboard/app/components/shared/Charts/RatingChart.tsx
+++ b/apps/lumi-dashboard/app/components/shared/Charts/RatingChart.tsx
@@ -207,7 +207,7 @@ export function RatingChart() {
         <YAxis hide />
         <Tooltip
           content={({ active, payload }) => {
-            if (active && payload && payload.length && payload[0]) {
+            if (active && payload?.length && payload[0]) {
               const item = payload[0].payload as {
                 label: string;
                 count: number;

--- a/apps/lumi-dashboard/app/components/shared/Charts/SurveyTypeDistribution.tsx
+++ b/apps/lumi-dashboard/app/components/shared/Charts/SurveyTypeDistribution.tsx
@@ -110,7 +110,7 @@ export function SurveyTypeDistribution({
         />
         <Tooltip
           content={({ active, payload }) => {
-            if (active && payload && payload.length && payload[0]) {
+            if (active && payload?.length && payload[0]) {
               const point = payload[0].payload as {
                 label: string;
                 count: number;

--- a/apps/lumi-dashboard/app/components/shared/Charts/TaskQuadrantChart.tsx
+++ b/apps/lumi-dashboard/app/components/shared/Charts/TaskQuadrantChart.tsx
@@ -276,7 +276,7 @@ export function TaskQuadrantChart({
         <Tooltip
           cursor={{ strokeDasharray: "3 3" }}
           content={({ active, payload }) => {
-            if (active && payload && payload.length && payload[0]) {
+            if (active && payload?.length && payload[0]) {
               const d = payload[0].payload as TaskDataPoint;
               const zoneLabels = {
                 crisis: "🔴 KRISE - Mange prøver, få lykkes",

--- a/apps/lumi-dashboard/app/components/shared/Charts/TimelineChart.tsx
+++ b/apps/lumi-dashboard/app/components/shared/Charts/TimelineChart.tsx
@@ -134,7 +134,7 @@ export function TimelineChart() {
         <Tooltip
           cursor={{ fill: colors.primaryFaded }}
           content={({ active, payload }) => {
-            if (active && payload && payload.length && payload[0]) {
+            if (active && payload?.length && payload[0]) {
               const point = payload[0].payload as {
                 date: string;
                 count: number;

--- a/apps/lumi-dashboard/app/components/shared/Charts/TopAppsChart.tsx
+++ b/apps/lumi-dashboard/app/components/shared/Charts/TopAppsChart.tsx
@@ -85,7 +85,7 @@ export function TopAppsChart() {
         />
         <Tooltip
           content={({ active, payload }) => {
-            if (active && payload && payload.length && payload[0]) {
+            if (active && payload?.length && payload[0]) {
               const point = payload[0].payload as {
                 app: string;
                 count: number;

--- a/apps/lumi-dashboard/app/components/shared/Charts/TopPathsChart.tsx
+++ b/apps/lumi-dashboard/app/components/shared/Charts/TopPathsChart.tsx
@@ -107,7 +107,7 @@ export function TopPathsChart() {
         />
         <Tooltip
           content={({ active, payload }) => {
-            if (active && payload && payload.length && payload[0]) {
+            if (active && payload?.length && payload[0]) {
               const point = payload[0].payload as {
                 pathname: string;
                 count: number;

--- a/apps/lumi-dashboard/app/mock/mockData.ts
+++ b/apps/lumi-dashboard/app/mock/mockData.ts
@@ -31,11 +31,11 @@ import {
 } from "./helpers";
 
 export {
-  generateSurveyData,
-  generateTopTasksMockData,
-  generateDiscoveryMockData,
-  generateTaskPriorityMockData,
   generateComplexSurveyData,
+  generateDiscoveryMockData,
+  generateSurveyData,
+  generateTaskPriorityMockData,
+  generateTopTasksMockData,
 };
 
 import { calculateStats } from "./stats";

--- a/apps/lumi-dashboard/app/utils/csv-export.ts
+++ b/apps/lumi-dashboard/app/utils/csv-export.ts
@@ -66,7 +66,7 @@ export function generateCsvExport(items: FeedbackItem[]): Response {
 
   // Helper to extract actual value from answer
   function getAnswerValue(answer: FeedbackAnswer | undefined): string {
-    if (!answer || !answer.value) return "";
+    if (!answer?.value) return "";
     const val = answer.value;
     if (val.type === "rating") return String(val.rating);
     if (val.type === "text") return val.text || "";

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "prepare": "husky"
   },
   "devDependencies": {
-    "@biomejs/biome": "2.4.6",
+    "@biomejs/biome": "2.4.10",
     "husky": "^9.1.7",
     "lint-staged": "^16.4.0"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,8 +9,8 @@ importers:
   .:
     devDependencies:
       '@biomejs/biome':
-        specifier: 2.4.6
-        version: 2.4.6
+        specifier: 2.4.10
+        version: 2.4.10
       husky:
         specifier: ^9.1.7
         version: 9.1.7
@@ -349,59 +349,59 @@ packages:
     resolution: {integrity: sha512-6zABk/ECA/QYSCQ1NGiVwwbQerUCZ+TQbp64Q3AgmfNvurHH0j8TtXa1qbShXA6qqkpAj4V5W8pP6mLe1mcMqA==}
     engines: {node: '>=18'}
 
-  '@biomejs/biome@2.4.6':
-    resolution: {integrity: sha512-QnHe81PMslpy3mnpL8DnO2M4S4ZnYPkjlGCLWBZT/3R9M6b5daArWMMtEfP52/n174RKnwRIf3oT8+wc9ihSfQ==}
+  '@biomejs/biome@2.4.10':
+    resolution: {integrity: sha512-xxA3AphFQ1geij4JTHXv4EeSTda1IFn22ye9LdyVPoJU19fNVl0uzfEuhsfQ4Yue/0FaLs2/ccVi4UDiE7R30w==}
     engines: {node: '>=14.21.3'}
     hasBin: true
 
-  '@biomejs/cli-darwin-arm64@2.4.6':
-    resolution: {integrity: sha512-NW18GSyxr+8sJIqgoGwVp5Zqm4SALH4b4gftIA0n62PTuBs6G2tHlwNAOj0Vq0KKSs7Sf88VjjmHh0O36EnzrQ==}
+  '@biomejs/cli-darwin-arm64@2.4.10':
+    resolution: {integrity: sha512-vuzzI1cWqDVzOMIkYyHbKqp+AkQq4K7k+UCXWpkYcY/HDn1UxdsbsfgtVpa40shem8Kax4TLDLlx8kMAecgqiw==}
     engines: {node: '>=14.21.3'}
     cpu: [arm64]
     os: [darwin]
 
-  '@biomejs/cli-darwin-x64@2.4.6':
-    resolution: {integrity: sha512-4uiE/9tuI7cnjtY9b07RgS7gGyYOAfIAGeVJWEfeCnAarOAS7qVmuRyX6d7JTKw28/mt+rUzMasYeZ+0R/U1Mw==}
+  '@biomejs/cli-darwin-x64@2.4.10':
+    resolution: {integrity: sha512-14fzASRo+BPotwp7nWULy2W5xeUyFnTaq1V13Etrrxkrih+ez/2QfgFm5Ehtf5vSjtgx/IJycMMpn5kPd5ZNaA==}
     engines: {node: '>=14.21.3'}
     cpu: [x64]
     os: [darwin]
 
-  '@biomejs/cli-linux-arm64-musl@2.4.6':
-    resolution: {integrity: sha512-F/JdB7eN22txiTqHM5KhIVt0jVkzZwVYrdTR1O3Y4auBOQcXxHK4dxULf4z43QyZI5tsnQJrRBHZy7wwtL+B3A==}
+  '@biomejs/cli-linux-arm64-musl@2.4.10':
+    resolution: {integrity: sha512-WrJY6UuiSD/Dh+nwK2qOTu8kdMDlLV3dLMmychIghHPAysWFq1/DGC1pVZx8POE3ZkzKR3PUUnVrtZfMfaJjyQ==}
     engines: {node: '>=14.21.3'}
     cpu: [arm64]
     os: [linux]
     libc: [musl]
 
-  '@biomejs/cli-linux-arm64@2.4.6':
-    resolution: {integrity: sha512-kMLaI7OF5GN1Q8Doymjro1P8rVEoy7BKQALNz6fiR8IC1WKduoNyteBtJlHT7ASIL0Cx2jR6VUOBIbcB1B8pew==}
+  '@biomejs/cli-linux-arm64@2.4.10':
+    resolution: {integrity: sha512-7MH1CMW5uuxQ/s7FLST63qF8B3Hgu2HRdZ7tA1X1+mk+St4JOuIrqdhIBnnyqeyWJNI+Bww7Es5QZ0wIc1Cmkw==}
     engines: {node: '>=14.21.3'}
     cpu: [arm64]
     os: [linux]
     libc: [glibc]
 
-  '@biomejs/cli-linux-x64-musl@2.4.6':
-    resolution: {integrity: sha512-C9s98IPDu7DYarjlZNuzJKTjVHN03RUnmHV5htvqsx6vEUXCDSJ59DNwjKVD5XYoSS4N+BYhq3RTBAL8X6svEg==}
+  '@biomejs/cli-linux-x64-musl@2.4.10':
+    resolution: {integrity: sha512-kDTi3pI6PBN6CiczsWYOyP2zk0IJI08EWEQyDMQWW221rPaaEz6FvjLhnU07KMzLv8q3qSuoB93ua6inSQ55Tw==}
     engines: {node: '>=14.21.3'}
     cpu: [x64]
     os: [linux]
     libc: [musl]
 
-  '@biomejs/cli-linux-x64@2.4.6':
-    resolution: {integrity: sha512-oHXmUFEoH8Lql1xfc3QkFLiC1hGR7qedv5eKNlC185or+o4/4HiaU7vYODAH3peRCfsuLr1g6v2fK9dFFOYdyw==}
+  '@biomejs/cli-linux-x64@2.4.10':
+    resolution: {integrity: sha512-tZLvEEi2u9Xu1zAqRjTcpIDGVtldigVvzug2fTuPG0ME/g8/mXpRPcNgLB22bGn6FvLJpHHnqLnwliOu8xjYrg==}
     engines: {node: '>=14.21.3'}
     cpu: [x64]
     os: [linux]
     libc: [glibc]
 
-  '@biomejs/cli-win32-arm64@2.4.6':
-    resolution: {integrity: sha512-xzThn87Pf3YrOGTEODFGONmqXpTwUNxovQb72iaUOdcw8sBSY3+3WD8Hm9IhMYLnPi0n32s3L3NWU6+eSjfqFg==}
+  '@biomejs/cli-win32-arm64@2.4.10':
+    resolution: {integrity: sha512-umwQU6qPzH+ISTf/eHyJ/QoQnJs3V9Vpjz2OjZXe9MVBZ7prgGafMy7yYeRGnlmDAn87AKTF3Q6weLoMGpeqdQ==}
     engines: {node: '>=14.21.3'}
     cpu: [arm64]
     os: [win32]
 
-  '@biomejs/cli-win32-x64@2.4.6':
-    resolution: {integrity: sha512-7++XhnsPlr1HDbor5amovPjOH6vsrFOCdp93iKXhFn6bcMUI6soodj3WWKfgEO6JosKU1W5n3uky3WW9RlRjTg==}
+  '@biomejs/cli-win32-x64@2.4.10':
+    resolution: {integrity: sha512-aW/JU5GuyH4uxMrNYpoC2kjaHlyJGLgIa3XkhPEZI0uKhZhJZU8BuEyJmvgzSPQNGozBwWjC972RaNdcJ9KyJg==}
     engines: {node: '>=14.21.3'}
     cpu: [x64]
     os: [win32]
@@ -693,9 +693,6 @@ packages:
       '@types/react': ^17.0.30 || ^18 || ^19
       react: ^17 || ^18 || ^19
       react-dom: ^17 || ^18 || ^19
-    peerDependenciesMeta:
-      '@types/react':
-        optional: true
 
   '@navikt/ds-tokens@8.9.0':
     resolution: {integrity: sha512-dIdV405Nxa5YsIOG51DjAhU5kDM3HE00VitV59RlujEJk92I4hSMpA9ysdetLEBEWlmpjXFgue9Tgg8bIorttA==, tarball: https://npm.pkg.github.com/download/@navikt/ds-tokens/8.9.0/c7f62f91df5fb35b063add5aad4636a7cfc4b802}
@@ -3552,39 +3549,39 @@ snapshots:
 
   '@bcoe/v8-coverage@1.0.2': {}
 
-  '@biomejs/biome@2.4.6':
+  '@biomejs/biome@2.4.10':
     optionalDependencies:
-      '@biomejs/cli-darwin-arm64': 2.4.6
-      '@biomejs/cli-darwin-x64': 2.4.6
-      '@biomejs/cli-linux-arm64': 2.4.6
-      '@biomejs/cli-linux-arm64-musl': 2.4.6
-      '@biomejs/cli-linux-x64': 2.4.6
-      '@biomejs/cli-linux-x64-musl': 2.4.6
-      '@biomejs/cli-win32-arm64': 2.4.6
-      '@biomejs/cli-win32-x64': 2.4.6
+      '@biomejs/cli-darwin-arm64': 2.4.10
+      '@biomejs/cli-darwin-x64': 2.4.10
+      '@biomejs/cli-linux-arm64': 2.4.10
+      '@biomejs/cli-linux-arm64-musl': 2.4.10
+      '@biomejs/cli-linux-x64': 2.4.10
+      '@biomejs/cli-linux-x64-musl': 2.4.10
+      '@biomejs/cli-win32-arm64': 2.4.10
+      '@biomejs/cli-win32-x64': 2.4.10
 
-  '@biomejs/cli-darwin-arm64@2.4.6':
+  '@biomejs/cli-darwin-arm64@2.4.10':
     optional: true
 
-  '@biomejs/cli-darwin-x64@2.4.6':
+  '@biomejs/cli-darwin-x64@2.4.10':
     optional: true
 
-  '@biomejs/cli-linux-arm64-musl@2.4.6':
+  '@biomejs/cli-linux-arm64-musl@2.4.10':
     optional: true
 
-  '@biomejs/cli-linux-arm64@2.4.6':
+  '@biomejs/cli-linux-arm64@2.4.10':
     optional: true
 
-  '@biomejs/cli-linux-x64-musl@2.4.6':
+  '@biomejs/cli-linux-x64-musl@2.4.10':
     optional: true
 
-  '@biomejs/cli-linux-x64@2.4.6':
+  '@biomejs/cli-linux-x64@2.4.10':
     optional: true
 
-  '@biomejs/cli-win32-arm64@2.4.6':
+  '@biomejs/cli-win32-arm64@2.4.10':
     optional: true
 
-  '@biomejs/cli-win32-x64@2.4.6':
+  '@biomejs/cli-win32-x64@2.4.10':
     optional: true
 
   '@bramus/specificity@2.4.2':
@@ -3801,12 +3798,11 @@ snapshots:
       '@floating-ui/react-dom': 2.1.8(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       '@navikt/aksel-icons': 8.9.0
       '@navikt/ds-tokens': 8.9.0
+      '@types/react': 19.2.14
       date-fns: 4.1.0
       react: 19.2.4
       react-day-picker: 9.7.0(react@19.2.4)
       react-dom: 19.2.4(react@19.2.4)
-    optionalDependencies:
-      '@types/react': 19.2.14
 
   '@navikt/ds-tokens@8.9.0': {}
 

--- a/scripts/tanstack-mcp.mjs
+++ b/scripts/tanstack-mcp.mjs
@@ -109,11 +109,12 @@ class McpStdioClient {
   }
 
   #send(message) {
-    if (!this.process?.stdin.writable) {
+    const stdin = this.process?.stdin;
+    if (!stdin || !stdin.writable) {
       throw new Error("MCP process is not writable");
     }
 
-    this.process.stdin.write(`${JSON.stringify(message)}\n`);
+    stdin.write(`${JSON.stringify(message)}\n`);
   }
 
   #drainBuffer() {

--- a/scripts/tanstack-mcp.mjs
+++ b/scripts/tanstack-mcp.mjs
@@ -109,7 +109,7 @@ class McpStdioClient {
   }
 
   #send(message) {
-    if (!this.process || !this.process.stdin.writable) {
+    if (!this.process?.stdin.writable) {
       throw new Error("MCP process is not writable");
     }
 


### PR DESCRIPTION
## Beskrivelse

Oppgraderer Biome til 2.4.10 i pnpm-workspace-et og gjør nødvendige kodeendringer for nye Biome-regler slik at PR-en er klar for review.

## Endringer

- package.json og pnpm-lock.yaml: oppgraderer @biomejs/biome til 2.4.10 med pnpm, uten å gjeninnføre package-lock.json
- dashboard-diagrammer og csv-export.ts: erstatter mønstre som bryter useOptionalChain
- apps/lumi-dashboard/app/mock/mockData.ts: organiserer eksportrekkefølge etter Biome
- scripts/tanstack-mcp.mjs: oppdaterer nullable prosess-sjekk til optional chaining

## Issue

Supersedes #212

## Sjekkliste

- [x] Koden kompilerer og linter uten feil
- [x] Endringene er testet (manuelt eller automatisk)
- [x] Ingen sensitiv data eksponert (tokens, credentials, PII)