### PR TITLE
chore(deps): refresh GitHub Actions SHAs

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -135,7 +135,7 @@ jobs:
           distribution: temurin
           java-version: 21
       - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@39e147cb9de83bb9910b8ef8bd7fff0ee20fcd6f
+        uses: gradle/actions/setup-gradle@50e97c2cd7a37755bbfafc9c5b7cafaece252f6e
         with:
           cache-read-only: ${{ github.ref != 'refs/heads/main' }}
           cache-overwrite-existing: true

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -31,10 +31,10 @@ jobs:
           java-version: "21"
 
       - name: Set up Gradle
-        uses: gradle/actions/setup-gradle@39e147cb9de83bb9910b8ef8bd7fff0ee20fcd6f
+        uses: gradle/actions/setup-gradle@50e97c2cd7a37755bbfafc9c5b7cafaece252f6e
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@c10b8064de6f491fea524254123dbe5e09572f13
+        uses: github/codeql-action/init@95e58e9a2cdfd71adc6e0353d5c52f41a045d225
         with:
           languages: "java-kotlin"
           build-mode: "manual"
@@ -46,7 +46,7 @@ jobs:
         working-directory: apps/lumi-api
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@c10b8064de6f491fea524254123dbe5e09572f13
+        uses: github/codeql-action/analyze@95e58e9a2cdfd71adc6e0353d5c52f41a045d225
 
   analyze-js:
     name: Analyze (JavaScript/TypeScript)
@@ -57,10 +57,10 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@c10b8064de6f491fea524254123dbe5e09572f13
+        uses: github/codeql-action/init@95e58e9a2cdfd71adc6e0353d5c52f41a045d225
         with:
           languages: "javascript-typescript"
           build-mode: "none"
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@c10b8064de6f491fea524254123dbe5e09572f13
+        uses: github/codeql-action/analyze@95e58e9a2cdfd71adc6e0353d5c52f41a045d225

--- a/.github/workflows/deploy-api.yaml
+++ b/.github/workflows/deploy-api.yaml
@@ -43,7 +43,7 @@ jobs:
           java-version: 21
 
       - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@39e147cb9de83bb9910b8ef8bd7fff0ee20fcd6f
+        uses: gradle/actions/setup-gradle@50e97c2cd7a37755bbfafc9c5b7cafaece252f6e
         with:
           cache-read-only: ${{ github.ref != 'refs/heads/main' }}
           cache-overwrite-existing: true
@@ -53,7 +53,7 @@ jobs:
         run: ./gradlew shadowJar
 
       - name: Push docker image to GAR
-        uses: nais/docker-build-push@45d352fb62fb52ccb5ff6cba22c047fa02b35321
+        uses: nais/docker-build-push@cd5ec5663feb0e05c3fa374d1fb442605b046c6b
         id: docker-build-push
         with:
           team: team-esyfo

--- a/.github/workflows/deploy-dashboard.yaml
+++ b/.github/workflows/deploy-dashboard.yaml
@@ -99,7 +99,7 @@ jobs:
           identity_provider: ${{ secrets.NAIS_WORKLOAD_IDENTITY_PROVIDER }}
 
       - name: Push to GAR
-        uses: nais/docker-build-push@45d352fb62fb52ccb5ff6cba22c047fa02b35321
+        uses: nais/docker-build-push@cd5ec5663feb0e05c3fa374d1fb442605b046c6b
         id: docker-build-push
         with:
           team: team-esyfo
@@ -154,7 +154,7 @@ jobs:
           identity_provider: ${{ secrets.NAIS_WORKLOAD_IDENTITY_PROVIDER }}
 
       - name: Push to GAR
-        uses: nais/docker-build-push@45d352fb62fb52ccb5ff6cba22c047fa02b35321
+        uses: nais/docker-build-push@cd5ec5663feb0e05c3fa374d1fb442605b046c6b
         id: docker-build-push
         with:
           team: team-esyfo

--- a/.github/workflows/deploy-docs.yaml
+++ b/.github/workflows/deploy-docs.yaml
@@ -50,7 +50,7 @@ jobs:
       - name: Copy Storybook into VitePress dist
         run: cp -r packages/lumi-survey/storybook-static docs/.vitepress/dist/storybook
       - uses: actions/configure-pages@45bfe0192ca1faeb007ade9deae92b16b8254a0d # v6.0.0
-      - uses: actions/upload-pages-artifact@7b1f4a764d45c48632c6b24a0339c27f5614fb0b # v4.0.0
+      - uses: actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9 # v5.0.0
         with:
           path: docs/.vitepress/dist
 

--- a/.github/workflows/deploy-proxy.yaml
+++ b/.github/workflows/deploy-proxy.yaml
@@ -32,7 +32,7 @@ jobs:
           java-version: 21
 
       - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@39e147cb9de83bb9910b8ef8bd7fff0ee20fcd6f
+        uses: gradle/actions/setup-gradle@50e97c2cd7a37755bbfafc9c5b7cafaece252f6e
         with:
           cache-read-only: ${{ github.ref != 'refs/heads/main' }}
           cache-overwrite-existing: true
@@ -42,7 +42,7 @@ jobs:
         run: ./gradlew build
 
       - name: Push docker image to GAR
-        uses: nais/docker-build-push@45d352fb62fb52ccb5ff6cba22c047fa02b35321
+        uses: nais/docker-build-push@cd5ec5663feb0e05c3fa374d1fb442605b046c6b
         id: docker-build-push
         with:
           team: team-esyfo


### PR DESCRIPTION
## Beskrivelse

Erstatter Dependabot-PR #232 på en fresh branch fra dagens `main`, slik at workflow-endringene kan kjøres mot en ren merge-ref. Jeg beholdt SHA-oppgraderingene som er verifisert, og lot `pnpm/action-setup` stå på eksisterende v5-pin fordi v6 ga reproducerbar Node-CI-feil på GitHub-hostede runners (`ERR_PNPM_BROKEN_LOCKFILE`) selv på fresh merge-ref.

## Endringer

- `.github/workflows/codeql.yml`: oppdaterer `gradle/actions` og `github/codeql-action`
- `.github/workflows/deploy-api.yaml`: oppdaterer `gradle/actions/setup-gradle` og `nais/docker-build-push`
- `.github/workflows/deploy-dashboard.yaml`: oppdaterer `nais/docker-build-push`
- `.github/workflows/deploy-docs.yaml`: oppdaterer `actions/upload-pages-artifact`
- `.github/workflows/deploy-proxy.yaml`: oppdaterer `gradle/actions/setup-gradle` og `nais/docker-build-push`
- `pnpm/action-setup` beholdes på eksisterende SHA i CI/dashboard/docs/publish-workflows inntil v6-feilen er avklart

## Issue

Supersedes #232

## Sjekkliste

- [x] Koden kompilerer og linter uten feil
- [x] Endringene er testet (manuelt eller automatisk)
- [x] Ingen sensitiv data eksponert (tokens, credentials, PII)