### PR TITLE
chore(hovmester): harden privileged sync workflow

### DIFF
--- a/.github/workflows/hovmester-sync.yml
+++ b/.github/workflows/hovmester-sync.yml
@@ -10,7 +10,7 @@ permissions:
 
 jobs:
   sync:
-    uses: navikt/hovmester/.github/workflows/hovmester-sync.yml@main
+    uses: navikt/hovmester/.github/workflows/hovmester-sync.yml@9147e8090826d82ed8a310c33c6032fe9b08f2e1 # pin privileged reusable workflow to reviewed commit on navikt/hovmester main
     with:
       collections: "hovmester,backend,frontend"
       github_project: "navikt/157"

--- a/.github/workflows/hovmester-verify.yml
+++ b/.github/workflows/hovmester-verify.yml
@@ -56,8 +56,10 @@ jobs:
           while IFS= read -r file; do
             [[ -z "$file" ]] && continue
             case "$file" in
+              .github/copilot-instructions.md|\
               .github/agents/*|\
               .github/instructions/*|\
+              .github/prompts/*|\
               .github/skills/*|\
               .github/ISSUE_TEMPLATE/*|\
               .github/PULL_REQUEST_TEMPLATE.md|\


### PR DESCRIPTION
## Beskrivelse

Følger opp #233 ved å herde hovmester-oppsettet for en privilegert reusable workflow. Denne PR-en fjerner flytende @main fra sync-jobben og låser den til en eksplisitt commit-SHA, slik at upstream-endringer ikke kan få write-rettigheter og app key-tilgang uten at vi aktivt oppdaterer referansen.

## Endringer

- .github/workflows/hovmester-sync.yml: pinnet navikt/hovmester/.github/workflows/hovmester-sync.yml til commit 9147e8090826d82ed8a310c33c6032fe9b08f2e1 i stedet for @main
- .github/workflows/hovmester-verify.yml: utvidet allowlisten til også å dekke .github/prompts/* og .github/copilot-instructions.md, slik at verify matcher repoets dokumenterte Copilot-scope

## Issue

Follow-up to #233

## Sjekkliste

- [x] Koden kompilerer og linter uten feil
- [x] Endringene er testet (manuelt eller automatisk)
- [x] Ingen sensitiv data eksponert (tokens, credentials, PII)