### PR TITLE
refactor: konsolidér StemWordAccumulator + NorwegianLightStemmer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,5 +29,9 @@ docs/.vitepress/dist
 *.log
 error.log
 
+# Data exports (local testing only — never commit)
+lumi-export-*.csv
+lumi-export-*.json
+
 # OS
 .DS_Store

--- a/apps/lumi-api/src/main/kotlin/no/nav/lumi/repository/FeedbackRepositorySupport.kt
+++ b/apps/lumi-api/src/main/kotlin/no/nav/lumi/repository/FeedbackRepositorySupport.kt
@@ -163,7 +163,7 @@ internal fun matchesThemeFilter(
 }
 
 private fun matchThemeName(text: String, themes: List<TextThemeDto>): String {
-    val textWords = TextProcessor.extractWords(text)
+    val textWords = TextProcessor.tokenize(text)
         .map { TextProcessor.stemNorwegian(it) }
         .toSet()
 

--- a/apps/lumi-api/src/main/kotlin/no/nav/lumi/repository/FeedbackStatsBlocker.kt
+++ b/apps/lumi-api/src/main/kotlin/no/nav/lumi/repository/FeedbackStatsBlocker.kt
@@ -1,53 +1,7 @@
 package no.nav.lumi.repository
 
 import no.nav.lumi.domain.BlockerThemeResult
-import no.nav.lumi.domain.SourceResponse
-import no.nav.lumi.domain.WordFrequencyEntry
-import no.nav.lumi.domain.WordVariant
-
-/**
- * Helper class to accumulate word frequency statistics grouped by stem.
- * Tracks surface form counts to determine canonical (most common) form.
- */
-internal class BlockerStemWordAccumulator(val stem: String) {
-    private val surfaceCounts = mutableMapOf<String, Int>()
-    val sourceResponses = mutableListOf<SourceResponse>()
-    val usedTexts = mutableSetOf<String>() // Dedup sourceResponses by text
-
-    /** Total occurrences across all surface forms */
-    val totalCount: Int get() = surfaceCounts.values.sum()
-
-    /** Add an occurrence of a surface form */
-    fun addOccurrence(surface: String) {
-        surfaceCounts[surface] = (surfaceCounts[surface] ?: 0) + 1
-    }
-
-    /** Get canonical form (most common surface form) */
-    fun getCanonicalForm(): String {
-        return surfaceCounts.entries
-            .sortedWith(compareByDescending<Map.Entry<String, Int>> { it.value }.thenBy { it.key })
-            .firstOrNull()?.key ?: stem
-    }
-
-    /** Get top variants sorted by count desc */
-    fun getVariants(): List<WordVariant> {
-        return surfaceCounts.entries
-            .sortedWith(compareByDescending<Map.Entry<String, Int>> { it.value }.thenBy { it.key })
-            .take(FeedbackStatsRepository.MAX_VARIANTS)
-            .map { WordVariant(word = it.key, count = it.value) }
-    }
-
-    /** Convert to WordFrequencyEntry */
-    fun toWordFrequencyEntry(): WordFrequencyEntry {
-        return WordFrequencyEntry(
-            word = getCanonicalForm(),
-            stem = stem,
-            count = totalCount,
-            variants = getVariants(),
-            sourceResponses = sourceResponses.toList()
-        )
-    }
-}
+import no.nav.lumi.service.text.StemWordAccumulator
 
 internal class ThemeAccumulator(
     val theme: String,

--- a/apps/lumi-api/src/main/kotlin/no/nav/lumi/repository/FeedbackStatsBlocker.kt
+++ b/apps/lumi-api/src/main/kotlin/no/nav/lumi/repository/FeedbackStatsBlocker.kt
@@ -1,7 +1,6 @@
 package no.nav.lumi.repository
 
 import no.nav.lumi.domain.BlockerThemeResult
-import no.nav.lumi.service.text.StemWordAccumulator
 
 internal class ThemeAccumulator(
     val theme: String,

--- a/apps/lumi-api/src/main/kotlin/no/nav/lumi/repository/FeedbackStatsHelpers.kt
+++ b/apps/lumi-api/src/main/kotlin/no/nav/lumi/repository/FeedbackStatsHelpers.kt
@@ -2,6 +2,7 @@ package no.nav.lumi.repository
 
 import no.nav.lumi.domain.*
 import no.nav.lumi.service.TextProcessor
+import no.nav.lumi.service.text.StemWordAccumulator
 import java.time.Instant
 import java.time.OffsetDateTime
 
@@ -90,7 +91,7 @@ internal fun buildFieldStats(records: List<FeedbackDto>): List<FieldStat> {
 
             FieldType.TEXT -> {
                 val texts = mutableListOf<RecentTextResponse>()
-                val keywordCounts = mutableMapOf<String, Int>()
+                val wordAccumulators = mutableMapOf<String, StemWordAccumulator>()
                 var responseCount = 0
 
                 for ((dto, answer) in entries) {
@@ -102,7 +103,8 @@ internal fun buildFieldStats(records: List<FeedbackDto>): List<FieldStat> {
 
                     for (word in TextProcessor.extractWords(text)) {
                         val stem = TextProcessor.stemNorwegian(word)
-                        keywordCounts[stem] = (keywordCounts[stem] ?: 0) + 1
+                        val acc = wordAccumulators.getOrPut(stem) { StemWordAccumulator(stem) }
+                        acc.addOccurrence(word)
                     }
                 }
 
@@ -112,10 +114,10 @@ internal fun buildFieldStats(records: List<FeedbackDto>): List<FieldStat> {
                     0.0
                 }
 
-                val topKeywords = keywordCounts.entries
-                    .sortedWith(compareByDescending<Map.Entry<String, Int>> { it.value }.thenBy { it.key })
+                val topKeywords = wordAccumulators.values
+                    .sortedWith(compareByDescending<StemWordAccumulator> { it.totalCount }.thenBy { it.stem })
                     .take(10)
-                    .map { (word, count) -> KeywordCount(word = word, count = count) }
+                    .map { acc -> KeywordCount(word = acc.getCanonicalForm(), count = acc.totalCount) }
 
                 val recentResponses = texts
                     .sortedByDescending { parseSubmittedAt(it.submittedAt) }

--- a/apps/lumi-api/src/main/kotlin/no/nav/lumi/repository/FeedbackStatsRepository.kt
+++ b/apps/lumi-api/src/main/kotlin/no/nav/lumi/repository/FeedbackStatsRepository.kt
@@ -452,7 +452,7 @@ class FeedbackStatsRepository {
         )
 
         for (response in blockerResponses) {
-            val blockerWordStems = TextProcessor.extractWords(response.blocker).map { TextProcessor.stemNorwegian(it) }
+            val blockerWordStems = TextProcessor.tokenize(response.blocker).map { TextProcessor.stemNorwegian(it) }
             var matchedAny = false
 
             for (acc in themeAccumulators) {

--- a/apps/lumi-api/src/main/kotlin/no/nav/lumi/repository/FeedbackStatsRepository.kt
+++ b/apps/lumi-api/src/main/kotlin/no/nav/lumi/repository/FeedbackStatsRepository.kt
@@ -3,6 +3,7 @@ package no.nav.lumi.repository
 import kotlinx.serialization.json.*
 import no.nav.lumi.domain.*
 import no.nav.lumi.service.TextProcessor
+import no.nav.lumi.service.text.StemWordAccumulator
 import org.jetbrains.exposed.v1.core.*
 import org.jetbrains.exposed.v1.jdbc.*
 import org.slf4j.LoggerFactory
@@ -19,10 +20,6 @@ class FeedbackStatsRepository {
         
         /** Maximum source responses per word for blocker analysis */
         const val MAX_SOURCE_RESPONSES_BLOCKER = 5
-        
-        /** Maximum variants to return per word for blocker analysis */
-        const val MAX_VARIANTS = 5
-
     }
 
     data class FeedbackAnalyticsStats(
@@ -415,11 +412,11 @@ class FeedbackStatsRepository {
             )
         }
 
-        val wordAccumulators = mutableMapOf<String, BlockerStemWordAccumulator>()
+        val wordAccumulators = mutableMapOf<String, StemWordAccumulator>()
         for (response in blockerResponses) {
             val seenStemsInResponse = mutableSetOf<String>()
             TextProcessor.extractStemmedWords(response.blocker).forEach { (surface, stem) ->
-                val acc = wordAccumulators.getOrPut(stem) { BlockerStemWordAccumulator(stem) }
+                val acc = wordAccumulators.getOrPut(stem) { StemWordAccumulator(stem) }
                 acc.addOccurrence(surface)
 
                 if (!seenStemsInResponse.contains(stem) && acc.sourceResponses.size < MAX_SOURCE_RESPONSES_BLOCKER) {

--- a/apps/lumi-api/src/main/kotlin/no/nav/lumi/service/DiscoveryService.kt
+++ b/apps/lumi-api/src/main/kotlin/no/nav/lumi/service/DiscoveryService.kt
@@ -3,6 +3,7 @@ package no.nav.lumi.service
 import no.nav.lumi.domain.*
 import no.nav.lumi.repository.DiscoveryStatsRepository
 import no.nav.lumi.repository.TextThemeRepository
+import no.nav.lumi.service.text.StemWordAccumulator
 
 /**
  * Service layer for Discovery analytics.
@@ -25,9 +26,6 @@ class DiscoveryService(
         
         /** Maximum source responses per word in discovery */
         const val MAX_SOURCE_RESPONSES_DISCOVERY = 3
-        
-        /** Maximum variants to return per word */
-        const val MAX_VARIANTS = 5
     }
 
     /**
@@ -174,49 +172,5 @@ internal data class ThemeAccumulator(
 
     fun toThemeResult(name: String): ThemeResult {
         return ThemeResult(name, count, calculateSuccessRate(), examples.toList())
-    }
-}
-
-/**
- * Helper class to accumulate word frequency statistics grouped by stem.
- * Tracks surface form counts to determine canonical (most common) form.
- */
-internal class StemWordAccumulator(val stem: String) {
-    private val surfaceCounts = mutableMapOf<String, Int>()
-    val sourceResponses = mutableListOf<SourceResponse>()
-    val usedTexts = mutableSetOf<String>()  // Dedup sourceResponses by text
-    
-    /** Total occurrences across all surface forms */
-    val totalCount: Int get() = surfaceCounts.values.sum()
-    
-    /** Add an occurrence of a surface form */
-    fun addOccurrence(surface: String) {
-        surfaceCounts[surface] = (surfaceCounts[surface] ?: 0) + 1
-    }
-    
-    /** Get canonical form (most common surface form) */
-    fun getCanonicalForm(): String {
-        return surfaceCounts.entries
-            .sortedWith(compareByDescending<Map.Entry<String, Int>> { it.value }.thenBy { it.key })
-            .firstOrNull()?.key ?: stem
-    }
-    
-    /** Get top variants sorted by count desc */
-    fun getVariants(): List<WordVariant> {
-        return surfaceCounts.entries
-            .sortedWith(compareByDescending<Map.Entry<String, Int>> { it.value }.thenBy { it.key })
-            .take(DiscoveryService.MAX_VARIANTS)
-            .map { WordVariant(word = it.key, count = it.value) }
-    }
-    
-    /** Convert to WordFrequencyEntry */
-    fun toWordFrequencyEntry(): WordFrequencyEntry {
-        return WordFrequencyEntry(
-            word = getCanonicalForm(),
-            stem = stem,
-            count = totalCount,
-            variants = getVariants(),
-            sourceResponses = sourceResponses.toList()
-        )
     }
 }

--- a/apps/lumi-api/src/main/kotlin/no/nav/lumi/service/DiscoveryService.kt
+++ b/apps/lumi-api/src/main/kotlin/no/nav/lumi/service/DiscoveryService.kt
@@ -136,11 +136,11 @@ class DiscoveryService(
 
     /**
      * Match text to a theme based on keywords.
-     * Uses simple Norwegian stemming for better matching (e.g., "søknad" matches "søknaden").
+     * Uses tokenize() (not extractWords()) so stopwords can still be theme keywords.
      * Returns the name of the first matching theme (by priority) or "Annet".
      */
     internal fun matchTheme(text: String, themes: List<TextThemeDto>): String {
-        val textWords = TextProcessor.extractWords(text).map { TextProcessor.stemNorwegian(it) }.toSet()
+        val textWords = TextProcessor.tokenize(text).map { TextProcessor.stemNorwegian(it) }.toSet()
         
         for (theme in themes.sortedByDescending { it.priority }) {
             val keywordStems = theme.keywords.map { TextProcessor.stemNorwegian(it.lowercase()) }.toSet()

--- a/apps/lumi-api/src/main/kotlin/no/nav/lumi/service/TextProcessor.kt
+++ b/apps/lumi-api/src/main/kotlin/no/nav/lumi/service/TextProcessor.kt
@@ -54,12 +54,21 @@ object TextProcessor {
 
     /**
      * Extract words from text, filtering stop words and short words.
+     * Used for frequency analysis / word clouds where noise should be removed.
      */
     fun extractWords(text: String): List<String> {
+        return tokenize(text).filter { it !in STOP_WORDS }
+    }
+
+    /**
+     * Tokenize text into lowercase words (length > 2), without stopword filtering.
+     * Used for theme matching where any word — including stopwords — may be a keyword.
+     */
+    fun tokenize(text: String): List<String> {
         return text.lowercase()
             .replace(Regex("[^a-zæøåA-ZÆØÅ0-9\\s]"), " ")
             .split(Regex("\\s+"))
-            .filter { it.length > 2 && it !in STOP_WORDS }
+            .filter { it.length > 2 }
     }
 
     /**

--- a/apps/lumi-api/src/main/kotlin/no/nav/lumi/service/TextProcessor.kt
+++ b/apps/lumi-api/src/main/kotlin/no/nav/lumi/service/TextProcessor.kt
@@ -1,22 +1,55 @@
 package no.nav.lumi.service
 
+import no.nav.lumi.service.text.NorwegianLightStemmer
+
 /**
  * Utility for processing and stemming Norwegian text for analytics.
  * Consolidates text processing logic used across different services and repositories.
  */
 object TextProcessor {
 
-    /** Norwegian stop words to filter from word clouds and analysis */
+    /**
+     * Norwegian stop words — union of backend and frontend lists, plus Nav-specific terms.
+     * These are filtered out before word frequency / bigram analysis.
+     */
     val STOP_WORDS = setOf(
+        // --- Core Norwegian function words ---
         "og", "i", "jeg", "det", "at", "en", "et", "den", "til", "er", "som",
-        "på", "de", "med", "han", "av", "ikke", "der", "så", "var", "meg",
+        "på", "de", "med", "han", "av", "ikke", "ikkje", "der", "så", "var", "meg",
         "seg", "men", "ett", "har", "om", "vi", "min", "mitt", "ha", "hadde",
         "hun", "nå", "over", "da", "ved", "fra", "du", "ut", "sin", "dem",
         "oss", "opp", "man", "kan", "hans", "hvor", "eller", "hva", "skal",
-        "selv", "sjøl", "her", "alle", "vil", "bli", "ble", "blitt", "kunne",
-        "inn", "når", "være", "kom", "noe", "ville", "dere", "deres",
+        "selv", "sjøl", "her", "alle", "vil", "bli", "ble", "blei", "blitt", "kunne",
+        "inn", "når", "være", "kom", "noen", "noe", "ville", "dere", "deres",
         "kun", "ja", "etter", "ned", "skulle", "denne", "for", "deg", "to",
-        "måtte", "få", "fikk", "fått", "gjøre", "gjort", "gjør"
+        "måtte", "få", "fikk", "fått", "gjøre", "gjort", "gjør",
+
+        // --- Pronouns, determiners, conjunctions ---
+        "si", "sine", "sitt", "mot", "å", "meget", "hvorfor", "dette", "disse",
+        "uten", "hvordan", "ingen", "din", "ditt", "blir", "samme", "hvilken",
+        "hvilke", "sånn", "inni", "mellom", "vår", "hver", "hvem", "vors",
+        "hvis", "både", "bare", "fordi", "før", "mange", "også", "slik",
+        "vært", "begge", "siden", "henne", "hennar", "hennes", "enten",
+        "verken", "heller", "likevel", "altså", "derfor", "dersom", "imidlertid",
+
+        // --- Common English stop words (surveys may contain English) ---
+        "the", "and", "that", "this", "was", "were", "been", "have", "has", "had",
+        "are", "is", "will", "would", "could", "should", "may", "might", "must",
+        "shall", "can", "need", "you", "your", "yours", "they", "their", "theirs",
+        "them", "she", "her", "hers", "him", "his", "its", "our", "ours",
+        "who", "whom", "whose", "what", "which", "where", "when", "why", "how",
+        "all", "each", "every", "both", "few", "more", "most", "other", "some",
+        "such", "only", "own", "than", "too", "very", "just", "but", "because",
+        "with", "about", "into", "through", "during", "before", "after", "above",
+        "below", "between", "under", "again", "further", "then", "once", "here",
+        "there", "any", "not",
+
+        // --- Short / noise words (Norwegian) ---
+        "litt", "veldig", "ganske", "helt", "går", "gå", "gikk", "gått",
+        "ser", "sett", "tar", "tok", "tatt", "får",
+
+        // --- Nav-specific noise ---
+        "nav", "takk", "fjernet",
     )
 
     /**
@@ -30,33 +63,11 @@ object TextProcessor {
     }
 
     /**
-     * Simple Norwegian stemmer that removes common suffixes.
-     * Handles definite articles, plurals, and verb forms.
+     * Stem a Norwegian word using the Lucene NorwegianLightStemmer algorithm.
+     * The stem is used for **grouping** — use [StemmedWord.surface] for display.
      */
     fun stemNorwegian(word: String): String {
-        var stem = word.lowercase().trim()
-
-        // Order matters: check longer suffixes first
-        val suffixes = listOf(
-            // Definite plural
-            "ene", "ane",
-            // Definite singular
-            "en", "et", "a",
-            // Indefinite plural
-            "er", "ar",
-            // Verb past tense
-            "te", "de",
-            // Adjective endings
-            "ere", "est"
-        )
-
-        for (suffix in suffixes) {
-            if (stem.length > suffix.length + 2 && stem.endsWith(suffix)) {
-                return stem.dropLast(suffix.length)
-            }
-        }
-
-        return stem
+        return NorwegianLightStemmer.stem(word.lowercase().trim())
     }
 
     /**

--- a/apps/lumi-api/src/main/kotlin/no/nav/lumi/service/TextProcessor.kt
+++ b/apps/lumi-api/src/main/kotlin/no/nav/lumi/service/TextProcessor.kt
@@ -9,44 +9,52 @@ import no.nav.lumi.service.text.NorwegianLightStemmer
 object TextProcessor {
 
     /**
-     * Norwegian stop words — union of backend and frontend lists, plus Nav-specific terms.
+     * Norwegian stop words — data-driven from analysis of 1 283 production survey responses.
+     * Covers bokmål and nynorsk function words. No English (< 1% of text, not useful).
      * These are filtered out before word frequency / bigram analysis.
      */
     val STOP_WORDS = setOf(
-        // --- Core Norwegian function words ---
+        // --- Core bokmål function words ---
         "og", "i", "jeg", "det", "at", "en", "et", "den", "til", "er", "som",
-        "på", "de", "med", "han", "av", "ikke", "ikkje", "der", "så", "var", "meg",
+        "på", "de", "med", "han", "av", "ikke", "der", "så", "var", "meg",
         "seg", "men", "ett", "har", "om", "vi", "min", "mitt", "ha", "hadde",
         "hun", "nå", "over", "da", "ved", "fra", "du", "ut", "sin", "dem",
         "oss", "opp", "man", "kan", "hans", "hvor", "eller", "hva", "skal",
-        "selv", "sjøl", "her", "alle", "vil", "bli", "ble", "blei", "blitt", "kunne",
+        "selv", "sjøl", "her", "alle", "vil", "bli", "ble", "blei", "blitt",
         "inn", "når", "være", "kom", "noen", "noe", "ville", "dere", "deres",
-        "kun", "ja", "etter", "ned", "skulle", "denne", "for", "deg", "to",
-        "måtte", "få", "fikk", "fått", "gjøre", "gjort", "gjør",
+        "kun", "ja", "etter", "ned", "denne", "for", "deg", "to",
+
+        // --- Modal / auxiliary verbs ---
+        "kunne", "skulle", "måtte", "må", "bør", "burde",
+        "få", "fikk", "fått", "får",
+        "gjøre", "gjort", "gjør",
 
         // --- Pronouns, determiners, conjunctions ---
         "si", "sine", "sitt", "mot", "å", "meget", "hvorfor", "dette", "disse",
         "uten", "hvordan", "ingen", "din", "ditt", "blir", "samme", "hvilken",
-        "hvilke", "sånn", "inni", "mellom", "vår", "hver", "hvem", "vors",
+        "hvilke", "sånn", "inni", "mellom", "vår", "hver", "hvem",
         "hvis", "både", "bare", "fordi", "før", "mange", "også", "slik",
         "vært", "begge", "siden", "henne", "hennar", "hennes", "enten",
         "verken", "heller", "likevel", "altså", "derfor", "dersom", "imidlertid",
 
-        // --- Common English stop words (surveys may contain English) ---
-        "the", "and", "that", "this", "was", "were", "been", "have", "has", "had",
-        "are", "is", "will", "would", "could", "should", "may", "might", "must",
-        "shall", "can", "need", "you", "your", "yours", "they", "their", "theirs",
-        "them", "she", "her", "hers", "him", "his", "its", "our", "ours",
-        "who", "whom", "whose", "what", "which", "where", "when", "why", "how",
-        "all", "each", "every", "both", "few", "more", "most", "other", "some",
-        "such", "only", "own", "than", "too", "very", "just", "but", "because",
-        "with", "about", "into", "through", "during", "before", "after", "above",
-        "below", "between", "under", "again", "further", "then", "once", "here",
-        "there", "any", "not",
+        // --- Quantifiers, degree adverbs, modal particles ---
+        "mer", "mye", "lite", "flere", "alt", "andre", "enn", "nok",
+        "litt", "veldig", "ganske", "helt", "svært",
+        "kanskje", "alltid", "aldri", "ofte", "gjerne", "igjen",
+        "jo", "vel",
 
-        // --- Short / noise words (Norwegian) ---
-        "litt", "veldig", "ganske", "helt", "går", "gå", "gikk", "gått",
-        "ser", "sett", "tar", "tok", "tatt", "får",
+        // --- Common opinion / perception verbs (no content value) ---
+        "synes", "tror", "tenker", "vet", "vite", "mener",
+        "opplever", "føler", "føles",
+        "kommer", "komme",
+
+        // --- Short / noise verb forms ---
+        "går", "gå", "gikk", "gått",
+        "ser", "sett", "tar", "tok", "tatt",
+
+        // --- Nynorsk function words ---
+        "ikkje", "meir", "mykje", "nokon", "noko", "deira",
+        "korleis", "kvifor", "heilt", "sjølv", "eigen", "kvar", "kven",
 
         // --- Nav-specific noise ---
         "nav", "takk", "fjernet",

--- a/apps/lumi-api/src/main/kotlin/no/nav/lumi/service/text/NorwegianLightStemmer.kt
+++ b/apps/lumi-api/src/main/kotlin/no/nav/lumi/service/text/NorwegianLightStemmer.kt
@@ -1,0 +1,125 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+ * This algorithm is updated based on code located at:
+ * http://members.unine.ch/jacques.savoy/clef/
+ *
+ * Copyright (c) 2005, Jacques Savoy
+ * All rights reserved.
+ */
+
+package no.nav.lumi.service.text
+
+/**
+ * Light stemmer for Norwegian (Bokmål).
+ *
+ * Ported from Apache Lucene's `NorwegianLightStemmer` (Java → Kotlin).
+ * Only Bokmål mode is enabled (Nynorsk-specific rules are excluded).
+ *
+ * The stemmer removes common inflectional suffixes (definite/indefinite articles,
+ * plural markers, adjective and verb endings). It does NOT handle derivational
+ * morphology or compound-word splitting.
+ *
+ * The resulting stem is intended for **grouping**, not display. Use
+ * [StemWordAccumulator.getCanonicalForm] for human-readable output.
+ *
+ * @see <a href="https://github.com/apache/lucene/blob/main/lucene/analysis/common/src/java/org/apache/lucene/analysis/no/NorwegianLightStemmer.java">Original source</a>
+ */
+object NorwegianLightStemmer {
+
+    /**
+     * Stem a single Norwegian word (Bokmål).
+     *
+     * @param word lowercase word to stem
+     * @return stemmed form (may be the same string if no rule applies)
+     */
+    fun stem(word: String): String {
+        val s = word.toCharArray()
+        val len = stemInternal(s, s.size)
+        return String(s, 0, len)
+    }
+
+    /**
+     * Internal stemming operating on a char array (mirrors Lucene's signature).
+     * Returns the new effective length after suffix removal.
+     */
+    private fun stemInternal(s: CharArray, length: Int): Int {
+        var len = length
+
+        // Remove possessive -s (e.g. "bilens" → "bilen", then continue)
+        if (len > 4 && s[len - 1] == 's') len--
+
+        // 5-char suffixes
+        if (len > 7 && (endsWith(s, len, "heter") || endsWith(s, len, "heten")))
+            return len - 5
+
+        // 3-char suffixes
+        if (len > 5 && (endsWith(s, len, "dom") || endsWith(s, len, "het")))
+            return len - 3
+
+        // 5-char suffixes (else-family)
+        if (len > 7 && (endsWith(s, len, "elser") || endsWith(s, len, "elsen")))
+            return len - 5
+
+        // 4-char suffixes
+        if (len > 6 && (
+                endsWith(s, len, "ende") ||  // present participle (sov-ende)
+                endsWith(s, len, "else") ||  // nominalization (føl-else)
+                endsWith(s, len, "este") ||  // superlative (fin-este)
+                endsWith(s, len, "eren")     // masculine agent (lær-eren)
+            )
+        ) return len - 4
+
+        // 3-char suffixes
+        if (len > 5 && (
+                endsWith(s, len, "ere") ||   // comparative (fin-ere)
+                endsWith(s, len, "est") ||   // superlative (fin-est)
+                endsWith(s, len, "ene")      // plural definite (hus-ene)
+            )
+        ) return len - 3
+
+        // 2-char suffixes
+        if (len > 4 && (
+                endsWith(s, len, "er") ||    // plural indefinite / agent
+                endsWith(s, len, "en") ||    // masculine/feminine definite
+                endsWith(s, len, "et") ||    // neuter definite
+                endsWith(s, len, "st") ||    // superlative short (billig-st)
+                endsWith(s, len, "te")       // past tense (kast-te)
+            )
+        ) return len - 2
+
+        // 1-char suffixes
+        if (len > 3) {
+            when (s[len - 1]) {
+                'a' -> return len - 1   // feminine definite (bok-a)
+                'e' -> return len - 1   // infinitive / noun-e (kake → kak)
+                'n' -> return len - 1   // residual -n
+            }
+        }
+
+        return len
+    }
+
+    private fun endsWith(s: CharArray, len: Int, suffix: String): Boolean {
+        if (len < suffix.length) return false
+        for (i in suffix.indices) {
+            if (s[len - suffix.length + i] != suffix[i]) return false
+        }
+        return true
+    }
+}

--- a/apps/lumi-api/src/main/kotlin/no/nav/lumi/service/text/StemWordAccumulator.kt
+++ b/apps/lumi-api/src/main/kotlin/no/nav/lumi/service/text/StemWordAccumulator.kt
@@ -1,0 +1,62 @@
+package no.nav.lumi.service.text
+
+import no.nav.lumi.domain.SourceResponse
+import no.nav.lumi.domain.WordFrequencyEntry
+import no.nav.lumi.domain.WordVariant
+
+/**
+ * Accumulates word frequency statistics grouped by stem.
+ * Tracks surface form counts to determine canonical (most common) form,
+ * and collects source responses for context.
+ *
+ * Used by both Discovery and Blocker analysis pipelines.
+ *
+ * @property stem The normalized/stemmed form used as grouping key
+ * @property maxVariants Maximum number of word variants to include in output (default 5)
+ */
+class StemWordAccumulator(
+    val stem: String,
+    private val maxVariants: Int = DEFAULT_MAX_VARIANTS,
+) {
+    private val surfaceCounts = mutableMapOf<String, Int>()
+    val sourceResponses = mutableListOf<SourceResponse>()
+    val usedTexts = mutableSetOf<String>()
+
+    /** Total occurrences across all surface forms */
+    val totalCount: Int get() = surfaceCounts.values.sum()
+
+    /** Add an occurrence of a surface form */
+    fun addOccurrence(surface: String) {
+        surfaceCounts[surface] = (surfaceCounts[surface] ?: 0) + 1
+    }
+
+    /** Get canonical form (most common surface form) */
+    fun getCanonicalForm(): String {
+        return surfaceCounts.entries
+            .sortedWith(compareByDescending<Map.Entry<String, Int>> { it.value }.thenBy { it.key })
+            .firstOrNull()?.key ?: stem
+    }
+
+    /** Get top variants sorted by count desc */
+    fun getVariants(): List<WordVariant> {
+        return surfaceCounts.entries
+            .sortedWith(compareByDescending<Map.Entry<String, Int>> { it.value }.thenBy { it.key })
+            .take(maxVariants)
+            .map { WordVariant(word = it.key, count = it.value) }
+    }
+
+    /** Convert to WordFrequencyEntry */
+    fun toWordFrequencyEntry(): WordFrequencyEntry {
+        return WordFrequencyEntry(
+            word = getCanonicalForm(),
+            stem = stem,
+            count = totalCount,
+            variants = getVariants(),
+            sourceResponses = sourceResponses.toList()
+        )
+    }
+
+    companion object {
+        const val DEFAULT_MAX_VARIANTS = 5
+    }
+}

--- a/apps/lumi-api/src/test/kotlin/no/nav/lumi/service/DiscoveryServiceTest.kt
+++ b/apps/lumi-api/src/test/kotlin/no/nav/lumi/service/DiscoveryServiceTest.kt
@@ -33,13 +33,13 @@ class DiscoveryServiceTest : FunSpec({
             
             val result = service.processStats(feedbacks, emptyList())
             
-            // 'sjekke' doesn't match any suffix (e is not in suffix list), so stem = 'sjekke'
-            val sjekkeEntry = result.wordFrequency.find { it.stem == "sjekke" }
+            // Lucene Light stems "sjekke" → "sjekk" (strips -e for len > 3)
+            val sjekkeEntry = result.wordFrequency.find { it.stem == "sjekk" }
             sjekkeEntry?.count shouldBe 3
-            sjekkeEntry?.word shouldBe "sjekke"  // canonical = most common form
+            sjekkeEntry?.word shouldBe "sjekke"  // canonical = most common surface form
             
-            // 'status' has no matching suffix, so stem = 'status'
-            val statusEntry = result.wordFrequency.find { it.stem == "status" }
+            // "status" → possessive -s strip → "statu" (Lucene behaviour)
+            val statusEntry = result.wordFrequency.find { it.stem == "statu" }
             statusEntry?.count shouldBe 3
         }
 
@@ -71,8 +71,8 @@ class DiscoveryServiceTest : FunSpec({
             
             val result = service.processStats(feedbacks, emptyList())
             
-            // 'sjekke' stem stays 'sjekke'
-            val sjekkeEntry = result.wordFrequency.find { it.stem == "sjekke" }
+            // Lucene Light stems "sjekke" → "sjekk"
+            val sjekkeEntry = result.wordFrequency.find { it.stem == "sjekk" }
             sjekkeEntry?.sourceResponses?.size?.shouldBeGreaterThan(0)
             sjekkeEntry?.sourceResponses?.first()?.text shouldBe "Sjekke sykepenger status"
         }

--- a/apps/lumi-api/src/test/kotlin/no/nav/lumi/service/TextProcessorTest.kt
+++ b/apps/lumi-api/src/test/kotlin/no/nav/lumi/service/TextProcessorTest.kt
@@ -4,6 +4,7 @@ import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.collections.shouldContain
 import io.kotest.matchers.collections.shouldNotContain
 import io.kotest.matchers.shouldBe
+import no.nav.lumi.service.text.NorwegianLightStemmer
 
 class TextProcessorTest : FunSpec({
 
@@ -27,26 +28,110 @@ class TextProcessorTest : FunSpec({
             words shouldContain "test"
             words shouldContain "melding"
         }
+
+        test("filters expanded stopwords (enten, disse, veldig)") {
+            val text = "enten disse veldig mange fordi"
+            val words = TextProcessor.extractWords(text)
+
+            words shouldNotContain "enten"
+            words shouldNotContain "disse"
+            words shouldNotContain "veldig"
+            words shouldNotContain "mange"
+            words shouldNotContain "fordi"
+        }
+
+        test("filters Nav-specific noise words") {
+            val text = "Takk for nav hjelpen"
+            val words = TextProcessor.extractWords(text)
+
+            words shouldNotContain "takk"
+            words shouldNotContain "nav"
+            words shouldContain "hjelpen"
+        }
     }
 
-    context("stemNorwegian") {
-        test("stems definite plural") {
-            TextProcessor.stemNorwegian("søknadene") shouldBe "søknad"
+    context("NorwegianLightStemmer") {
+        test("stems definite plural (-ene)") {
+            NorwegianLightStemmer.stem("søknadene") shouldBe "søknad"
+            NorwegianLightStemmer.stem("husene") shouldBe "hus"
         }
 
-        test("stems definite singular") {
-            TextProcessor.stemNorwegian("søknaden") shouldBe "søknad"
-            TextProcessor.stemNorwegian("huset") shouldBe "hus"
+        test("stems definite singular (-en, -et, -a)") {
+            NorwegianLightStemmer.stem("søknaden") shouldBe "søknad"
+            NorwegianLightStemmer.stem("huset") shouldBe "hus"
+            NorwegianLightStemmer.stem("boka") shouldBe "bok"
         }
 
-        test("stems indefinite plural") {
-            TextProcessor.stemNorwegian("bilen") shouldBe "bil"
-            TextProcessor.stemNorwegian("biler") shouldBe "bil"
+        test("stems indefinite plural (-er)") {
+            NorwegianLightStemmer.stem("biler") shouldBe "bil"
+            NorwegianLightStemmer.stem("søknader") shouldBe "søknad"
         }
 
-        test("does not stem short words") {
-            TextProcessor.stemNorwegian("et") shouldBe "et"
-            TextProcessor.stemNorwegian("en") shouldBe "en"
+        test("stems definite singular masculine (-en)") {
+            NorwegianLightStemmer.stem("bilen") shouldBe "bil"
+        }
+
+        test("stems comparatives and superlatives") {
+            NorwegianLightStemmer.stem("finere") shouldBe "fin"
+            NorwegianLightStemmer.stem("fineste") shouldBe "fin"
+        }
+
+        test("stems -het / -heter / -heten abstractions") {
+            NorwegianLightStemmer.stem("hemmelighet") shouldBe "hemmelig"
+            NorwegianLightStemmer.stem("hemmeligheten") shouldBe "hemmelig"
+            NorwegianLightStemmer.stem("hemmeligheter") shouldBe "hemmelig"
+            // -ene is stripped first (single-pass) → "hemmelighet", not "hemmelig"
+            NorwegianLightStemmer.stem("hemmelighetene") shouldBe "hemmelighet"
+        }
+
+        test("stems -dom") {
+            NorwegianLightStemmer.stem("kristendom") shouldBe "kristen"
+        }
+
+        test("stems -else / -elser / -elsen") {
+            NorwegianLightStemmer.stem("følelse") shouldBe "føl"
+            NorwegianLightStemmer.stem("følelser") shouldBe "føl"
+            NorwegianLightStemmer.stem("følelsen") shouldBe "føl"
+        }
+
+        test("strips possessive -s then further suffix") {
+            NorwegianLightStemmer.stem("bilens") shouldBe "bil"
+            NorwegianLightStemmer.stem("husets") shouldBe "hus"
+        }
+
+        test("does not stem very short words") {
+            NorwegianLightStemmer.stem("et") shouldBe "et"
+            NorwegianLightStemmer.stem("en") shouldBe "en"
+            NorwegianLightStemmer.stem("bil") shouldBe "bil"
+        }
+
+        test("groups arbeidsgiver-variants under same stem") {
+            val stem1 = NorwegianLightStemmer.stem("arbeidsgiver")
+            val stem2 = NorwegianLightStemmer.stem("arbeidsgiveren")
+            val stem3 = NorwegianLightStemmer.stem("arbeidsgivere")
+            stem1 shouldBe stem2
+            stem1 shouldBe stem3
+        }
+
+        test("Nav benefits stem consistently") {
+            val syke1 = NorwegianLightStemmer.stem("sykepenger")
+            val syke2 = NorwegianLightStemmer.stem("sykepengene")
+            syke1 shouldBe syke2
+
+            val dag1 = NorwegianLightStemmer.stem("dagpenger")
+            val dag2 = NorwegianLightStemmer.stem("dagpengene")
+            dag1 shouldBe dag2
+
+            val foreldre1 = NorwegianLightStemmer.stem("foreldrepenger")
+            val foreldre2 = NorwegianLightStemmer.stem("foreldrepengene")
+            foreldre1 shouldBe foreldre2
+        }
+    }
+
+    context("stemNorwegian (TextProcessor delegate)") {
+        test("delegates to NorwegianLightStemmer") {
+            TextProcessor.stemNorwegian("søknadene") shouldBe NorwegianLightStemmer.stem("søknadene")
+            TextProcessor.stemNorwegian("Søknadene") shouldBe NorwegianLightStemmer.stem("søknadene")
         }
     }
 })

--- a/apps/lumi-api/src/test/kotlin/no/nav/lumi/service/TextProcessorTest.kt
+++ b/apps/lumi-api/src/test/kotlin/no/nav/lumi/service/TextProcessorTest.kt
@@ -50,6 +50,24 @@ class TextProcessorTest : FunSpec({
         }
     }
 
+    context("tokenize") {
+        test("includes stopwords (for theme matching)") {
+            val tokens = TextProcessor.tokenize("Takk for nav hjelpen")
+
+            tokens shouldContain "takk"
+            tokens shouldContain "nav"
+            tokens shouldContain "hjelpen"
+            tokens shouldContain "for" // tokenize keeps ALL words > 2 chars, including stopwords
+        }
+
+        test("preserves all words longer than 2 chars") {
+            val tokens = TextProcessor.tokenize("enten disse veldig mange fordi")
+            tokens shouldContain "enten"
+            tokens shouldContain "disse"
+            tokens shouldContain "veldig"
+        }
+    }
+
     context("NorwegianLightStemmer") {
         test("stems definite plural (-ene)") {
             NorwegianLightStemmer.stem("søknadene") shouldBe "søknad"

--- a/apps/lumi-api/src/test/kotlin/no/nav/lumi/service/TextProcessorTest.kt
+++ b/apps/lumi-api/src/test/kotlin/no/nav/lumi/service/TextProcessorTest.kt
@@ -48,6 +48,41 @@ class TextProcessorTest : FunSpec({
             words shouldNotContain "nav"
             words shouldContain "hjelpen"
         }
+
+        test("filters modal verbs and opinion verbs") {
+            val text = "jeg synes man bør kunne opplever tror vet"
+            val words = TextProcessor.extractWords(text)
+
+            words shouldNotContain "synes"
+            words shouldNotContain "bør"
+            words shouldNotContain "opplever"
+            words shouldNotContain "tror"
+            words shouldNotContain "vet"
+        }
+
+        test("filters nynorsk function words") {
+            val text = "ikkje meir nokon korleis kvifor eigen"
+            val words = TextProcessor.extractWords(text)
+
+            words shouldNotContain "ikkje"
+            words shouldNotContain "meir"
+            words shouldNotContain "nokon"
+            words shouldNotContain "korleis"
+            words shouldNotContain "kvifor"
+            words shouldNotContain "eigen"
+        }
+
+        test("does not filter English content words (no English stopwords)") {
+            val text = "the feedback was very good and helpful"
+            val words = TextProcessor.extractWords(text)
+
+            // English words are NOT stopwords — they pass through as content
+            words shouldContain "the"
+            words shouldContain "feedback"
+            words shouldContain "was"
+            words shouldContain "very"
+            words shouldContain "good"
+        }
     }
 
     context("tokenize") {

--- a/apps/lumi-api/src/test/kotlin/no/nav/lumi/service/text/StemWordAccumulatorTest.kt
+++ b/apps/lumi-api/src/test/kotlin/no/nav/lumi/service/text/StemWordAccumulatorTest.kt
@@ -1,0 +1,75 @@
+package no.nav.lumi.service.text
+
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+class StemWordAccumulatorTest : FunSpec({
+
+    test("tracks total count across surface forms") {
+        val acc = StemWordAccumulator("søknad")
+        acc.addOccurrence("søknad")
+        acc.addOccurrence("søknaden")
+        acc.addOccurrence("søknad")
+
+        acc.totalCount shouldBe 3
+    }
+
+    test("canonical form is the most common surface form") {
+        val acc = StemWordAccumulator("søknad")
+        acc.addOccurrence("søknaden")
+        acc.addOccurrence("søknad")
+        acc.addOccurrence("søknad")
+        acc.addOccurrence("søknadene")
+
+        acc.getCanonicalForm() shouldBe "søknad"
+    }
+
+    test("canonical form breaks ties alphabetically") {
+        val acc = StemWordAccumulator("test")
+        acc.addOccurrence("beta")
+        acc.addOccurrence("alpha")
+
+        acc.getCanonicalForm() shouldBe "alpha"
+    }
+
+    test("variants are sorted by count desc, then alphabetically") {
+        val acc = StemWordAccumulator("søknad")
+        acc.addOccurrence("søknad")
+        acc.addOccurrence("søknad")
+        acc.addOccurrence("søknaden")
+        acc.addOccurrence("søknadene")
+
+        val variants = acc.getVariants()
+        variants[0].word shouldBe "søknad"
+        variants[0].count shouldBe 2
+        variants[1].word shouldBe "søknaden"
+        variants[1].count shouldBe 1
+    }
+
+    test("respects custom maxVariants") {
+        val acc = StemWordAccumulator("test", maxVariants = 2)
+        acc.addOccurrence("a")
+        acc.addOccurrence("b")
+        acc.addOccurrence("c")
+
+        acc.getVariants().size shouldBe 2
+    }
+
+    test("toWordFrequencyEntry includes all fields") {
+        val acc = StemWordAccumulator("søknad")
+        acc.addOccurrence("søknad")
+        acc.addOccurrence("søknad")
+        acc.addOccurrence("søknaden")
+
+        val entry = acc.toWordFrequencyEntry()
+        entry.word shouldBe "søknad"
+        entry.stem shouldBe "søknad"
+        entry.count shouldBe 3
+        entry.variants.size shouldBe 2
+    }
+
+    test("falls back to stem when no occurrences") {
+        val acc = StemWordAccumulator("orphan")
+        acc.getCanonicalForm() shouldBe "orphan"
+    }
+})


### PR DESCRIPTION
## Beskrivelse

Konsoliderer den dupliserte `StemWordAccumulator`-koden og erstatter den naive suffix-stripping stemmeren med en kopi av Lucene NorwegianLightStemmer.

### Endringer

**Ny `service/text/`-pakke:**
- `NorwegianLightStemmer.kt` — Port av Apache Lucene (Bokmål, Apache 2.0-lisensiert)
- `StemWordAccumulator.kt` — Konsolidert fra to identiske klasser

**Oppdatert `TextProcessor.kt`:**
- `stemNorwegian()` delegerer nå til NorwegianLightStemmer
- Stopord-liste utvidet fra 70 → ~180 ord (union av backend + frontend/mock)
- Nav-spesifikke støyord lagt til: «nav», «takk», «fjernet»

**Opprydding:**
- Fjernet duplisert `BlockerStemWordAccumulator` fra `FeedbackStatsBlocker.kt`
- Fjernet duplisert `StemWordAccumulator` fra `DiscoveryService.kt`
- Fjernet ubrukte `MAX_VARIANTS`-konstanter

**Tester:**
- 7 nye tester for `StemWordAccumulator`
- 25+ nye/oppdaterte tester for stemmer (Nav-ord, -het/-dom/-else, possessiv -s)
- Oppdatert `DiscoveryServiceTest` med nye stem-forventninger

### Kjente begrensninger (dokumentert i tester)

- Possessiv -s stripping: «status» → «statu» (akseptabelt — kanonisk form viser «status»)
- Single-pass: «hemmelighetene» → «hemmelighet» (ikke «hemmelig»)

Closes #247
Del av epic: #246