### PR TITLE
feat(fieldstats): add bigram phrases to TextFieldCard

### DIFF
--- a/apps/lumi-api/src/main/kotlin/no/nav/lumi/domain/Models.kt
+++ b/apps/lumi-api/src/main/kotlin/no/nav/lumi/domain/Models.kt
@@ -314,6 +314,7 @@ sealed class FieldStats {
         val responseCount: Int,
         val responseRate: Double,
         val topKeywords: List<KeywordCount> = emptyList(),
+        val topPhrases: List<TextPhrase> = emptyList(),
         val recentResponses: List<RecentTextResponse> = emptyList()
     ) : FieldStats()
 
@@ -332,6 +333,9 @@ data class KeywordCount(
     val word: String,
     val count: Int
 )
+
+@Serializable
+data class TextPhrase(val text: String, val count: Int)
 
 @Serializable
 data class RecentTextResponse(

--- a/apps/lumi-api/src/main/kotlin/no/nav/lumi/repository/FeedbackStatsHelpers.kt
+++ b/apps/lumi-api/src/main/kotlin/no/nav/lumi/repository/FeedbackStatsHelpers.kt
@@ -115,7 +115,8 @@ internal fun buildFieldStats(records: List<FeedbackDto>): List<FieldStat> {
                         bigramCounts[bigram] = (bigramCounts[bigram] ?: 0) + 1
                     }
 
-                    for (bigram in bigrams) {
+                    // Dedup surfaces per response to avoid bias from repeated phrases
+                    for (bigram in bigrams.distinctBy { it.stemKey to it.surface }) {
                         val surfaces = bigramSurfaces.getOrPut(bigram.stemKey) { mutableMapOf() }
                         surfaces[bigram.surface] = (surfaces[bigram.surface] ?: 0) + 1
                     }

--- a/apps/lumi-api/src/main/kotlin/no/nav/lumi/repository/FeedbackStatsHelpers.kt
+++ b/apps/lumi-api/src/main/kotlin/no/nav/lumi/repository/FeedbackStatsHelpers.kt
@@ -92,6 +92,8 @@ internal fun buildFieldStats(records: List<FeedbackDto>): List<FieldStat> {
             FieldType.TEXT -> {
                 val texts = mutableListOf<RecentTextResponse>()
                 val wordAccumulators = mutableMapOf<String, StemWordAccumulator>()
+                val bigramCounts = mutableMapOf<String, Int>()
+                val bigramSurfaces = mutableMapOf<String, MutableMap<String, Int>>()
                 var responseCount = 0
 
                 for ((dto, answer) in entries) {
@@ -106,6 +108,17 @@ internal fun buildFieldStats(records: List<FeedbackDto>): List<FieldStat> {
                         val acc = wordAccumulators.getOrPut(stem) { StemWordAccumulator(stem) }
                         acc.addOccurrence(word)
                     }
+
+                    val bigrams = TextProcessor.extractBigrams(text)
+
+                    for (bigram in bigrams.map { it.stemKey }.toSet()) {
+                        bigramCounts[bigram] = (bigramCounts[bigram] ?: 0) + 1
+                    }
+
+                    for (bigram in bigrams) {
+                        val surfaces = bigramSurfaces.getOrPut(bigram.stemKey) { mutableMapOf() }
+                        surfaces[bigram.surface] = (surfaces[bigram.surface] ?: 0) + 1
+                    }
                 }
 
                 val responseRate = if (totalFeedbackCount > 0) {
@@ -118,6 +131,17 @@ internal fun buildFieldStats(records: List<FeedbackDto>): List<FieldStat> {
                     .sortedWith(compareByDescending<StemWordAccumulator> { it.totalCount }.thenBy { it.stem })
                     .take(10)
                     .map { acc -> KeywordCount(word = acc.getCanonicalForm(), count = acc.totalCount) }
+
+                val topPhrases = bigramCounts.entries
+                    .asSequence()
+                    .filter { it.value >= 2 }
+                    .sortedWith(compareByDescending<Map.Entry<String, Int>> { it.value }.thenBy { it.key })
+                    .take(10)
+                    .map { (stemKey, count) ->
+                        val bestSurface = bigramSurfaces[stemKey]?.maxByOrNull { it.value }?.key ?: stemKey
+                        TextPhrase(text = bestSurface, count = count)
+                    }
+                    .toList()
 
                 val recentResponses = texts
                     .sortedByDescending { parseSubmittedAt(it.submittedAt) }
@@ -132,6 +156,7 @@ internal fun buildFieldStats(records: List<FeedbackDto>): List<FieldStat> {
                             responseCount = responseCount,
                             responseRate = responseRate,
                             topKeywords = topKeywords,
+                            topPhrases = topPhrases,
                             recentResponses = recentResponses
                         )
                     )

--- a/apps/lumi-api/src/main/kotlin/no/nav/lumi/service/TextProcessor.kt
+++ b/apps/lumi-api/src/main/kotlin/no/nav/lumi/service/TextProcessor.kt
@@ -7,7 +7,8 @@ import no.nav.lumi.service.text.NorwegianLightStemmer
  * Consolidates text processing logic used across different services and repositories.
  */
 object TextProcessor {
-    private val redactionMarkerRegex = Regex("\\[[A-ZÆØÅ][A-ZÆØÅ\\s-]*FJERNET]")
+    // Matches all redaction markers: [FØDSELSNUMMER FJERNET], [HEMMELIG ADRESSE], etc.
+    private val redactionMarkerRegex = Regex("\\[[A-ZÆØÅ][A-ZÆØÅ\\s-]+]")
     private val tokenCleanupRegex = Regex("[^a-zæøåA-ZÆØÅ0-9\\s]")
     private val whitespaceRegex = Regex("\\s+")
 

--- a/apps/lumi-api/src/main/kotlin/no/nav/lumi/service/TextProcessor.kt
+++ b/apps/lumi-api/src/main/kotlin/no/nav/lumi/service/TextProcessor.kt
@@ -7,6 +7,9 @@ import no.nav.lumi.service.text.NorwegianLightStemmer
  * Consolidates text processing logic used across different services and repositories.
  */
 object TextProcessor {
+    private val redactionMarkerRegex = Regex("\\[[A-ZÆØÅ][A-ZÆØÅ\\s-]*FJERNET]")
+    private val tokenCleanupRegex = Regex("[^a-zæøåA-ZÆØÅ0-9\\s]")
+    private val whitespaceRegex = Regex("\\s+")
 
     /**
      * Norwegian stop words — data-driven from analysis of 1 283 production survey responses.
@@ -73,10 +76,15 @@ object TextProcessor {
      * Used for theme matching where any word — including stopwords — may be a keyword.
      */
     fun tokenize(text: String): List<String> {
-        return text.lowercase()
-            .replace(Regex("[^a-zæøåA-ZÆØÅ0-9\\s]"), " ")
-            .split(Regex("\\s+"))
-            .filter { it.length > 2 }
+        return rawTokens(text).filter { it.length > 2 }
+    }
+
+    private fun rawTokens(text: String): List<String> {
+        return text.replace(redactionMarkerRegex, " ")
+            .lowercase()
+            .replace(tokenCleanupRegex, " ")
+            .split(whitespaceRegex)
+            .filter { it.isNotBlank() }
     }
 
     /**

--- a/apps/lumi-api/src/test/kotlin/no/nav/lumi/repository/FeedbackStatsHelpersTest.kt
+++ b/apps/lumi-api/src/test/kotlin/no/nav/lumi/repository/FeedbackStatsHelpersTest.kt
@@ -1,11 +1,15 @@
 package no.nav.lumi.repository
 
 import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.collections.shouldContain
+import io.kotest.matchers.collections.shouldHaveSize
+import io.kotest.matchers.collections.shouldNotContain
 import io.kotest.matchers.shouldBe
 import no.nav.lumi.domain.Answer
 import no.nav.lumi.domain.AnswerValue
 import no.nav.lumi.domain.ChoiceOption
 import no.nav.lumi.domain.FeedbackDto
+import no.nav.lumi.domain.FieldStats
 import no.nav.lumi.domain.FieldType
 import no.nav.lumi.domain.Question
 import no.nav.lumi.domain.SurveyType
@@ -32,11 +36,11 @@ class FeedbackStatsHelpersTest : FunSpec({
         value = AnswerValue.SingleChoice(selectedOptionId = "often")
     )
 
-    fun textAnswer() = Answer(
+    fun textAnswer(text: String = "Kommentar") = Answer(
         fieldId = "text-comment",
         fieldType = FieldType.TEXT,
         question = Question(label = "Q3"),
-        value = AnswerValue.Text(text = "Kommentar")
+        value = AnswerValue.Text(text = text)
     )
 
     fun multiChoiceAnswer() = Answer(
@@ -158,5 +162,52 @@ class FeedbackStatsHelpersTest : FunSpec({
             "multi-choice"
         )
         fieldIdsInReverseOrder shouldBe fieldIdsInForwardOrder
+    }
+
+    test("buildFieldStats returns top phrases with per-response deduplication and max 10 entries") {
+        val repeatedPhraseText = "digital søknad digital søknad hjelper"
+        val longPhraseText = "anker bjerk cider drage elgen fabel glimt havet isbre jolle kanel lampe måne"
+        val uniquePhraseText = "ensom frase unik"
+
+        val textStats = buildFieldStats(
+            listOf(
+                feedbackDto(
+                    id = "text-1",
+                    submittedAt = "2026-01-21T10:00:00Z",
+                    answers = listOf(textAnswer(repeatedPhraseText))
+                ),
+                feedbackDto(
+                    id = "text-2",
+                    submittedAt = "2026-01-21T10:01:00Z",
+                    answers = listOf(textAnswer("digitale søknader hjelper"))
+                ),
+                feedbackDto(
+                    id = "text-3",
+                    submittedAt = "2026-01-21T10:02:00Z",
+                    answers = listOf(textAnswer("digital søknad fungerer"))
+                ),
+                feedbackDto(
+                    id = "text-4",
+                    submittedAt = "2026-01-21T10:03:00Z",
+                    answers = listOf(textAnswer(longPhraseText))
+                ),
+                feedbackDto(
+                    id = "text-5",
+                    submittedAt = "2026-01-21T10:04:00Z",
+                    answers = listOf(textAnswer(longPhraseText))
+                ),
+                feedbackDto(
+                    id = "text-6",
+                    submittedAt = "2026-01-21T10:05:00Z",
+                    answers = listOf(textAnswer(uniquePhraseText))
+                )
+            )
+        ).single().stats as FieldStats.Text
+
+        textStats.topPhrases shouldHaveSize 10
+        textStats.topPhrases.map { it.text } shouldContain "digital søknad"
+        textStats.topPhrases.map { it.text } shouldContain "anker bjerk"
+        textStats.topPhrases.map { it.text } shouldNotContain "ensom frase"
+        textStats.topPhrases.first { it.text == "digital søknad" }.count shouldBe 3
     }
 })

--- a/apps/lumi-api/src/test/kotlin/no/nav/lumi/service/TextProcessorTest.kt
+++ b/apps/lumi-api/src/test/kotlin/no/nav/lumi/service/TextProcessorTest.kt
@@ -84,6 +84,16 @@ class TextProcessorTest : FunSpec({
             words shouldContain "very"
             words shouldContain "good"
         }
+
+        test("strips redaction markers so PII labels do not appear as keywords") {
+            val words = TextProcessor.extractWords(
+                "Min fnr er [FØDSELSNUMMER FJERNET] og mail er [E-POST FJERNET]"
+            )
+
+            words shouldNotContain "fødselsnummer"
+            words shouldNotContain "fjernet"
+            words shouldContain "mail"
+        }
     }
 
     context("tokenize") {
@@ -133,6 +143,21 @@ class TextProcessorTest : FunSpec({
         test("stem key uses pipe separator") {
             val bigrams = TextProcessor.extractBigrams("dårlig design")
             bigrams[0].stemKey.contains("|") shouldBe true
+        }
+
+        test("strips redaction markers before forming bigrams") {
+            val bigrams = TextProcessor.extractBigrams("ring [TELEFON FJERNET] snarest")
+
+            bigrams.map { it.surface } shouldNotContain "telefon"
+            bigrams.any { it.surface == "ring snarest" } shouldBe true
+        }
+
+        test("strips multi-word redaction markers like MULIG NAVN FJERNET") {
+            val bigrams = TextProcessor.extractBigrams("kontaktet [MULIG NAVN FJERNET] igår")
+
+            bigrams.flatMap { it.surface.split(" ") } shouldNotContain "mulig"
+            bigrams.flatMap { it.surface.split(" ") } shouldNotContain "navn"
+            bigrams.any { it.surface == "kontaktet igår" } shouldBe true
         }
     }
 

--- a/apps/lumi-api/src/test/kotlin/no/nav/lumi/service/TextProcessorTest.kt
+++ b/apps/lumi-api/src/test/kotlin/no/nav/lumi/service/TextProcessorTest.kt
@@ -94,6 +94,17 @@ class TextProcessorTest : FunSpec({
             words shouldNotContain "fjernet"
             words shouldContain "mail"
         }
+
+        test("strips redaction markers without FJERNET suffix like HEMMELIG ADRESSE") {
+            val words = TextProcessor.extractWords(
+                "Bor på [HEMMELIG ADRESSE] og trenger hjelp"
+            )
+
+            words shouldNotContain "hemmelig"
+            words shouldNotContain "adresse"
+            words shouldContain "trenger"
+            words shouldContain "hjelp"
+        }
     }
 
     context("tokenize") {

--- a/apps/lumi-dashboard/app/components/dashboard/sections/FieldStats/FieldCards/TextFieldCard.module.css
+++ b/apps/lumi-dashboard/app/components/dashboard/sections/FieldStats/FieldCards/TextFieldCard.module.css
@@ -13,6 +13,58 @@
   font-size: 0.75rem;
 }
 
+.phraseList {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+.phraseLink {
+  display: block;
+  padding: var(--ax-space-4) var(--ax-space-8);
+  border-radius: var(--ax-border-radius-medium);
+  text-decoration: none;
+  color: inherit;
+  transition: background-color 0.15s ease;
+}
+
+.phraseLink:hover {
+  background-color: var(--ax-bg-neutral-moderate-hover);
+}
+
+.phraseLink:focus-visible {
+  outline: 2px solid var(--ax-border-focus);
+  outline-offset: 2px;
+}
+
+.phraseProgress {
+  width: 50px;
+  height: 5px;
+  border-radius: 3px;
+  appearance: none;
+  overflow: hidden;
+  background: var(--ax-bg-neutral-moderate);
+}
+
+.phraseProgress::-webkit-progress-bar {
+  background: var(--ax-bg-neutral-moderate);
+  border-radius: 3px;
+}
+
+.phraseProgress::-webkit-progress-value {
+  background: var(--ax-border-accent);
+  border-radius: 3px;
+}
+
+.phraseProgress::-moz-progress-bar {
+  background: var(--ax-border-accent);
+  border-radius: 3px;
+}
+
+.phraseMeta {
+  flex-shrink: 0;
+}
+
 .responseCard {
   padding: 0.5rem 0.75rem;
   background-color: var(--ax-bg-neutral-soft);

--- a/apps/lumi-dashboard/app/components/dashboard/sections/FieldStats/FieldCards/TextFieldCard.tsx
+++ b/apps/lumi-dashboard/app/components/dashboard/sections/FieldStats/FieldCards/TextFieldCard.tsx
@@ -1,5 +1,6 @@
 import { ChatExclamationmarkIcon } from "@navikt/aksel-icons";
-import { BodyShort, HStack, Tag, VStack } from "@navikt/ds-react";
+import { BodyShort, Detail, HStack, Tag, VStack } from "@navikt/ds-react";
+import { Link } from "@tanstack/react-router";
 
 import { DashboardCard } from "~/components/dashboard";
 import type { TextStats } from "~/types/api";
@@ -9,10 +10,19 @@ import { FieldCardHeader } from "./FieldCardHeader";
 import styles from "./TextFieldCard.module.css";
 import type { FieldCardProps } from "./types";
 
+// Phrase rendering is intentionally inlined rather than reusing PhraseList,
+// because PhraseList wraps itself in DashboardCard — and TextFieldCard IS a
+// DashboardCard, which would cause visual nesting. Extract a shared
+// "PhraseItems" sub-component if a third consumer appears.
 export function TextFieldCard({ field, totalCount }: FieldCardProps) {
   const stats = field.stats as TextStats;
   const responseRate =
     totalCount > 0 ? Math.round((stats.responseCount / totalCount) * 100) : 0;
+
+  const phrases = stats.topPhrases ?? [];
+  const hasPhrases = phrases.length > 0;
+  const displayedPhrases = phrases.slice(0, 5);
+  const maxCount = displayedPhrases[0]?.count ?? 1;
 
   const hasKeywords = stats.topKeywords && stats.topKeywords.length > 0;
   const hasRecentResponses =
@@ -27,29 +37,82 @@ export function TextFieldCard({ field, totalCount }: FieldCardProps) {
         subtitle={`${stats.responseCount} av ${totalCount} har svart (${responseRate}%)`}
       />
 
-      {hasKeywords && (
+      {hasPhrases ? (
         <VStack gap="space-8" marginBlock="space-12 space-0">
           <BodyShort
             size="small"
             weight="semibold"
             className={styles.sectionHeading}
           >
-            Hyppigste ord
+            Hyppigste fraser
           </BodyShort>
-          <HStack gap="space-8" wrap>
-            {stats.topKeywords.map(({ word, count }) => (
-              <Tag
-                data-color="neutral"
-                key={word}
-                size="small"
-                variant="outline"
-              >
-                {word}
-                <span className={styles.keywordCount}>{count}</span>
-              </Tag>
+          <ol className={styles.phraseList} aria-label="Hyppigste fraser">
+            {displayedPhrases.map((phrase) => (
+              <li key={phrase.text}>
+                <Link
+                  to="/feedback"
+                  search={(prev) => ({
+                    ...prev,
+                    query: phrase.text,
+                    page: "1",
+                    hasText: "true",
+                  })}
+                  className={styles.phraseLink}
+                  aria-label={`Vis ${phrase.count} tilbakemeldinger som inneholder frasen «${phrase.text}»`}
+                >
+                  <HStack
+                    align="center"
+                    gap="space-8"
+                    justify="space-between"
+                    wrap={false}
+                  >
+                    <BodyShort size="small" weight="semibold" truncate>
+                      {phrase.text}
+                    </BodyShort>
+                    <HStack
+                      gap="space-8"
+                      align="center"
+                      className={styles.phraseMeta}
+                    >
+                      <progress
+                        className={styles.phraseProgress}
+                        value={phrase.count}
+                        max={maxCount}
+                        aria-hidden
+                      />
+                      <Detail>{phrase.count}</Detail>
+                    </HStack>
+                  </HStack>
+                </Link>
+              </li>
             ))}
-          </HStack>
+          </ol>
         </VStack>
+      ) : (
+        hasKeywords && (
+          <VStack gap="space-8" marginBlock="space-12 space-0">
+            <BodyShort
+              size="small"
+              weight="semibold"
+              className={styles.sectionHeading}
+            >
+              Hyppigste ord
+            </BodyShort>
+            <HStack gap="space-8" wrap>
+              {stats.topKeywords.map(({ word, count }) => (
+                <Tag
+                  data-color="neutral"
+                  key={word}
+                  size="small"
+                  variant="outline"
+                >
+                  {word}
+                  <span className={styles.keywordCount}>{count}</span>
+                </Tag>
+              ))}
+            </HStack>
+          </VStack>
+        )
       )}
 
       {hasRecentResponses && (
@@ -79,7 +142,7 @@ export function TextFieldCard({ field, totalCount }: FieldCardProps) {
         </VStack>
       )}
 
-      {!hasKeywords && !hasRecentResponses && (
+      {!hasPhrases && !hasKeywords && !hasRecentResponses && (
         <BodyShort size="small" className={styles.emptyState}>
           Ingen tekstsvar ennå
         </BodyShort>

--- a/apps/lumi-dashboard/app/components/dashboard/sections/FieldStats/FieldCards/__tests__/TextFieldCard.test.tsx
+++ b/apps/lumi-dashboard/app/components/dashboard/sections/FieldStats/FieldCards/__tests__/TextFieldCard.test.tsx
@@ -1,0 +1,178 @@
+import { createMemoryHistory } from "@tanstack/history";
+import {
+  createRootRoute,
+  createRoute,
+  createRouter,
+  RouterProvider,
+} from "@tanstack/react-router";
+import { render, screen } from "@testing-library/react";
+import { createElement } from "react";
+import { describe, expect, it } from "vitest";
+
+import type { FieldStat, TextStats } from "~/types/api";
+import { TextFieldCard } from "../TextFieldCard";
+
+async function renderWithRouter(ui: React.ReactElement) {
+  const rootRoute = createRootRoute({ component: () => ui });
+  const feedbackRoute = createRoute({
+    getParentRoute: () => rootRoute,
+    path: "/feedback",
+    component: () => null,
+  });
+  const router = createRouter({
+    routeTree: rootRoute.addChildren([feedbackRoute]),
+    history: createMemoryHistory({ initialEntries: ["/"] }),
+  });
+
+  await router.load();
+  const result = render(createElement(RouterProvider, { router }));
+  return result;
+}
+
+const mockTextStatsWithPhrases: TextStats = {
+  type: "text",
+  responseCount: 82,
+  responseRate: 68,
+  topKeywords: [
+    { word: "vanskelig", count: 8 },
+    { word: "forstå", count: 6 },
+  ],
+  topPhrases: [
+    { text: "vanskelig forstå", count: 8 },
+    { text: "digitale tjenester", count: 6 },
+    { text: "god dialog", count: 5 },
+    { text: "litt tungvint", count: 4 },
+    { text: "svare mobilen", count: 3 },
+    { text: "neste gang", count: 2 },
+  ],
+  recentResponses: [
+    { text: "Vanskelig å forstå", submittedAt: "2024-01-15T10:00:00Z" },
+  ],
+};
+
+const mockTextStatsKeywordsOnly: TextStats = {
+  type: "text",
+  responseCount: 12,
+  responseRate: 40,
+  topKeywords: [
+    { word: "bra", count: 3 },
+    { word: "enkel", count: 2 },
+  ],
+  recentResponses: [],
+};
+
+function mockField(stats: TextStats): FieldStat {
+  return {
+    fieldId: "comment-field",
+    fieldType: "TEXT",
+    label: "Hva synes du?",
+    stats,
+  };
+}
+
+describe("TextFieldCard", () => {
+  it("rendrer topp 5 fraser som klikkbare lenker", async () => {
+    await renderWithRouter(
+      <TextFieldCard
+        field={mockField(mockTextStatsWithPhrases)}
+        totalCount={120}
+      />,
+    );
+
+    expect(screen.getByText("Hyppigste fraser")).toBeInTheDocument();
+
+    // First 5 phrases should be visible
+    expect(screen.getByText("vanskelig forstå")).toBeInTheDocument();
+    expect(screen.getByText("digitale tjenester")).toBeInTheDocument();
+    expect(screen.getByText("god dialog")).toBeInTheDocument();
+    expect(screen.getByText("litt tungvint")).toBeInTheDocument();
+    expect(screen.getByText("svare mobilen")).toBeInTheDocument();
+
+    // 6th phrase should NOT be visible (max 5)
+    expect(screen.queryByText("neste gang")).not.toBeInTheDocument();
+
+    // All 5 phrases should be links
+    const phraseLinks = screen.getAllByRole("link");
+    expect(phraseLinks).toHaveLength(5);
+  });
+
+  it("frase-lenker har korrekte søkeparametere", async () => {
+    await renderWithRouter(
+      <TextFieldCard
+        field={mockField(mockTextStatsWithPhrases)}
+        totalCount={120}
+      />,
+    );
+
+    const link = screen.getByRole("link", {
+      name: /vanskelig forstå/,
+    });
+
+    const href = link.getAttribute("href") ?? "";
+    expect(href).toContain("/feedback");
+    expect(href).toMatch(
+      /query=vanskelig(%20|\+| )forst%C3%A5|query=vanskelig\+forst%C3%A5|query=vanskelig%20forst%C3%A5|query=vanskelig.forst/,
+    );
+    // TanStack Router serializes string values — "true" and "1" may be quoted
+    expect(href).toMatch(/hasText=(%22|"|)true(%22|"|)/);
+    expect(href).toMatch(/page=(%22|"|)1(%22|"|)/);
+  });
+
+  it("faller tilbake til keyword-tags når topPhrases mangler", async () => {
+    await renderWithRouter(
+      <TextFieldCard
+        field={mockField(mockTextStatsKeywordsOnly)}
+        totalCount={30}
+      />,
+    );
+
+    expect(screen.getByText("Hyppigste ord")).toBeInTheDocument();
+    expect(screen.getByText(/bra/)).toBeInTheDocument();
+    expect(screen.getByText(/enkel/)).toBeInTheDocument();
+
+    // Should NOT have an ordered list (phrases use <ol>)
+    expect(screen.queryByRole("list")).not.toBeInTheDocument();
+
+    // Should NOT show phrase heading
+    expect(screen.queryByText("Hyppigste fraser")).not.toBeInTheDocument();
+  });
+
+  it("viser tom tilstand uten data", async () => {
+    const emptyStats: TextStats = {
+      type: "text",
+      responseCount: 0,
+      responseRate: 0,
+      topKeywords: [],
+      recentResponses: [],
+    };
+
+    await renderWithRouter(
+      <TextFieldCard field={mockField(emptyStats)} totalCount={30} />,
+    );
+
+    expect(screen.getByText("Ingen tekstsvar ennå")).toBeInTheDocument();
+  });
+
+  it("fraser har korrekte aria-labels", async () => {
+    await renderWithRouter(
+      <TextFieldCard
+        field={mockField(mockTextStatsWithPhrases)}
+        totalCount={120}
+      />,
+    );
+
+    const link = screen.getByRole("link", {
+      name: /8.*vanskelig forstå|vanskelig forstå.*8/,
+    });
+    expect(link).toBeInTheDocument();
+
+    // Verify all phrase links have descriptive aria-labels
+    const allLinks = screen.getAllByRole("link");
+    for (const phraseLink of allLinks) {
+      expect(phraseLink).toHaveAttribute(
+        "aria-label",
+        expect.stringMatching(/Vis \d+ tilbakemeldinger som inneholder frasen/),
+      );
+    }
+  });
+});

--- a/apps/lumi-dashboard/app/mock/stats.ts
+++ b/apps/lumi-dashboard/app/mock/stats.ts
@@ -15,6 +15,7 @@ import { parseChoiceParam } from "~/utils/choiceFilterUtils";
 import { parseRatingParam } from "~/utils/ratingFilterUtils";
 import { getTopKeywords, IGNORED_WORDS } from "~/utils/wordAnalysis";
 import { getRating, hasTextResponse } from "./helpers";
+import { extractPhrases } from "./stats/phrases";
 
 // Note: circular dependency if we import mockFeedbackItems here directly while mockData imports stats.
 // To avoid this, we will accept items as arguments in the functions.
@@ -221,6 +222,12 @@ export function calculateFieldStats(items: FeedbackDto[]): FieldStat[] {
         )
         .slice(0, 3);
 
+      // Extract top bigram phrases from text responses
+      const { phrases } = extractPhrases(field.textResponses);
+      const topPhrases = phrases
+        .slice(0, 10)
+        .map((p) => ({ text: p.text, count: p.count }));
+
       fieldStats.push({
         fieldId: field.fieldId,
         fieldType: "TEXT",
@@ -232,6 +239,7 @@ export function calculateFieldStats(items: FeedbackDto[]): FieldStat[] {
           responseRate: 0,
           topKeywords,
           recentResponses,
+          ...(topPhrases.length > 0 ? { topPhrases } : {}),
         },
       });
     } else if (

--- a/apps/lumi-dashboard/app/mock/stats/phrases.ts
+++ b/apps/lumi-dashboard/app/mock/stats/phrases.ts
@@ -1,0 +1,97 @@
+import type { ConfidenceLevel, PhraseEntry, QuoteEntry } from "~/types/api";
+import { STOP_WORDS } from "../utils/textAnalysis";
+
+interface TextWithMeta {
+  text: string;
+  submittedAt: string;
+  id?: string;
+}
+
+/**
+ * Extract bigrams, representative quotes, and confidence level from text responses.
+ * Used by mock discovery and blocker stats to populate phrase fields.
+ */
+export function extractPhrases(responses: TextWithMeta[]): {
+  phrases: PhraseEntry[];
+  quotes: QuoteEntry[];
+  confidenceLevel: ConfidenceLevel;
+} {
+  const total = responses.length;
+  const confidenceLevel: ConfidenceLevel =
+    total < 30 ? "low" : total <= 100 ? "medium" : "high";
+
+  // Build bigram counts, deduplicated per response
+  const bigramCounts = new Map<
+    string,
+    { count: number; sourceIds: string[] }
+  >();
+
+  for (const [idx, response] of responses.entries()) {
+    // Tokenize but keep all words — filter stopwords per-bigram, not before.
+    // This ensures bigrams reflect adjacent words in the original text
+    // so "vanskelig å svare" → bigram "vanskelig svare" is avoided.
+    const words = response.text
+      .toLowerCase()
+      .replace(/[^\wæøå\s]/g, "")
+      .split(/\s+/)
+      .filter((w) => w.length > 0);
+
+    const seenInResponse = new Set<string>();
+
+    for (let i = 0; i < words.length - 1; i++) {
+      const a = words[i];
+      const b = words[i + 1];
+      // Both words must be content words (not stopwords, length > 2)
+      if (a.length <= 2 || b.length <= 2) continue;
+      if (STOP_WORDS.has(a) || STOP_WORDS.has(b)) continue;
+
+      const bigram = `${a} ${b}`;
+      if (seenInResponse.has(bigram)) continue;
+      seenInResponse.add(bigram);
+
+      const existing = bigramCounts.get(bigram);
+      const sourceId = response.id ?? `mock-${idx}`;
+      if (existing) {
+        existing.count++;
+        existing.sourceIds.push(sourceId);
+      } else {
+        bigramCounts.set(bigram, { count: 1, sourceIds: [sourceId] });
+      }
+    }
+  }
+
+  const phrases: PhraseEntry[] = Array.from(bigramCounts.entries())
+    .filter(([, v]) => v.count >= 2)
+    .sort((a, b) => b[1].count - a[1].count)
+    .slice(0, 20)
+    .map(([text, v]) => ({
+      text,
+      count: v.count,
+      sourceResponseIds: v.sourceIds,
+    }));
+
+  // Select 3-5 representative quotes (30-300 chars), deterministic
+  const validQuotes = responses
+    .filter((r) => r.text.length >= 30 && r.text.length <= 300)
+    .sort((a, b) => a.submittedAt.localeCompare(b.submittedAt));
+
+  const quoteCount = Math.min(Math.max(3, Math.floor(total / 20)), 5);
+  const step =
+    validQuotes.length > quoteCount
+      ? Math.floor(validQuotes.length / quoteCount)
+      : 1;
+
+  const quotes: QuoteEntry[] = [];
+  for (
+    let i = 0;
+    i < validQuotes.length && quotes.length < quoteCount;
+    i += step
+  ) {
+    quotes.push({
+      text: validQuotes[i].text,
+      answeredAt: validQuotes[i].submittedAt,
+    });
+  }
+
+  return { phrases, quotes, confidenceLevel };
+}

--- a/apps/lumi-dashboard/app/server/actions/__tests__/fetchStats.contract.test.ts
+++ b/apps/lumi-dashboard/app/server/actions/__tests__/fetchStats.contract.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 
-import { FeedbackStatsSchema } from "~/types/schemas";
+import { DiscoveryResponseSchema, FeedbackStatsSchema } from "~/types/schemas";
 import {
   buildStatsDashboardUrl,
   STATS_DASHBOARD_PATH,
@@ -85,5 +85,109 @@ describe("fetchStats contract", () => {
     };
 
     expect(() => FeedbackStatsSchema.parse(payload)).not.toThrow();
+  });
+
+  it("accepts TextStats field with topPhrases", () => {
+    const payload = {
+      totalCount: 10,
+      countWithText: 4,
+      countWithoutText: 6,
+      byRating: { "1": 1, "2": 2, "3": 3, "4": 2, "5": 2 },
+      byApp: { "app-1": 10 },
+      byDate: { "2026-01-21": 10 },
+      bySurveyId: { "survey-1": 10 },
+      averageRating: 3.2,
+      ratingByDate: {
+        "2026-01-21": { average: 3.2, count: 10 },
+      },
+      byDevice: { mobile: { count: 10, averageRating: 3.2 } },
+      byPathname: { "/": { count: 10, averageRating: 3.2 } },
+      lowestRatingPaths: {},
+      fieldStats: [
+        {
+          fieldId: "text-1",
+          fieldType: "TEXT",
+          label: "Hva synes du?",
+          stats: {
+            type: "text",
+            responseCount: 4,
+            responseRate: 0.4,
+            topKeywords: [{ word: "vanskelig", count: 3 }],
+            recentResponses: [
+              { text: "Alt var bra", submittedAt: "2026-01-21T10:00:00Z" },
+            ],
+            topPhrases: [{ text: "vanskelig forstå", count: 5 }],
+          },
+        },
+      ],
+      surveyType: "rating",
+      period: { fromDate: "2026-01-01", toDate: "2026-01-21", days: 21 },
+      privacy: { masked: false, threshold: 5 },
+    };
+
+    const parsed = FeedbackStatsSchema.parse(payload);
+    const textField = parsed.fieldStats[0]?.stats;
+    expect(textField).toBeDefined();
+    if (textField?.type === "text") {
+      expect(textField.topPhrases).toEqual([
+        { text: "vanskelig forstå", count: 5 },
+      ]);
+    }
+  });
+
+  it("accepts TextStats field without topPhrases (backwards-compat)", () => {
+    const payload = {
+      totalCount: 5,
+      countWithText: 2,
+      countWithoutText: 3,
+      byRating: {},
+      byApp: {},
+      byDate: {},
+      bySurveyId: {},
+      averageRating: null,
+      ratingByDate: {},
+      byDevice: {},
+      byPathname: {},
+      lowestRatingPaths: {},
+      fieldStats: [
+        {
+          fieldId: "text-1",
+          fieldType: "TEXT",
+          label: "Kommentar",
+          stats: {
+            type: "text",
+            responseCount: 2,
+            responseRate: 0.4,
+            topKeywords: [],
+            recentResponses: [],
+          },
+        },
+      ],
+      period: { fromDate: null, toDate: null, days: 0 },
+    };
+
+    const parsed = FeedbackStatsSchema.parse(payload);
+    const textField = parsed.fieldStats[0]?.stats;
+    expect(textField).toBeDefined();
+    if (textField?.type === "text") {
+      expect(textField.topPhrases).toBeUndefined();
+    }
+  });
+
+  it("accepts PhraseEntry without sourceResponseIds (backwards-compat)", () => {
+    const discoveryPayload = {
+      totalSubmissions: 10,
+      wordFrequency: [],
+      themes: [],
+      recentResponses: [],
+      phrases: [
+        { text: "vanskelig svare", count: 8 },
+        { text: "greie spørsmål", count: 4, sourceResponseIds: ["id-1"] },
+      ],
+    };
+
+    const parsed = DiscoveryResponseSchema.parse(discoveryPayload);
+    expect(parsed.phrases?.[0]?.sourceResponseIds).toBeUndefined();
+    expect(parsed.phrases?.[1]?.sourceResponseIds).toEqual(["id-1"]);
   });
 });

--- a/apps/lumi-dashboard/e2e/text-field-phrases.spec.ts
+++ b/apps/lumi-dashboard/e2e/text-field-phrases.spec.ts
@@ -1,0 +1,84 @@
+import { expect, test } from "@playwright/test";
+
+test.describe("TextFieldCard phrases", () => {
+  test("displays clickable phrases in text field card", async ({ page }) => {
+    // Rating survey has a TEXT field ("Legg gjerne til en begrunnelse")
+    await page.goto("/?surveyId=survey-vurdering");
+    await page.waitForLoadState("networkidle");
+    await expect(page.locator("main")).toBeVisible({ timeout: 15000 });
+
+    // Look for phrase heading in the text field card
+    const heading = page.getByText("Hyppigste fraser");
+
+    // Skip if no phrases available (mock data may not generate enough bigrams)
+    if (
+      !(await heading
+        .first()
+        .isVisible({ timeout: 5000 })
+        .catch(() => false))
+    ) {
+      test.skip(true, "No phrases available in mock data for this survey");
+      return;
+    }
+
+    await expect(heading.first()).toBeVisible();
+
+    // Should have an ordered list of phrase links
+    const phraseList = page.getByRole("list", { name: /hyppigste fraser/i });
+    await expect(phraseList.first()).toBeVisible();
+
+    // Phrase links should be visible and clickable
+    const phraseLinks = page.getByRole("link", {
+      name: /Vis \d+ tilbakemeldinger som inneholder frasen/i,
+    });
+    await expect(phraseLinks.first()).toBeVisible({ timeout: 5000 });
+
+    // Should have at most 5 phrases per card
+    const phraseCount = await phraseList.first().locator("li").count();
+    expect(phraseCount).toBeLessThanOrEqual(5);
+    expect(phraseCount).toBeGreaterThan(0);
+  });
+
+  test("clicking phrase navigates to feedback with query", async ({ page }) => {
+    await page.goto("/?surveyId=survey-vurdering");
+    await page.waitForLoadState("networkidle");
+    await expect(page.locator("main")).toBeVisible({ timeout: 15000 });
+
+    const phraseLinks = page.getByRole("link", {
+      name: /Vis \d+ tilbakemeldinger som inneholder frasen/i,
+    });
+
+    if (
+      !(await phraseLinks
+        .first()
+        .isVisible({ timeout: 5000 })
+        .catch(() => false))
+    ) {
+      test.skip(true, "No phrase links available in mock data");
+      return;
+    }
+
+    // Extract phrase text from aria-label before clicking
+    const firstLink = phraseLinks.first();
+    const ariaLabel = await firstLink.getAttribute("aria-label");
+    const phraseMatch = ariaLabel?.match(/frasen «(.+?)»/);
+    const phraseText = phraseMatch?.[1] ?? "";
+
+    await firstLink.click();
+
+    // Should navigate to /feedback with query param
+    await expect(page).toHaveURL(/\/feedback/, { timeout: 10000 });
+    await expect
+      .poll(() => new URL(page.url()).searchParams.get("query"), {
+        timeout: 5000,
+      })
+      .toBe(phraseText);
+
+    // Should have hasText param set
+    await expect
+      .poll(() => new URL(page.url()).searchParams.get("hasText"), {
+        timeout: 5000,
+      })
+      .toBe("true");
+  });
+});

--- a/apps/lumi-dashboard/e2e/text-field-phrases.spec.ts
+++ b/apps/lumi-dashboard/e2e/text-field-phrases.spec.ts
@@ -3,25 +3,14 @@ import { expect, test } from "@playwright/test";
 test.describe("TextFieldCard phrases", () => {
   test("displays clickable phrases in text field card", async ({ page }) => {
     // Rating survey has a TEXT field ("Legg gjerne til en begrunnelse")
+    // with 120 items cycling through a fixed topic pool — bigrams are guaranteed
     await page.goto("/?surveyId=survey-vurdering");
     await page.waitForLoadState("networkidle");
     await expect(page.locator("main")).toBeVisible({ timeout: 15000 });
 
-    // Look for phrase heading in the text field card
+    // Phrase heading must be visible
     const heading = page.getByText("Hyppigste fraser");
-
-    // Skip if no phrases available (mock data may not generate enough bigrams)
-    if (
-      !(await heading
-        .first()
-        .isVisible({ timeout: 5000 })
-        .catch(() => false))
-    ) {
-      test.skip(true, "No phrases available in mock data for this survey");
-      return;
-    }
-
-    await expect(heading.first()).toBeVisible();
+    await expect(heading.first()).toBeVisible({ timeout: 10000 });
 
     // Should have an ordered list of phrase links
     const phraseList = page.getByRole("list", { name: /hyppigste fraser/i });
@@ -47,16 +36,7 @@ test.describe("TextFieldCard phrases", () => {
     const phraseLinks = page.getByRole("link", {
       name: /Vis \d+ tilbakemeldinger som inneholder frasen/i,
     });
-
-    if (
-      !(await phraseLinks
-        .first()
-        .isVisible({ timeout: 5000 })
-        .catch(() => false))
-    ) {
-      test.skip(true, "No phrase links available in mock data");
-      return;
-    }
+    await expect(phraseLinks.first()).toBeVisible({ timeout: 10000 });
 
     // Extract phrase text from aria-label before clicking
     const firstLink = phraseLinks.first();

--- a/packages/lumi-types/src/api.ts
+++ b/packages/lumi-types/src/api.ts
@@ -134,6 +134,8 @@ export interface TextStats {
   topKeywords: Array<{ word: string; count: number }>;
   /** Most recent text responses with timestamps */
   recentResponses: Array<{ text: string; submittedAt: string }>;
+  /** Top bigram phrases extracted from text responses */
+  topPhrases?: Array<{ text: string; count: number }>;
 }
 
 export interface ChoiceStats {
@@ -346,7 +348,8 @@ export interface WordFrequency {
 export interface PhraseEntry {
   text: string;
   count: number;
-  sourceResponseIds: string[];
+  /** UUIDer til kildesvar for frasen. Optional fordi TextStats-konteksten ikke beregner dette. */
+  sourceResponseIds?: string[];
 }
 
 export interface QuoteEntry {

--- a/packages/lumi-types/src/schemas.ts
+++ b/packages/lumi-types/src/schemas.ts
@@ -635,6 +635,9 @@ const TextStatsSchema = z.object({
   recentResponses: z.array(
     z.object({ text: z.string(), submittedAt: z.string() }),
   ),
+  topPhrases: z
+    .array(z.object({ text: z.string(), count: z.number() }))
+    .optional(),
 });
 
 const ChoiceStatsSchema = z.object({
@@ -764,7 +767,7 @@ const WordFrequencySchema = z.object({
 const PhraseEntrySchema = z.object({
   text: z.string(),
   count: z.number(),
-  sourceResponseIds: z.array(z.string()),
+  sourceResponseIds: z.array(z.string()).optional(),
 });
 
 const QuoteEntrySchema = z.object({


### PR DESCRIPTION
## Beskrivelse

Erstatter ubrukelige enkeltord-tagger i TextFieldCard (Rating/Custom-undersøkelser) med klikkbare bigram-fraser som driller ned til tilbakemeldingssøk.

## Endringer

### Backend
- `TextProcessor.kt`: Kompilerte regex + `rawTokens()` helper med redaction marker stripping (`[...FJERNET]`)
- `FeedbackStatsHelpers.kt`: Integrerer `extractBigrams()` i TEXT-branch — grupperer på `stemKey`, viser hyppigste surface-form, dedup per svar, `count≥2` terskel, topp 10
- `Models.kt`: Ny `TextPhrase(text, count)` data class + `topPhrases` i `FieldStats.Text`

### Types
- `api.ts`: `topPhrases?` i `TextStats` (additivt, bakoverkompatibelt)
- `schemas.ts`: Zod-skjema oppdatert
- `PhraseEntry.sourceResponseIds` gjort optional

### Frontend
- `TextFieldCard.tsx`: Viser topp 5 klikkbare fraser med progress bar, fallback til keyword-tagger
- `TextFieldCard.module.css`: Styling for fraseliste, hover/focus, progress bar
- `mock/stats.ts` + `phrases.ts`: Mock-data med bigram-ekstraksjon for TEXT-felt

### Tester
- Backend: Redaction marker stripping + topPhrases integrasjon (dedup, terskel, top-10)
- Contract: 3 nye tester (med/uten topPhrases, optional sourceResponseIds)
- Component: 5 tester (rendering, link params, fallback, tom tilstand, a11y)
- E2E: 2 tester (frasevisning + klikk-navigasjon)

## Issue

Closes #255
Del av epic: #246

## Verifisering

- ✅ `pnpm run typecheck` (3/3 pakker)
- ✅ `pnpm run lint` (1 pre-existing warning)
- ✅ `pnpm run test` (213 tester)
- ✅ `pnpm run e2e` (31 E2E)
- ✅ `./gradlew test` + `./gradlew build`
- ✅ Dobbel gjennomgang

### Merknader fra inspeksjon
- Frase-rendering er bevisst inline (ikke gjenbruk av PhraseList som er DashboardCard → nesting)
- Case-sensitiv LIKE-søk er en pre-eksisterende begrensning (gjelder alle query-filtre)
- PII redaction markers strippes nå fra tokenisering → renser både keywords og bigrammer

## Sjekkliste

- [x] Koden kompilerer og linter uten feil
- [x] Endringene er testet (manuelt eller automatisk)
- [x] Ingen sensitiv data eksponert (tokens, credentials, PII)