### PR TITLE
feat(dashboard,api): bigram phrase drilldown med eksakt-match-filter

### DIFF
--- a/apps/lumi-api/src/main/kotlin/no/nav/lumi/domain/Models.kt
+++ b/apps/lumi-api/src/main/kotlin/no/nav/lumi/domain/Models.kt
@@ -375,6 +375,11 @@ data class TeamsAndApps(
     val teams: Map<String, Set<String>>
 )
 
+data class PhraseFilter(
+    val fieldId: String,
+    val surface: String
+)
+
 /**
  * Query parameters for feedback list.
  * 
@@ -412,6 +417,8 @@ data class FeedbackQuery(
     val choiceFilters: List<Pair<String, String>> = emptyList(),
     /** Multi-value rating filters: list of (fieldId, ratingValue) pairs */
     val ratingFilters: List<Pair<String, Int>> = emptyList(),
+    /** Single phrase filter for exact bigram matching */
+    val phraseFilter: PhraseFilter? = null,
 )
 
 /**

--- a/apps/lumi-api/src/main/kotlin/no/nav/lumi/repository/FeedbackRepository.kt
+++ b/apps/lumi-api/src/main/kotlin/no/nav/lumi/repository/FeedbackRepository.kt
@@ -145,7 +145,9 @@ class FeedbackRepository(
         } else {
             emptyList()
         }
-        val needsInMemoryFiltering = !query.task.isNullOrBlank() || !query.theme.isNullOrBlank()
+        val phraseFilter = query.phraseFilter
+        val needsInMemoryFiltering =
+            !query.task.isNullOrBlank() || !query.theme.isNullOrBlank() || phraseFilter != null
 
         if (!needsInMemoryFiltering) {
             val snapshot = dbQuery {
@@ -201,10 +203,12 @@ class FeedbackRepository(
         }
 
         val taskFilter = query.task?.trim()?.takeIf { it.isNotBlank() }
+        val phraseMatcher = phraseFilter?.let { it.fieldId to buildPhraseStemKey(it.surface) }
 
         val filtered = dtos.filter { feedback ->
             matchesTaskFilter(feedback, taskFilter) &&
-                matchesThemeFilter(feedback, themeFilter, themes)
+                matchesThemeFilter(feedback, themeFilter, themes) &&
+                (phraseMatcher == null || matchesPhraseFilter(feedback, phraseMatcher.first, phraseMatcher.second))
         }
 
         val total = filtered.size.toLong()

--- a/apps/lumi-api/src/main/kotlin/no/nav/lumi/repository/FeedbackRepositorySupport.kt
+++ b/apps/lumi-api/src/main/kotlin/no/nav/lumi/repository/FeedbackRepositorySupport.kt
@@ -162,6 +162,22 @@ internal fun matchesThemeFilter(
     return matchedTheme == targetTheme.name
 }
 
+internal fun buildPhraseStemKey(surface: String): String {
+    val words = TextProcessor.extractWords(surface)
+    require(words.size == 2) { "Invalid phrase filter" }
+    return "${TextProcessor.stemNorwegian(words[0])}|${TextProcessor.stemNorwegian(words[1])}"
+}
+
+internal fun matchesPhraseFilter(feedback: FeedbackDto, fieldId: String, expectedStemKey: String): Boolean {
+    return feedback.answers
+        .asSequence()
+        .filter { it.fieldId == fieldId && it.fieldType == FieldType.TEXT }
+        .mapNotNull { (it.value as? AnswerValue.Text)?.text }
+        .any { text ->
+            TextProcessor.extractBigrams(text).any { it.stemKey == expectedStemKey }
+        }
+}
+
 private fun matchThemeName(text: String, themes: List<TextThemeDto>): String {
     val textWords = TextProcessor.tokenize(text)
         .map { TextProcessor.stemNorwegian(it) }

--- a/apps/lumi-api/src/main/kotlin/no/nav/lumi/routes/ExportRoutes.kt
+++ b/apps/lumi-api/src/main/kotlin/no/nav/lumi/routes/ExportRoutes.kt
@@ -48,6 +48,7 @@ fun Route.exportRoutes(exportService: ExportService = defaultExportService) {
             segments = segments,
             choiceFilters = parseChoiceFilters(params.choice, params.choiceFieldId, params.choiceValue),
             ratingFilters = parseRatingFilters(params.rating, params.ratingFieldId, params.ratingValue),
+            phraseFilter = parsePhraseFilter(params.phrase),
         )
         
         val feedbacks = exportService.getFeedbackForExport(query)

--- a/apps/lumi-api/src/main/kotlin/no/nav/lumi/routes/FeedbackRoutes.kt
+++ b/apps/lumi-api/src/main/kotlin/no/nav/lumi/routes/FeedbackRoutes.kt
@@ -58,6 +58,7 @@ fun Route.feedbackRoutes(
             segments = segments,
             choiceFilters = parseChoiceFilters(params.choice, params.choiceFieldId, params.choiceValue),
             ratingFilters = parseRatingFilters(params.rating, params.ratingFieldId, params.ratingValue),
+            phraseFilter = parsePhraseFilter(params.phrase),
         )
         
         val (content, total, page) = service.findPaginated(query)

--- a/apps/lumi-api/src/main/kotlin/no/nav/lumi/routes/QueryValidation.kt
+++ b/apps/lumi-api/src/main/kotlin/no/nav/lumi/routes/QueryValidation.kt
@@ -1,9 +1,13 @@
 package no.nav.lumi.routes
 
 import no.nav.lumi.config.exception.ApiErrorException
+import no.nav.lumi.domain.PhraseFilter
 import no.nav.lumi.repository.MAX_CHOICE_VALUE_LENGTH
 import no.nav.lumi.repository.MAX_FIELD_ID_LENGTH
 import no.nav.lumi.repository.isSafeChoiceValue
+import no.nav.lumi.repository.validateJsonPathFieldId
+import no.nav.lumi.service.TextProcessor
+import org.slf4j.LoggerFactory
 import java.time.LocalDate
 
 private const val MAX_PAGE_SIZE = 200
@@ -13,6 +17,9 @@ private const val MAX_TAG_LENGTH = 50
 private const val MAX_SEGMENTS = 20
 private const val MAX_SEGMENT_KEY_LENGTH = 50
 private const val MAX_SEGMENT_VALUE_LENGTH = 100
+private const val MAX_PHRASE_WORD_LENGTH = 30
+private const val MAX_PHRASE_TOTAL_LENGTH = 80
+private val validationLog = LoggerFactory.getLogger("QueryValidation")
 
 internal data class Paging(
     val page: Int,
@@ -234,4 +241,35 @@ internal fun parseRatingFilters(
     }
 
     return filters
+}
+
+internal fun parsePhraseFilter(raw: List<String>?): PhraseFilter? {
+    if (raw.isNullOrEmpty()) return null
+    if (raw.size > 1) {
+        throw ApiErrorException.BadRequestException("Only a single phrase filter is supported")
+    }
+
+    val filter = raw.single()
+    val parts = filter.split(":", limit = 2)
+    if (parts.size != 2) {
+        throw ApiErrorException.BadRequestException("Invalid phrase format")
+    }
+
+    val fieldId = validateJsonPathFieldId(parts[0], "phraseFieldId", validationLog)
+        ?: throw ApiErrorException.BadRequestException("Invalid phrase format")
+
+    val normalizedWords = TextProcessor.extractWords(parts[1])
+    if (normalizedWords.size != 2) {
+        throw ApiErrorException.BadRequestException("Invalid phrase format")
+    }
+    if (normalizedWords.any { it.length > MAX_PHRASE_WORD_LENGTH }) {
+        throw ApiErrorException.BadRequestException("Invalid phrase format")
+    }
+
+    val normalizedSurface = normalizedWords.joinToString(" ")
+    if (normalizedSurface.length > MAX_PHRASE_TOTAL_LENGTH) {
+        throw ApiErrorException.BadRequestException("Invalid phrase format")
+    }
+
+    return PhraseFilter(fieldId = fieldId, surface = normalizedSurface)
 }

--- a/apps/lumi-api/src/main/kotlin/no/nav/lumi/routes/Resources.kt
+++ b/apps/lumi-api/src/main/kotlin/no/nav/lumi/routes/Resources.kt
@@ -41,6 +41,8 @@ class ApiV1Intern {
         val choice: List<String>? = null,
         /** Rating filters — repeated params, each in format "fieldId:ratingValue" */
         val rating: List<String>? = null,
+        /** Phrase filter — repeated param support is validated server-side, single value only */
+        val phrase: List<String>? = null,
         // Legacy single-value params (backward compat for bookmarked URLs)
         val ratingFieldId: String? = null,
         val ratingValue: Int? = null,
@@ -255,6 +257,8 @@ class ApiV1Intern {
         val choice: List<String>? = null,
         /** Rating filters — repeated params, each in format "fieldId:ratingValue" */
         val rating: List<String>? = null,
+        /** Phrase filter — repeated param support is validated server-side, single value only */
+        val phrase: List<String>? = null,
         // Legacy single-value params (backward compat for bookmarked URLs)
         val ratingFieldId: String? = null,
         val ratingValue: Int? = null,

--- a/apps/lumi-api/src/test/kotlin/no/nav/lumi/repository/FeedbackRepositoryTest.kt
+++ b/apps/lumi-api/src/test/kotlin/no/nav/lumi/repository/FeedbackRepositoryTest.kt
@@ -9,8 +9,14 @@ import io.kotest.matchers.nulls.shouldNotBeNull
 import io.kotest.matchers.shouldBe
 import no.nav.lumi.TestDatabase
 import no.nav.lumi.config.DatabaseHolder
+import no.nav.lumi.domain.Answer
+import no.nav.lumi.domain.AnswerValue
 import no.nav.lumi.domain.FieldType
+import no.nav.lumi.domain.FeedbackDto
 import no.nav.lumi.domain.FeedbackQuery
+import no.nav.lumi.domain.PhraseFilter
+import no.nav.lumi.domain.Question
+import no.nav.lumi.domain.SubmissionContext
 import no.nav.lumi.domain.StatsQuery
 import no.nav.lumi.insertTestFeedback
 import no.nav.lumi.insertTestFeedbackWithJson
@@ -495,6 +501,73 @@ class FeedbackRepositoryTest : FunSpec({
             content.first().id shouldBe "match-both"
         }
 
+        test("filters by phrase with same bigram pipeline as dashboard stats") {
+            insertTestFeedbackWithJson(
+                id = "phrase-match-1",
+                team = "team-test",
+                app = "app-test",
+                feedbackJson = """
+                    {
+                        "surveyId": "survey-phrase",
+                        "answers": [
+                            {
+                                "fieldId": "feedback",
+                                "fieldType": "TEXT",
+                                "question": {"label": "Hvorfor?"},
+                                "value": {"type": "text", "text": "Det er vanskelig å svare raskt"}
+                            }
+                        ]
+                    }
+                """.trimIndent()
+            )
+            insertTestFeedbackWithJson(
+                id = "phrase-match-2",
+                team = "team-test",
+                app = "app-test",
+                feedbackJson = """
+                    {
+                        "surveyId": "survey-phrase",
+                        "answers": [
+                            {
+                                "fieldId": "feedback",
+                                "fieldType": "TEXT",
+                                "question": {"label": "Hvorfor?"},
+                                "value": {"type": "text", "text": "Dette var vanskelige svaret å gi"}
+                            }
+                        ]
+                    }
+                """.trimIndent()
+            )
+            insertTestFeedbackWithJson(
+                id = "phrase-other-field",
+                team = "team-test",
+                app = "app-test",
+                feedbackJson = """
+                    {
+                        "surveyId": "survey-phrase",
+                        "answers": [
+                            {
+                                "fieldId": "other",
+                                "fieldType": "TEXT",
+                                "question": {"label": "Annet?"},
+                                "value": {"type": "text", "text": "Det er vanskelig å svare raskt"}
+                            }
+                        ]
+                    }
+                """.trimIndent()
+            )
+
+            val (content, total, _) = repository.findPaginated(
+                FeedbackQuery(
+                    team = "team-test",
+                    phraseFilter = PhraseFilter(fieldId = "feedback", surface = "vanskelig svare")
+                )
+            )
+
+            total shouldBe 2
+            content.map { it.id }.toSet() shouldBe setOf("phrase-match-1", "phrase-match-2")
+        }
+
         test("filters by segments") {
             insertTestFeedbackWithJson(
                 id = "segment-match",
@@ -531,6 +604,76 @@ class FeedbackRepositoryTest : FunSpec({
 
             content shouldHaveSize 1
             content.first().id shouldBe "segment-match"
+        }
+    }
+
+    context("matchesPhraseFilter") {
+        fun feedbackWithText(vararg answers: Pair<String, String>): FeedbackDto {
+            return FeedbackDto(
+                id = UUID.randomUUID().toString(),
+                submittedAt = Instant.parse("2026-01-21T09:00:00Z").toString(),
+                app = "app-test",
+                surveyId = "survey-test",
+                context = SubmissionContext(),
+                answers = answers.map { (fieldId, text) ->
+                    Answer(
+                        fieldId = fieldId,
+                        fieldType = FieldType.TEXT,
+                        question = Question(label = fieldId),
+                        value = AnswerValue.Text(text)
+                    )
+                }
+            )
+        }
+
+        test("matches via stemming across normalized bigrams") {
+            val filter = PhraseFilter(fieldId = "feedback", surface = "vanskelig svare")
+            val expectedStemKey = buildPhraseStemKey(filter.surface)
+
+            matchesPhraseFilter(
+                feedbackWithText("feedback" to "Det er vanskelig å svare raskt"),
+                filter.fieldId,
+                expectedStemKey
+            ) shouldBe true
+
+            matchesPhraseFilter(
+                feedbackWithText("feedback" to "Dette var vanskelige svaret å gi"),
+                filter.fieldId,
+                expectedStemKey
+            ) shouldBe true
+        }
+
+        test("respects fieldId when the same phrase exists in another field") {
+            val filter = PhraseFilter(fieldId = "feedback", surface = "vanskelig svare")
+            val expectedStemKey = buildPhraseStemKey(filter.surface)
+
+            matchesPhraseFilter(
+                feedbackWithText("other" to "Det er vanskelig å svare raskt"),
+                filter.fieldId,
+                expectedStemKey
+            ) shouldBe false
+        }
+
+        test("returns false for empty text answers") {
+            val filter = PhraseFilter(fieldId = "feedback", surface = "vanskelig svare")
+            val expectedStemKey = buildPhraseStemKey(filter.surface)
+
+            matchesPhraseFilter(
+                feedbackWithText("feedback" to "   "),
+                filter.fieldId,
+                expectedStemKey
+            ) shouldBe false
+        }
+
+        test("constructs the same stem key as the dashboard bigram pipeline") {
+            val filter = PhraseFilter(fieldId = "feedback", surface = "vanskelige svarene")
+            val expectedStemKey = buildPhraseStemKey(filter.surface)
+
+            matchesPhraseFilter(
+                feedbackWithText("feedback" to "Det er vanskelig å svare raskt"),
+                filter.fieldId,
+                expectedStemKey
+            ) shouldBe true
         }
     }
 

--- a/apps/lumi-api/src/test/kotlin/no/nav/lumi/routes/ExportRoutesTest.kt
+++ b/apps/lumi-api/src/test/kotlin/no/nav/lumi/routes/ExportRoutesTest.kt
@@ -122,6 +122,20 @@ class ExportRoutesTest : FunSpec({
         }
     }
 
+    test("GET /api/v1/intern/export rejects multiple phrase filters") {
+        testApplication {
+            application { testModule() }
+
+            val response = createTestClient().get(
+                "/api/v1/intern/export?team=flex&phrase=feedback:vanskelig%20svare&phrase=feedback:digital%20soknad"
+            ) {
+                header(HttpHeaders.Authorization, "Bearer test-token")
+            }
+
+            response.status shouldBe HttpStatusCode.BadRequest
+        }
+    }
+
     test("GET /api/v1/intern/export rejects too long query") {
         testApplication {
             application { testModule() }

--- a/apps/lumi-api/src/test/kotlin/no/nav/lumi/routes/FeedbackRoutesTest.kt
+++ b/apps/lumi-api/src/test/kotlin/no/nav/lumi/routes/FeedbackRoutesTest.kt
@@ -107,6 +107,83 @@ class FeedbackRoutesTest : FunSpec({
         }
     }
 
+    test("GET /api/v1/intern/feedback supports phrase filtering") {
+        testApplication {
+            application { testModule() }
+
+            val team = "team-test"
+            val app = "app-test"
+            val surveyId = "survey-phrase-route"
+
+            insertTestFeedbackWithJson(
+                team = team,
+                app = app,
+                feedbackJson = """
+                    {
+                      "schemaVersion": 1,
+                      "surveyId": "$surveyId",
+                      "surveyType": "rating",
+                      "context": { "pathname": "/phrase", "deviceType": "desktop" },
+                      "answers": [
+                        {
+                          "fieldId": "feedback",
+                          "fieldType": "TEXT",
+                          "question": { "label": "Har du tilbakemelding?" },
+                          "value": { "type": "text", "text": "Det er vanskelig å svare raskt" }
+                        }
+                      ],
+                      "submittedAt": "2026-01-21T09:00:00Z"
+                    }
+                """.trimIndent()
+            )
+            insertTestFeedbackWithJson(
+                team = team,
+                app = app,
+                feedbackJson = """
+                    {
+                      "schemaVersion": 1,
+                      "surveyId": "$surveyId",
+                      "surveyType": "rating",
+                      "context": { "pathname": "/phrase", "deviceType": "desktop" },
+                      "answers": [
+                        {
+                          "fieldId": "feedback",
+                          "fieldType": "TEXT",
+                          "question": { "label": "Har du tilbakemelding?" },
+                          "value": { "type": "text", "text": "Dette er lett å lese" }
+                        }
+                      ],
+                      "submittedAt": "2026-01-21T09:05:00Z"
+                    }
+                """.trimIndent()
+            )
+
+            val response = createTestClient().get(
+                "/api/v1/intern/feedback?team=$team&app=$app&surveyId=$surveyId&phrase=feedback:vanskelig%20svare"
+            ) {
+                header(HttpHeaders.Authorization, "Bearer test-token")
+            }
+
+            response.status shouldBe HttpStatusCode.OK
+            val body = Json.parseToJsonElement(response.bodyAsText()).jsonObject
+            body["totalElements"]?.jsonPrimitive?.int shouldBe 1
+        }
+    }
+
+    test("GET /api/v1/intern/feedback rejects multiple phrase filters") {
+        testApplication {
+            application { testModule() }
+
+            val response = createTestClient().get(
+                "/api/v1/intern/feedback?team=team-test&phrase=feedback:vanskelig%20svare&phrase=feedback:digital%20soknad"
+            ) {
+                header(HttpHeaders.Authorization, "Bearer test-token")
+            }
+
+            response.status shouldBe HttpStatusCode.BadRequest
+        }
+    }
+
     test("GET /api/v1/intern/feedback/tags returns list of tags") {
         testApplication {
             application { testModule() }

--- a/apps/lumi-api/src/test/kotlin/no/nav/lumi/routes/QueryValidationTest.kt
+++ b/apps/lumi-api/src/test/kotlin/no/nav/lumi/routes/QueryValidationTest.kt
@@ -5,7 +5,9 @@ import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.string.shouldContain
+import io.kotest.matchers.string.shouldNotContain
 import no.nav.lumi.config.exception.ApiErrorException
+import no.nav.lumi.domain.PhraseFilter
 
 class QueryValidationTest : FunSpec({
 
@@ -143,6 +145,80 @@ class QueryValidationTest : FunSpec({
                 parseRatingFilters(filters, null, null)
             }
             ex.message shouldContain "Too many"
+        }
+    }
+
+    context("parsePhraseFilter") {
+        test("parses valid phrase filter") {
+            val result = parsePhraseFilter(listOf("fieldId:vanskelig svare"))
+
+            result shouldBe PhraseFilter(fieldId = "fieldId", surface = "vanskelig svare")
+        }
+
+        test("returns null for null input") {
+            parsePhraseFilter(null) shouldBe null
+        }
+
+        test("returns null for empty input") {
+            parsePhraseFilter(emptyList()) shouldBe null
+        }
+
+        test("rejects missing colon separator") {
+            val rawInput = "fieldId vanskelig svare"
+            val ex = shouldThrow<ApiErrorException.BadRequestException> {
+                parsePhraseFilter(listOf(rawInput))
+            }
+
+            ex.message shouldContain "Invalid phrase format"
+            ex.message.shouldNotContain(rawInput)
+        }
+
+        test("rejects blank surface after normalization") {
+            val rawInput = "fieldId:!!!"
+            val ex = shouldThrow<ApiErrorException.BadRequestException> {
+                parsePhraseFilter(listOf(rawInput))
+            }
+
+            ex.message shouldContain "Invalid phrase format"
+            ex.message.shouldNotContain(rawInput)
+        }
+
+        test("rejects phrase with only stopwords") {
+            val rawInput = "fieldId:og en"
+            val ex = shouldThrow<ApiErrorException.BadRequestException> {
+                parsePhraseFilter(listOf(rawInput))
+            }
+
+            ex.message shouldContain "Invalid phrase format"
+            ex.message.shouldNotContain(rawInput)
+        }
+
+        test("rejects phrase with more than two content words") {
+            val rawInput = "fieldId:vanskelig svare spørsmål"
+            val ex = shouldThrow<ApiErrorException.BadRequestException> {
+                parsePhraseFilter(listOf(rawInput))
+            }
+
+            ex.message shouldContain "Invalid phrase format"
+            ex.message.shouldNotContain(rawInput)
+        }
+
+        test("rejects invalid fieldId") {
+            val rawInput = "field\$id:vanskelig svare"
+            val ex = shouldThrow<ApiErrorException.BadRequestException> {
+                parsePhraseFilter(listOf(rawInput))
+            }
+
+            ex.message shouldContain "Invalid phrase format"
+            ex.message.shouldNotContain(rawInput)
+        }
+
+        test("rejects more than one phrase filter") {
+            val ex = shouldThrow<ApiErrorException.BadRequestException> {
+                parsePhraseFilter(listOf("fieldId:vanskelig svare", "fieldId:enkelt svar"))
+            }
+
+            ex.message shouldContain "Only a single phrase filter is supported"
         }
     }
 

--- a/apps/lumi-api/src/test/kotlin/no/nav/lumi/routes/StatsDashboardRoutesTest.kt
+++ b/apps/lumi-api/src/test/kotlin/no/nav/lumi/routes/StatsDashboardRoutesTest.kt
@@ -11,11 +11,14 @@ import io.ktor.client.request.delete
 import io.ktor.client.statement.bodyAsText
 import io.ktor.http.HttpHeaders
 import io.ktor.http.HttpStatusCode
+import io.ktor.http.encodeURLParameter
 import io.ktor.server.testing.testApplication
 import kotlinx.serialization.decodeFromString
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.buildJsonArray
 import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
 import kotlinx.serialization.json.put
 import kotlinx.serialization.json.putJsonArray
 import kotlinx.serialization.json.putJsonObject
@@ -316,6 +319,70 @@ class StatsDashboardRoutesTest : FunSpec({
             val textStats = textField.stats as FieldStats.Text
             textStats.responseCount shouldBe 5
             textStats.responseRate shouldBe (1.0 plusOrMinus 0.0001)
+        }
+    }
+
+    test("dashboard top phrase counts match feedback phrase filter totals") {
+        testApplication {
+            application { testModule() }
+
+            val team = "flex"
+            val app = "spinnsyn"
+            val surveyId = "survey-phrase-contract"
+            val submittedAt = OffsetDateTime.parse("2026-01-21T10:00:00+01:00")
+
+            val texts = listOf(
+                "Digital søknad er vanskelig å svare på",
+                "Digital søknad har vanskelig å svare flyt",
+                "Digital søknaden gir vanskelig svar i skjema",
+                "Anker Bjerk lager anker bjerk igjen",
+                "Anker Bjerk og digital søknad dukker opp"
+            )
+
+            texts.forEachIndexed { idx, text ->
+                val time = submittedAt.minusMinutes(idx.toLong())
+                insertTestFeedbackWithJson(
+                    team = team,
+                    app = app,
+                    feedbackJson = feedbackJson(
+                        surveyId = surveyId,
+                        pathname = "/survey",
+                        deviceType = "desktop",
+                        rating = 4,
+                        text = text,
+                        startedAt = time.minusSeconds(30),
+                        submittedAt = time,
+                    ),
+                    opprettet = time,
+                )
+            }
+
+            val client = createTestClient()
+
+            val statsResponse = client.get("/api/v1/intern/stats/dashboard?team=$team&app=$app&surveyId=$surveyId") {
+                header(HttpHeaders.Authorization, "Bearer test-token")
+            }
+
+            statsResponse.status shouldBe HttpStatusCode.OK
+
+            val stats = json.decodeFromString<FeedbackStats>(statsResponse.bodyAsText())
+            val textField = stats.fieldStats.first { it.fieldId == "feedback" }
+            val textStats = textField.stats as FieldStats.Text
+            textStats.topPhrases.isEmpty() shouldBe false
+
+            textStats.topPhrases.forEach { phrase ->
+                val encodedPhrase = "feedback:${phrase.text}".encodeURLParameter()
+                val feedbackResponse = client.get(
+                    "/api/v1/intern/feedback?team=$team&app=$app&surveyId=$surveyId&hasText=true&size=200&phrase=$encodedPhrase"
+                ) {
+                    header(HttpHeaders.Authorization, "Bearer test-token")
+                }
+
+                feedbackResponse.status shouldBe HttpStatusCode.OK
+
+                val feedbackPage = Json.parseToJsonElement(feedbackResponse.bodyAsText()).jsonObject
+                feedbackPage["totalElements"]?.jsonPrimitive?.content?.toInt() shouldBe phrase.count
+            }
         }
     }
 

--- a/apps/lumi-dashboard/app/components/dashboard/sections/FieldStats/FieldCards/ChoiceFieldCard.tsx
+++ b/apps/lumi-dashboard/app/components/dashboard/sections/FieldStats/FieldCards/ChoiceFieldCard.tsx
@@ -59,7 +59,9 @@ export function ChoiceFieldCard({
   return (
     <DashboardCard padding="space-20" className={styles.cardContent}>
       <FieldCardHeader
-        icon={<ChatElipsisIcon fontSize="1.25rem" aria-hidden />}
+        icon={
+          <ChatElipsisIcon fontSize="var(--ax-font-size-xlarge)" aria-hidden />
+        }
         label={field.label}
         titleTestId={`field-stat-title-${field.fieldId}`}
         subtitle={`${responseCount} av ${totalCount} har svart (${responsePct}%)`}

--- a/apps/lumi-dashboard/app/components/dashboard/sections/FieldStats/FieldCards/Rating/RatingFieldCard.tsx
+++ b/apps/lumi-dashboard/app/components/dashboard/sections/FieldStats/FieldCards/Rating/RatingFieldCard.tsx
@@ -60,7 +60,7 @@ export function RatingFieldCard({ field, totalCount }: FieldCardProps) {
   return (
     <DashboardCard padding="space-20">
       <FieldCardHeader
-        icon={<StarIcon fontSize="1.25rem" aria-hidden />}
+        icon={<StarIcon fontSize="var(--ax-font-size-xlarge)" aria-hidden />}
         label={field.label}
         titleTestId={`field-stat-title-${field.fieldId}`}
         subtitle={`${fieldTotalResponses} av ${totalCount} har svart (${responsePct}%)`}

--- a/apps/lumi-dashboard/app/components/dashboard/sections/FieldStats/FieldCards/TextFieldCard.module.css
+++ b/apps/lumi-dashboard/app/components/dashboard/sections/FieldStats/FieldCards/TextFieldCard.module.css
@@ -9,8 +9,8 @@
 
 .keywordCount {
   opacity: 0.5;
-  margin-left: 0.35rem;
-  font-size: 0.75rem;
+  margin-left: var(--ax-space-6);
+  font-size: var(--ax-font-size-small);
 }
 
 .phraseList {
@@ -19,10 +19,17 @@
   padding: 0;
 }
 
+.phraseItem {
+  border-bottom: 1px solid var(--ax-border-neutral-subtleA);
+}
+
+.phraseItem:last-child {
+  border-bottom: none;
+}
+
 .phraseLink {
   display: block;
-  padding: var(--ax-space-4) var(--ax-space-8);
-  border-radius: var(--ax-border-radius-medium);
+  padding: var(--ax-space-6) var(--ax-space-8);
   text-decoration: none;
   color: inherit;
   transition: background-color 0.15s ease;
@@ -32,44 +39,71 @@
   background-color: var(--ax-bg-neutral-moderate-hover);
 }
 
+.phraseLink:hover .phraseArrow {
+  opacity: 1;
+}
+
 .phraseLink:focus-visible {
   outline: 2px solid var(--ax-border-focus);
   outline-offset: 2px;
 }
 
-.phraseProgress {
-  width: 50px;
-  height: 5px;
-  border-radius: 3px;
-  appearance: none;
+.phraseRank {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: var(--ax-space-20);
+  height: var(--ax-space-20);
+  border-radius: var(--ax-border-radius-full);
+  background: var(--ax-bg-neutral-moderate);
+  font-size: var(--ax-font-size-small);
+  font-weight: 600;
+  color: var(--ax-text-neutral-subtle);
+  flex-shrink: 0;
+}
+
+.phraseBar {
+  position: relative;
+  flex: 1;
+  min-width: 0;
+  border-radius: var(--ax-border-radius-medium);
   overflow: hidden;
-  background: var(--ax-bg-neutral-moderate);
 }
 
-.phraseProgress::-webkit-progress-bar {
-  background: var(--ax-bg-neutral-moderate);
-  border-radius: 3px;
+.phraseBarFill {
+  position: absolute;
+  inset: 0;
+  width: 0;
+  background: var(--ax-bg-accent-softA);
+  border-radius: inherit;
+  pointer-events: none;
 }
 
-.phraseProgress::-webkit-progress-value {
-  background: var(--ax-border-accent);
-  border-radius: 3px;
-}
-
-.phraseProgress::-moz-progress-bar {
-  background: var(--ax-border-accent);
-  border-radius: 3px;
+.phraseContent {
+  position: relative;
+  padding: var(--ax-space-2) var(--ax-space-8);
 }
 
 .phraseMeta {
   flex-shrink: 0;
 }
 
+.phraseCount {
+  color: var(--ax-text-neutral-subtle);
+}
+
+.phraseArrow {
+  color: var(--ax-text-neutral-subtle);
+  opacity: 0;
+  transition: opacity 0.15s ease;
+  flex-shrink: 0;
+}
+
 .responseCard {
-  padding: 0.5rem 0.75rem;
+  padding: var(--ax-space-8) var(--ax-space-12);
   background-color: var(--ax-bg-neutral-soft);
   border-radius: var(--ax-border-radius-medium);
-  border-left: 3px solid var(--ax-border-info);
+  border-left: var(--ax-space-4) solid var(--ax-border-info);
 }
 
 .responseText {
@@ -82,12 +116,12 @@
 
 .responseTime {
   color: var(--ax-text-neutral-subtle);
-  margin-top: 0.25rem;
-  font-size: 0.75rem;
+  margin-top: var(--ax-space-4);
+  font-size: var(--ax-font-size-small);
 }
 
 .emptyState {
   color: var(--ax-text-neutral-subtle);
-  margin-top: 0.5rem;
+  margin-top: var(--ax-space-8);
   font-style: italic;
 }

--- a/apps/lumi-dashboard/app/components/dashboard/sections/FieldStats/FieldCards/TextFieldCard.module.css
+++ b/apps/lumi-dashboard/app/components/dashboard/sections/FieldStats/FieldCards/TextFieldCard.module.css
@@ -103,7 +103,7 @@
   padding: var(--ax-space-8) var(--ax-space-12);
   background-color: var(--ax-bg-neutral-soft);
   border-radius: var(--ax-border-radius-medium);
-  border-left: var(--ax-space-4) solid var(--ax-border-info);
+  border-left: 2px solid var(--ax-border-info);
 }
 
 .responseText {

--- a/apps/lumi-dashboard/app/components/dashboard/sections/FieldStats/FieldCards/TextFieldCard.tsx
+++ b/apps/lumi-dashboard/app/components/dashboard/sections/FieldStats/FieldCards/TextFieldCard.tsx
@@ -32,7 +32,12 @@ export function TextFieldCard({ field, totalCount }: FieldCardProps) {
   return (
     <DashboardCard padding="space-20" className={styles.cardContent}>
       <FieldCardHeader
-        icon={<ChatExclamationmarkIcon fontSize="1.25rem" aria-hidden />}
+        icon={
+          <ChatExclamationmarkIcon
+            fontSize="var(--ax-font-size-xlarge)"
+            aria-hidden
+          />
+        }
         label={field.label}
         titleTestId={`field-stat-title-${field.fieldId}`}
         subtitle={`${stats.responseCount} av ${totalCount} har svart (${responseRate}%)`}
@@ -90,7 +95,7 @@ export function TextFieldCard({ field, totalCount }: FieldCardProps) {
                             {phrase.count}
                           </Detail>
                           <ArrowRightIcon
-                            fontSize="1rem"
+                            fontSize="var(--ax-font-size-medium)"
                             className={styles.phraseArrow}
                             aria-hidden
                           />

--- a/apps/lumi-dashboard/app/components/dashboard/sections/FieldStats/FieldCards/TextFieldCard.tsx
+++ b/apps/lumi-dashboard/app/components/dashboard/sections/FieldStats/FieldCards/TextFieldCard.tsx
@@ -1,9 +1,10 @@
-import { ChatExclamationmarkIcon } from "@navikt/aksel-icons";
+import { ArrowRightIcon, ChatExclamationmarkIcon } from "@navikt/aksel-icons";
 import { BodyShort, Detail, HStack, Tag, VStack } from "@navikt/ds-react";
 import { Link } from "@tanstack/react-router";
 
 import { DashboardCard } from "~/components/dashboard";
 import type { TextStats } from "~/types/api";
+import { stringifyPhraseFilter } from "~/utils/phraseFilterUtils";
 import { formatRelativeTime } from "~/utils/wordAnalysis";
 
 import { FieldCardHeader } from "./FieldCardHeader";
@@ -47,41 +48,55 @@ export function TextFieldCard({ field, totalCount }: FieldCardProps) {
             Hyppigste fraser
           </BodyShort>
           <ol className={styles.phraseList} aria-label="Hyppigste fraser">
-            {displayedPhrases.map((phrase) => (
-              <li key={phrase.text}>
+            {displayedPhrases.map((phrase, index) => (
+              <li key={phrase.text} className={styles.phraseItem}>
                 <Link
                   to="/feedback"
                   search={(prev) => ({
                     ...prev,
-                    query: phrase.text,
+                    phrase: stringifyPhraseFilter(field.fieldId, phrase.text),
+                    query: undefined,
                     page: "1",
                     hasText: "true",
                   })}
                   className={styles.phraseLink}
-                  aria-label={`Vis ${phrase.count} tilbakemeldinger som inneholder frasen «${phrase.text}»`}
+                  aria-label={`Vis ${phrase.count} tilbakemeldinger med frasen «${phrase.text}»`}
                 >
-                  <HStack
-                    align="center"
-                    gap="space-8"
-                    justify="space-between"
-                    wrap={false}
-                  >
-                    <BodyShort size="small" weight="semibold" truncate>
-                      {phrase.text}
-                    </BodyShort>
-                    <HStack
-                      gap="space-8"
-                      align="center"
-                      className={styles.phraseMeta}
-                    >
-                      <progress
-                        className={styles.phraseProgress}
-                        value={phrase.count}
-                        max={maxCount}
-                        aria-hidden
+                  <HStack align="center" gap="space-8" wrap={false}>
+                    <span className={styles.phraseRank}>{index + 1}</span>
+                    <span className={styles.phraseBar}>
+                      <span
+                        className={styles.phraseBarFill}
+                        style={{
+                          width: `${Math.round((phrase.count / maxCount) * 100)}%`,
+                        }}
                       />
-                      <Detail>{phrase.count}</Detail>
-                    </HStack>
+                      <HStack
+                        align="center"
+                        gap="space-8"
+                        justify="space-between"
+                        wrap={false}
+                        className={styles.phraseContent}
+                      >
+                        <BodyShort size="small" weight="semibold" truncate>
+                          {phrase.text}
+                        </BodyShort>
+                        <HStack
+                          gap="space-8"
+                          align="center"
+                          className={styles.phraseMeta}
+                        >
+                          <Detail className={styles.phraseCount}>
+                            {phrase.count}
+                          </Detail>
+                          <ArrowRightIcon
+                            fontSize="1rem"
+                            className={styles.phraseArrow}
+                            aria-hidden
+                          />
+                        </HStack>
+                      </HStack>
+                    </span>
                   </HStack>
                 </Link>
               </li>
@@ -125,7 +140,7 @@ export function TextFieldCard({ field, totalCount }: FieldCardProps) {
             Siste svar
           </BodyShort>
           <VStack gap="space-8">
-            {stats.recentResponses.map((response) => (
+            {stats.recentResponses.slice(0, 3).map((response) => (
               <div
                 key={`${response.text}-${response.submittedAt}`}
                 className={styles.responseCard}

--- a/apps/lumi-dashboard/app/components/dashboard/sections/FieldStats/FieldCards/__tests__/TextFieldCard.test.tsx
+++ b/apps/lumi-dashboard/app/components/dashboard/sections/FieldStats/FieldCards/__tests__/TextFieldCard.test.tsx
@@ -96,7 +96,7 @@ describe("TextFieldCard", () => {
     expect(phraseLinks).toHaveLength(5);
   });
 
-  it("frase-lenker har korrekte søkeparametere", async () => {
+  it("frase-lenker bruker phrase-param i stedet for query", async () => {
     await renderWithRouter(
       <TextFieldCard
         field={mockField(mockTextStatsWithPhrases)}
@@ -110,10 +110,12 @@ describe("TextFieldCard", () => {
 
     const href = link.getAttribute("href") ?? "";
     expect(href).toContain("/feedback");
-    expect(href).toMatch(
-      /query=vanskelig(%20|\+| )forst%C3%A5|query=vanskelig\+forst%C3%A5|query=vanskelig%20forst%C3%A5|query=vanskelig.forst/,
-    );
-    // TanStack Router serializes string values — "true" and "1" may be quoted
+    // Should use phrase param with fieldId:surface format
+    expect(href).toMatch(/phrase=comment-field/);
+    expect(href).toMatch(/vanskelig/);
+    // Should NOT have query param (mutual exclusion)
+    expect(href).not.toMatch(/query=/);
+    // Should have hasText and page
     expect(href).toMatch(/hasText=(%22|"|)true(%22|"|)/);
     expect(href).toMatch(/page=(%22|"|)1(%22|"|)/);
   });
@@ -153,7 +155,7 @@ describe("TextFieldCard", () => {
     expect(screen.getByText("Ingen tekstsvar ennå")).toBeInTheDocument();
   });
 
-  it("fraser har korrekte aria-labels", async () => {
+  it("fraser har korrekte aria-labels med «»-format", async () => {
     await renderWithRouter(
       <TextFieldCard
         field={mockField(mockTextStatsWithPhrases)}
@@ -171,8 +173,37 @@ describe("TextFieldCard", () => {
     for (const phraseLink of allLinks) {
       expect(phraseLink).toHaveAttribute(
         "aria-label",
-        expect.stringMatching(/Vis \d+ tilbakemeldinger som inneholder frasen/),
+        expect.stringMatching(/Vis \d+ tilbakemeldinger med frasen/),
       );
     }
+  });
+
+  it("viser maks 3 siste svar selv om backend leverer flere", async () => {
+    const statsWithManyResponses: TextStats = {
+      type: "text",
+      responseCount: 50,
+      responseRate: 80,
+      topKeywords: [],
+      recentResponses: [
+        { text: "Svar 1", submittedAt: "2024-01-15T10:00:00Z" },
+        { text: "Svar 2", submittedAt: "2024-01-14T10:00:00Z" },
+        { text: "Svar 3", submittedAt: "2024-01-13T10:00:00Z" },
+        { text: "Svar 4", submittedAt: "2024-01-12T10:00:00Z" },
+        { text: "Svar 5", submittedAt: "2024-01-11T10:00:00Z" },
+      ],
+    };
+
+    await renderWithRouter(
+      <TextFieldCard
+        field={mockField(statsWithManyResponses)}
+        totalCount={60}
+      />,
+    );
+
+    expect(screen.getByText('"Svar 1"')).toBeInTheDocument();
+    expect(screen.getByText('"Svar 2"')).toBeInTheDocument();
+    expect(screen.getByText('"Svar 3"')).toBeInTheDocument();
+    expect(screen.queryByText('"Svar 4"')).not.toBeInTheDocument();
+    expect(screen.queryByText('"Svar 5"')).not.toBeInTheDocument();
   });
 });

--- a/apps/lumi-dashboard/app/components/export/ActiveFilters.tsx
+++ b/apps/lumi-dashboard/app/components/export/ActiveFilters.tsx
@@ -4,6 +4,7 @@ import type { SearchParams } from "~/hooks/useSearchParams";
 import { useStats } from "~/hooks/useStats";
 import { useThemes } from "~/hooks/useThemes";
 import { getFilterLabels } from "~/utils/filterLabels";
+import { parsePhraseParam } from "~/utils/phraseFilterUtils";
 import {
   formatMetadataLabel,
   formatMetadataValue,
@@ -25,6 +26,12 @@ export function ActiveFilters({ params }: ActiveFiltersProps) {
     stats,
     themes,
   });
+
+  const phraseFilter = parsePhraseParam(params.phrase);
+  const phraseLabel = phraseFilter
+    ? (stats?.fieldStats?.find((f) => f.fieldId === phraseFilter.fieldId)
+        ?.label ?? "Frase")
+    : undefined;
 
   return (
     <VStack gap="space-12">
@@ -100,6 +107,12 @@ export function ActiveFilters({ params }: ActiveFiltersProps) {
           <strong>{filter.label}:</strong> {filter.value}
         </BodyShort>
       ))}
+
+      {phraseFilter && phraseLabel && (
+        <BodyShort size="small" spacing>
+          <strong>{phraseLabel}:</strong> «{phraseFilter.surface}»
+        </BodyShort>
+      )}
 
       {segmentEntries.length > 0 && (
         <VStack gap="space-4">

--- a/apps/lumi-dashboard/app/components/export/Panel.tsx
+++ b/apps/lumi-dashboard/app/components/export/Panel.tsx
@@ -56,6 +56,7 @@ export function ExportPanel() {
           segment: params.segment,
           choice: splitChoiceParam(params.choice),
           rating: splitRatingParam(params.rating),
+          phrase: params.phrase,
         },
       });
 

--- a/apps/lumi-dashboard/app/components/shared/ActiveFiltersChips/__tests__/ActiveFiltersChips.test.tsx
+++ b/apps/lumi-dashboard/app/components/shared/ActiveFiltersChips/__tests__/ActiveFiltersChips.test.tsx
@@ -4,6 +4,7 @@ import type { ReactNode } from "react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import { useChoiceFilter } from "~/hooks/useChoiceFilter";
+import { usePhraseFilter } from "~/hooks/usePhraseFilter";
 import { useRatingFilter } from "~/hooks/useRatingFilter";
 import type { SearchParams } from "~/hooks/useSearchParams";
 import { useSearchParams } from "~/hooks/useSearchParams";
@@ -26,6 +27,10 @@ vi.mock("~/hooks/useChoiceFilter", () => ({
 
 vi.mock("~/hooks/useRatingFilter", () => ({
   useRatingFilter: vi.fn(),
+}));
+
+vi.mock("~/hooks/usePhraseFilter", () => ({
+  usePhraseFilter: vi.fn(),
 }));
 
 vi.mock("~/hooks/useStats", () => ({
@@ -60,12 +65,14 @@ const mockUseSearchParams = vi.mocked(useSearchParams);
 const mockUseSegmentFilter = vi.mocked(useSegmentFilter);
 const mockUseChoiceFilter = vi.mocked(useChoiceFilter);
 const mockUseRatingFilter = vi.mocked(useRatingFilter);
+const mockUsePhraseFilter = vi.mocked(usePhraseFilter);
 const mockUseStats = vi.mocked(useStats);
 const mockUseThemes = vi.mocked(useThemes);
 
 const removeSegment = vi.fn();
 const removeChoice = vi.fn();
 const removeRating = vi.fn();
+const removePhrase = vi.fn();
 const setParams = vi.fn();
 
 const stats = {
@@ -90,6 +97,18 @@ const stats = {
         type: "rating",
         average: 1.8,
         distribution: { "1": 2, "2": 8 },
+      },
+    },
+    {
+      fieldId: "comment",
+      fieldType: "TEXT",
+      label: "Legg gjerne til en begrunnelse",
+      stats: {
+        type: "text",
+        responseCount: 42,
+        responseRate: 70,
+        topKeywords: [],
+        recentResponses: [],
       },
     },
   ],
@@ -135,6 +154,12 @@ beforeEach(() => {
     removeRating,
     clearRatings: vi.fn(),
     isActive: vi.fn(),
+  } as never);
+
+  mockUsePhraseFilter.mockReturnValue({
+    activeFilter: null,
+    setPhrase: vi.fn(),
+    removePhrase,
   } as never);
 
   mockUseStats.mockReturnValue({
@@ -302,5 +327,56 @@ describe("ActiveFiltersChips", () => {
     expect(screen.getByText("Fikk du hjelp?: Ja")).toBeInTheDocument();
     expect(screen.getByText("User Type: Arbeidsgiver")).toBeInTheDocument();
     expect(screen.getAllByRole("button")).toHaveLength(5);
+  });
+
+  it("renders a phrase filter chip with field label and quoted surface", () => {
+    mockUsePhraseFilter.mockReturnValue({
+      activeFilter: { fieldId: "comment", surface: "vanskelig forstå" },
+      setPhrase: vi.fn(),
+      removePhrase,
+    } as never);
+
+    renderActiveFiltersChips({
+      phrase: "comment:vanskelig forstå",
+    });
+
+    expect(
+      screen.getByText("Legg gjerne til en begrunnelse: «vanskelig forstå»"),
+    ).toBeInTheDocument();
+  });
+
+  it("phrase chip falls back to 'Frase' when field not found in stats", () => {
+    mockUsePhraseFilter.mockReturnValue({
+      activeFilter: { fieldId: "unknown-field", surface: "test phrase" },
+      setPhrase: vi.fn(),
+      removePhrase,
+    } as never);
+
+    renderActiveFiltersChips({
+      phrase: "unknown-field:test phrase",
+    });
+
+    expect(screen.getByText("Frase: «test phrase»")).toBeInTheDocument();
+  });
+
+  it("clicking the remove button on phrase chip calls removePhrase", async () => {
+    const user = userEvent.setup();
+    mockUsePhraseFilter.mockReturnValue({
+      activeFilter: { fieldId: "comment", surface: "vanskelig forstå" },
+      setPhrase: vi.fn(),
+      removePhrase,
+    } as never);
+
+    renderActiveFiltersChips({
+      phrase: "comment:vanskelig forstå",
+    });
+
+    await user.click(
+      screen.getByRole("button", {
+        name: "Fjern filter Legg gjerne til en begrunnelse: «vanskelig forstå»",
+      }),
+    );
+
+    expect(removePhrase).toHaveBeenCalled();
   });
 });

--- a/apps/lumi-dashboard/app/components/shared/ActiveFiltersChips/index.tsx
+++ b/apps/lumi-dashboard/app/components/shared/ActiveFiltersChips/index.tsx
@@ -142,7 +142,10 @@ export function ActiveFiltersChips() {
             className={styles.removeButton}
             aria-label={`Fjern filter ${chip.label}: ${chip.value}`}
           >
-            <XMarkIcon fontSize="1rem" className={styles.removeIcon} />
+            <XMarkIcon
+              fontSize="var(--ax-font-size-medium)"
+              className={styles.removeIcon}
+            />
           </button>
         </Tag>
       ))}

--- a/apps/lumi-dashboard/app/components/shared/ActiveFiltersChips/index.tsx
+++ b/apps/lumi-dashboard/app/components/shared/ActiveFiltersChips/index.tsx
@@ -1,6 +1,7 @@
 import { XMarkIcon } from "@navikt/aksel-icons";
 import { HStack, Tag } from "@navikt/ds-react";
 import { useChoiceFilter } from "~/hooks/useChoiceFilter";
+import { usePhraseFilter } from "~/hooks/usePhraseFilter";
 import { useRatingFilter } from "~/hooks/useRatingFilter";
 import { useSearchParams } from "~/hooks/useSearchParams";
 import { useSegmentFilter } from "~/hooks/useSegmentFilter";
@@ -28,6 +29,7 @@ export function ActiveFiltersChips() {
   const { activeFilters: activeSegments, removeSegment } = useSegmentFilter();
   const { removeChoice } = useChoiceFilter();
   const { removeRating } = useRatingFilter();
+  const { activeFilter: phraseFilter, removePhrase } = usePhraseFilter();
   const statsQuery = useStats();
   const { themes } = useThemes();
   const { choiceFilters, ratingFilters, themeLabel } = getFilterLabels({
@@ -101,6 +103,19 @@ export function ActiveFiltersChips() {
       label: formatMetadataLabel(key),
       value,
       onRemove: () => removeSegment(`${key}:${value}`),
+    });
+  }
+
+  if (phraseFilter) {
+    const fieldLabel =
+      statsQuery.data?.fieldStats?.find(
+        (f) => f.fieldId === phraseFilter.fieldId,
+      )?.label ?? "Frase";
+    chips.push({
+      key: `phrase-${phraseFilter.fieldId}`,
+      label: fieldLabel,
+      value: `«${phraseFilter.surface}»`,
+      onRemove: () => removePhrase(),
     });
   }
 

--- a/apps/lumi-dashboard/app/components/shared/FilterBar/index.tsx
+++ b/apps/lumi-dashboard/app/components/shared/FilterBar/index.tsx
@@ -86,11 +86,13 @@ export function FilterBar({ showDetails = false }: FilterBarProps) {
     setParams({
       app: newApp,
       page: "1",
+      // phrase, choice and rating are field-bound (belong to a specific survey
+      // in a specific app) — always clear on app change to avoid stale filters.
+      phrase: undefined,
+      choice: undefined,
+      rating: undefined,
       ...(shouldClearSurvey && {
         surveyId: undefined,
-        choice: undefined,
-        rating: undefined,
-        phrase: undefined,
       }),
     });
   };

--- a/apps/lumi-dashboard/app/components/shared/FilterBar/index.tsx
+++ b/apps/lumi-dashboard/app/components/shared/FilterBar/index.tsx
@@ -90,6 +90,7 @@ export function FilterBar({ showDetails = false }: FilterBarProps) {
         surveyId: undefined,
         choice: undefined,
         rating: undefined,
+        phrase: undefined,
       }),
     });
   };
@@ -99,6 +100,7 @@ export function FilterBar({ showDetails = false }: FilterBarProps) {
       surveyId: newSurveyId,
       choice: undefined,
       rating: undefined,
+      phrase: undefined,
       page: "1",
     });
   };
@@ -135,6 +137,7 @@ export function FilterBar({ showDetails = false }: FilterBarProps) {
       theme: undefined,
       choice: undefined,
       rating: undefined,
+      phrase: undefined,
       page: undefined,
       size: undefined,
     });
@@ -152,7 +155,8 @@ export function FilterBar({ showDetails = false }: FilterBarProps) {
     params.task ||
     params.theme ||
     params.choice ||
-    params.rating;
+    params.rating ||
+    params.phrase;
 
   const isPending = isPendingBootstrap || isPendingStats;
 
@@ -242,6 +246,7 @@ export function FilterBar({ showDetails = false }: FilterBarProps) {
                   onChange={(e) =>
                     setParams({
                       query: e.target.value || undefined,
+                      phrase: undefined,
                       page: "1",
                     })
                   }
@@ -376,6 +381,7 @@ export function FilterBar({ showDetails = false }: FilterBarProps) {
                 onChange={(e) =>
                   setParams({
                     query: e.target.value || undefined,
+                    phrase: undefined,
                     page: "1",
                   })
                 }

--- a/apps/lumi-dashboard/app/hooks/useFeedback.ts
+++ b/apps/lumi-dashboard/app/hooks/useFeedback.ts
@@ -9,6 +9,10 @@ export type { FeedbackPage } from "~/types/api";
 export function useFeedback() {
   const { params } = useSearchParams();
 
+  // Canonicalize: when phrase is active, ignore free-text query to avoid
+  // conflicting filters (phrase is the more specific filter).
+  const effectiveQuery = params.phrase ? undefined : params.query;
+
   return useQuery({
     queryKey: [
       "feedback",
@@ -20,7 +24,7 @@ export function useFeedback() {
       params.fromDate,
       params.toDate,
       params.hasText,
-      params.query,
+      effectiveQuery,
       params.tag,
       params.lowRating,
       params.deviceType,
@@ -42,7 +46,7 @@ export function useFeedback() {
           fromDate: params.fromDate,
           toDate: params.toDate,
           hasText: params.hasText,
-          query: params.query,
+          query: effectiveQuery,
           tag: params.tag,
           lowRating: params.lowRating,
           deviceType: params.deviceType,

--- a/apps/lumi-dashboard/app/hooks/useFeedback.ts
+++ b/apps/lumi-dashboard/app/hooks/useFeedback.ts
@@ -29,6 +29,7 @@ export function useFeedback() {
       params.segment,
       params.rating,
       params.choice,
+      params.phrase,
     ],
     queryFn: () =>
       fetchFeedbackServerFn({
@@ -50,6 +51,7 @@ export function useFeedback() {
           segment: params.segment,
           rating: splitRatingParam(params.rating),
           choice: splitChoiceParam(params.choice),
+          phrase: params.phrase,
         },
       }),
     staleTime: 10000,

--- a/apps/lumi-dashboard/app/hooks/usePhraseFilter.ts
+++ b/apps/lumi-dashboard/app/hooks/usePhraseFilter.ts
@@ -1,0 +1,34 @@
+import { useSearchParams } from "~/hooks/useSearchParams";
+import {
+  type PhraseFilterValue,
+  parsePhraseParam,
+  stringifyPhraseFilter,
+} from "~/utils/phraseFilterUtils";
+
+export function usePhraseFilter() {
+  const { params, setParams } = useSearchParams();
+  const activeFilter: PhraseFilterValue | null = parsePhraseParam(
+    params.phrase,
+  );
+
+  const setPhrase = (fieldId: string, surface: string) => {
+    setParams({
+      phrase: stringifyPhraseFilter(fieldId, surface),
+      query: undefined,
+      page: "1",
+    });
+  };
+
+  const removePhrase = () => {
+    setParams({
+      phrase: undefined,
+      page: "1",
+    });
+  };
+
+  return {
+    activeFilter,
+    setPhrase,
+    removePhrase,
+  };
+}

--- a/apps/lumi-dashboard/app/mock/utils/filters.ts
+++ b/apps/lumi-dashboard/app/mock/utils/filters.ts
@@ -201,6 +201,7 @@ export function applyFeedbackFilters(
 
     const [phraseWord1, phraseWord2] = phraseFilter.surface
       .toLowerCase()
+      .replace(/[^\wæøå\s]/g, "")
       .split(" ");
 
     filtered = filtered.filter((item) =>
@@ -208,7 +209,11 @@ export function applyFeedbackFilters(
         if (answer.fieldId !== phraseFilter.fieldId) return false;
         if (answer.fieldType !== "TEXT") return false;
         const text = (answer.value.text ?? "").toLowerCase();
-        const words = text.split(/\s+/).filter(Boolean);
+        // Strip punctuation before splitting — matches extractPhrases normalization
+        const words = text
+          .replace(/[^\wæøå\s]/g, "")
+          .split(/\s+/)
+          .filter(Boolean);
 
         for (let i = 0; i < words.length - 1; i++) {
           // Direct adjacency

--- a/apps/lumi-dashboard/app/mock/utils/filters.ts
+++ b/apps/lumi-dashboard/app/mock/utils/filters.ts
@@ -4,6 +4,7 @@
 
 import type { FeedbackDto } from "~/types/api";
 import { parseChoiceParam } from "~/utils/choiceFilterUtils";
+import { parsePhraseParam } from "~/utils/phraseFilterUtils";
 import { parseRatingParam } from "~/utils/ratingFilterUtils";
 import { mockThemes } from "../themes";
 import { getTaskNameFromFeedback } from "./extractors";
@@ -22,6 +23,7 @@ export interface FilterParams {
   theme?: string;
   rating?: string;
   choice?: string;
+  phrase?: string;
 }
 
 export function applyFeedbackFilters(
@@ -160,6 +162,74 @@ export function applyFeedbackFilters(
     );
   }
 
+  const phraseFilter = parsePhraseParam(filters.phrase);
+  if (phraseFilter) {
+    // Simplified adjacency matching for mock — backend does full stem-bigram matching.
+    // We split the text into words and check if the two phrase words appear adjacent
+    // (or separated by at most one stopword). This is a deliberate simplification;
+    // real matching uses Norwegian stemming on server side.
+    const STOPWORDS = new Set([
+      "og",
+      "i",
+      "på",
+      "er",
+      "det",
+      "en",
+      "et",
+      "å",
+      "som",
+      "for",
+      "med",
+      "av",
+      "til",
+      "den",
+      "de",
+      "har",
+      "jeg",
+      "fra",
+      "var",
+      "vi",
+      "kan",
+      "om",
+      "men",
+      "da",
+      "ikke",
+      "så",
+      "han",
+      "hun",
+    ]);
+
+    const [phraseWord1, phraseWord2] = phraseFilter.surface
+      .toLowerCase()
+      .split(" ");
+
+    filtered = filtered.filter((item) =>
+      item.answers.some((answer) => {
+        if (answer.fieldId !== phraseFilter.fieldId) return false;
+        if (answer.fieldType !== "TEXT") return false;
+        const text = (answer.value.text ?? "").toLowerCase();
+        const words = text.split(/\s+/).filter(Boolean);
+
+        for (let i = 0; i < words.length - 1; i++) {
+          // Direct adjacency
+          if (words[i] === phraseWord1 && words[i + 1] === phraseWord2) {
+            return true;
+          }
+          // One stopword in between
+          if (
+            i < words.length - 2 &&
+            words[i] === phraseWord1 &&
+            STOPWORDS.has(words[i + 1]) &&
+            words[i + 2] === phraseWord2
+          ) {
+            return true;
+          }
+        }
+        return false;
+      }),
+    );
+  }
+
   return filtered;
 }
 
@@ -183,6 +253,7 @@ function normalizeParams(params: FilterParams | URLSearchParams): FilterParams {
       theme: params.get("theme") ?? undefined,
       rating: params.get("rating") ?? undefined,
       choice: params.get("choice") ?? undefined,
+      phrase: params.get("phrase") ?? undefined,
     };
   }
 

--- a/apps/lumi-dashboard/app/schemas/searchSchema.ts
+++ b/apps/lumi-dashboard/app/schemas/searchSchema.ts
@@ -24,6 +24,7 @@ export const searchSchema = z
     task: optionalStringParam,
     choice: optionalStringParam,
     rating: optionalStringParam,
+    phrase: optionalStringParam,
     // Legacy params — kept temporarily for bookmarked URL migration
     choiceFieldId: optionalStringParam,
     choiceValue: optionalStringParam,

--- a/apps/lumi-dashboard/app/server/actions/export.ts
+++ b/apps/lumi-dashboard/app/server/actions/export.ts
@@ -189,6 +189,7 @@ function transformToBackendParams(data: ExportParams) {
     segment: data.segment?.split(",").filter(Boolean),
     choice: data.choice?.length ? data.choice : undefined,
     rating: data.rating?.length ? data.rating : undefined,
+    phrase: data.phrase,
   };
 }
 

--- a/apps/lumi-dashboard/app/server/actions/export.ts
+++ b/apps/lumi-dashboard/app/server/actions/export.ts
@@ -172,6 +172,9 @@ function transformToBackendParams(data: ExportParams) {
     .map((t) => t.trim())
     .filter(Boolean);
 
+  // Canonicalize: phrase wins over query (same rule as useFeedback)
+  const effectiveQuery = data.phrase ? undefined : data.query;
+
   return {
     format: data.format,
     team: data.team,
@@ -181,7 +184,7 @@ function transformToBackendParams(data: ExportParams) {
     toDate: data.toDate,
     hasText: data.hasText === "true" ? "true" : undefined,
     lowRating: data.lowRating === "true" ? "true" : undefined,
-    query: data.query,
+    query: effectiveQuery,
     tag: tag && tag.length > 0 ? tag : undefined,
     deviceType: data.deviceType,
     theme: data.theme,

--- a/apps/lumi-dashboard/app/server/actions/fetchFeedback.ts
+++ b/apps/lumi-dashboard/app/server/actions/fetchFeedback.ts
@@ -61,6 +61,9 @@ function transformToBackendParams(data: FeedbackActionParams) {
     .map((entry) => entry.trim())
     .filter(Boolean);
 
+  // Canonicalize: phrase wins over query (same rule as useFeedback)
+  const effectiveQuery = data.phrase ? undefined : data.query;
+
   return {
     team: data.team,
     app: data.app,
@@ -71,7 +74,7 @@ function transformToBackendParams(data: FeedbackActionParams) {
     toDate: data.toDate,
     hasText: data.hasText === "true" ? "true" : undefined,
     lowRating: data.lowRating === "true" ? "true" : undefined,
-    query: data.query,
+    query: effectiveQuery,
     tag: tag && tag.length > 0 ? tag : undefined,
     deviceType: data.deviceType,
     theme: data.theme,

--- a/apps/lumi-dashboard/app/server/actions/fetchFeedback.ts
+++ b/apps/lumi-dashboard/app/server/actions/fetchFeedback.ts
@@ -31,6 +31,7 @@ interface FeedbackActionParams {
   segment?: string;
   choice?: string[];
   rating?: string[];
+  phrase?: string;
 }
 
 function toMockSearchParams(data: FeedbackActionParams): URLSearchParams {
@@ -78,6 +79,7 @@ function transformToBackendParams(data: FeedbackActionParams) {
     segment: data.segment?.split(",").filter(Boolean),
     choice: data.choice,
     rating: data.rating,
+    phrase: data.phrase,
   };
 }
 

--- a/apps/lumi-dashboard/app/utils/__tests__/phraseFilterUtils.test.ts
+++ b/apps/lumi-dashboard/app/utils/__tests__/phraseFilterUtils.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  parsePhraseParam,
+  stringifyPhraseFilter,
+} from "~/utils/phraseFilterUtils";
+
+describe("parsePhraseParam", () => {
+  it("parses valid bigram phrase param", () => {
+    expect(parsePhraseParam("comment:vanskelig forstå")).toEqual({
+      fieldId: "comment",
+      surface: "vanskelig forstå",
+    });
+  });
+
+  it("returns null for single-word surface", () => {
+    expect(parsePhraseParam("field-1:hello")).toBeNull();
+  });
+
+  it("returns null for 3+ word surface", () => {
+    expect(parsePhraseParam("field:one two three")).toBeNull();
+  });
+
+  it("returns null for surface with colon", () => {
+    expect(parsePhraseParam("field:with:colon")).toBeNull();
+  });
+
+  it("returns null for undefined", () => {
+    expect(parsePhraseParam(undefined)).toBeNull();
+  });
+
+  it("returns null for empty string", () => {
+    expect(parsePhraseParam("")).toBeNull();
+  });
+
+  it("returns null for missing colon", () => {
+    expect(parsePhraseParam("no-colon-here")).toBeNull();
+  });
+
+  it("returns null for empty fieldId", () => {
+    expect(parsePhraseParam(":surface")).toBeNull();
+  });
+
+  it("returns null for empty surface", () => {
+    expect(parsePhraseParam("field:")).toBeNull();
+  });
+
+  it("returns null for surface with multiple consecutive spaces", () => {
+    expect(parsePhraseParam("field:word1  word2")).toBeNull();
+  });
+
+  it("returns null for surface with leading space", () => {
+    expect(parsePhraseParam("field: word1 word2")).toBeNull();
+  });
+
+  it("returns null for surface with trailing space", () => {
+    expect(parsePhraseParam("field:word1 word2 ")).toBeNull();
+  });
+
+  it("roundtrips with stringifyPhraseFilter", () => {
+    const fieldId = "comment-field";
+    const surface = "vanskelig forstå";
+    const raw = stringifyPhraseFilter(fieldId, surface);
+    const result = parsePhraseParam(raw);
+    expect(result).toEqual({ fieldId, surface });
+  });
+});
+
+describe("stringifyPhraseFilter", () => {
+  it("formats fieldId:surface", () => {
+    expect(stringifyPhraseFilter("comment", "vanskelig forstå")).toBe(
+      "comment:vanskelig forstå",
+    );
+  });
+});

--- a/apps/lumi-dashboard/app/utils/phraseFilterUtils.ts
+++ b/apps/lumi-dashboard/app/utils/phraseFilterUtils.ts
@@ -1,0 +1,42 @@
+export interface PhraseFilterValue {
+  fieldId: string;
+  surface: string;
+}
+
+/**
+ * Parse URL phrase param into structured filter value.
+ * Format: "fieldId:word1 word2"
+ * Splits on first ":", validates that fieldId is non-empty
+ * and surface is "word word" (one space between words, each word ≥1 char).
+ */
+export function parsePhraseParam(
+  raw: string | undefined,
+): PhraseFilterValue | null {
+  if (!raw) return null;
+
+  const colonIndex = raw.indexOf(":");
+  if (colonIndex <= 0) return null;
+
+  const fieldId = raw.slice(0, colonIndex);
+  const surface = raw.slice(colonIndex + 1);
+
+  if (!fieldId || !surface) return null;
+
+  // Validate surface: must be exactly two words (bigram) separated by single space, no colons allowed
+  const words = surface.split(" ");
+  if (words.length !== 2) return null;
+  if (words.some((w) => w.length === 0 || w.includes(":"))) return null;
+
+  return { fieldId, surface };
+}
+
+/**
+ * Stringify phrase filter to URL param format.
+ * Returns "fieldId:surface"
+ */
+export function stringifyPhraseFilter(
+  fieldId: string,
+  surface: string,
+): string {
+  return `${fieldId}:${surface}`;
+}

--- a/apps/lumi-dashboard/e2e/text-field-phrases.spec.ts
+++ b/apps/lumi-dashboard/e2e/text-field-phrases.spec.ts
@@ -18,7 +18,7 @@ test.describe("TextFieldCard phrases", () => {
 
     // Phrase links should be visible and clickable
     const phraseLinks = page.getByRole("link", {
-      name: /Vis \d+ tilbakemeldinger som inneholder frasen/i,
+      name: /Vis \d+ tilbakemeldinger med frasen/i,
     });
     await expect(phraseLinks.first()).toBeVisible({ timeout: 5000 });
 
@@ -28,13 +28,15 @@ test.describe("TextFieldCard phrases", () => {
     expect(phraseCount).toBeGreaterThan(0);
   });
 
-  test("clicking phrase navigates to feedback with query", async ({ page }) => {
+  test("clicking phrase navigates to feedback with phrase param", async ({
+    page,
+  }) => {
     await page.goto("/?surveyId=survey-vurdering");
     await page.waitForLoadState("networkidle");
     await expect(page.locator("main")).toBeVisible({ timeout: 15000 });
 
     const phraseLinks = page.getByRole("link", {
-      name: /Vis \d+ tilbakemeldinger som inneholder frasen/i,
+      name: /Vis \d+ tilbakemeldinger med frasen/i,
     });
     await expect(phraseLinks.first()).toBeVisible({ timeout: 10000 });
 
@@ -44,15 +46,28 @@ test.describe("TextFieldCard phrases", () => {
     const phraseMatch = ariaLabel?.match(/frasen «(.+?)»/);
     const phraseText = phraseMatch?.[1] ?? "";
 
+    // Extract count from aria-label
+    const countMatch = ariaLabel?.match(/Vis (\d+)/);
+    const expectedCount = countMatch?.[1] ?? "";
+
     await firstLink.click();
 
-    // Should navigate to /feedback with query param
+    // Should navigate to /feedback with phrase param (not query)
     await expect(page).toHaveURL(/\/feedback/, { timeout: 10000 });
+
+    // phrase param should contain fieldId:surface
+    await expect
+      .poll(() => new URL(page.url()).searchParams.get("phrase"), {
+        timeout: 5000,
+      })
+      .toContain(phraseText);
+
+    // query param should NOT be present (mutual exclusion)
     await expect
       .poll(() => new URL(page.url()).searchParams.get("query"), {
         timeout: 5000,
       })
-      .toBe(phraseText);
+      .toBeNull();
 
     // Should have hasText param set
     await expect
@@ -60,5 +75,27 @@ test.describe("TextFieldCard phrases", () => {
         timeout: 5000,
       })
       .toBe("true");
+
+    // A phrase filter chip should appear
+    const chipText = new RegExp(`«${phraseText}»`);
+    await expect(page.getByText(chipText)).toBeVisible({ timeout: 5000 });
+
+    // totalElements header or row count should reflect the expected count
+    if (expectedCount) {
+      const total = page.getByText(
+        new RegExp(`${expectedCount}\\s*(tilbakemelding|treff|resultat)`),
+      );
+      // This is a soft check — mock may render differently
+      const totalVisible = await total
+        .first()
+        .isVisible()
+        .catch(() => false);
+      if (!totalVisible) {
+        // Fallback: at least verify some feedback rows render
+        await expect(page.locator("main")).toContainText("tilbakemelding", {
+          timeout: 5000,
+        });
+      }
+    }
   });
 });

--- a/packages/lumi-types/src/schemas.ts
+++ b/packages/lumi-types/src/schemas.ts
@@ -58,6 +58,8 @@ export const FeedbackParamsSchema = z.object({
   choice: z.array(z.string()).optional(),
   /** Rating filters as repeated query params, each in format "fieldId:value" */
   rating: z.array(z.string()).optional(),
+  /** Phrase filter in format "fieldId:word1 word2" — exact bigram match */
+  phrase: z.string().optional(),
 });
 
 export type FeedbackParams = z.infer<typeof FeedbackParamsSchema>;
@@ -337,6 +339,8 @@ export const ExportParamsSchema = z.object({
   choice: z.array(z.string()).optional(),
   /** Rating filters as repeated query params, each in format "fieldId:value" */
   rating: z.array(z.string()).optional(),
+  /** Phrase filter in format "fieldId:word1 word2" — exact bigram match */
+  phrase: z.string().optional(),
 });
 
 export type ExportParams = z.infer<typeof ExportParamsSchema>;


### PR DESCRIPTION
## Hva

Følger opp tilbakemeldinger på bigram-fraser fra forrige iterasjon (#256).
Tre forbedringer på TextFieldCard for Rating- og Custom-undersøkelser:

1. **Eksakt-match drilldown** — klikk på en frase i "Hyppigste fraser" går
   nå til feedback-listen og viser **nøyaktig samme antall** svar som
   tallet i kortet. Tidligere brukte vi `LIKE '%query%'` mot hele
   JSON-blobben, noe som ga både overtelling (matchet i question-labels,
   options, tags) og undertelling (krevde sammenhengende streng — "svare
   spørsmål" matchet ikke "svare på spørsmål").
2. **Designløft** for "Hyppigste fraser" — tydeligere visuell inndeling
   med rang-pille, bakgrunns-bar og separatorer.
3. **"Siste svar"** cappes til 3 (var 5) for å spare plass.

## Hvordan

**Backend (Kotlin/Ktor):**
- Ny `PhraseFilter(fieldId, surface)` på `FeedbackQuery` (single, ikke liste — multi i senere iterasjon).
- `parsePhraseFilter` validerer på normalisert form: `TextProcessor.extractWords(surface)` må gi nøyaktig 2 ord. `fieldId` valideres via samme `validateJsonPathFieldId` som choice/rating. PII-safe feilmeldinger (logger aldri råinput).
- `phrase`-query-parameter på Feedback- og Export-resources.
- `matchesPhraseFilter` i `FeedbackRepositorySupport` bruker **samme** `TextProcessor.extractBigrams()`-pipeline som `FeedbackStatsHelpers` → garantert paritet med dashboard-count. `stemKey` pre-beregnes utenfor filter-løkka i `findPaginated`.
- **Contract-test** itererer over alle topPhrases og verifiserer paritet (robust mot ties).

**Frontend (TanStack Start + Aksel):**
- `phrase: optionalStringParam` i søke-skjema, format `?phrase=<fieldId>:<word1> <word2>` (kolon-separator, `splitN(":", 2)`).
- `usePhraseFilter`-hook speiler `useChoiceFilter`-mønsteret.
- **Mutual exclusion**: phrase og query rydder hverandre — også scope-bytte rydder phrase. `hasActiveFilters` inkluderer phrase.
- `ActiveFiltersChips` viser phrase-chip med felt-label.
- Mock-filter med adjacency-matching for E2E.

**Design (Aksel):**
- Rang-pille (1–5), full-bredde proporsjonell bakgrunns-bar, subtile separatorer, ArrowRightIcon på hover.
- Kun Aksel-tokens (`--ax-space-*`, `--ax-font-size-*`).
- Beholder `<ol>`/`<Link>`-semantikk og WCAG AA.

## URL-format

`?phrase=<fieldId>:<word1> <word2>` — single value. Phrase og `query` er gjensidig utelukkende (klikk på phrase fjerner query og omvendt).

## Risikovurdering

- **Stemming-paritet** — låst via contract-test.
- **Felt fjernet fra survey** — chip vises, liste blir tom, akseptabelt.
- **PII** — phrase logges aldri (kun strukturelle valideringsfeil).
- **In-memory ytelse** — samme presedens som theme/task-filtre.

## Sjekkliste

- [x] `pnpm run lint` (kun pre-eksisterende warnings)
- [x] `pnpm run typecheck`
- [x] `pnpm run test` — 231 tester
- [x] `pnpm run api:test` — inkl. ny contract-test
- [x] Backend og frontend gjennomgått — alle merknader adressert
- [ ] E2E lokalt (anbefales før merge)

## Issues

Følger opp tilbakemeldinger på #256.