### PR TITLE
feat(api): aktiver pgaudit for database-audit

### DIFF
--- a/apps/lumi-api/nais/app/prod.yaml
+++ b/apps/lumi-api/nais/app/prod.yaml
@@ -61,6 +61,11 @@ spec:
         tier: db-custom-1-3840
         diskAutoresize: true
         highAvailability: false
+        flags:
+          - name: "cloudsql.enable_pgaudit"
+            value: "on"
+          - name: "pgaudit.log"
+            value: "write,ddl,role"
         databases:
           - name: lumi
             envVarPrefix: DB


### PR DESCRIPTION
## Hva

Aktiverer pgaudit på CloudSQL-instansen i prod for å oppfylle etterlevelseskrav K267.

### Endring
- `cloudsql.enable_pgaudit=on` + `pgaudit.log=write,ddl,role` i prod NAIS-manifest
- `log_parameter` utelatt — unngår PII-lekkasje av feedback-innhold

### Manuelt steg etter deploy
```sh
nais postgres enable-audit --team team-esyfo --environment prod lumi-api
```

Closes #262