### PR TITLE
feat(dashboard): vis context.tags i ekspandert tilbakemeldingsvisning

### DIFF
--- a/apps/lumi-dashboard/app/components/feedback/FeedbackTable/FeedbackCard.tsx
+++ b/apps/lumi-dashboard/app/components/feedback/FeedbackTable/FeedbackCard.tsx
@@ -24,6 +24,8 @@ import styles from "./styles.module.css";
 import { TimelineView } from "./TimelineView";
 import {
   deviceToIcon,
+  formatMetadataKey,
+  formatMetadataValue,
   getAllRatings,
   getFeedbackPreview,
   getMainTextPreview,
@@ -204,6 +206,30 @@ export function FeedbackCard({
               </div>
             </div>
 
+            {/* Section: Segment (context.tags) */}
+            {feedback.context?.tags &&
+              Object.keys(feedback.context.tags).length > 0 && (
+                <div className={styles.expandedSection}>
+                  <span className={styles.expandedSectionLabel}>🏷️ Segment</span>
+                  <div className={styles.contextGrid}>
+                    {Object.entries(feedback.context.tags).map(
+                      ([key, value]) => (
+                        <div key={key} className={styles.contextItem}>
+                          <div className={styles.contextContent}>
+                            <span className={styles.contextLabel}>
+                              {formatMetadataKey(key)}
+                            </span>
+                            <span className={styles.contextValue}>
+                              {formatMetadataValue(value)}
+                            </span>
+                          </div>
+                        </div>
+                      ),
+                    )}
+                  </div>
+                </div>
+              )}
+
             {/* Section: Tags */}
             {feedback.tags && feedback.tags.length > 0 && (
               <div className={styles.expandedSection}>
@@ -231,8 +257,12 @@ export function FeedbackCard({
                   {Object.entries(feedback.metadata).map(([key, value]) => (
                     <div key={key} className={styles.contextItem}>
                       <div className={styles.contextContent}>
-                        <span className={styles.contextLabel}>{key}</span>
-                        <span className={styles.contextValue}>{value}</span>
+                        <span className={styles.contextLabel}>
+                          {formatMetadataKey(key)}
+                        </span>
+                        <span className={styles.contextValue}>
+                          {formatMetadataValue(value)}
+                        </span>
                       </div>
                     </div>
                   ))}

--- a/apps/lumi-dashboard/app/components/feedback/FeedbackTable/FeedbackCard.tsx
+++ b/apps/lumi-dashboard/app/components/feedback/FeedbackTable/FeedbackCard.tsx
@@ -9,7 +9,9 @@ import {
   Button,
   CopyButton,
   Detail,
+  HGrid,
   HStack,
+  Label,
   Tag,
   Tooltip,
   VStack,
@@ -129,10 +131,10 @@ export function FeedbackCard({
           <VStack gap="space-16">
             {/* Section: Svar (Answers) */}
             {feedback.answers && feedback.answers.length > 0 && (
-              <div className={styles.expandedSection}>
-                <span className={styles.expandedSectionLabel}>
+              <VStack gap="space-8">
+                <Label size="small" className={styles.expandedSectionLabel}>
                   Svar ({feedback.answers.length})
-                </span>
+                </Label>
                 {/* Timeline on larger screens, simple cards on small screens */}
                 {showTimeline ? (
                   <TimelineView answers={feedback.answers} styles={styles} />
@@ -145,45 +147,59 @@ export function FeedbackCard({
                     ))}
                   </VStack>
                 )}
-              </div>
+              </VStack>
             )}
 
             {/* Section: Kontekst (Context) - using contextGrid styling */}
-            <div className={styles.expandedSection}>
-              <span className={styles.expandedSectionLabel}>Kontekst</span>
-              <div className={styles.contextGrid}>
+            <VStack gap="space-8">
+              <Label size="small" className={styles.expandedSectionLabel}>
+                Kontekst
+              </Label>
+              <HGrid
+                columns="repeat(auto-fit, minmax(180px, 1fr))"
+                gap="space-12"
+              >
                 {/* Survey */}
                 <div className={styles.contextItem}>
                   <span className={styles.contextIcon}>📋</span>
-                  <div className={styles.contextContent}>
-                    <span className={styles.contextLabel}>Survey</span>
-                    <span className={styles.contextValue}>
+                  <VStack gap="space-2">
+                    <Detail className={styles.contextLabel} textColor="subtle">
+                      Survey
+                    </Detail>
+                    <BodyShort className={styles.contextValue}>
                       {feedback.surveyId}
-                    </span>
-                  </div>
+                    </BodyShort>
+                  </VStack>
                 </div>
 
                 {/* Timestamp */}
                 <div className={styles.contextItem}>
                   <span className={styles.contextIcon}>🕐</span>
-                  <div className={styles.contextContent}>
-                    <span className={styles.contextLabel}>Tidspunkt</span>
-                    <span className={styles.contextValue}>
+                  <VStack gap="space-2">
+                    <Detail className={styles.contextLabel} textColor="subtle">
+                      Tidspunkt
+                    </Detail>
+                    <BodyShort className={styles.contextValue}>
                       {dayjs(feedback.submittedAt).format("DD. MMM, HH:mm")}
-                    </span>
-                  </div>
+                    </BodyShort>
+                  </VStack>
                 </div>
 
                 {/* URL/Pathname */}
                 {feedback.context?.pathname && (
                   <div className={styles.contextItem}>
                     <span className={styles.contextIcon}>📍</span>
-                    <div className={styles.contextContent}>
-                      <span className={styles.contextLabel}>Side</span>
-                      <span className={styles.contextValue}>
+                    <VStack gap="space-2">
+                      <Detail
+                        className={styles.contextLabel}
+                        textColor="subtle"
+                      >
+                        Side
+                      </Detail>
+                      <BodyShort className={styles.contextValue}>
                         {feedback.context.pathname}
-                      </span>
-                    </div>
+                      </BodyShort>
+                    </VStack>
                   </div>
                 )}
 
@@ -193,47 +209,62 @@ export function FeedbackCard({
                     <span className={styles.contextIcon}>
                       {deviceToIcon(feedback.context.deviceType)}
                     </span>
-                    <div className={styles.contextContent}>
-                      <span className={styles.contextLabel}>Enhet</span>
-                      <span className={styles.contextValue}>
+                    <VStack gap="space-2">
+                      <Detail
+                        className={styles.contextLabel}
+                        textColor="subtle"
+                      >
+                        Enhet
+                      </Detail>
+                      <BodyShort className={styles.contextValue}>
                         {feedback.context.deviceType}
                         {feedback.context.viewportWidth &&
                           ` (viewport ${feedback.context.viewportWidth}×${feedback.context.viewportHeight})`}
-                      </span>
-                    </div>
+                      </BodyShort>
+                    </VStack>
                   </div>
                 )}
-              </div>
-            </div>
+              </HGrid>
+            </VStack>
 
             {/* Section: Segment (context.tags) */}
             {feedback.context?.tags &&
               Object.keys(feedback.context.tags).length > 0 && (
-                <div className={styles.expandedSection}>
-                  <span className={styles.expandedSectionLabel}>🏷️ Segment</span>
-                  <div className={styles.contextGrid}>
+                <VStack gap="space-8">
+                  <Label size="small" className={styles.expandedSectionLabel}>
+                    🏷️ Segment
+                  </Label>
+                  <HGrid
+                    columns="repeat(auto-fit, minmax(180px, 1fr))"
+                    gap="space-12"
+                  >
                     {Object.entries(feedback.context.tags).map(
                       ([key, value]) => (
                         <div key={key} className={styles.contextItem}>
-                          <div className={styles.contextContent}>
-                            <span className={styles.contextLabel}>
+                          <VStack gap="space-2">
+                            <Detail
+                              className={styles.contextLabel}
+                              textColor="subtle"
+                            >
                               {formatMetadataKey(key)}
-                            </span>
-                            <span className={styles.contextValue}>
+                            </Detail>
+                            <BodyShort className={styles.contextValue}>
                               {formatMetadataValue(value)}
-                            </span>
-                          </div>
+                            </BodyShort>
+                          </VStack>
                         </div>
                       ),
                     )}
-                  </div>
-                </div>
+                  </HGrid>
+                </VStack>
               )}
 
             {/* Section: Tags */}
             {feedback.tags && feedback.tags.length > 0 && (
-              <div className={styles.expandedSection}>
-                <span className={styles.expandedSectionLabel}>🏷️ Tagger</span>
+              <VStack gap="space-8">
+                <Label size="small" className={styles.expandedSectionLabel}>
+                  🏷️ Tagger
+                </Label>
                 <HStack gap="space-8" wrap>
                   {feedback.tags.map((tag) => (
                     <Tag
@@ -246,28 +277,36 @@ export function FeedbackCard({
                     </Tag>
                   ))}
                 </HStack>
-              </div>
+              </VStack>
             )}
 
             {/* Section: Metadata */}
             {feedback.metadata && Object.keys(feedback.metadata).length > 0 && (
-              <div className={styles.expandedSection}>
-                <span className={styles.expandedSectionLabel}>📋 Metadata</span>
-                <div className={styles.contextGrid}>
+              <VStack gap="space-8">
+                <Label size="small" className={styles.expandedSectionLabel}>
+                  📋 Metadata
+                </Label>
+                <HGrid
+                  columns="repeat(auto-fit, minmax(180px, 1fr))"
+                  gap="space-12"
+                >
                   {Object.entries(feedback.metadata).map(([key, value]) => (
                     <div key={key} className={styles.contextItem}>
-                      <div className={styles.contextContent}>
-                        <span className={styles.contextLabel}>
+                      <VStack gap="space-2">
+                        <Detail
+                          className={styles.contextLabel}
+                          textColor="subtle"
+                        >
                           {formatMetadataKey(key)}
-                        </span>
-                        <span className={styles.contextValue}>
+                        </Detail>
+                        <BodyShort className={styles.contextValue}>
                           {formatMetadataValue(value)}
-                        </span>
-                      </div>
+                        </BodyShort>
+                      </VStack>
                     </div>
                   ))}
-                </div>
-              </div>
+                </HGrid>
+              </VStack>
             )}
 
             {/* Sensitive data warning */}
@@ -278,12 +317,12 @@ export function FeedbackCard({
             )}
 
             {/* IDs Footer */}
-            <div className={styles.metadata}>
+            <HStack className={styles.metadata} gap="space-16" wrap>
               <Detail textColor="subtle">ID: {feedback.id}</Detail>
               {feedback.surveyVersion && (
                 <Detail textColor="subtle">v{feedback.surveyVersion}</Detail>
               )}
-            </div>
+            </HStack>
           </VStack>
         )}
 

--- a/apps/lumi-dashboard/app/components/feedback/FeedbackTable/FeedbackCard.tsx
+++ b/apps/lumi-dashboard/app/components/feedback/FeedbackTable/FeedbackCard.tsx
@@ -140,9 +140,11 @@ export function FeedbackCard({
                 ) : (
                   <VStack gap="space-8">
                     {feedback.answers.map((answer) => (
-                      <div key={answer.fieldId} className={styles.answerCard}>
-                        <RenderAnswer answer={answer} styles={styles} />
-                      </div>
+                      <RenderAnswer
+                        key={answer.fieldId}
+                        answer={answer}
+                        styles={styles}
+                      />
                     ))}
                   </VStack>
                 )}

--- a/apps/lumi-dashboard/app/components/feedback/FeedbackTable/FeedbackCard.tsx
+++ b/apps/lumi-dashboard/app/components/feedback/FeedbackTable/FeedbackCard.tsx
@@ -20,13 +20,16 @@ import { DashboardCard } from "~/components/dashboard";
 import { useBreakpoint } from "~/hooks/useBreakpoint";
 import type { FeedbackDto } from "~/types/api";
 import { RenderAnswer } from "./AnswerRenderer";
+import {
+  ContextItem,
+  ExpandedSection,
+  MetadataGrid,
+} from "./FeedbackDetailParts";
 import { RatingBadge } from "./RatingBadge";
 import styles from "./styles.module.css";
 import { TimelineView } from "./TimelineView";
 import {
   deviceToIcon,
-  formatMetadataKey,
-  formatMetadataValue,
   getAllRatings,
   getFeedbackPreview,
   getMainTextPreview,
@@ -130,10 +133,7 @@ export function FeedbackCard({
           <VStack gap="space-16">
             {/* Section: Svar (Answers) */}
             {feedback.answers && feedback.answers.length > 0 && (
-              <VStack gap="space-8">
-                <Detail className={styles.expandedSectionLabel}>
-                  Svar ({feedback.answers.length})
-                </Detail>
+              <ExpandedSection label={`Svar (${feedback.answers.length})`}>
                 {/* Timeline on larger screens, simple cards on small screens */}
                 {showTimeline ? (
                   <TimelineView answers={feedback.answers} styles={styles} />
@@ -146,122 +146,58 @@ export function FeedbackCard({
                     ))}
                   </VStack>
                 )}
-              </VStack>
+              </ExpandedSection>
             )}
 
-            {/* Section: Kontekst (Context) - using contextGrid styling */}
-            <VStack gap="space-8">
-              <Detail className={styles.expandedSectionLabel}>Kontekst</Detail>
+            {/* Section: Kontekst (Context) */}
+            <ExpandedSection label="Kontekst">
               <HGrid
                 columns="repeat(auto-fit, minmax(180px, 1fr))"
                 gap="space-12"
               >
-                {/* Survey */}
-                <div className={styles.contextItem}>
-                  <span className={styles.contextIcon}>📋</span>
-                  <VStack gap="space-2">
-                    <Detail className={styles.contextLabel} textColor="subtle">
-                      Survey
-                    </Detail>
-                    <BodyShort className={styles.contextValue}>
-                      {feedback.surveyId}
-                    </BodyShort>
-                  </VStack>
-                </div>
-
-                {/* Timestamp */}
-                <div className={styles.contextItem}>
-                  <span className={styles.contextIcon}>🕐</span>
-                  <VStack gap="space-2">
-                    <Detail className={styles.contextLabel} textColor="subtle">
-                      Tidspunkt
-                    </Detail>
-                    <BodyShort className={styles.contextValue}>
-                      {dayjs(feedback.submittedAt).format("DD. MMM, HH:mm")}
-                    </BodyShort>
-                  </VStack>
-                </div>
-
-                {/* URL/Pathname */}
+                <ContextItem
+                  icon="📋"
+                  label="Survey"
+                  value={feedback.surveyId}
+                />
+                <ContextItem
+                  icon="🕐"
+                  label="Tidspunkt"
+                  value={dayjs(feedback.submittedAt).format("DD. MMM, HH:mm")}
+                />
                 {feedback.context?.pathname && (
-                  <div className={styles.contextItem}>
-                    <span className={styles.contextIcon}>📍</span>
-                    <VStack gap="space-2">
-                      <Detail
-                        className={styles.contextLabel}
-                        textColor="subtle"
-                      >
-                        Side
-                      </Detail>
-                      <BodyShort className={styles.contextValue}>
-                        {feedback.context.pathname}
-                      </BodyShort>
-                    </VStack>
-                  </div>
+                  <ContextItem
+                    icon="📍"
+                    label="Side"
+                    value={feedback.context.pathname}
+                  />
                 )}
-
-                {/* Device info */}
                 {feedback.context?.deviceType && (
-                  <div className={styles.contextItem}>
-                    <span className={styles.contextIcon}>
-                      {deviceToIcon(feedback.context.deviceType)}
-                    </span>
-                    <VStack gap="space-2">
-                      <Detail
-                        className={styles.contextLabel}
-                        textColor="subtle"
-                      >
-                        Enhet
-                      </Detail>
-                      <BodyShort className={styles.contextValue}>
-                        {feedback.context.deviceType}
-                        {feedback.context.viewportWidth &&
-                          ` (viewport ${feedback.context.viewportWidth}×${feedback.context.viewportHeight})`}
-                      </BodyShort>
-                    </VStack>
-                  </div>
+                  <ContextItem
+                    icon={deviceToIcon(feedback.context.deviceType)}
+                    label="Enhet"
+                    value={
+                      feedback.context.deviceType +
+                      (feedback.context.viewportWidth
+                        ? ` (viewport ${feedback.context.viewportWidth}×${feedback.context.viewportHeight})`
+                        : "")
+                    }
+                  />
                 )}
               </HGrid>
-            </VStack>
+            </ExpandedSection>
 
             {/* Section: Segment (context.tags) */}
             {feedback.context?.tags &&
               Object.keys(feedback.context.tags).length > 0 && (
-                <VStack gap="space-8">
-                  <Detail className={styles.expandedSectionLabel}>
-                    🏷️ Segment
-                  </Detail>
-                  <HGrid
-                    columns="repeat(auto-fit, minmax(180px, 1fr))"
-                    gap="space-12"
-                  >
-                    {Object.entries(feedback.context.tags).map(
-                      ([key, value]) => (
-                        <div key={key} className={styles.contextItem}>
-                          <VStack gap="space-2">
-                            <Detail
-                              className={styles.contextLabel}
-                              textColor="subtle"
-                            >
-                              {formatMetadataKey(key)}
-                            </Detail>
-                            <BodyShort className={styles.contextValue}>
-                              {formatMetadataValue(value)}
-                            </BodyShort>
-                          </VStack>
-                        </div>
-                      ),
-                    )}
-                  </HGrid>
-                </VStack>
+                <ExpandedSection label="🏷️ Segment">
+                  <MetadataGrid metadata={feedback.context.tags} />
+                </ExpandedSection>
               )}
 
             {/* Section: Tags */}
             {feedback.tags && feedback.tags.length > 0 && (
-              <VStack gap="space-8">
-                <Detail className={styles.expandedSectionLabel}>
-                  🏷️ Tagger
-                </Detail>
+              <ExpandedSection label="🏷️ Tagger">
                 <HStack gap="space-8" wrap>
                   {feedback.tags.map((tag) => (
                     <Tag
@@ -274,36 +210,14 @@ export function FeedbackCard({
                     </Tag>
                   ))}
                 </HStack>
-              </VStack>
+              </ExpandedSection>
             )}
 
             {/* Section: Metadata */}
             {feedback.metadata && Object.keys(feedback.metadata).length > 0 && (
-              <VStack gap="space-8">
-                <Detail className={styles.expandedSectionLabel}>
-                  📋 Metadata
-                </Detail>
-                <HGrid
-                  columns="repeat(auto-fit, minmax(180px, 1fr))"
-                  gap="space-12"
-                >
-                  {Object.entries(feedback.metadata).map(([key, value]) => (
-                    <div key={key} className={styles.contextItem}>
-                      <VStack gap="space-2">
-                        <Detail
-                          className={styles.contextLabel}
-                          textColor="subtle"
-                        >
-                          {formatMetadataKey(key)}
-                        </Detail>
-                        <BodyShort className={styles.contextValue}>
-                          {formatMetadataValue(value)}
-                        </BodyShort>
-                      </VStack>
-                    </div>
-                  ))}
-                </HGrid>
-              </VStack>
+              <ExpandedSection label="📋 Metadata">
+                <MetadataGrid metadata={feedback.metadata} />
+              </ExpandedSection>
             )}
 
             {/* Sensitive data warning */}

--- a/apps/lumi-dashboard/app/components/feedback/FeedbackTable/FeedbackCard.tsx
+++ b/apps/lumi-dashboard/app/components/feedback/FeedbackTable/FeedbackCard.tsx
@@ -181,7 +181,7 @@ export function FeedbackCard({
                     value={
                       feedback.context.deviceType +
                       (feedback.context.viewportWidth
-                        ? ` (viewport ${feedback.context.viewportWidth}×${feedback.context.viewportHeight})`
+                        ? ` (viewport ${feedback.context.viewportWidth}×${feedback.context.viewportHeight ?? "?"})`
                         : "")
                     }
                   />

--- a/apps/lumi-dashboard/app/components/feedback/FeedbackTable/FeedbackCard.tsx
+++ b/apps/lumi-dashboard/app/components/feedback/FeedbackTable/FeedbackCard.tsx
@@ -11,7 +11,6 @@ import {
   Detail,
   HGrid,
   HStack,
-  Label,
   Tag,
   Tooltip,
   VStack,
@@ -132,9 +131,9 @@ export function FeedbackCard({
             {/* Section: Svar (Answers) */}
             {feedback.answers && feedback.answers.length > 0 && (
               <VStack gap="space-8">
-                <Label size="small" className={styles.expandedSectionLabel}>
+                <Detail className={styles.expandedSectionLabel}>
                   Svar ({feedback.answers.length})
-                </Label>
+                </Detail>
                 {/* Timeline on larger screens, simple cards on small screens */}
                 {showTimeline ? (
                   <TimelineView answers={feedback.answers} styles={styles} />
@@ -152,9 +151,7 @@ export function FeedbackCard({
 
             {/* Section: Kontekst (Context) - using contextGrid styling */}
             <VStack gap="space-8">
-              <Label size="small" className={styles.expandedSectionLabel}>
-                Kontekst
-              </Label>
+              <Detail className={styles.expandedSectionLabel}>Kontekst</Detail>
               <HGrid
                 columns="repeat(auto-fit, minmax(180px, 1fr))"
                 gap="space-12"
@@ -231,9 +228,9 @@ export function FeedbackCard({
             {feedback.context?.tags &&
               Object.keys(feedback.context.tags).length > 0 && (
                 <VStack gap="space-8">
-                  <Label size="small" className={styles.expandedSectionLabel}>
+                  <Detail className={styles.expandedSectionLabel}>
                     🏷️ Segment
-                  </Label>
+                  </Detail>
                   <HGrid
                     columns="repeat(auto-fit, minmax(180px, 1fr))"
                     gap="space-12"
@@ -262,9 +259,9 @@ export function FeedbackCard({
             {/* Section: Tags */}
             {feedback.tags && feedback.tags.length > 0 && (
               <VStack gap="space-8">
-                <Label size="small" className={styles.expandedSectionLabel}>
+                <Detail className={styles.expandedSectionLabel}>
                   🏷️ Tagger
-                </Label>
+                </Detail>
                 <HStack gap="space-8" wrap>
                   {feedback.tags.map((tag) => (
                     <Tag
@@ -283,9 +280,9 @@ export function FeedbackCard({
             {/* Section: Metadata */}
             {feedback.metadata && Object.keys(feedback.metadata).length > 0 && (
               <VStack gap="space-8">
-                <Label size="small" className={styles.expandedSectionLabel}>
+                <Detail className={styles.expandedSectionLabel}>
                   📋 Metadata
-                </Label>
+                </Detail>
                 <HGrid
                   columns="repeat(auto-fit, minmax(180px, 1fr))"
                   gap="space-12"

--- a/apps/lumi-dashboard/app/components/feedback/FeedbackTable/FeedbackDetailParts.tsx
+++ b/apps/lumi-dashboard/app/components/feedback/FeedbackTable/FeedbackDetailParts.tsx
@@ -83,7 +83,7 @@ export function ContextGrid({
         <ContextItem
           icon="🖼️"
           label="Viewport"
-          value={`${context.viewportWidth || "?"}×${context.viewportHeight || "?"} `}
+          value={`${context.viewportWidth || "?"}×${context.viewportHeight || "?"}`}
         />
       )}
     </HGrid>

--- a/apps/lumi-dashboard/app/components/feedback/FeedbackTable/FeedbackDetailParts.tsx
+++ b/apps/lumi-dashboard/app/components/feedback/FeedbackTable/FeedbackDetailParts.tsx
@@ -1,0 +1,118 @@
+import { BodyShort, Detail, HGrid, HStack, VStack } from "@navikt/ds-react";
+import type { ReactNode } from "react";
+import type { FeedbackDto } from "~/types/api";
+import styles from "./styles.module.css";
+import { deviceToIcon, formatMetadataKey, formatMetadataValue } from "./utils";
+
+/**
+ * Reusable section wrapper with label.
+ * Used in both desktop expanded view and mobile card.
+ */
+export function ExpandedSection({
+  label,
+  icon,
+  children,
+}: {
+  label: string;
+  icon?: ReactNode;
+  children: ReactNode;
+}) {
+  return (
+    <VStack gap="space-8">
+      {icon ? (
+        <HStack gap="space-4" align="center">
+          {icon}
+          <Detail className={styles.expandedSectionLabel}>{label}</Detail>
+        </HStack>
+      ) : (
+        <Detail className={styles.expandedSectionLabel}>{label}</Detail>
+      )}
+      {children}
+    </VStack>
+  );
+}
+
+/**
+ * Single item in the context grid.
+ * Displays an icon, label, and value for a context property.
+ */
+export function ContextItem({
+  icon,
+  label,
+  value,
+}: {
+  icon: string;
+  label: string;
+  value: string;
+}) {
+  return (
+    <div className={styles.contextItem}>
+      <span className={styles.contextIcon}>{icon}</span>
+      <VStack gap="space-2">
+        <Detail className={styles.contextLabel} textColor="subtle">
+          {label}
+        </Detail>
+        <BodyShort className={styles.contextValue}>{value}</BodyShort>
+      </VStack>
+    </div>
+  );
+}
+
+/**
+ * Displays submission context (pathname, device, viewport).
+ * Used in the desktop expanded view.
+ */
+export function ContextGrid({
+  context,
+}: {
+  context: NonNullable<FeedbackDto["context"]>;
+}) {
+  return (
+    <HGrid columns="repeat(auto-fit, minmax(180px, 1fr))" gap="space-12">
+      {context.pathname && (
+        <ContextItem icon="📍" label="Side" value={context.pathname} />
+      )}
+      {context.deviceType && (
+        <ContextItem
+          icon={deviceToIcon(context.deviceType)}
+          label="Enhet"
+          value={context.deviceType}
+        />
+      )}
+      {(context.viewportWidth || context.viewportHeight) && (
+        <ContextItem
+          icon="🖼️"
+          label="Viewport"
+          value={`${context.viewportWidth || "?"}×${context.viewportHeight || "?"} `}
+        />
+      )}
+    </HGrid>
+  );
+}
+
+/**
+ * Displays key-value pairs in a grid layout.
+ * Used for segment tags and custom metadata.
+ */
+export function MetadataGrid({
+  metadata,
+}: {
+  metadata: Record<string, string>;
+}) {
+  return (
+    <HGrid columns="repeat(auto-fit, minmax(180px, 1fr))" gap="space-12">
+      {Object.entries(metadata).map(([key, value]) => (
+        <div key={key} className={styles.contextItem}>
+          <VStack gap="space-2">
+            <Detail className={styles.contextLabel} textColor="subtle">
+              {formatMetadataKey(key)}
+            </Detail>
+            <BodyShort className={styles.contextValue}>
+              {formatMetadataValue(value)}
+            </BodyShort>
+          </VStack>
+        </div>
+      ))}
+    </HGrid>
+  );
+}

--- a/apps/lumi-dashboard/app/components/feedback/FeedbackTable/FeedbackExpandedView.tsx
+++ b/apps/lumi-dashboard/app/components/feedback/FeedbackTable/FeedbackExpandedView.tsx
@@ -40,6 +40,14 @@ export function FeedbackExpandedView({ feedback }: FeedbackExpandedViewProps) {
               </ExpandedSection>
             )}
 
+            {/* Segment (context.tags) */}
+            {feedback.context?.tags &&
+              Object.keys(feedback.context.tags).length > 0 && (
+                <ExpandedSection label="🏷️ Segment">
+                  <MetadataGrid metadata={feedback.context.tags} />
+                </ExpandedSection>
+              )}
+
             {/* Custom Metadata */}
             {feedback.metadata && Object.keys(feedback.metadata).length > 0 && (
               <ExpandedSection label="📋 Metadata">

--- a/apps/lumi-dashboard/app/components/feedback/FeedbackTable/FeedbackExpandedView.tsx
+++ b/apps/lumi-dashboard/app/components/feedback/FeedbackTable/FeedbackExpandedView.tsx
@@ -1,18 +1,14 @@
 import { TagIcon } from "@navikt/aksel-icons";
-import {
-  BodyShort,
-  Box,
-  Detail,
-  HGrid,
-  HStack,
-  Table,
-  VStack,
-} from "@navikt/ds-react";
+import { Box, Detail, HStack, Table, VStack } from "@navikt/ds-react";
 import type { FeedbackDto } from "~/types/api";
 import { TagEditor } from "../TagEditor";
+import {
+  ContextGrid,
+  ExpandedSection,
+  MetadataGrid,
+} from "./FeedbackDetailParts";
 import styles from "./styles.module.css";
 import { TimelineView } from "./TimelineView";
-import { deviceToIcon, formatMetadataKey, formatMetadataValue } from "./utils";
 
 interface FeedbackExpandedViewProps {
   feedback: FeedbackDto;
@@ -75,110 +71,5 @@ export function FeedbackExpandedView({ feedback }: FeedbackExpandedViewProps) {
         </Box>
       </Table.DataCell>
     </Table.Row>
-  );
-}
-
-/**
- * Reusable section wrapper with label.
- */
-function ExpandedSection({
-  label,
-  icon,
-  children,
-}: {
-  label: string;
-  icon?: React.ReactNode;
-  children: React.ReactNode;
-}) {
-  return (
-    <VStack gap="space-8">
-      {icon ? (
-        <HStack gap="space-4" align="center">
-          {icon}
-          <Detail className={styles.expandedSectionLabel}>{label}</Detail>
-        </HStack>
-      ) : (
-        <Detail className={styles.expandedSectionLabel}>{label}</Detail>
-      )}
-      {children}
-    </VStack>
-  );
-}
-
-/**
- * Displays submission context (pathname, device, viewport).
- */
-function ContextGrid({
-  context,
-}: {
-  context: NonNullable<FeedbackDto["context"]>;
-}) {
-  return (
-    <HGrid columns="repeat(auto-fit, minmax(180px, 1fr))" gap="space-12">
-      {context.pathname && (
-        <ContextItem icon="📍" label="Side" value={context.pathname} />
-      )}
-      {context.deviceType && (
-        <ContextItem
-          icon={deviceToIcon(context.deviceType)}
-          label="Enhet"
-          value={context.deviceType}
-        />
-      )}
-      {(context.viewportWidth || context.viewportHeight) && (
-        <ContextItem
-          icon="🖼️"
-          label="Viewport"
-          value={`${context.viewportWidth || "?"}×${context.viewportHeight || "?"} `}
-        />
-      )}
-    </HGrid>
-  );
-}
-
-/**
- * Single item in the context grid.
- */
-function ContextItem({
-  icon,
-  label,
-  value,
-}: {
-  icon: string;
-  label: string;
-  value: string;
-}) {
-  return (
-    <div className={styles.contextItem}>
-      <span className={styles.contextIcon}>{icon}</span>
-      <VStack gap="space-2">
-        <Detail className={styles.contextLabel} textColor="subtle">
-          {label}
-        </Detail>
-        <BodyShort className={styles.contextValue}>{value}</BodyShort>
-      </VStack>
-    </div>
-  );
-}
-
-/**
- * Displays custom metadata key-value pairs.
- */
-function MetadataGrid({ metadata }: { metadata: Record<string, string> }) {
-  return (
-    <HGrid columns="repeat(auto-fit, minmax(180px, 1fr))" gap="space-12">
-      {Object.entries(metadata).map(([key, value]) => (
-        <div key={key} className={styles.contextItem}>
-          <VStack gap="space-2">
-            <Detail className={styles.contextLabel} textColor="subtle">
-              {formatMetadataKey(key)}
-            </Detail>
-            <BodyShort className={styles.contextValue}>
-              {formatMetadataValue(value)}
-            </BodyShort>
-          </VStack>
-        </div>
-      ))}
-    </HGrid>
   );
 }

--- a/apps/lumi-dashboard/app/components/feedback/FeedbackTable/FeedbackExpandedView.tsx
+++ b/apps/lumi-dashboard/app/components/feedback/FeedbackTable/FeedbackExpandedView.tsx
@@ -1,5 +1,14 @@
 import { TagIcon } from "@navikt/aksel-icons";
-import { Box, Detail, HStack, Label, Table, VStack } from "@navikt/ds-react";
+import {
+  BodyShort,
+  Box,
+  Detail,
+  HGrid,
+  HStack,
+  Label,
+  Table,
+  VStack,
+} from "@navikt/ds-react";
 import type { FeedbackDto } from "~/types/api";
 import { TagEditor } from "../TagEditor";
 import styles from "./styles.module.css";
@@ -56,13 +65,13 @@ export function FeedbackExpandedView({ feedback }: FeedbackExpandedViewProps) {
             )}
 
             {/* IDs Footer */}
-            <div className={styles.metadata}>
+            <HStack className={styles.metadata} gap="space-16" wrap>
               <Detail textColor="subtle">ID: {feedback.id}</Detail>
               <Detail textColor="subtle">Survey: {feedback.surveyId}</Detail>
               {feedback.surveyVersion && (
                 <Detail textColor="subtle">v{feedback.surveyVersion}</Detail>
               )}
-            </div>
+            </HStack>
           </VStack>
         </Box>
       </Table.DataCell>
@@ -83,7 +92,7 @@ function ExpandedSection({
   children: React.ReactNode;
 }) {
   return (
-    <div className={styles.expandedSection}>
+    <VStack gap="space-8">
       <Label size="small" className={styles.expandedSectionLabel}>
         {icon ? (
           <HStack gap="space-4" align="center">
@@ -95,7 +104,7 @@ function ExpandedSection({
         )}
       </Label>
       {children}
-    </div>
+    </VStack>
   );
 }
 
@@ -108,7 +117,7 @@ function ContextGrid({
   context: NonNullable<FeedbackDto["context"]>;
 }) {
   return (
-    <div className={styles.contextGrid}>
+    <HGrid columns="repeat(auto-fit, minmax(180px, 1fr))" gap="space-12">
       {context.pathname && (
         <ContextItem icon="📍" label="Side" value={context.pathname} />
       )}
@@ -126,7 +135,7 @@ function ContextGrid({
           value={`${context.viewportWidth || "?"}×${context.viewportHeight || "?"} `}
         />
       )}
-    </div>
+    </HGrid>
   );
 }
 
@@ -145,10 +154,12 @@ function ContextItem({
   return (
     <div className={styles.contextItem}>
       <span className={styles.contextIcon}>{icon}</span>
-      <div className={styles.contextContent}>
-        <span className={styles.contextLabel}>{label}</span>
-        <span className={styles.contextValue}>{value}</span>
-      </div>
+      <VStack gap="space-2">
+        <Detail className={styles.contextLabel} textColor="subtle">
+          {label}
+        </Detail>
+        <BodyShort className={styles.contextValue}>{value}</BodyShort>
+      </VStack>
     </div>
   );
 }
@@ -158,19 +169,19 @@ function ContextItem({
  */
 function MetadataGrid({ metadata }: { metadata: Record<string, string> }) {
   return (
-    <div className={styles.contextGrid}>
+    <HGrid columns="repeat(auto-fit, minmax(180px, 1fr))" gap="space-12">
       {Object.entries(metadata).map(([key, value]) => (
         <div key={key} className={styles.contextItem}>
-          <div className={styles.contextContent}>
-            <span className={styles.contextLabel}>
+          <VStack gap="space-2">
+            <Detail className={styles.contextLabel} textColor="subtle">
               {formatMetadataKey(key)}
-            </span>
-            <span className={styles.contextValue}>
+            </Detail>
+            <BodyShort className={styles.contextValue}>
               {formatMetadataValue(value)}
-            </span>
-          </div>
+            </BodyShort>
+          </VStack>
         </div>
       ))}
-    </div>
+    </HGrid>
   );
 }

--- a/apps/lumi-dashboard/app/components/feedback/FeedbackTable/FeedbackExpandedView.tsx
+++ b/apps/lumi-dashboard/app/components/feedback/FeedbackTable/FeedbackExpandedView.tsx
@@ -5,7 +5,6 @@ import {
   Detail,
   HGrid,
   HStack,
-  Label,
   Table,
   VStack,
 } from "@navikt/ds-react";
@@ -93,16 +92,14 @@ function ExpandedSection({
 }) {
   return (
     <VStack gap="space-8">
-      <Label size="small" className={styles.expandedSectionLabel}>
-        {icon ? (
-          <HStack gap="space-4" align="center">
-            {icon}
-            {label}
-          </HStack>
-        ) : (
-          label
-        )}
-      </Label>
+      {icon ? (
+        <HStack gap="space-4" align="center">
+          {icon}
+          <Detail className={styles.expandedSectionLabel}>{label}</Detail>
+        </HStack>
+      ) : (
+        <Detail className={styles.expandedSectionLabel}>{label}</Detail>
+      )}
       {children}
     </VStack>
   );

--- a/apps/lumi-dashboard/app/components/feedback/FeedbackTable/styles.module.css
+++ b/apps/lumi-dashboard/app/components/feedback/FeedbackTable/styles.module.css
@@ -94,7 +94,7 @@
 
 /* Inner expanded content box is handled by Box.New */
 
-/* Expanded section label (used with Aksel Label component) */
+/* Expanded section label (used with Aksel Detail component) */
 .expandedSectionLabel {
   color: var(--ax-text-subtle);
   text-transform: uppercase;

--- a/apps/lumi-dashboard/app/components/feedback/FeedbackTable/styles.module.css
+++ b/apps/lumi-dashboard/app/components/feedback/FeedbackTable/styles.module.css
@@ -94,32 +94,19 @@
 
 /* Inner expanded content box is handled by Box.New */
 
-.expandedSection {
-  display: flex;
-  flex-direction: column;
-  gap: 0.5rem;
-}
-
+/* Expanded section label (used with Aksel Label component) */
 .expandedSectionLabel {
   color: var(--ax-text-subtle);
-  font-weight: 500;
   text-transform: uppercase;
   font-size: 0.6875rem;
   letter-spacing: 0.05em;
 }
 
-/* Context grid for expanded view */
-.contextGrid {
-  display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
-  gap: 0.75rem;
-}
-
 .contextItem {
   display: flex;
   align-items: flex-start;
-  gap: 0.75rem;
-  padding: 0.875rem 1rem;
+  gap: var(--ax-space-12, 0.75rem);
+  padding: 0.875rem var(--ax-space-16, 1rem);
   background: var(--ax-bg-default);
   border-radius: 8px;
   border: 1px solid var(--ax-border-subtle);
@@ -140,34 +127,24 @@
   margin-top: 0.125rem;
 }
 
-.contextContent {
-  display: flex;
-  flex-direction: column;
-  gap: 0.125rem;
-  min-width: 0;
-}
-
+/* Context label (used with Aksel Detail component — color handled by textColor prop) */
 .contextLabel {
   font-size: 0.6875rem;
   font-weight: 500;
   text-transform: uppercase;
   letter-spacing: 0.03em;
-  color: var(--ax-text-subtle);
 }
 
+/* Context value (used with Aksel BodyShort component — color handled by default) */
 .contextValue {
   font-size: 0.9375rem;
   font-weight: 500;
-  color: var(--ax-text-default);
   word-break: break-word;
 }
 
-/* Metadata row */
+/* Metadata footer row (layout handled by Aksel HStack) */
 .metadata {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 1rem;
-  padding-top: 0.75rem;
+  padding-top: var(--ax-space-12, 0.75rem);
   border-top: 1px solid var(--ax-border-subtle);
 }
 

--- a/apps/lumi-dashboard/app/components/feedback/FeedbackTable/styles.module.css
+++ b/apps/lumi-dashboard/app/components/feedback/FeedbackTable/styles.module.css
@@ -92,7 +92,7 @@
   background: transparent;
 }
 
-/* Inner expanded content box is handled by Box.New */
+/* Inner expanded content box is handled by Box */
 
 /* Expanded section label (used with Aksel Detail component) */
 .expandedSectionLabel {


### PR DESCRIPTION
## Beskrivelse

Segmenteringsdata (`context.tags`) som «Text Field Visible» og «Skjemavariant» vises i segmenteringsseksjonen på dashboardet, men ble ikke vist når man ekspanderte en enkelt tilbakemelding. Dataene leveres allerede fra API-et — feilen var at frontend ikke rendret `context.tags` i den ekspanderte visningen.

Legger til en ny «🏷️ Segment»-seksjon i både desktop (`FeedbackExpandedView`) og mobil (`FeedbackCard`) som viser `context.tags` med formaterte nøkler og verdier.

## Endringer

- `FeedbackExpandedView.tsx`: Ny «🏷️ Segment»-seksjon mellom Kontekst og Metadata, gjenbruker `MetadataGrid`
- `FeedbackCard.tsx`: Ny «🏷️ Segment»-seksjon + eksisterende Metadata-seksjon bruker nå `formatMetadataKey`/`formatMetadataValue` for konsistens med desktop

## Issue

Ingen tilknyttet issue.

## Sjekkliste

- [x] Koden kompilerer og linter uten feil
- [x] Endringene er testet (manuelt eller automatisk)
- [x] Ingen sensitiv data eksponert (tokens, credentials, PII)

**Verifisering:** lint ✅ · typecheck ✅ · kryssmodell-inspeksjon (GPT) ✅ — ingen blokkere funnet