### PR TITLE
feat(api): bigram-ekstraksjon + sitater + confidenceLevel

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,4 @@ lumi-export-*.json
 
 # OS
 .DS_Store
+.playwright-mcp/

--- a/apps/lumi-api/src/main/kotlin/no/nav/lumi/domain/TextTheme.kt
+++ b/apps/lumi-api/src/main/kotlin/no/nav/lumi/domain/TextTheme.kt
@@ -112,6 +112,25 @@ data class DiscoveryRecentResponse(
 )
 
 /**
+ * A frequently occurring two-word phrase (bigram) extracted from free-text responses.
+ */
+@Serializable
+data class PhraseEntry(
+    val text: String,
+    val count: Int,
+    val sourceResponseIds: List<String> = emptyList()
+)
+
+/**
+ * A representative quote from a free-text response.
+ */
+@Serializable
+data class QuoteEntry(
+    val text: String,
+    val answeredAt: String,
+)
+
+/**
  * Full discovery statistics response
  */
 @Serializable
@@ -119,7 +138,10 @@ data class DiscoveryStatsResponse(
     val totalSubmissions: Int,
     val wordFrequency: List<WordFrequencyEntry>,
     val themes: List<ThemeResult>,
-    val recentResponses: List<DiscoveryRecentResponse>
+    val recentResponses: List<DiscoveryRecentResponse>,
+    val phrases: List<PhraseEntry> = emptyList(),
+    val quotes: List<QuoteEntry> = emptyList(),
+    val confidenceLevel: String = "low",
 )
 
 // ============================================
@@ -147,6 +169,8 @@ data class BlockerStatsResponse(
     val totalBlockers: Int,
     val wordFrequency: List<WordFrequencyEntry>,  // Uses unified WordFrequencyEntry
     val themes: List<BlockerThemeResult>,
-    val recentBlockers: List<RecentBlockerResponse>
+    val recentBlockers: List<RecentBlockerResponse>,
+    val phrases: List<PhraseEntry> = emptyList(),
+    val quotes: List<QuoteEntry> = emptyList(),
+    val confidenceLevel: String = "low",
 )
-

--- a/apps/lumi-api/src/main/kotlin/no/nav/lumi/domain/TextTheme.kt
+++ b/apps/lumi-api/src/main/kotlin/no/nav/lumi/domain/TextTheme.kt
@@ -1,5 +1,6 @@
 package no.nav.lumi.domain
 
+import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
 @Serializable
@@ -131,6 +132,17 @@ data class QuoteEntry(
 )
 
 /**
+ * Confidence level for text analysis based on response volume.
+ * Determines how much weight to give bigram phrases vs. individual quotes.
+ */
+@Serializable
+enum class ConfidenceLevel {
+    @SerialName("low") LOW,
+    @SerialName("medium") MEDIUM,
+    @SerialName("high") HIGH,
+}
+
+/**
  * Full discovery statistics response
  */
 @Serializable
@@ -141,7 +153,7 @@ data class DiscoveryStatsResponse(
     val recentResponses: List<DiscoveryRecentResponse>,
     val phrases: List<PhraseEntry> = emptyList(),
     val quotes: List<QuoteEntry> = emptyList(),
-    val confidenceLevel: String = "low",
+    val confidenceLevel: ConfidenceLevel = ConfidenceLevel.LOW,
 )
 
 // ============================================
@@ -172,5 +184,5 @@ data class BlockerStatsResponse(
     val recentBlockers: List<RecentBlockerResponse>,
     val phrases: List<PhraseEntry> = emptyList(),
     val quotes: List<QuoteEntry> = emptyList(),
-    val confidenceLevel: String = "low",
+    val confidenceLevel: ConfidenceLevel = ConfidenceLevel.LOW,
 )

--- a/apps/lumi-api/src/main/kotlin/no/nav/lumi/repository/FeedbackStatsRepository.kt
+++ b/apps/lumi-api/src/main/kotlin/no/nav/lumi/repository/FeedbackStatsRepository.kt
@@ -454,7 +454,7 @@ class FeedbackStatsRepository {
             .take(MAX_PHRASES_BLOCKER)
             .map { it.toPhraseEntry(maxSourceIds = MAX_SOURCE_RESPONSES_BLOCKER) }
 
-        val quoteSeed = blockerResponses.size.toLong() xor (dtos.firstOrNull()?.id?.hashCode()?.toLong() ?: 0L)
+        val quoteSeed = blockerResponses.size.toLong() xor (quoteCandidates.firstOrNull()?.first?.hashCode()?.toLong() ?: 0L)
         val quotes = QuoteSelector.selectQuotes(quoteCandidates, seed = quoteSeed)
         val confidence = QuoteSelector.confidenceLevel(blockerResponses.size)
 

--- a/apps/lumi-api/src/main/kotlin/no/nav/lumi/repository/FeedbackStatsRepository.kt
+++ b/apps/lumi-api/src/main/kotlin/no/nav/lumi/repository/FeedbackStatsRepository.kt
@@ -382,7 +382,7 @@ class FeedbackStatsRepository {
             dbQuery.map { it.toDbRecord() }
         }
 
-        val dtos = records.map { it.toDto() }
+        val dtos = records.map { it.toDto() }.sortedBy { it.submittedAt }
 
         val blockerResponses = mutableListOf<RecentBlockerResponse>()
         val bigramAccumulators = mutableMapOf<String, BigramAccumulator>()
@@ -454,7 +454,8 @@ class FeedbackStatsRepository {
             .take(MAX_PHRASES_BLOCKER)
             .map { it.toPhraseEntry(maxSourceIds = MAX_SOURCE_RESPONSES_BLOCKER) }
 
-        val quotes = QuoteSelector.selectQuotes(quoteCandidates, seed = blockerResponses.size.toLong())
+        val quoteSeed = blockerResponses.size.toLong() xor (dtos.firstOrNull()?.id?.hashCode()?.toLong() ?: 0L)
+        val quotes = QuoteSelector.selectQuotes(quoteCandidates, seed = quoteSeed)
         val confidence = QuoteSelector.confidenceLevel(blockerResponses.size)
 
         val themeAccumulators = themes.map { theme ->

--- a/apps/lumi-api/src/main/kotlin/no/nav/lumi/repository/FeedbackStatsRepository.kt
+++ b/apps/lumi-api/src/main/kotlin/no/nav/lumi/repository/FeedbackStatsRepository.kt
@@ -3,6 +3,8 @@ package no.nav.lumi.repository
 import kotlinx.serialization.json.*
 import no.nav.lumi.domain.*
 import no.nav.lumi.service.TextProcessor
+import no.nav.lumi.service.text.BigramAccumulator
+import no.nav.lumi.service.text.QuoteSelector
 import no.nav.lumi.service.text.StemWordAccumulator
 import org.jetbrains.exposed.v1.core.*
 import org.jetbrains.exposed.v1.jdbc.*
@@ -20,6 +22,9 @@ class FeedbackStatsRepository {
         
         /** Maximum source responses per word for blocker analysis */
         const val MAX_SOURCE_RESPONSES_BLOCKER = 5
+
+        private const val MAX_PHRASES_BLOCKER = 30
+        private const val MIN_PHRASE_OCCURRENCES = 2
     }
 
     data class FeedbackAnalyticsStats(
@@ -380,6 +385,8 @@ class FeedbackStatsRepository {
         val dtos = records.map { it.toDto() }
 
         val blockerResponses = mutableListOf<RecentBlockerResponse>()
+        val bigramAccumulators = mutableMapOf<String, BigramAccumulator>()
+        val quoteCandidates = mutableListOf<Pair<String, String>>()
 
         for (feedback in dtos) {
             val blockerAnswer = feedback.answers.find { a ->
@@ -410,6 +417,13 @@ class FeedbackStatsRepository {
                     submittedAt = feedback.submittedAt
                 )
             )
+
+            // Track bigrams and quote candidates for this blocker text
+            TextProcessor.extractBigrams(blockerText).forEach { bg ->
+                val acc = bigramAccumulators.getOrPut(bg.stemKey) { BigramAccumulator(bg.stemKey) }
+                acc.addOccurrence(bg.surface, feedback.id)
+            }
+            quoteCandidates.add(blockerText to feedback.submittedAt)
         }
 
         val wordAccumulators = mutableMapOf<String, StemWordAccumulator>()
@@ -433,6 +447,15 @@ class FeedbackStatsRepository {
             .sortedByDescending { it.totalCount }
             .take(30)
             .map { it.toWordFrequencyEntry() }
+
+        val phrases = bigramAccumulators.values
+            .filter { it.totalCount >= MIN_PHRASE_OCCURRENCES }
+            .sortedByDescending { it.totalCount }
+            .take(MAX_PHRASES_BLOCKER)
+            .map { it.toPhraseEntry(maxSourceIds = MAX_SOURCE_RESPONSES_BLOCKER) }
+
+        val quotes = QuoteSelector.selectQuotes(quoteCandidates, seed = blockerResponses.size.toLong())
+        val confidence = QuoteSelector.confidenceLevel(blockerResponses.size)
 
         val themeAccumulators = themes.map { theme ->
             ThemeAccumulator(
@@ -493,7 +516,10 @@ class FeedbackStatsRepository {
             totalBlockers = blockerResponses.size,
             wordFrequency = wordFrequency,
             themes = themeResults,
-            recentBlockers = recentBlockers
+            recentBlockers = recentBlockers,
+            phrases = phrases,
+            quotes = quotes,
+            confidenceLevel = confidence,
         )
     }
 

--- a/apps/lumi-api/src/main/kotlin/no/nav/lumi/service/DiscoveryService.kt
+++ b/apps/lumi-api/src/main/kotlin/no/nav/lumi/service/DiscoveryService.kt
@@ -3,6 +3,8 @@ package no.nav.lumi.service
 import no.nav.lumi.domain.*
 import no.nav.lumi.repository.DiscoveryStatsRepository
 import no.nav.lumi.repository.TextThemeRepository
+import no.nav.lumi.service.text.BigramAccumulator
+import no.nav.lumi.service.text.QuoteSelector
 import no.nav.lumi.service.text.StemWordAccumulator
 
 /**
@@ -23,6 +25,9 @@ class DiscoveryService(
         
         /** Maximum words in frequency list */
         const val MAX_WORD_FREQUENCY = 50
+
+        const val MAX_PHRASES = 30
+        const val MIN_PHRASE_OCCURRENCES = 2
         
         /** Maximum source responses per word in discovery */
         const val MAX_SOURCE_RESPONSES_DISCOVERY = 3
@@ -47,6 +52,8 @@ class DiscoveryService(
     ): DiscoveryStatsResponse {
         // Stem-based word frequency accumulator
         val wordAccumulators = mutableMapOf<String, StemWordAccumulator>()
+        val bigramAccumulators = mutableMapOf<String, BigramAccumulator>()
+        val quoteCandidates = mutableListOf<Pair<String, String>>()
         val themeStats = themes.associate { it.name to ThemeAccumulator() }.toMutableMap()
         themeStats["Annet"] = ThemeAccumulator() // Catch-all for unmatched
         
@@ -90,6 +97,15 @@ class DiscoveryService(
                     seenStemsInResponse.add(stem)
                 }
             }
+
+            // Bigram extraction — pairs of adjacent content words
+            TextProcessor.extractBigrams(taskText).forEach { bg ->
+                val acc = bigramAccumulators.getOrPut(bg.stemKey) { BigramAccumulator(bg.stemKey) }
+                acc.addOccurrence(bg.surface, dto.id)
+            }
+
+            // Collect quote candidates
+            quoteCandidates.add(taskText to dto.submittedAt)
             
             // Theme matching (find first matching theme based on priority)
             val matchedTheme = matchTheme(taskText, themes)
@@ -119,6 +135,17 @@ class DiscoveryService(
             .sortedByDescending { it.totalCount }
             .take(MAX_WORD_FREQUENCY)
             .map { it.toWordFrequencyEntry() }
+
+        // Build phrase list from bigram accumulators
+        val phrases = bigramAccumulators.values
+            .filter { it.totalCount >= MIN_PHRASE_OCCURRENCES }
+            .sortedByDescending { it.totalCount }
+            .take(MAX_PHRASES)
+            .map { it.toPhraseEntry(maxSourceIds = MAX_SOURCE_RESPONSES_DISCOVERY) }
+
+        // Select representative quotes
+        val quotes = QuoteSelector.selectQuotes(quoteCandidates, seed = feedbacks.size.toLong())
+        val confidence = QuoteSelector.confidenceLevel(feedbacks.size)
         
         // Build theme results (exclude empty themes)
         val themeResults = themeStats
@@ -130,7 +157,10 @@ class DiscoveryService(
             totalSubmissions = feedbacks.size,
             wordFrequency = wordFrequency,
             themes = themeResults,
-            recentResponses = recentResponses
+            recentResponses = recentResponses,
+            phrases = phrases,
+            quotes = quotes,
+            confidenceLevel = confidence,
         )
     }
 

--- a/apps/lumi-api/src/main/kotlin/no/nav/lumi/service/DiscoveryService.kt
+++ b/apps/lumi-api/src/main/kotlin/no/nav/lumi/service/DiscoveryService.kt
@@ -143,8 +143,9 @@ class DiscoveryService(
             .take(MAX_PHRASES)
             .map { it.toPhraseEntry(maxSourceIds = MAX_SOURCE_RESPONSES_DISCOVERY) }
 
-        // Select representative quotes
-        val quotes = QuoteSelector.selectQuotes(quoteCandidates, seed = feedbacks.size.toLong())
+        // Select representative quotes (seed combines size + first ID for uniqueness per dataset)
+        val quoteSeed = feedbacks.size.toLong() xor (feedbacks.firstOrNull()?.id?.hashCode()?.toLong() ?: 0L)
+        val quotes = QuoteSelector.selectQuotes(quoteCandidates, seed = quoteSeed)
         val confidence = QuoteSelector.confidenceLevel(feedbacks.size)
         
         // Build theme results (exclude empty themes)

--- a/apps/lumi-api/src/main/kotlin/no/nav/lumi/service/TextProcessor.kt
+++ b/apps/lumi-api/src/main/kotlin/no/nav/lumi/service/TextProcessor.kt
@@ -93,12 +93,38 @@ object TextProcessor {
     data class StemmedWord(val surface: String, val stem: String)
 
     /**
+     * A bigram (two-word phrase) with its stemmed key for grouping.
+     */
+    data class StemmedBigram(
+        val surface: String,
+        val stemKey: String,
+    )
+
+    /**
      * Extract words from text with their stems.
      * @return List of (surfaceForm, stem) pairs
      */
     fun extractStemmedWords(text: String): List<StemmedWord> {
         return extractWords(text).map { word ->
             StemmedWord(surface = word, stem = stemNorwegian(word))
+        }
+    }
+
+    /**
+     * Extract content-word bigrams from text.
+     * Stopwords are filtered first, then adjacent content words are paired.
+     * This means stopwords between content words are skipped:
+     * "vanskelig å svare" → ["vanskelig", "svare"] → bigram "vanskelig svare"
+     */
+    fun extractBigrams(text: String): List<StemmedBigram> {
+        val contentWords = extractWords(text)
+        if (contentWords.size < 2) return emptyList()
+
+        return contentWords.zipWithNext().map { (w1, w2) ->
+            StemmedBigram(
+                surface = "$w1 $w2",
+                stemKey = "${stemNorwegian(w1)}|${stemNorwegian(w2)}",
+            )
         }
     }
 }

--- a/apps/lumi-api/src/main/kotlin/no/nav/lumi/service/text/BigramAccumulator.kt
+++ b/apps/lumi-api/src/main/kotlin/no/nav/lumi/service/text/BigramAccumulator.kt
@@ -1,0 +1,51 @@
+package no.nav.lumi.service.text
+
+import no.nav.lumi.domain.PhraseEntry
+
+/**
+ * Accumulates bigram (two-word phrase) frequency statistics grouped by stem key.
+ * Tracks surface form counts to determine canonical (most common) display form,
+ * and enforces per-response deduplication (one response contributes at most 1 count).
+ *
+ * @property stemKey Compound key "stem1|stem2" for grouping
+ */
+class BigramAccumulator(val stemKey: String) {
+    private val surfaceCounts = mutableMapOf<String, Int>()
+    private val seenResponseIds = mutableSetOf<String>()
+    private val _sourceResponseIds = mutableListOf<String>()
+
+    /** Total unique responses containing this bigram */
+    val totalCount: Int get() = seenResponseIds.size
+
+    /**
+     * Record an occurrence of this bigram from a specific response.
+     * Each response contributes at most 1 count regardless of how many times
+     * the bigram appears in that response.
+     */
+    fun addOccurrence(surface: String, responseId: String) {
+        if (responseId in seenResponseIds) return
+        seenResponseIds.add(responseId)
+        surfaceCounts[surface] = (surfaceCounts[surface] ?: 0) + 1
+        _sourceResponseIds.add(responseId)
+    }
+
+    /** Get canonical surface form (most common, tiebreaker alphabetical) */
+    fun getCanonicalSurface(): String {
+        return surfaceCounts.entries
+            .sortedWith(compareByDescending<Map.Entry<String, Int>> { it.value }.thenBy { it.key })
+            .firstOrNull()?.key ?: stemKey
+    }
+
+    /** Convert to PhraseEntry for API response */
+    fun toPhraseEntry(maxSourceIds: Int = DEFAULT_MAX_SOURCE_IDS): PhraseEntry {
+        return PhraseEntry(
+            text = getCanonicalSurface(),
+            count = totalCount,
+            sourceResponseIds = _sourceResponseIds.take(maxSourceIds)
+        )
+    }
+
+    companion object {
+        const val DEFAULT_MAX_SOURCE_IDS = 5
+    }
+}

--- a/apps/lumi-api/src/main/kotlin/no/nav/lumi/service/text/BigramAccumulator.kt
+++ b/apps/lumi-api/src/main/kotlin/no/nav/lumi/service/text/BigramAccumulator.kt
@@ -26,7 +26,9 @@ class BigramAccumulator(val stemKey: String) {
         if (responseId in seenResponseIds) return
         seenResponseIds.add(responseId)
         surfaceCounts[surface] = (surfaceCounts[surface] ?: 0) + 1
-        _sourceResponseIds.add(responseId)
+        if (_sourceResponseIds.size < DEFAULT_MAX_SOURCE_IDS) {
+            _sourceResponseIds.add(responseId)
+        }
     }
 
     /** Get canonical surface form (most common, tiebreaker alphabetical) */

--- a/apps/lumi-api/src/main/kotlin/no/nav/lumi/service/text/QuoteSelector.kt
+++ b/apps/lumi-api/src/main/kotlin/no/nav/lumi/service/text/QuoteSelector.kt
@@ -1,0 +1,53 @@
+package no.nav.lumi.service.text
+
+import no.nav.lumi.domain.QuoteEntry
+import kotlin.random.Random
+
+/**
+ * Selects representative quotes and computes confidence levels for text analysis.
+ */
+object QuoteSelector {
+
+    private const val MIN_QUOTE_LENGTH = 30
+    private const val MAX_QUOTE_LENGTH = 300
+    private const val DEFAULT_TARGET_COUNT = 5
+
+    /**
+     * Select representative quotes from candidate texts.
+     * Filters to quotes between [MIN_QUOTE_LENGTH] and [MAX_QUOTE_LENGTH] characters,
+     * then shuffles with a deterministic seed for reproducibility within the same dataset.
+     *
+     * @param candidates List of (text, submittedAt) pairs
+     * @param targetCount Maximum number of quotes to return (default 5)
+     * @param seed Random seed for reproducible shuffling
+     */
+    fun selectQuotes(
+        candidates: List<Pair<String, String>>,
+        targetCount: Int = DEFAULT_TARGET_COUNT,
+        seed: Long,
+    ): List<QuoteEntry> {
+        val eligible = candidates.filter { (text, _) ->
+            text.length in MIN_QUOTE_LENGTH..MAX_QUOTE_LENGTH
+        }
+        if (eligible.isEmpty()) return emptyList()
+
+        return eligible
+            .shuffled(Random(seed))
+            .take(targetCount)
+            .map { (text, submittedAt) -> QuoteEntry(text = text, answeredAt = submittedAt) }
+    }
+
+    /**
+     * Determine confidence level based on total response count.
+     * - "low": fewer than 30 responses — bigrams are unreliable, prefer quotes
+     * - "medium": 30–100 responses — bigrams are useful alongside quotes
+     * - "high": more than 100 responses — bigrams provide strong signal
+     */
+    fun confidenceLevel(totalResponses: Int): String {
+        return when {
+            totalResponses < 30 -> "low"
+            totalResponses <= 100 -> "medium"
+            else -> "high"
+        }
+    }
+}

--- a/apps/lumi-api/src/main/kotlin/no/nav/lumi/service/text/QuoteSelector.kt
+++ b/apps/lumi-api/src/main/kotlin/no/nav/lumi/service/text/QuoteSelector.kt
@@ -1,5 +1,6 @@
 package no.nav.lumi.service.text
 
+import no.nav.lumi.domain.ConfidenceLevel
 import no.nav.lumi.domain.QuoteEntry
 import kotlin.random.Random
 
@@ -43,11 +44,11 @@ object QuoteSelector {
      * - "medium": 30–100 responses — bigrams are useful alongside quotes
      * - "high": more than 100 responses — bigrams provide strong signal
      */
-    fun confidenceLevel(totalResponses: Int): String {
+    fun confidenceLevel(totalResponses: Int): ConfidenceLevel {
         return when {
-            totalResponses < 30 -> "low"
-            totalResponses <= 100 -> "medium"
-            else -> "high"
+            totalResponses < 30 -> ConfidenceLevel.LOW
+            totalResponses <= 100 -> ConfidenceLevel.MEDIUM
+            else -> ConfidenceLevel.HIGH
         }
     }
 }

--- a/apps/lumi-api/src/main/kotlin/no/nav/lumi/service/text/QuoteSelector.kt
+++ b/apps/lumi-api/src/main/kotlin/no/nav/lumi/service/text/QuoteSelector.kt
@@ -18,7 +18,7 @@ object QuoteSelector {
      * Filters to quotes between [MIN_QUOTE_LENGTH] and [MAX_QUOTE_LENGTH] characters,
      * then shuffles with a deterministic seed for reproducibility within the same dataset.
      *
-     * @param candidates List of (text, submittedAt) pairs
+     * @param candidates List of (text, answeredAt) pairs
      * @param targetCount Maximum number of quotes to return (default 5)
      * @param seed Random seed for reproducible shuffling
      */
@@ -35,7 +35,7 @@ object QuoteSelector {
         return eligible
             .shuffled(Random(seed))
             .take(targetCount)
-            .map { (text, submittedAt) -> QuoteEntry(text = text, answeredAt = submittedAt) }
+            .map { (text, answeredAt) -> QuoteEntry(text = text, answeredAt = answeredAt) }
     }
 
     /**

--- a/apps/lumi-api/src/test/kotlin/no/nav/lumi/service/DiscoveryServiceTest.kt
+++ b/apps/lumi-api/src/test/kotlin/no/nav/lumi/service/DiscoveryServiceTest.kt
@@ -161,7 +161,7 @@ class DiscoveryServiceTest : FunSpec({
             test("confidenceLevel reflects total submissions") {
                 val fewFeedbacks = (1..10).map { createDiscoveryFeedback("tekst $it", "yes") }
                 val result = service.processStats(fewFeedbacks, emptyList())
-                result.confidenceLevel shouldBe "low"
+                result.confidenceLevel shouldBe ConfidenceLevel.LOW
             }
 
             test("wordFrequency is unchanged with bigram addition") {

--- a/apps/lumi-api/src/test/kotlin/no/nav/lumi/service/DiscoveryServiceTest.kt
+++ b/apps/lumi-api/src/test/kotlin/no/nav/lumi/service/DiscoveryServiceTest.kt
@@ -135,6 +135,46 @@ class DiscoveryServiceTest : FunSpec({
             
             result.recentResponses shouldHaveSize DiscoveryService.MAX_RECENT_RESPONSES
         }
+
+        context("bigram extraction in processStats") {
+            test("extracts phrases from repeated bigrams") {
+                val feedbacks = listOf(
+                    createDiscoveryFeedback("vanskelig å svare på spørsmålene", "no"),
+                    createDiscoveryFeedback("vanskelig å svare riktig", "partial"),
+                    createDiscoveryFeedback("helt greit å bruke skjemaet", "yes"),
+                )
+                val result = service.processStats(feedbacks, emptyList())
+
+                result.phrases.any { it.text.contains("vanskelig") && it.text.contains("svar") } shouldBe true
+                result.phrases.first { it.text.contains("vanskelig") }.count shouldBe 2
+            }
+
+            test("bigrams with only 1 occurrence are excluded") {
+                val feedbacks = listOf(
+                    createDiscoveryFeedback("dårlig design overalt", "no"),
+                    createDiscoveryFeedback("god brukeropplevelse ellers", "yes"),
+                )
+                val result = service.processStats(feedbacks, emptyList())
+                result.phrases.shouldBeEmpty()
+            }
+
+            test("confidenceLevel reflects total submissions") {
+                val fewFeedbacks = (1..10).map { createDiscoveryFeedback("tekst $it", "yes") }
+                val result = service.processStats(fewFeedbacks, emptyList())
+                result.confidenceLevel shouldBe "low"
+            }
+
+            test("wordFrequency is unchanged with bigram addition") {
+                val feedbacks = listOf(
+                    createDiscoveryFeedback("vanskelig å svare", "no"),
+                    createDiscoveryFeedback("vanskelig å svare riktig", "partial"),
+                )
+                val result = service.processStats(feedbacks, emptyList())
+
+                result.wordFrequency.isNotEmpty() shouldBe true
+                result.phrases.isNotEmpty() shouldBe true
+            }
+        }
     }
 })
 

--- a/apps/lumi-api/src/test/kotlin/no/nav/lumi/service/TextProcessorTest.kt
+++ b/apps/lumi-api/src/test/kotlin/no/nav/lumi/service/TextProcessorTest.kt
@@ -2,6 +2,7 @@ package no.nav.lumi.service
 
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.collections.shouldContain
+import io.kotest.matchers.collections.shouldHaveSize
 import io.kotest.matchers.collections.shouldNotContain
 import io.kotest.matchers.shouldBe
 import no.nav.lumi.service.text.NorwegianLightStemmer
@@ -100,6 +101,38 @@ class TextProcessorTest : FunSpec({
             tokens shouldContain "enten"
             tokens shouldContain "disse"
             tokens shouldContain "veldig"
+        }
+    }
+
+    context("extractBigrams") {
+        test("pairs adjacent content words, skipping stopwords") {
+            val bigrams = TextProcessor.extractBigrams("vanskelig å svare")
+            bigrams shouldHaveSize 1
+            bigrams[0].surface shouldBe "vanskelig svare"
+        }
+
+        test("generates multiple bigrams from content words") {
+            val bigrams = TextProcessor.extractBigrams("dårlig design er helt forvirrende")
+            bigrams shouldHaveSize 2
+            bigrams[0].surface shouldBe "dårlig design"
+            bigrams[1].surface shouldBe "design forvirrende"
+        }
+
+        test("returns empty for text with fewer than 2 content words") {
+            TextProcessor.extractBigrams("bare stoppord og ja") shouldHaveSize 0
+            TextProcessor.extractBigrams("hjelp") shouldHaveSize 0
+            TextProcessor.extractBigrams("") shouldHaveSize 0
+        }
+
+        test("stem key groups inflected forms") {
+            val bg1 = TextProcessor.extractBigrams("digitale søknader")
+            val bg2 = TextProcessor.extractBigrams("digital søknaden")
+            bg1[0].stemKey shouldBe bg2[0].stemKey
+        }
+
+        test("stem key uses pipe separator") {
+            val bigrams = TextProcessor.extractBigrams("dårlig design")
+            bigrams[0].stemKey.contains("|") shouldBe true
         }
     }
 

--- a/apps/lumi-api/src/test/kotlin/no/nav/lumi/service/text/BigramAccumulatorTest.kt
+++ b/apps/lumi-api/src/test/kotlin/no/nav/lumi/service/text/BigramAccumulatorTest.kt
@@ -1,0 +1,51 @@
+package no.nav.lumi.service.text
+
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.collections.shouldHaveSize
+import io.kotest.matchers.shouldBe
+
+class BigramAccumulatorTest : FunSpec({
+
+    test("counts unique responses, not total occurrences") {
+        val acc = BigramAccumulator("dårlig|design")
+        acc.addOccurrence("dårlig design", "r1")
+        acc.addOccurrence("dårlig design", "r1")
+        acc.totalCount shouldBe 1
+    }
+
+    test("counts distinct responses") {
+        val acc = BigramAccumulator("dårlig|design")
+        acc.addOccurrence("dårlig design", "r1")
+        acc.addOccurrence("dårlig design", "r2")
+        acc.addOccurrence("dårlige design", "r3")
+        acc.totalCount shouldBe 3
+    }
+
+    test("canonical surface is most common form") {
+        val acc = BigramAccumulator("dårlig|design")
+        acc.addOccurrence("dårlig design", "r1")
+        acc.addOccurrence("dårlig design", "r2")
+        acc.addOccurrence("dårlige design", "r3")
+        acc.getCanonicalSurface() shouldBe "dårlig design"
+    }
+
+    test("canonical surface tiebreaks alphabetically") {
+        val acc = BigramAccumulator("test|key")
+        acc.addOccurrence("beta form", "r1")
+        acc.addOccurrence("alpha form", "r2")
+        acc.getCanonicalSurface() shouldBe "alpha form"
+    }
+
+    test("toPhraseEntry respects maxSourceIds") {
+        val acc = BigramAccumulator("test|key")
+        repeat(10) { acc.addOccurrence("test phrase", "r$it") }
+        val entry = acc.toPhraseEntry(maxSourceIds = 3)
+        entry.sourceResponseIds shouldHaveSize 3
+        entry.count shouldBe 10
+    }
+
+    test("empty accumulator returns stemKey as canonical") {
+        val acc = BigramAccumulator("foo|bar")
+        acc.getCanonicalSurface() shouldBe "foo|bar"
+    }
+})

--- a/apps/lumi-api/src/test/kotlin/no/nav/lumi/service/text/BigramAccumulatorTest.kt
+++ b/apps/lumi-api/src/test/kotlin/no/nav/lumi/service/text/BigramAccumulatorTest.kt
@@ -44,6 +44,15 @@ class BigramAccumulatorTest : FunSpec({
         entry.count shouldBe 10
     }
 
+    test("caps internal sourceResponseIds at default max") {
+        val acc = BigramAccumulator("test|key")
+        repeat(20) { acc.addOccurrence("test phrase", "r$it") }
+        // Internal list capped at DEFAULT_MAX_SOURCE_IDS (5), but count tracks all
+        val entry = acc.toPhraseEntry()
+        entry.sourceResponseIds shouldHaveSize BigramAccumulator.DEFAULT_MAX_SOURCE_IDS
+        entry.count shouldBe 20
+    }
+
     test("empty accumulator returns stemKey as canonical") {
         val acc = BigramAccumulator("foo|bar")
         acc.getCanonicalSurface() shouldBe "foo|bar"

--- a/apps/lumi-api/src/test/kotlin/no/nav/lumi/service/text/QuoteSelectorTest.kt
+++ b/apps/lumi-api/src/test/kotlin/no/nav/lumi/service/text/QuoteSelectorTest.kt
@@ -1,0 +1,61 @@
+package no.nav.lumi.service.text
+
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.collections.shouldBeEmpty
+import io.kotest.matchers.collections.shouldHaveSize
+import io.kotest.matchers.shouldBe
+
+class QuoteSelectorTest : FunSpec({
+
+    context("selectQuotes") {
+        test("filters by length (30-300 chars)") {
+            val candidates = listOf(
+                "Short" to "2024-01-01T00:00:00Z",
+                "This is a quote that is long enough to pass the filter" to "2024-01-02T00:00:00Z",
+                "x".repeat(301) to "2024-01-03T00:00:00Z",
+            )
+            val quotes = QuoteSelector.selectQuotes(candidates, seed = 42L)
+            quotes shouldHaveSize 1
+            quotes[0].text shouldBe "This is a quote that is long enough to pass the filter"
+        }
+
+        test("returns empty for no eligible candidates") {
+            val candidates = listOf("Too short" to "2024-01-01T00:00:00Z")
+            QuoteSelector.selectQuotes(candidates, seed = 42L).shouldBeEmpty()
+        }
+
+        test("deterministic with same seed") {
+            val candidates = (1..20).map {
+                "Quote number $it with enough length to pass filter" to "2024-01-${it.toString().padStart(2, '0')}T00:00:00Z"
+            }
+            val first = QuoteSelector.selectQuotes(candidates, seed = 123L)
+            val second = QuoteSelector.selectQuotes(candidates, seed = 123L)
+            first shouldBe second
+        }
+
+        test("respects targetCount") {
+            val candidates = (1..20).map {
+                "Quote number $it with enough length to pass filter" to "2024-01-${it.toString().padStart(2, '0')}T00:00:00Z"
+            }
+            val quotes = QuoteSelector.selectQuotes(candidates, targetCount = 3, seed = 42L)
+            quotes shouldHaveSize 3
+        }
+    }
+
+    context("confidenceLevel") {
+        test("low for fewer than 30 responses") {
+            QuoteSelector.confidenceLevel(0) shouldBe "low"
+            QuoteSelector.confidenceLevel(29) shouldBe "low"
+        }
+
+        test("medium for 30-100 responses") {
+            QuoteSelector.confidenceLevel(30) shouldBe "medium"
+            QuoteSelector.confidenceLevel(100) shouldBe "medium"
+        }
+
+        test("high for more than 100 responses") {
+            QuoteSelector.confidenceLevel(101) shouldBe "high"
+            QuoteSelector.confidenceLevel(1000) shouldBe "high"
+        }
+    }
+})

--- a/apps/lumi-api/src/test/kotlin/no/nav/lumi/service/text/QuoteSelectorTest.kt
+++ b/apps/lumi-api/src/test/kotlin/no/nav/lumi/service/text/QuoteSelectorTest.kt
@@ -4,6 +4,7 @@ import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.collections.shouldBeEmpty
 import io.kotest.matchers.collections.shouldHaveSize
 import io.kotest.matchers.shouldBe
+import no.nav.lumi.domain.ConfidenceLevel
 
 class QuoteSelectorTest : FunSpec({
 
@@ -44,18 +45,18 @@ class QuoteSelectorTest : FunSpec({
 
     context("confidenceLevel") {
         test("low for fewer than 30 responses") {
-            QuoteSelector.confidenceLevel(0) shouldBe "low"
-            QuoteSelector.confidenceLevel(29) shouldBe "low"
+            QuoteSelector.confidenceLevel(0) shouldBe ConfidenceLevel.LOW
+            QuoteSelector.confidenceLevel(29) shouldBe ConfidenceLevel.LOW
         }
 
         test("medium for 30-100 responses") {
-            QuoteSelector.confidenceLevel(30) shouldBe "medium"
-            QuoteSelector.confidenceLevel(100) shouldBe "medium"
+            QuoteSelector.confidenceLevel(30) shouldBe ConfidenceLevel.MEDIUM
+            QuoteSelector.confidenceLevel(100) shouldBe ConfidenceLevel.MEDIUM
         }
 
         test("high for more than 100 responses") {
-            QuoteSelector.confidenceLevel(101) shouldBe "high"
-            QuoteSelector.confidenceLevel(1000) shouldBe "high"
+            QuoteSelector.confidenceLevel(101) shouldBe ConfidenceLevel.HIGH
+            QuoteSelector.confidenceLevel(1000) shouldBe ConfidenceLevel.HIGH
         }
     }
 })

--- a/packages/lumi-types/src/api.ts
+++ b/packages/lumi-types/src/api.ts
@@ -343,6 +343,19 @@ export interface WordFrequency {
   sourceResponses?: SourceResponse[];
 }
 
+export interface PhraseEntry {
+  text: string;
+  count: number;
+  sourceResponseIds: string[];
+}
+
+export interface QuoteEntry {
+  text: string;
+  answeredAt: string;
+}
+
+export type ConfidenceLevel = "low" | "medium" | "high";
+
 export interface DiscoveryTheme {
   theme: string;
   count: number;
@@ -360,6 +373,9 @@ export interface DiscoveryResponse {
     blocker?: string;
     submittedAt: string;
   }>;
+  phrases?: PhraseEntry[];
+  quotes?: QuoteEntry[];
+  confidenceLevel?: ConfidenceLevel;
 }
 
 // ============================================
@@ -383,6 +399,9 @@ export interface BlockerResponse {
     task: string;
     submittedAt: string;
   }>;
+  phrases?: PhraseEntry[];
+  quotes?: QuoteEntry[];
+  confidenceLevel?: ConfidenceLevel;
 }
 
 // ============================================

--- a/packages/lumi-types/src/schemas.ts
+++ b/packages/lumi-types/src/schemas.ts
@@ -761,6 +761,19 @@ const WordFrequencySchema = z.object({
   sourceResponses: z.array(SourceResponseSchema).optional(),
 });
 
+const PhraseEntrySchema = z.object({
+  text: z.string(),
+  count: z.number(),
+  sourceResponseIds: z.array(z.string()),
+});
+
+const QuoteEntrySchema = z.object({
+  text: z.string(),
+  answeredAt: z.string(),
+});
+
+const ConfidenceLevelSchema = z.enum(["low", "medium", "high"]);
+
 // Discovery schemas
 const DiscoveryThemeSchema = z.object({
   theme: z.string(),
@@ -781,6 +794,9 @@ export const DiscoveryResponseSchema = z.object({
       submittedAt: z.string(),
     }),
   ),
+  phrases: z.array(PhraseEntrySchema).optional(),
+  quotes: z.array(QuoteEntrySchema).optional(),
+  confidenceLevel: ConfidenceLevelSchema.optional(),
 });
 
 // Blocker schemas (for Top Tasks)
@@ -803,6 +819,9 @@ export const BlockerResponseSchema = z.object({
       submittedAt: z.string(),
     }),
   ),
+  phrases: z.array(PhraseEntrySchema).optional(),
+  quotes: z.array(QuoteEntrySchema).optional(),
+  confidenceLevel: ConfidenceLevelSchema.optional(),
 });
 
 // Task Priority schemas


### PR DESCRIPTION
## Hva

Legger til bigram-fraseutvinning, representative sitater og konfidensindikator i Discovery- og Blocker-API-responsene. Første backend-del av epic #246.

Closes #248
Del av epic: #246

## Endringer

### Nytt
- `TextProcessor.extractBigrams()` — skippar stoppord, stemmer og grupperer nabopar
- `BigramAccumulator` — per-respons dedup, kanonisk overflateform, cappa sourceResponseIds
- `QuoteSelector` — seedet tilfeldig utvalg (30–300 tegn), `ConfidenceLevel` enum
- `PhraseEntry`, `QuoteEntry`, `ConfidenceLevel` Kotlin DTOer + TS-typer + Zod-skjemaer

### Integrert
- `DiscoveryService.processStats()` — frasene inn i pipelinen
- `FeedbackStatsRepository.getBlockerStats()` — frasene inn i blocker-pipelinen
- Sortert blocker-input etter submittedAt for determinisme

### Inspektør-fikser (andre commit)
- `ConfidenceLevel`: String → Kotlin enum med `@SerialName`
- QuoteSelector seed: xor med første feedback ID for unikhet per datasett
- BigramAccumulator: cap `_sourceResponseIds` i `addOccurrence()`
- BlockerStats: sorter input etter `submittedAt` for determinisme

## Verifisert

- [x] `./gradlew compileKotlin` ✅
- [x] Unit tests (TextProcessor, BigramAccumulator, QuoteSelector, DiscoveryService) ✅
- [x] `pnpm run lint` ✅
- [x] `pnpm run typecheck` ✅
- [x] Dobbel gjennomgang → 4 funn fikset

## Merknader

- `wordFrequency` beholdes for bakoverkompatibilitet (fjernes i #251)
- TS-typer bruker optional (?`) for å tåle gamle Valkey-cache-entries
- Fullstendig `./gradlew test` ikke kjørt (Testcontainers/Docker utilgjengelig lokalt)
