### PR TITLE
build(deps): align vitest and tanstack router versions

### DIFF
--- a/apps/lumi-dashboard/package.json
+++ b/apps/lumi-dashboard/package.json
@@ -24,7 +24,7 @@
     "@navikt/oasis": "^4.1.4",
     "@navikt/pino-logger": "^4.5.1",
     "@tanstack/react-query": "^5.96.1",
-    "@tanstack/react-router": "^1.153.2",
+    "@tanstack/react-router": "^1.168.10",
     "@tanstack/router-core": "^1.168.9",
     "@tanstack/react-start": "^1.167.16",
     "@tanstack/start-storage-context": "^1.166.23",
@@ -50,7 +50,7 @@
     "@types/react": "^19.2.14",
     "@types/react-dom": "^19.0.3",
     "@vitejs/plugin-react": "^5.1.4",
-    "@vitest/coverage-v8": "^4.0.18",
+    "@vitest/coverage-v8": "^4.1.3",
     "chokidar": "^5.0.0",
     "jsdom": "^28.1.0",
     "lru-cache": "^11.2.7",
@@ -58,7 +58,7 @@
     "typescript": "^5.7.2",
     "vite": "^7.3.2",
     "vite-tsconfig-paths": "^6.1.1",
-    "vitest": "^4.0.17"
+    "vitest": "^4.1.3"
   },
   "engines": {
     "node": ">=22"

--- a/packages/lumi-survey/package.json
+++ b/packages/lumi-survey/package.json
@@ -52,7 +52,7 @@
     "@types/node": "^25.5.0",
     "@types/react": "^19.2.14",
     "@types/react-dom": "^19.0.3",
-    "@vitest/coverage-v8": "^4.0.18",
+    "@vitest/coverage-v8": "^4.1.3",
     "axe-core": "^4.11.1",
     "jsdom": "^28.1.0",
     "react": "^19.0.0",
@@ -60,6 +60,6 @@
     "storybook": "^10.2.6",
     "tsup": "^8.5.0",
     "typescript": "^5.7.2",
-    "vitest": "^4.0.17"
+    "vitest": "^4.1.3"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -42,7 +42,7 @@ importers:
         specifier: ^5.96.1
         version: 5.96.2(react@19.2.4)
       '@tanstack/react-router':
-        specifier: ^1.153.2
+        specifier: ^1.168.10
         version: 1.168.10(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       '@tanstack/react-start':
         specifier: ^1.167.16
@@ -115,7 +115,7 @@ importers:
         specifier: ^5.1.4
         version: 5.2.0(vite@7.3.2(@types/node@25.5.2)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))
       '@vitest/coverage-v8':
-        specifier: ^4.0.18
+        specifier: ^4.1.3
         version: 4.1.3(vitest@4.1.3)
       chokidar:
         specifier: ^5.0.0
@@ -139,7 +139,7 @@ importers:
         specifier: ^6.1.1
         version: 6.1.1(typescript@5.9.3)(vite@7.3.2(@types/node@25.5.2)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))
       vitest:
-        specifier: ^4.0.17
+        specifier: ^4.1.3
         version: 4.1.3(@opentelemetry/api@1.9.1)(@types/node@25.5.2)(@vitest/coverage-v8@4.1.3)(jsdom@28.1.0)(vite@7.3.2(@types/node@25.5.2)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))
 
   packages/lumi-survey:
@@ -179,7 +179,7 @@ importers:
         specifier: ^19.0.3
         version: 19.2.3(@types/react@19.2.14)
       '@vitest/coverage-v8':
-        specifier: ^4.0.18
+        specifier: ^4.1.3
         version: 4.1.3(vitest@4.1.3)
       axe-core:
         specifier: ^4.11.1
@@ -203,7 +203,7 @@ importers:
         specifier: ^5.7.2
         version: 5.9.3
       vitest:
-        specifier: ^4.0.17
+        specifier: ^4.1.3
         version: 4.1.3(@opentelemetry/api@1.9.1)(@types/node@25.5.2)(@vitest/coverage-v8@4.1.3)(jsdom@28.1.0)(vite@7.3.2(@types/node@25.5.2)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))
 
   packages/lumi-types:


### PR DESCRIPTION
## Beskrivelse

Dette erstatter den stale dependency-diffen i #188 med en smal PR fra dagens `main`. Scope er begrenset til det som fortsatt er verdifullt i det gamle sporet: å alignere deklarerte versjonsområder med Vitest 4.1 / coverage-v8 4.1 og TanStack Router-versjonen som allerede er låst i `pnpm-lock.yaml`.

`.github`-/`AGENTS.md`-endringer og `package-lock.json`-støy fra #188 er bevisst tatt ut fordi de ikke hører hjemme i denne dependency-bunten og/eller er utdatert etter pnpm-migreringen.

## Endringer

- `apps/lumi-dashboard/package.json`: oppdaterer `vitest`, `@vitest/coverage-v8` og `@tanstack/react-router` til versjoner som matcher dagens lockfile
- `packages/lumi-survey/package.json`: oppdaterer `vitest` og `@vitest/coverage-v8` til Vitest 4.1-sporet
- `pnpm-lock.yaml`: oppdaterer kun specifier-feltene etter `pnpm install --lockfile-only`

## Issue

Supersedes #188

## Sjekkliste

- [x] Koden linter uten feil, og typecheck/test/e2e er kjørt
- [x] Endringene er testet automatisk
- [x] Ingen sensitiv data eksponert (tokens, credentials, PII)
- [ ] `pnpm run build` passerer – blokkert av eksisterende TS6-/`baseUrl`-feil i `packages/lumi-types`, også reproduserbar uten disse endringene
