### PR TITLE
feat(api): extend PII redaction to URL, tags, and debug fields

### DIFF
--- a/apps/lumi-api/src/main/kotlin/no/nav/lumi/sensitive/JsonRedactor.kt
+++ b/apps/lumi-api/src/main/kotlin/no/nav/lumi/sensitive/JsonRedactor.kt
@@ -24,13 +24,14 @@ class JsonRedactor(
         fun walk(el: JsonElement): JsonElement {
             return when (el) {
                 is JsonObject -> {
+                    val originalKeys = el.keys
                     val newEntries = mutableMapOf<String, JsonElement>()
                     for ((key, value) in el) {
                         val keyResult = sensitiveDataFilter.redact(key)
                         val finalKey = if (keyResult.wasRedacted) {
                             wasRedacted = true
                             keyCounter++
-                            generateUniqueKey(newEntries, keyCounter)
+                            generateUniqueKey(newEntries, originalKeys, keyCounter)
                         } else {
                             key
                         }
@@ -56,7 +57,6 @@ class JsonRedactor(
                         }
                     }
                 }
-                else -> el
             }
         }
 
@@ -64,10 +64,14 @@ class JsonRedactor(
         return result to wasRedacted
     }
 
-    private fun generateUniqueKey(existing: Map<String, *>, startCounter: Int): String {
+    private fun generateUniqueKey(
+        written: Map<String, *>,
+        originalKeys: Set<String>,
+        startCounter: Int
+    ): String {
         var candidate = "[REDACTED_KEY_$startCounter]"
         var suffix = startCounter
-        while (existing.containsKey(candidate)) {
+        while (written.containsKey(candidate) || originalKeys.contains(candidate)) {
             suffix++
             candidate = "[REDACTED_KEY_$suffix]"
         }

--- a/apps/lumi-api/src/main/kotlin/no/nav/lumi/sensitive/JsonRedactor.kt
+++ b/apps/lumi-api/src/main/kotlin/no/nav/lumi/sensitive/JsonRedactor.kt
@@ -5,9 +5,10 @@ import kotlinx.serialization.json.*
 /**
  * Recursively walks a JsonElement tree and redacts PII from:
  * - String primitive values
+ * - Numeric primitive values (converted to string for PII matching)
  * - Object keys containing PII (replaced with [REDACTED_KEY_n])
  *
- * Numbers, booleans, and nulls are left untouched.
+ * Booleans and nulls are left untouched.
  */
 class JsonRedactor(
     private val sensitiveDataFilter: SensitiveDataFilter = SensitiveDataFilter.DEFAULT
@@ -42,7 +43,10 @@ class JsonRedactor(
                     JsonArray(el.map { walk(it) })
                 }
                 is JsonPrimitive -> {
-                    if (el.isString) {
+                    // Check strings and numbers for PII (skip booleans)
+                    if (el.booleanOrNull != null) {
+                        el
+                    } else {
                         val content = el.content
                         val result = sensitiveDataFilter.redact(content)
                         if (result.wasRedacted) {
@@ -51,8 +55,6 @@ class JsonRedactor(
                         } else {
                             el
                         }
-                    } else {
-                        el // numbers, booleans, nulls — leave as-is
                     }
                 }
                 is JsonNull -> el

--- a/apps/lumi-api/src/main/kotlin/no/nav/lumi/sensitive/JsonRedactor.kt
+++ b/apps/lumi-api/src/main/kotlin/no/nav/lumi/sensitive/JsonRedactor.kt
@@ -43,8 +43,8 @@ class JsonRedactor(
                     JsonArray(el.map { walk(it) })
                 }
                 is JsonPrimitive -> {
-                    // Check strings and numbers for PII (skip booleans)
-                    if (el.booleanOrNull != null) {
+                    // Skip booleans and null
+                    if (el is JsonNull || el.booleanOrNull != null) {
                         el
                     } else {
                         val content = el.content
@@ -57,7 +57,7 @@ class JsonRedactor(
                         }
                     }
                 }
-                is JsonNull -> el
+                else -> el
             }
         }
 

--- a/apps/lumi-api/src/main/kotlin/no/nav/lumi/sensitive/JsonRedactor.kt
+++ b/apps/lumi-api/src/main/kotlin/no/nav/lumi/sensitive/JsonRedactor.kt
@@ -26,12 +26,11 @@ class JsonRedactor(
                 is JsonObject -> {
                     val newEntries = mutableMapOf<String, JsonElement>()
                     for ((key, value) in el) {
-                        // Check if key contains PII
                         val keyResult = sensitiveDataFilter.redact(key)
                         val finalKey = if (keyResult.wasRedacted) {
                             wasRedacted = true
                             keyCounter++
-                            "[REDACTED_KEY_$keyCounter]"
+                            generateUniqueKey(newEntries, keyCounter)
                         } else {
                             key
                         }
@@ -63,5 +62,15 @@ class JsonRedactor(
 
         val result = walk(element)
         return result to wasRedacted
+    }
+
+    private fun generateUniqueKey(existing: Map<String, *>, startCounter: Int): String {
+        var candidate = "[REDACTED_KEY_$startCounter]"
+        var suffix = startCounter
+        while (existing.containsKey(candidate)) {
+            suffix++
+            candidate = "[REDACTED_KEY_$suffix]"
+        }
+        return candidate
     }
 }

--- a/apps/lumi-api/src/main/kotlin/no/nav/lumi/sensitive/JsonRedactor.kt
+++ b/apps/lumi-api/src/main/kotlin/no/nav/lumi/sensitive/JsonRedactor.kt
@@ -1,0 +1,65 @@
+package no.nav.lumi.sensitive
+
+import kotlinx.serialization.json.*
+
+/**
+ * Recursively walks a JsonElement tree and redacts PII from:
+ * - String primitive values
+ * - Object keys containing PII (replaced with [REDACTED_KEY_n])
+ *
+ * Numbers, booleans, and nulls are left untouched.
+ */
+class JsonRedactor(
+    private val sensitiveDataFilter: SensitiveDataFilter = SensitiveDataFilter.DEFAULT
+) {
+    /**
+     * Redact PII from a JSON element recursively.
+     * Returns the redacted element and whether any redaction occurred.
+     */
+    fun redactJsonElement(element: JsonElement): Pair<JsonElement, Boolean> {
+        var wasRedacted = false
+        var keyCounter = 0
+
+        fun walk(el: JsonElement): JsonElement {
+            return when (el) {
+                is JsonObject -> {
+                    val newEntries = mutableMapOf<String, JsonElement>()
+                    for ((key, value) in el) {
+                        // Check if key contains PII
+                        val keyResult = sensitiveDataFilter.redact(key)
+                        val finalKey = if (keyResult.wasRedacted) {
+                            wasRedacted = true
+                            keyCounter++
+                            "[REDACTED_KEY_$keyCounter]"
+                        } else {
+                            key
+                        }
+                        newEntries[finalKey] = walk(value)
+                    }
+                    JsonObject(newEntries)
+                }
+                is JsonArray -> {
+                    JsonArray(el.map { walk(it) })
+                }
+                is JsonPrimitive -> {
+                    if (el.isString) {
+                        val content = el.content
+                        val result = sensitiveDataFilter.redact(content)
+                        if (result.wasRedacted) {
+                            wasRedacted = true
+                            JsonPrimitive(result.redactedText)
+                        } else {
+                            el
+                        }
+                    } else {
+                        el // numbers, booleans, nulls — leave as-is
+                    }
+                }
+                is JsonNull -> el
+            }
+        }
+
+        val result = walk(element)
+        return result to wasRedacted
+    }
+}

--- a/apps/lumi-api/src/main/kotlin/no/nav/lumi/sensitive/JsonRedactor.kt
+++ b/apps/lumi-api/src/main/kotlin/no/nav/lumi/sensitive/JsonRedactor.kt
@@ -63,18 +63,4 @@ class JsonRedactor(
         val result = walk(element)
         return result to wasRedacted
     }
-
-    private fun generateUniqueKey(
-        written: Map<String, *>,
-        originalKeys: Set<String>,
-        startCounter: Int
-    ): String {
-        var candidate = "[REDACTED_KEY_$startCounter]"
-        var suffix = startCounter
-        while (written.containsKey(candidate) || originalKeys.contains(candidate)) {
-            suffix++
-            candidate = "[REDACTED_KEY_$suffix]"
-        }
-        return candidate
-    }
 }

--- a/apps/lumi-api/src/main/kotlin/no/nav/lumi/sensitive/RedactionUtils.kt
+++ b/apps/lumi-api/src/main/kotlin/no/nav/lumi/sensitive/RedactionUtils.kt
@@ -1,0 +1,15 @@
+package no.nav.lumi.sensitive
+
+internal fun generateUniqueKey(
+    written: Map<String, *>,
+    originalKeys: Set<String>,
+    startCounter: Int
+): String {
+    var candidate = "[REDACTED_KEY_$startCounter]"
+    var suffix = startCounter
+    while (written.containsKey(candidate) || originalKeys.contains(candidate)) {
+        suffix++
+        candidate = "[REDACTED_KEY_$suffix]"
+    }
+    return candidate
+}

--- a/apps/lumi-api/src/main/kotlin/no/nav/lumi/sensitive/UrlRedactor.kt
+++ b/apps/lumi-api/src/main/kotlin/no/nav/lumi/sensitive/UrlRedactor.kt
@@ -2,6 +2,7 @@ package no.nav.lumi.sensitive
 
 import java.net.URLDecoder
 import java.net.URLEncoder
+import java.nio.charset.StandardCharsets
 
 data class UrlRedactionResult(
     val redactedUrl: String,
@@ -26,9 +27,15 @@ class UrlRedactor(
             return UrlRedactionResult(redactedUrl = "", wasRedacted = false)
         }
 
-        return try {
-            redactParsedUrl(url)
-        } catch (_: Exception) {
+        return if (looksLikeStructuredUrl(url)) {
+            try {
+                redactParsedUrl(url)
+            } catch (_: Exception) {
+                // Fallback: treat as plain text
+                val result = sensitiveDataFilter.redact(url)
+                UrlRedactionResult(result.redactedText, result.wasRedacted)
+            }
+        } else {
             // Fallback: treat as plain text
             val result = sensitiveDataFilter.redact(url)
             UrlRedactionResult(result.redactedText, result.wasRedacted)
@@ -66,7 +73,7 @@ class UrlRedactor(
         val baseResult = sensitiveDataFilter.redact(decodedBase)
         val redactedBase = if (baseResult.wasRedacted) {
             wasRedacted = true
-            baseResult.redactedText
+            percentEncodeUriUnsafe(baseResult.redactedText)
         } else {
             baseUrl // preserve original encoding when no PII found
         }
@@ -121,7 +128,7 @@ class UrlRedactor(
             val fragResult = sensitiveDataFilter.redact(decodedFragment)
             if (fragResult.wasRedacted) {
                 wasRedacted = true
-                fragResult.redactedText
+                percentEncodeUriUnsafe(fragResult.redactedText)
             } else {
                 fragment
             }
@@ -142,7 +149,34 @@ class UrlRedactor(
         return UrlRedactionResult(result, wasRedacted)
     }
 
+    /**
+     * Percent-encodes characters that are invalid in a URI path/fragment
+     * while preserving URL structural characters (scheme, host, slashes, etc.).
+     */
+    private fun percentEncodeUriUnsafe(text: String): String {
+        val sb = StringBuilder(text.length + 32)
+        for (char in text) {
+            when {
+                char.code in 0x21..0x7E && char !in " []{}|\\^`" -> sb.append(char)
+                else -> {
+                    for (b in char.toString().toByteArray(StandardCharsets.UTF_8)) {
+                        sb.append('%')
+                        sb.append(String.format("%02X", b.toInt() and 0xFF))
+                    }
+                }
+            }
+        }
+        return sb.toString()
+    }
+
     private fun decodeUntilStable(input: String): String = decodePercentEncoding(input)
+
+    private fun looksLikeStructuredUrl(input: String): Boolean {
+        if (input.startsWith("/")) return true
+        if (input.contains("://")) return true
+        if (!input.contains(' ') && (input.contains('?') || input.contains('#'))) return true
+        return false
+    }
 
     companion object {
         private val VALID_PERCENT = Regex("%[0-9A-Fa-f]{2}")

--- a/apps/lumi-api/src/main/kotlin/no/nav/lumi/sensitive/UrlRedactor.kt
+++ b/apps/lumi-api/src/main/kotlin/no/nav/lumi/sensitive/UrlRedactor.kt
@@ -145,7 +145,7 @@ class UrlRedactor(
     /**
      * Iteratively percent-decode until the string no longer changes.
      * Prevents double-encoding bypass (e.g. %2530%2531... → %30%31... → 01...).
-     * Limited to 3 passes to avoid infinite loops on pathological input.
+     * Limited to 10 passes to avoid infinite loops on pathological input.
      *
      * Uses percent-only decoding: `+` is preserved as literal `+` (not treated as space).
      * This prevents multi-pass degradation where `%2B` → `+` → ` ` would break
@@ -153,7 +153,7 @@ class UrlRedactor(
      */
     private fun decodeUntilStable(input: String): String {
         var current = input
-        repeat(3) {
+        repeat(10) {
             val decoded = try {
                 percentDecode(current)
             } catch (_: Exception) {

--- a/apps/lumi-api/src/main/kotlin/no/nav/lumi/sensitive/UrlRedactor.kt
+++ b/apps/lumi-api/src/main/kotlin/no/nav/lumi/sensitive/UrlRedactor.kt
@@ -168,10 +168,42 @@ class UrlRedactor(
     /**
      * Decode only %xx sequences, preserving `+` as literal.
      * Unlike URLDecoder.decode(), this does NOT treat `+` as space.
+     * Invalid percent sequences (lone `%` or `%` not followed by two hex digits)
+     * are escaped to `%25` before decoding so they don't abort the entire decode.
      */
     private fun percentDecode(input: String): String {
         // Protect `+` from URLDecoder's form-encoding interpretation
         val preserved = input.replace("+", "%2B")
-        return URLDecoder.decode(preserved, Charsets.UTF_8.name())
+        // Escape invalid percent sequences so URLDecoder doesn't throw
+        val sanitized = sanitizePercentEncoding(preserved)
+        return URLDecoder.decode(sanitized, Charsets.UTF_8.name())
+    }
+
+    private val VALID_PERCENT = Regex("%[0-9A-Fa-f]{2}")
+
+    /**
+     * Replace lone `%` or `%` not followed by two hex digits with `%25` (literal percent).
+     * This prevents URLDecoder from throwing on malformed input like `value%` or `%zz`.
+     */
+    private fun sanitizePercentEncoding(input: String): String {
+        val sb = StringBuilder(input.length)
+        var i = 0
+        while (i < input.length) {
+            if (input[i] == '%') {
+                if (i + 2 < input.length && VALID_PERCENT.matchesAt(input, i)) {
+                    // Valid %xx — keep as-is
+                    sb.append(input, i, i + 3)
+                    i += 3
+                } else {
+                    // Invalid/incomplete percent — escape to literal %
+                    sb.append("%25")
+                    i++
+                }
+            } else {
+                sb.append(input[i])
+                i++
+            }
+        }
+        return sb.toString()
     }
 }

--- a/apps/lumi-api/src/main/kotlin/no/nav/lumi/sensitive/UrlRedactor.kt
+++ b/apps/lumi-api/src/main/kotlin/no/nav/lumi/sensitive/UrlRedactor.kt
@@ -142,68 +142,61 @@ class UrlRedactor(
         return UrlRedactionResult(result, wasRedacted)
     }
 
-    /**
-     * Iteratively percent-decode until the string no longer changes.
-     * Prevents double-encoding bypass (e.g. %2530%2531... → %30%31... → 01...).
-     * Limited to 10 passes to avoid infinite loops on pathological input.
-     *
-     * Uses percent-only decoding: `+` is preserved as literal `+` (not treated as space).
-     * This prevents multi-pass degradation where `%2B` → `+` → ` ` would break
-     * email matching for plus-alias addresses like `ola+alias@nav.no`.
-     */
-    private fun decodeUntilStable(input: String): String {
-        var current = input
-        repeat(10) {
-            val decoded = try {
-                percentDecode(current)
-            } catch (_: Exception) {
-                return current
+    private fun decodeUntilStable(input: String): String = decodePercentEncoding(input)
+
+    companion object {
+        private val VALID_PERCENT = Regex("%[0-9A-Fa-f]{2}")
+
+        /**
+         * Iteratively percent-decode until stable (max 10 passes).
+         * Preserves `+` as literal (no form-encoding interpretation).
+         * Handles malformed percent sequences without throwing.
+         */
+        internal fun decodePercentEncoding(input: String): String {
+            var current = input
+            repeat(10) {
+                val decoded = try {
+                    percentDecode(current)
+                } catch (_: Exception) {
+                    return current
+                }
+                if (decoded == current) return current
+                current = decoded
             }
-            if (decoded == current) return current
-            current = decoded
+            return current
         }
-        return current
-    }
 
-    /**
-     * Decode only %xx sequences, preserving `+` as literal.
-     * Unlike URLDecoder.decode(), this does NOT treat `+` as space.
-     * Invalid percent sequences (lone `%` or `%` not followed by two hex digits)
-     * are escaped to `%25` before decoding so they don't abort the entire decode.
-     */
-    private fun percentDecode(input: String): String {
-        // Protect `+` from URLDecoder's form-encoding interpretation
-        val preserved = input.replace("+", "%2B")
-        // Escape invalid percent sequences so URLDecoder doesn't throw
-        val sanitized = sanitizePercentEncoding(preserved)
-        return URLDecoder.decode(sanitized, Charsets.UTF_8.name())
-    }
+        /**
+         * Decode only %xx sequences, preserving `+` as literal.
+         * Unlike URLDecoder.decode(), this does NOT treat `+` as space.
+         */
+        private fun percentDecode(input: String): String {
+            val preserved = input.replace("+", "%2B")
+            val sanitized = sanitizePercentEncoding(preserved)
+            return URLDecoder.decode(sanitized, Charsets.UTF_8.name())
+        }
 
-    private val VALID_PERCENT = Regex("%[0-9A-Fa-f]{2}")
-
-    /**
-     * Replace lone `%` or `%` not followed by two hex digits with `%25` (literal percent).
-     * This prevents URLDecoder from throwing on malformed input like `value%` or `%zz`.
-     */
-    private fun sanitizePercentEncoding(input: String): String {
-        val sb = StringBuilder(input.length)
-        var i = 0
-        while (i < input.length) {
-            if (input[i] == '%') {
-                if (i + 2 < input.length && VALID_PERCENT.matchesAt(input, i)) {
-                    // Valid %xx — keep as-is
-                    sb.append(input, i, i + 3)
-                    i += 3
+        /**
+         * Replace lone `%` or `%` not followed by two hex digits with `%25` (literal percent).
+         */
+        private fun sanitizePercentEncoding(input: String): String {
+            val sb = StringBuilder(input.length)
+            var i = 0
+            while (i < input.length) {
+                if (input[i] == '%') {
+                    if (i + 2 < input.length && VALID_PERCENT.matchesAt(input, i)) {
+                        sb.append(input, i, i + 3)
+                        i += 3
+                    } else {
+                        sb.append("%25")
+                        i++
+                    }
                 } else {
-                    // Invalid/incomplete percent — escape to literal %
-                    sb.append("%25")
+                    sb.append(input[i])
                     i++
                 }
-            } else {
-                sb.append(input[i])
-                i++
             }
+            return sb.toString()
         }
-        return sb.toString()
     }
 }

--- a/apps/lumi-api/src/main/kotlin/no/nav/lumi/sensitive/UrlRedactor.kt
+++ b/apps/lumi-api/src/main/kotlin/no/nav/lumi/sensitive/UrlRedactor.kt
@@ -1,6 +1,5 @@
 package no.nav.lumi.sensitive
 
-import java.net.URI
 import java.net.URLDecoder
 import java.net.URLEncoder
 
@@ -11,8 +10,12 @@ data class UrlRedactionResult(
 
 /**
  * Redacts PII from URLs by:
- * 1. Parsing query parameters and redacting each value individually
- * 2. Running full-string PII redaction on the non-query portion (path, etc.)
+ * 1. Parsing query parameters and redacting each key+value individually
+ * 2. Running full-string PII redaction on the path (URL-decoded first)
+ * 3. Redacting PII in fragments (URL-decoded first)
+ *
+ * Assumes standard URL ordering (path?query#fragment).
+ * Falls back to plain-text redaction for unparseable input.
  */
 class UrlRedactor(
     private val sensitiveDataFilter: SensitiveDataFilter = SensitiveDataFilter.DEFAULT
@@ -35,7 +38,7 @@ class UrlRedactor(
     private fun redactParsedUrl(url: String): UrlRedactionResult {
         var wasRedacted = false
 
-        // Split on '?' to separate base from query
+        // Split on '?' to separate base from query (standard ordering assumed)
         val questionIdx = url.indexOf('?')
         val fragmentIdx = url.indexOf('#', if (questionIdx >= 0) questionIdx else 0)
 
@@ -58,10 +61,15 @@ class UrlRedactor(
             fragment = if (fragmentIdx >= 0) url.substring(fragmentIdx + 1) else null
         }
 
-        // Redact PII in path/base via full-string redaction
-        val baseResult = sensitiveDataFilter.redact(baseUrl)
-        val redactedBase = baseResult.redactedText
-        if (baseResult.wasRedacted) wasRedacted = true
+        // Redact PII in path/base — decode first to catch percent-encoded PII
+        val decodedBase = decodeUntilStable(baseUrl)
+        val baseResult = sensitiveDataFilter.redact(decodedBase)
+        val redactedBase = if (baseResult.wasRedacted) {
+            wasRedacted = true
+            baseResult.redactedText
+        } else {
+            baseUrl // preserve original encoding when no PII found
+        }
 
         // Redact each query parameter (both key and value)
         val redactedQuery = if (queryString != null) {
@@ -69,9 +77,7 @@ class UrlRedactor(
                 val eqIdx = param.indexOf('=')
                 if (eqIdx < 0) {
                     // Bare token without '=' — redact it as data
-                    val decoded = try {
-                        URLDecoder.decode(param, Charsets.UTF_8.name())
-                    } catch (_: Exception) { param }
+                    val decoded = decodeUntilStable(param)
                     val redacted = sensitiveDataFilter.redact(decoded)
                     if (redacted.wasRedacted) {
                         wasRedacted = true
@@ -84,9 +90,7 @@ class UrlRedactor(
                     val rawValue = param.substring(eqIdx + 1)
 
                     // Redact key
-                    val decodedKey = try {
-                        URLDecoder.decode(rawKey, Charsets.UTF_8.name())
-                    } catch (_: Exception) { rawKey }
+                    val decodedKey = decodeUntilStable(rawKey)
                     val keyResult = sensitiveDataFilter.redact(decodedKey)
                     val finalKey = if (keyResult.wasRedacted) {
                         wasRedacted = true
@@ -96,9 +100,7 @@ class UrlRedactor(
                     }
 
                     // Redact value
-                    val decodedValue = try {
-                        URLDecoder.decode(rawValue, Charsets.UTF_8.name())
-                    } catch (_: Exception) { rawValue }
+                    val decodedValue = decodeUntilStable(rawValue)
                     val valueResult = sensitiveDataFilter.redact(decodedValue)
                     val finalValue = if (valueResult.wasRedacted) {
                         wasRedacted = true
@@ -113,9 +115,10 @@ class UrlRedactor(
             params.joinToString("&")
         } else null
 
-        // Redact PII in fragment
+        // Redact PII in fragment — decode first
         val redactedFragment = if (fragment != null) {
-            val fragResult = sensitiveDataFilter.redact(fragment)
+            val decodedFragment = decodeUntilStable(fragment)
+            val fragResult = sensitiveDataFilter.redact(decodedFragment)
             if (fragResult.wasRedacted) {
                 wasRedacted = true
                 fragResult.redactedText
@@ -137,5 +140,24 @@ class UrlRedactor(
         }
 
         return UrlRedactionResult(result, wasRedacted)
+    }
+
+    /**
+     * Iteratively URL-decode until the string no longer changes.
+     * Prevents double-encoding bypass (e.g. %2530%2531... → %30%31... → 01...).
+     * Limited to 3 passes to avoid infinite loops on pathological input.
+     */
+    private fun decodeUntilStable(input: String): String {
+        var current = input
+        repeat(3) {
+            val decoded = try {
+                URLDecoder.decode(current, Charsets.UTF_8.name())
+            } catch (_: Exception) {
+                return current
+            }
+            if (decoded == current) return current
+            current = decoded
+        }
+        return current
     }
 }

--- a/apps/lumi-api/src/main/kotlin/no/nav/lumi/sensitive/UrlRedactor.kt
+++ b/apps/lumi-api/src/main/kotlin/no/nav/lumi/sensitive/UrlRedactor.kt
@@ -51,11 +51,11 @@ class UrlRedactor(
                 url.substring(questionIdx + 1)
             }
             queryString = afterQuestion.ifEmpty { null }
-            fragment = if (fragmentIdx >= 0) url.substring(fragmentIdx) else null
+            fragment = if (fragmentIdx >= 0) url.substring(fragmentIdx + 1) else null
         } else {
             baseUrl = if (fragmentIdx >= 0) url.substring(0, fragmentIdx) else url
             queryString = null
-            fragment = if (fragmentIdx >= 0) url.substring(fragmentIdx) else null
+            fragment = if (fragmentIdx >= 0) url.substring(fragmentIdx + 1) else null
         }
 
         // Redact PII in path/base via full-string redaction
@@ -63,29 +63,65 @@ class UrlRedactor(
         val redactedBase = baseResult.redactedText
         if (baseResult.wasRedacted) wasRedacted = true
 
-        // Redact each query parameter value individually
+        // Redact each query parameter (both key and value)
         val redactedQuery = if (queryString != null) {
             val params = queryString.split("&").map { param ->
                 val eqIdx = param.indexOf('=')
-                if (eqIdx < 0) return@map param
-
-                val key = param.substring(0, eqIdx)
-                val rawValue = param.substring(eqIdx + 1)
-                val decodedValue = try {
-                    URLDecoder.decode(rawValue, Charsets.UTF_8.name())
-                } catch (_: Exception) {
-                    rawValue
-                }
-
-                val redacted = sensitiveDataFilter.redact(decodedValue)
-                if (redacted.wasRedacted) {
-                    wasRedacted = true
-                    "$key=${URLEncoder.encode(redacted.redactedText, Charsets.UTF_8.name())}"
+                if (eqIdx < 0) {
+                    // Bare token without '=' — redact it as data
+                    val decoded = try {
+                        URLDecoder.decode(param, Charsets.UTF_8.name())
+                    } catch (_: Exception) { param }
+                    val redacted = sensitiveDataFilter.redact(decoded)
+                    if (redacted.wasRedacted) {
+                        wasRedacted = true
+                        URLEncoder.encode(redacted.redactedText, Charsets.UTF_8.name())
+                    } else {
+                        param
+                    }
                 } else {
-                    param
+                    val rawKey = param.substring(0, eqIdx)
+                    val rawValue = param.substring(eqIdx + 1)
+
+                    // Redact key
+                    val decodedKey = try {
+                        URLDecoder.decode(rawKey, Charsets.UTF_8.name())
+                    } catch (_: Exception) { rawKey }
+                    val keyResult = sensitiveDataFilter.redact(decodedKey)
+                    val finalKey = if (keyResult.wasRedacted) {
+                        wasRedacted = true
+                        URLEncoder.encode(keyResult.redactedText, Charsets.UTF_8.name())
+                    } else {
+                        rawKey
+                    }
+
+                    // Redact value
+                    val decodedValue = try {
+                        URLDecoder.decode(rawValue, Charsets.UTF_8.name())
+                    } catch (_: Exception) { rawValue }
+                    val valueResult = sensitiveDataFilter.redact(decodedValue)
+                    val finalValue = if (valueResult.wasRedacted) {
+                        wasRedacted = true
+                        URLEncoder.encode(valueResult.redactedText, Charsets.UTF_8.name())
+                    } else {
+                        rawValue
+                    }
+
+                    "$finalKey=$finalValue"
                 }
             }
             params.joinToString("&")
+        } else null
+
+        // Redact PII in fragment
+        val redactedFragment = if (fragment != null) {
+            val fragResult = sensitiveDataFilter.redact(fragment)
+            if (fragResult.wasRedacted) {
+                wasRedacted = true
+                fragResult.redactedText
+            } else {
+                fragment
+            }
         } else null
 
         val result = buildString {
@@ -94,7 +130,10 @@ class UrlRedactor(
                 append('?')
                 if (redactedQuery != null) append(redactedQuery)
             }
-            if (fragment != null) append(fragment)
+            if (redactedFragment != null) {
+                append('#')
+                append(redactedFragment)
+            }
         }
 
         return UrlRedactionResult(result, wasRedacted)

--- a/apps/lumi-api/src/main/kotlin/no/nav/lumi/sensitive/UrlRedactor.kt
+++ b/apps/lumi-api/src/main/kotlin/no/nav/lumi/sensitive/UrlRedactor.kt
@@ -143,15 +143,19 @@ class UrlRedactor(
     }
 
     /**
-     * Iteratively URL-decode until the string no longer changes.
+     * Iteratively percent-decode until the string no longer changes.
      * Prevents double-encoding bypass (e.g. %2530%2531... → %30%31... → 01...).
      * Limited to 3 passes to avoid infinite loops on pathological input.
+     *
+     * Uses percent-only decoding: `+` is preserved as literal `+` (not treated as space).
+     * This prevents multi-pass degradation where `%2B` → `+` → ` ` would break
+     * email matching for plus-alias addresses like `ola+alias@nav.no`.
      */
     private fun decodeUntilStable(input: String): String {
         var current = input
         repeat(3) {
             val decoded = try {
-                URLDecoder.decode(current, Charsets.UTF_8.name())
+                percentDecode(current)
             } catch (_: Exception) {
                 return current
             }
@@ -159,5 +163,15 @@ class UrlRedactor(
             current = decoded
         }
         return current
+    }
+
+    /**
+     * Decode only %xx sequences, preserving `+` as literal.
+     * Unlike URLDecoder.decode(), this does NOT treat `+` as space.
+     */
+    private fun percentDecode(input: String): String {
+        // Protect `+` from URLDecoder's form-encoding interpretation
+        val preserved = input.replace("+", "%2B")
+        return URLDecoder.decode(preserved, Charsets.UTF_8.name())
     }
 }

--- a/apps/lumi-api/src/main/kotlin/no/nav/lumi/sensitive/UrlRedactor.kt
+++ b/apps/lumi-api/src/main/kotlin/no/nav/lumi/sensitive/UrlRedactor.kt
@@ -1,0 +1,102 @@
+package no.nav.lumi.sensitive
+
+import java.net.URI
+import java.net.URLDecoder
+import java.net.URLEncoder
+
+data class UrlRedactionResult(
+    val redactedUrl: String,
+    val wasRedacted: Boolean
+)
+
+/**
+ * Redacts PII from URLs by:
+ * 1. Parsing query parameters and redacting each value individually
+ * 2. Running full-string PII redaction on the non-query portion (path, etc.)
+ */
+class UrlRedactor(
+    private val sensitiveDataFilter: SensitiveDataFilter = SensitiveDataFilter.DEFAULT
+) {
+
+    fun redactUrl(url: String?): UrlRedactionResult {
+        if (url.isNullOrEmpty()) {
+            return UrlRedactionResult(redactedUrl = "", wasRedacted = false)
+        }
+
+        return try {
+            redactParsedUrl(url)
+        } catch (_: Exception) {
+            // Fallback: treat as plain text
+            val result = sensitiveDataFilter.redact(url)
+            UrlRedactionResult(result.redactedText, result.wasRedacted)
+        }
+    }
+
+    private fun redactParsedUrl(url: String): UrlRedactionResult {
+        var wasRedacted = false
+
+        // Split on '?' to separate base from query
+        val questionIdx = url.indexOf('?')
+        val fragmentIdx = url.indexOf('#', if (questionIdx >= 0) questionIdx else 0)
+
+        val baseUrl: String
+        val queryString: String?
+        val fragment: String?
+
+        if (questionIdx >= 0) {
+            baseUrl = url.substring(0, questionIdx)
+            val afterQuestion = if (fragmentIdx >= 0) {
+                url.substring(questionIdx + 1, fragmentIdx)
+            } else {
+                url.substring(questionIdx + 1)
+            }
+            queryString = afterQuestion.ifEmpty { null }
+            fragment = if (fragmentIdx >= 0) url.substring(fragmentIdx) else null
+        } else {
+            baseUrl = if (fragmentIdx >= 0) url.substring(0, fragmentIdx) else url
+            queryString = null
+            fragment = if (fragmentIdx >= 0) url.substring(fragmentIdx) else null
+        }
+
+        // Redact PII in path/base via full-string redaction
+        val baseResult = sensitiveDataFilter.redact(baseUrl)
+        val redactedBase = baseResult.redactedText
+        if (baseResult.wasRedacted) wasRedacted = true
+
+        // Redact each query parameter value individually
+        val redactedQuery = if (queryString != null) {
+            val params = queryString.split("&").map { param ->
+                val eqIdx = param.indexOf('=')
+                if (eqIdx < 0) return@map param
+
+                val key = param.substring(0, eqIdx)
+                val rawValue = param.substring(eqIdx + 1)
+                val decodedValue = try {
+                    URLDecoder.decode(rawValue, Charsets.UTF_8.name())
+                } catch (_: Exception) {
+                    rawValue
+                }
+
+                val redacted = sensitiveDataFilter.redact(decodedValue)
+                if (redacted.wasRedacted) {
+                    wasRedacted = true
+                    "$key=${URLEncoder.encode(redacted.redactedText, Charsets.UTF_8.name())}"
+                } else {
+                    param
+                }
+            }
+            params.joinToString("&")
+        } else null
+
+        val result = buildString {
+            append(redactedBase)
+            if (questionIdx >= 0) {
+                append('?')
+                if (redactedQuery != null) append(redactedQuery)
+            }
+            if (fragment != null) append(fragment)
+        }
+
+        return UrlRedactionResult(result, wasRedacted)
+    }
+}

--- a/apps/lumi-api/src/main/kotlin/no/nav/lumi/sensitive/UrlRedactor.kt
+++ b/apps/lumi-api/src/main/kotlin/no/nav/lumi/sensitive/UrlRedactor.kt
@@ -155,14 +155,24 @@ class UrlRedactor(
      */
     private fun percentEncodeUriUnsafe(text: String): String {
         val sb = StringBuilder(text.length + 32)
-        for (char in text) {
+        var index = 0
+        while (index < text.length) {
+            val char = text[index]
             when {
-                char.code in 0x21..0x7E && char !in " []{}|\\^`" -> sb.append(char)
+                char == '%' && index + 2 < text.length && VALID_PERCENT.matchesAt(text, index) -> {
+                    sb.append(text, index, index + 3)
+                    index += 3
+                }
+                char.code in 0x21..0x7E && char !in " %[]{}|\\^`" -> {
+                    sb.append(char)
+                    index++
+                }
                 else -> {
                     for (b in char.toString().toByteArray(StandardCharsets.UTF_8)) {
                         sb.append('%')
                         sb.append(String.format("%02X", b.toInt() and 0xFF))
                     }
+                    index++
                 }
             }
         }

--- a/apps/lumi-api/src/main/kotlin/no/nav/lumi/service/FeedbackService.kt
+++ b/apps/lumi-api/src/main/kotlin/no/nav/lumi/service/FeedbackService.kt
@@ -101,7 +101,7 @@ class FeedbackService(
                                 val redacted = sensitiveDataFilter.redact(originalText)
                                 if (redacted.wasRedacted) {
                                     hasRedactions = true
-                                    log.info("Redacted sensitive data from answer fieldId={}: {}", answerObj["fieldId"], redacted.matchedPatterns)
+                                    log.info("Redacted sensitive data from text answer: {}", redacted.matchedPatterns)
                                 }
                                 valueObj["text"] = JsonPrimitive(redacted.redactedText)
                                 answerObj["value"] = JsonObject(valueObj)

--- a/apps/lumi-api/src/main/kotlin/no/nav/lumi/service/FeedbackService.kt
+++ b/apps/lumi-api/src/main/kotlin/no/nav/lumi/service/FeedbackService.kt
@@ -166,9 +166,9 @@ class FeedbackService(
             if (tagsRedacted) wasRedacted = true
         }
 
-        // PII-redact debug recursively
+        // PII-redact debug recursively (handles both JsonObject and JsonArray)
         val debug = sanitized["debug"]
-        if (debug != null && debug is JsonObject) {
+        if (debug != null && (debug is JsonObject || debug is JsonArray)) {
             val (redactedDebug, debugRedacted) = jsonRedactor.redactJsonElement(debug)
             sanitized["debug"] = redactedDebug
             if (debugRedacted) wasRedacted = true

--- a/apps/lumi-api/src/main/kotlin/no/nav/lumi/service/FeedbackService.kt
+++ b/apps/lumi-api/src/main/kotlin/no/nav/lumi/service/FeedbackService.kt
@@ -186,14 +186,15 @@ class FeedbackService(
         val result = mutableMapOf<String, JsonElement>()
 
         for ((key, value) in tags) {
-            // Redact PII in key
-            val keyResult = sensitiveDataFilter.redact(key)
+            // HTML-strip + PII-redact key
+            val strippedKey = htmlSanitizer.stripTags(key)
+            val keyResult = sensitiveDataFilter.redact(strippedKey)
             val finalKey = if (keyResult.wasRedacted) {
                 wasRedacted = true
                 keyCounter++
-                "[REDACTED_KEY_$keyCounter]"
+                generateUniqueKey(result, keyCounter)
             } else {
-                key
+                strippedKey
             }
 
             // Redact PII in value + HTML strip
@@ -211,6 +212,16 @@ class FeedbackService(
         }
 
         return JsonObject(result) to wasRedacted
+    }
+
+    private fun generateUniqueKey(existing: Map<String, *>, startCounter: Int): String {
+        var candidate = "[REDACTED_KEY_$startCounter]"
+        var suffix = startCounter
+        while (existing.containsKey(candidate)) {
+            suffix++
+            candidate = "[REDACTED_KEY_$suffix]"
+        }
+        return candidate
     }
 
     private fun sanitizeStringField(container: MutableMap<String, JsonElement>, fieldName: String) {

--- a/apps/lumi-api/src/main/kotlin/no/nav/lumi/service/FeedbackService.kt
+++ b/apps/lumi-api/src/main/kotlin/no/nav/lumi/service/FeedbackService.kt
@@ -145,11 +145,12 @@ class FeedbackService(
             }
         }
 
-        // HTML-strip + PII-redact pathname
+        // HTML-strip + percent-decode + PII-redact pathname
         sanitizeStringField(sanitized, "pathname")
         val pathValue = sanitized["pathname"]?.jsonPrimitive?.contentOrNull
         if (pathValue != null) {
-            val pathResult = sensitiveDataFilter.redact(pathValue)
+            val decoded = UrlRedactor.decodePercentEncoding(pathValue)
+            val pathResult = sensitiveDataFilter.redact(decoded)
             if (pathResult.wasRedacted) {
                 wasRedacted = true
                 sanitized["pathname"] = JsonPrimitive(pathResult.redactedText)
@@ -192,6 +193,10 @@ class FeedbackService(
             val keyResult = sensitiveDataFilter.redact(strippedKey)
             val finalKey = if (keyResult.wasRedacted) {
                 wasRedacted = true
+                keyCounter++
+                generateUniqueKey(result, originalKeys, keyCounter)
+            } else if (result.containsKey(strippedKey)) {
+                // HTML-stripping caused collision — generate unique key to avoid data loss
                 keyCounter++
                 generateUniqueKey(result, originalKeys, keyCounter)
             } else {

--- a/apps/lumi-api/src/main/kotlin/no/nav/lumi/service/FeedbackService.kt
+++ b/apps/lumi-api/src/main/kotlin/no/nav/lumi/service/FeedbackService.kt
@@ -101,7 +101,7 @@ class FeedbackService(
                                 val redacted = sensitiveDataFilter.redact(originalText)
                                 if (redacted.wasRedacted) {
                                     hasRedactions = true
-                                    log.info("Redacted sensitive data from answer fieldId=${answerObj["fieldId"]}: ${redacted.matchedPatterns}")
+                                    log.info("Redacted sensitive data from answer fieldId={}: {}", answerObj["fieldId"], redacted.matchedPatterns)
                                 }
                                 valueObj["text"] = JsonPrimitive(redacted.redactedText)
                                 answerObj["value"] = JsonObject(valueObj)

--- a/apps/lumi-api/src/main/kotlin/no/nav/lumi/service/FeedbackService.kt
+++ b/apps/lumi-api/src/main/kotlin/no/nav/lumi/service/FeedbackService.kt
@@ -1,6 +1,7 @@
 package no.nav.lumi.service
 
 import kotlinx.serialization.json.*
+import no.nav.lumi.config.exception.ApiErrorException
 import no.nav.lumi.domain.FeedbackDto
 import no.nav.lumi.domain.FeedbackQuery
 import no.nav.lumi.repository.FeedbackRepository
@@ -91,28 +92,23 @@ class FeedbackService(
             val answers = jsonObj["answers"] as? JsonArray
             if (answers != null) {
                 val redactedAnswers = answers.map { answerEl ->
-                    try {
-                        val answerObj = answerEl.jsonObject.toMutableMap()
-                        val valueObj = answerObj["value"]?.jsonObject?.toMutableMap()
-                        
-                        if (valueObj != null) {
-                            val type = valueObj["type"]?.jsonPrimitive?.contentOrNull
-                            if (type == "text") {
-                                val originalText = valueObj["text"]?.jsonPrimitive?.contentOrNull ?: ""
-                                val redacted = sensitiveDataFilter.redact(originalText)
-                                if (redacted.wasRedacted) {
-                                    hasRedactions = true
-                                    log.info("Redacted sensitive data from text answer: {}", redacted.matchedPatterns)
-                                }
-                                valueObj["text"] = JsonPrimitive(redacted.redactedText)
-                                answerObj["value"] = JsonObject(valueObj)
+                    val answerObj = answerEl.jsonObject.toMutableMap()
+                    val valueObj = answerObj["value"]?.jsonObject?.toMutableMap()
+
+                    if (valueObj != null) {
+                        val type = valueObj["type"]?.jsonPrimitive?.contentOrNull
+                        if (type == "text") {
+                            val originalText = valueObj["text"]?.jsonPrimitive?.contentOrNull ?: ""
+                            val redacted = sensitiveDataFilter.redact(originalText)
+                            if (redacted.wasRedacted) {
+                                hasRedactions = true
+                                log.info("Redacted sensitive data from text answer: {}", redacted.matchedPatterns)
                             }
+                            valueObj["text"] = JsonPrimitive(redacted.redactedText)
+                            answerObj["value"] = JsonObject(valueObj)
                         }
-                        JsonObject(answerObj)
-                    } catch (e: Exception) {
-                        log.warn("Failed to process answer for redaction", e)
-                        answerEl
                     }
+                    JsonObject(answerObj)
                 }
                 jsonObj["answers"] = JsonArray(redactedAnswers)
             }
@@ -123,7 +119,7 @@ class FeedbackService(
             json.encodeToString(JsonObject.serializer(), JsonObject(jsonObj))
         } catch (e: Exception) {
             log.error("Failed to redact feedback JSON, rejecting submission to avoid storing unredacted data", e)
-            throw IllegalStateException("Failed to redact feedback JSON", e)
+            throw ApiErrorException.InternalServerErrorException("Failed to redact feedback JSON", e)
         }
     }
 
@@ -192,7 +188,7 @@ class FeedbackService(
             // HTML-strip + PII-redact key
             val strippedKey = htmlSanitizer.stripTags(key)
             val keyResult = sensitiveDataFilter.redact(strippedKey)
-            val finalKey = if (keyResult.wasRedacted) {
+            val finalKey = if (keyResult.wasRedacted || strippedKey.isBlank()) {
                 wasRedacted = true
                 keyCounter++
                 generateUniqueKey(result, originalKeys, keyCounter)

--- a/apps/lumi-api/src/main/kotlin/no/nav/lumi/service/FeedbackService.kt
+++ b/apps/lumi-api/src/main/kotlin/no/nav/lumi/service/FeedbackService.kt
@@ -5,13 +5,17 @@ import no.nav.lumi.domain.FeedbackDto
 import no.nav.lumi.domain.FeedbackQuery
 import no.nav.lumi.repository.FeedbackRepository
 import no.nav.lumi.sensitive.HtmlSanitizer
+import no.nav.lumi.sensitive.JsonRedactor
 import no.nav.lumi.sensitive.SensitiveDataFilter
+import no.nav.lumi.sensitive.UrlRedactor
 import org.slf4j.LoggerFactory
 
 class FeedbackService(
     private val repository: FeedbackRepository = FeedbackRepository(),
     private val sensitiveDataFilter: SensitiveDataFilter = SensitiveDataFilter.DEFAULT,
-    private val htmlSanitizer: HtmlSanitizer = HtmlSanitizer.DEFAULT
+    private val htmlSanitizer: HtmlSanitizer = HtmlSanitizer.DEFAULT,
+    private val urlRedactor: UrlRedactor = UrlRedactor(),
+    private val jsonRedactor: JsonRedactor = JsonRedactor()
 ) {
     private val log = LoggerFactory.getLogger(FeedbackService::class.java)
     private val json = Json { ignoreUnknownKeys = true }
@@ -61,8 +65,11 @@ class FeedbackService(
      *
      * Security strategy:
      * 1. Context fields (url, pathname, userAgent, tags) — HTML tags stripped (defense-in-depth)
-     * 2. Text answers — PII redacted, but HTML preserved (React escapes at render)
-     * 3. Metadata fields (question.label, options[].label etc.) — NOT sanitized
+     * 2. Context URL — PII redacted per query-param + full-string fallback for path
+     * 3. Context tags — PII redacted in both keys and values
+     * 4. Context debug — recursive PII redaction of all string values and keys
+     * 5. Text answers — PII redacted, but HTML preserved (React escapes at render)
+     * 6. Metadata fields (question.label, options[].label etc.) — NOT sanitized
      *    These are survey-defined by the team admin, not user-authored free text.
      *    SubmissionValidator enforces length limits on all metadata fields.
      *    React escapes all output, so stored HTML is inert in the dashboard.
@@ -75,7 +82,9 @@ class FeedbackService(
 
             val context = jsonObj["context"] as? JsonObject
             if (context != null) {
-                jsonObj["context"] = sanitizeContext(context)
+                val (sanitizedContext, contextHadRedactions) = sanitizeAndRedactContext(context)
+                jsonObj["context"] = sanitizedContext
+                if (contextHadRedactions) hasRedactions = true
             }
             
             val answers = jsonObj["answers"] as? JsonArray
@@ -117,22 +126,91 @@ class FeedbackService(
         }
     }
 
-    private fun sanitizeContext(context: JsonObject): JsonObject {
+    /**
+     * Sanitize context fields (HTML strip) AND redact PII from URL, tags, and debug.
+     * Returns the sanitized context and whether any PII was redacted.
+     */
+    private fun sanitizeAndRedactContext(context: JsonObject): Pair<JsonObject, Boolean> {
         val sanitized = context.toMutableMap()
-        sanitizeStringField(sanitized, "url")
-        sanitizeStringField(sanitized, "pathname")
-        sanitizeStringField(sanitized, "userAgent")
+        var wasRedacted = false
 
-        val tags = sanitized["tags"] as? JsonObject
-        if (tags != null) {
-            val sanitizedTags = tags.mapValues { (_, value) ->
-                val content = (value as? JsonPrimitive)?.contentOrNull
-                if (content != null) JsonPrimitive(htmlSanitizer.stripTags(content)) else value
+        // HTML-strip + PII-redact URL
+        sanitizeStringField(sanitized, "url")
+        val urlValue = sanitized["url"]?.jsonPrimitive?.contentOrNull
+        if (urlValue != null) {
+            val urlResult = urlRedactor.redactUrl(urlValue)
+            if (urlResult.wasRedacted) {
+                wasRedacted = true
+                sanitized["url"] = JsonPrimitive(urlResult.redactedUrl)
             }
-            sanitized["tags"] = JsonObject(sanitizedTags)
         }
 
-        return JsonObject(sanitized)
+        // HTML-strip + PII-redact pathname
+        sanitizeStringField(sanitized, "pathname")
+        val pathValue = sanitized["pathname"]?.jsonPrimitive?.contentOrNull
+        if (pathValue != null) {
+            val pathResult = sensitiveDataFilter.redact(pathValue)
+            if (pathResult.wasRedacted) {
+                wasRedacted = true
+                sanitized["pathname"] = JsonPrimitive(pathResult.redactedText)
+            }
+        }
+
+        sanitizeStringField(sanitized, "userAgent")
+
+        // PII-redact tags (keys and values)
+        val tags = sanitized["tags"] as? JsonObject
+        if (tags != null) {
+            val (redactedTags, tagsRedacted) = redactTags(tags)
+            sanitized["tags"] = redactedTags
+            if (tagsRedacted) wasRedacted = true
+        }
+
+        // PII-redact debug recursively
+        val debug = sanitized["debug"]
+        if (debug != null && debug is JsonObject) {
+            val (redactedDebug, debugRedacted) = jsonRedactor.redactJsonElement(debug)
+            sanitized["debug"] = redactedDebug
+            if (debugRedacted) wasRedacted = true
+        }
+
+        return JsonObject(sanitized) to wasRedacted
+    }
+
+    /**
+     * Redact PII from tag keys and values. Also strips HTML from values.
+     */
+    private fun redactTags(tags: JsonObject): Pair<JsonObject, Boolean> {
+        var wasRedacted = false
+        var keyCounter = 0
+        val result = mutableMapOf<String, JsonElement>()
+
+        for ((key, value) in tags) {
+            // Redact PII in key
+            val keyResult = sensitiveDataFilter.redact(key)
+            val finalKey = if (keyResult.wasRedacted) {
+                wasRedacted = true
+                keyCounter++
+                "[REDACTED_KEY_$keyCounter]"
+            } else {
+                key
+            }
+
+            // Redact PII in value + HTML strip
+            val content = (value as? JsonPrimitive)?.contentOrNull
+            val finalValue = if (content != null) {
+                val stripped = htmlSanitizer.stripTags(content)
+                val redacted = sensitiveDataFilter.redact(stripped)
+                if (redacted.wasRedacted) wasRedacted = true
+                JsonPrimitive(redacted.redactedText)
+            } else {
+                value
+            }
+
+            result[finalKey] = finalValue
+        }
+
+        return JsonObject(result) to wasRedacted
     }
 
     private fun sanitizeStringField(container: MutableMap<String, JsonElement>, fieldName: String) {

--- a/apps/lumi-api/src/main/kotlin/no/nav/lumi/service/FeedbackService.kt
+++ b/apps/lumi-api/src/main/kotlin/no/nav/lumi/service/FeedbackService.kt
@@ -8,6 +8,7 @@ import no.nav.lumi.sensitive.HtmlSanitizer
 import no.nav.lumi.sensitive.JsonRedactor
 import no.nav.lumi.sensitive.SensitiveDataFilter
 import no.nav.lumi.sensitive.UrlRedactor
+import no.nav.lumi.sensitive.generateUniqueKey
 import org.slf4j.LoggerFactory
 
 class FeedbackService(
@@ -121,8 +122,8 @@ class FeedbackService(
             
             json.encodeToString(JsonObject.serializer(), JsonObject(jsonObj))
         } catch (e: Exception) {
-            log.error("Failed to redact feedback JSON, storing unredacted — investigate immediately", e)
-            feedbackJson
+            log.error("Failed to redact feedback JSON, rejecting submission to avoid storing unredacted data", e)
+            throw IllegalStateException("Failed to redact feedback JSON", e)
         }
     }
 
@@ -219,21 +220,6 @@ class FeedbackService(
 
         return JsonObject(result) to wasRedacted
     }
-
-    private fun generateUniqueKey(
-        written: Map<String, *>,
-        originalKeys: Set<String>,
-        startCounter: Int
-    ): String {
-        var candidate = "[REDACTED_KEY_$startCounter]"
-        var suffix = startCounter
-        while (written.containsKey(candidate) || originalKeys.contains(candidate)) {
-            suffix++
-            candidate = "[REDACTED_KEY_$suffix]"
-        }
-        return candidate
-    }
-
     private fun sanitizeStringField(container: MutableMap<String, JsonElement>, fieldName: String) {
         val rawValue = container[fieldName]?.jsonPrimitive?.contentOrNull ?: return
         container[fieldName] = JsonPrimitive(htmlSanitizer.stripTags(rawValue))

--- a/apps/lumi-api/src/main/kotlin/no/nav/lumi/service/FeedbackService.kt
+++ b/apps/lumi-api/src/main/kotlin/no/nav/lumi/service/FeedbackService.kt
@@ -14,8 +14,8 @@ class FeedbackService(
     private val repository: FeedbackRepository = FeedbackRepository(),
     private val sensitiveDataFilter: SensitiveDataFilter = SensitiveDataFilter.DEFAULT,
     private val htmlSanitizer: HtmlSanitizer = HtmlSanitizer.DEFAULT,
-    private val urlRedactor: UrlRedactor = UrlRedactor(),
-    private val jsonRedactor: JsonRedactor = JsonRedactor()
+    private val urlRedactor: UrlRedactor = UrlRedactor(sensitiveDataFilter),
+    private val jsonRedactor: JsonRedactor = JsonRedactor(sensitiveDataFilter)
 ) {
     private val log = LoggerFactory.getLogger(FeedbackService::class.java)
     private val json = Json { ignoreUnknownKeys = true }

--- a/apps/lumi-api/src/main/kotlin/no/nav/lumi/service/FeedbackService.kt
+++ b/apps/lumi-api/src/main/kotlin/no/nav/lumi/service/FeedbackService.kt
@@ -167,7 +167,7 @@ class FeedbackService(
             if (tagsRedacted) wasRedacted = true
         }
 
-        // PII-redact debug recursively (handles JsonObject, JsonArray, and string primitives)
+        // PII-redact debug recursively (handles JsonObject, JsonArray, strings, and numbers)
         val debug = sanitized["debug"]
         if (debug != null && debug !is JsonNull) {
             val (redactedDebug, debugRedacted) = jsonRedactor.redactJsonElement(debug)

--- a/apps/lumi-api/src/main/kotlin/no/nav/lumi/service/FeedbackService.kt
+++ b/apps/lumi-api/src/main/kotlin/no/nav/lumi/service/FeedbackService.kt
@@ -166,9 +166,9 @@ class FeedbackService(
             if (tagsRedacted) wasRedacted = true
         }
 
-        // PII-redact debug recursively (handles both JsonObject and JsonArray)
+        // PII-redact debug recursively (handles JsonObject, JsonArray, and string primitives)
         val debug = sanitized["debug"]
-        if (debug != null && (debug is JsonObject || debug is JsonArray)) {
+        if (debug != null && debug !is JsonNull) {
             val (redactedDebug, debugRedacted) = jsonRedactor.redactJsonElement(debug)
             sanitized["debug"] = redactedDebug
             if (debugRedacted) wasRedacted = true

--- a/apps/lumi-api/src/main/kotlin/no/nav/lumi/service/FeedbackService.kt
+++ b/apps/lumi-api/src/main/kotlin/no/nav/lumi/service/FeedbackService.kt
@@ -121,7 +121,7 @@ class FeedbackService(
             
             json.encodeToString(JsonObject.serializer(), JsonObject(jsonObj))
         } catch (e: Exception) {
-            log.warn("Failed to redact feedback JSON, returning original", e)
+            log.error("Failed to redact feedback JSON, storing unredacted — investigate immediately", e)
             feedbackJson
         }
     }
@@ -183,6 +183,7 @@ class FeedbackService(
     private fun redactTags(tags: JsonObject): Pair<JsonObject, Boolean> {
         var wasRedacted = false
         var keyCounter = 0
+        val originalKeys = tags.keys
         val result = mutableMapOf<String, JsonElement>()
 
         for ((key, value) in tags) {
@@ -192,7 +193,7 @@ class FeedbackService(
             val finalKey = if (keyResult.wasRedacted) {
                 wasRedacted = true
                 keyCounter++
-                generateUniqueKey(result, keyCounter)
+                generateUniqueKey(result, originalKeys, keyCounter)
             } else {
                 strippedKey
             }
@@ -214,10 +215,14 @@ class FeedbackService(
         return JsonObject(result) to wasRedacted
     }
 
-    private fun generateUniqueKey(existing: Map<String, *>, startCounter: Int): String {
+    private fun generateUniqueKey(
+        written: Map<String, *>,
+        originalKeys: Set<String>,
+        startCounter: Int
+    ): String {
         var candidate = "[REDACTED_KEY_$startCounter]"
         var suffix = startCounter
-        while (existing.containsKey(candidate)) {
+        while (written.containsKey(candidate) || originalKeys.contains(candidate)) {
             suffix++
             candidate = "[REDACTED_KEY_$suffix]"
         }

--- a/apps/lumi-api/src/test/kotlin/no/nav/lumi/sensitive/JsonRedactorTest.kt
+++ b/apps/lumi-api/src/test/kotlin/no/nav/lumi/sensitive/JsonRedactorTest.kt
@@ -1,0 +1,128 @@
+package no.nav.lumi.sensitive
+
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import kotlinx.serialization.json.*
+
+class JsonRedactorTest : FunSpec({
+
+    val redactor = JsonRedactor()
+
+    context("string value redaction") {
+        test("redacts fødselsnummer in string value") {
+            val input = JsonObject(mapOf("bruker" to JsonPrimitive("01020349294")))
+            val (result, wasRedacted) = redactor.redactJsonElement(input)
+            wasRedacted shouldBe true
+            result.jsonObject["bruker"]?.jsonPrimitive?.content shouldBe "[FØDSELSNUMMER FJERNET]"
+        }
+
+        test("leaves clean string values unchanged") {
+            val input = JsonObject(mapOf("team" to JsonPrimitive("flex")))
+            val (result, wasRedacted) = redactor.redactJsonElement(input)
+            wasRedacted shouldBe false
+            result.jsonObject["team"]?.jsonPrimitive?.content shouldBe "flex"
+        }
+
+        test("redacts email in value") {
+            val input = JsonObject(mapOf("contact" to JsonPrimitive("ola@nav.no")))
+            val (result, wasRedacted) = redactor.redactJsonElement(input)
+            wasRedacted shouldBe true
+            result.jsonObject["contact"]?.jsonPrimitive?.content shouldBe "[E-POST FJERNET]"
+        }
+    }
+
+    context("key redaction") {
+        test("redacts PII in object key") {
+            val input = JsonObject(mapOf("01020349294" to JsonPrimitive("data")))
+            val (result, wasRedacted) = redactor.redactJsonElement(input)
+            wasRedacted shouldBe true
+            val keys = result.jsonObject.keys
+            keys shouldBe setOf("[REDACTED_KEY_1]")
+            result.jsonObject["[REDACTED_KEY_1]"]?.jsonPrimitive?.content shouldBe "data"
+        }
+
+        test("redacts multiple PII keys with incrementing counter") {
+            val input = JsonObject(mapOf(
+                "01020349294" to JsonPrimitive("a"),
+                "ola@nav.no" to JsonPrimitive("b")
+            ))
+            val (result, wasRedacted) = redactor.redactJsonElement(input)
+            wasRedacted shouldBe true
+            result.jsonObject.keys shouldBe setOf("[REDACTED_KEY_1]", "[REDACTED_KEY_2]")
+        }
+    }
+
+    context("nested objects") {
+        test("recursively redacts nested object values") {
+            val input = JsonObject(mapOf(
+                "nested" to JsonObject(mapOf(
+                    "value" to JsonPrimitive("ring 98765432")
+                ))
+            ))
+            val (result, wasRedacted) = redactor.redactJsonElement(input)
+            wasRedacted shouldBe true
+            val nested = result.jsonObject["nested"]?.jsonObject
+            nested?.get("value")?.jsonPrimitive?.content shouldBe "ring [TELEFON FJERNET]"
+        }
+
+        test("deeply nested redaction") {
+            val input = JsonObject(mapOf(
+                "a" to JsonObject(mapOf(
+                    "b" to JsonObject(mapOf(
+                        "c" to JsonPrimitive("mitt fnr er 01020349294")
+                    ))
+                ))
+            ))
+            val (result, wasRedacted) = redactor.redactJsonElement(input)
+            wasRedacted shouldBe true
+        }
+    }
+
+    context("arrays") {
+        test("redacts PII in array elements") {
+            val input = JsonObject(mapOf(
+                "items" to JsonArray(listOf(
+                    JsonObject(mapOf("fnr" to JsonPrimitive("01020349294")))
+                ))
+            ))
+            val (result, wasRedacted) = redactor.redactJsonElement(input)
+            wasRedacted shouldBe true
+            val item = result.jsonObject["items"]?.jsonArray?.first()?.jsonObject
+            item?.get("fnr")?.jsonPrimitive?.content shouldBe "[FØDSELSNUMMER FJERNET]"
+        }
+    }
+
+    context("number values") {
+        test("number that looks like fødselsnummer is NOT redacted (numbers stay as-is)") {
+            // 11-digit numbers as JSON numbers are extremely unlikely to be PII
+            // and converting them breaks JSON type expectations
+            val input = JsonObject(mapOf("count" to JsonPrimitive(42)))
+            val (result, wasRedacted) = redactor.redactJsonElement(input)
+            wasRedacted shouldBe false
+            result.jsonObject["count"]?.jsonPrimitive?.content shouldBe "42"
+        }
+    }
+
+    context("edge cases") {
+        test("null JSON values are preserved") {
+            val input = JsonObject(mapOf("field" to JsonNull))
+            val (result, wasRedacted) = redactor.redactJsonElement(input)
+            wasRedacted shouldBe false
+            result.jsonObject["field"] shouldBe JsonNull
+        }
+
+        test("boolean values are preserved") {
+            val input = JsonObject(mapOf("active" to JsonPrimitive(true)))
+            val (result, wasRedacted) = redactor.redactJsonElement(input)
+            wasRedacted shouldBe false
+            result.jsonObject["active"]?.jsonPrimitive?.content shouldBe "true"
+        }
+
+        test("empty object returns empty") {
+            val input = JsonObject(emptyMap())
+            val (result, wasRedacted) = redactor.redactJsonElement(input)
+            wasRedacted shouldBe false
+            result.jsonObject.size shouldBe 0
+        }
+    }
+})

--- a/apps/lumi-api/src/test/kotlin/no/nav/lumi/sensitive/JsonRedactorTest.kt
+++ b/apps/lumi-api/src/test/kotlin/no/nav/lumi/sensitive/JsonRedactorTest.kt
@@ -93,13 +93,28 @@ class JsonRedactorTest : FunSpec({
     }
 
     context("number values") {
-        test("number that looks like fødselsnummer is NOT redacted (numbers stay as-is)") {
-            // 11-digit numbers as JSON numbers are extremely unlikely to be PII
-            // and converting them breaks JSON type expectations
+        test("small numbers are not redacted") {
             val input = JsonObject(mapOf("count" to JsonPrimitive(42)))
             val (result, wasRedacted) = redactor.redactJsonElement(input)
             wasRedacted shouldBe false
             result.jsonObject["count"]?.jsonPrimitive?.content shouldBe "42"
+        }
+
+        test("numeric phone number is redacted") {
+            val input = JsonObject(mapOf("phone" to JsonPrimitive(98765432)))
+            val (result, wasRedacted) = redactor.redactJsonElement(input)
+            wasRedacted shouldBe true
+            result.jsonObject["phone"]?.jsonPrimitive?.content shouldBe "[TELEFON FJERNET]"
+        }
+
+        test("numeric value in nested debug object is redacted") {
+            val input = JsonObject(mapOf(
+                "debug" to JsonObject(mapOf(
+                    "callerPhone" to JsonPrimitive(98765432)
+                ))
+            ))
+            val (result, wasRedacted) = redactor.redactJsonElement(input)
+            wasRedacted shouldBe true
         }
     }
 

--- a/apps/lumi-api/src/test/kotlin/no/nav/lumi/sensitive/JsonRedactorTest.kt
+++ b/apps/lumi-api/src/test/kotlin/no/nav/lumi/sensitive/JsonRedactorTest.kt
@@ -1,6 +1,7 @@
 package no.nav.lumi.sensitive
 
 import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.collections.shouldContain
 import io.kotest.matchers.shouldBe
 import kotlinx.serialization.json.*
 
@@ -49,6 +50,21 @@ class JsonRedactorTest : FunSpec({
             val (result, wasRedacted) = redactor.redactJsonElement(input)
             wasRedacted shouldBe true
             result.jsonObject.keys shouldBe setOf("[REDACTED_KEY_1]", "[REDACTED_KEY_2]")
+        }
+
+        test("avoids collision with existing key named REDACTED_KEY_1") {
+            val input = JsonObject(mapOf(
+                "01020349294" to JsonPrimitive("pii-data"),
+                "[REDACTED_KEY_1]" to JsonPrimitive("legitimate-data")
+            ))
+            val (result, wasRedacted) = redactor.redactJsonElement(input)
+            wasRedacted shouldBe true
+            // Should skip [REDACTED_KEY_1] since it already exists as an original key
+            val keys = result.jsonObject.keys
+            keys.size shouldBe 2
+            keys shouldContain "[REDACTED_KEY_1]"
+            // The PII key should get a different placeholder
+            result.jsonObject["[REDACTED_KEY_1]"]?.jsonPrimitive?.content shouldBe "legitimate-data"
         }
     }
 

--- a/apps/lumi-api/src/test/kotlin/no/nav/lumi/sensitive/UrlRedactorTest.kt
+++ b/apps/lumi-api/src/test/kotlin/no/nav/lumi/sensitive/UrlRedactorTest.kt
@@ -1,0 +1,94 @@
+package no.nav.lumi.sensitive
+
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+class UrlRedactorTest : FunSpec({
+
+    val redactor = UrlRedactor()
+
+    context("URL query parameter redaction") {
+        test("URL without query params is unchanged") {
+            val result = redactor.redactUrl("https://nav.no/arbeid")
+            result.redactedUrl shouldBe "https://nav.no/arbeid"
+            result.wasRedacted shouldBe false
+        }
+
+        test("redacts fødselsnummer in query param value") {
+            val result = redactor.redactUrl("https://nav.no/sok?soek=01020349294")
+            result.redactedUrl shouldBe "https://nav.no/sok?soek=%5BF%C3%98DSELSNUMMER+FJERNET%5D"
+            result.wasRedacted shouldBe true
+        }
+
+        test("redacts only param with PII, leaves others intact") {
+            val result = redactor.redactUrl("https://nav.no/sok?a=ok&b=01020349294&c=test")
+            result.redactedUrl shouldBe "https://nav.no/sok?a=ok&b=%5BF%C3%98DSELSNUMMER+FJERNET%5D&c=test"
+            result.wasRedacted shouldBe true
+        }
+
+        test("redacts email in query param") {
+            val result = redactor.redactUrl("https://nav.no/finn?email=ola.nordmann@nav.no")
+            result.redactedUrl shouldBe "https://nav.no/finn?email=%5BE-POST+FJERNET%5D"
+            result.wasRedacted shouldBe true
+        }
+
+        test("preserves fragment") {
+            val result = redactor.redactUrl("https://nav.no/sok?q=01020349294#section")
+            result.redactedUrl shouldBe "https://nav.no/sok?q=%5BF%C3%98DSELSNUMMER+FJERNET%5D#section"
+            result.wasRedacted shouldBe true
+        }
+
+        test("empty query string is unchanged") {
+            val result = redactor.redactUrl("https://nav.no/sok?")
+            result.redactedUrl shouldBe "https://nav.no/sok?"
+            result.wasRedacted shouldBe false
+        }
+
+        test("null input returns empty unchanged") {
+            val result = redactor.redactUrl(null)
+            result.redactedUrl shouldBe ""
+            result.wasRedacted shouldBe false
+        }
+
+        test("empty string returns empty unchanged") {
+            val result = redactor.redactUrl("")
+            result.redactedUrl shouldBe ""
+            result.wasRedacted shouldBe false
+        }
+
+        test("URL-encoded PII is decoded before redaction") {
+            // %30%31%30%32%30%33%34%39%32%39%34 = 01020349294 URL-encoded
+            val result = redactor.redactUrl("https://nav.no/sok?q=%30%31%30%32%30%33%34%39%32%39%34")
+            result.wasRedacted shouldBe true
+            result.redactedUrl shouldBe "https://nav.no/sok?q=%5BF%C3%98DSELSNUMMER+FJERNET%5D"
+        }
+    }
+
+    context("PII in URL path (fallback full-string redaction)") {
+        test("redacts fødselsnummer in path") {
+            val result = redactor.redactUrl("https://nav.no/bruker/01020349294/status")
+            result.redactedUrl shouldBe "https://nav.no/bruker/[FØDSELSNUMMER FJERNET]/status"
+            result.wasRedacted shouldBe true
+        }
+
+        test("redacts PII in both path and query params") {
+            val result = redactor.redactUrl("https://nav.no/bruker/01020349294?email=test@nav.no")
+            result.wasRedacted shouldBe true
+            // Path PII redacted by full-string pass, query PII by param-level
+            result.redactedUrl shouldBe "https://nav.no/bruker/[FØDSELSNUMMER FJERNET]?email=%5BE-POST+FJERNET%5D"
+        }
+    }
+
+    context("malformed URLs") {
+        test("non-URL string is redacted as plain text") {
+            val result = redactor.redactUrl("ring meg på 98765432")
+            result.redactedUrl shouldBe "ring meg på [TELEFON FJERNET]"
+            result.wasRedacted shouldBe true
+        }
+
+        test("relative path without host") {
+            val result = redactor.redactUrl("/sok?q=01020349294")
+            result.wasRedacted shouldBe true
+        }
+    }
+})

--- a/apps/lumi-api/src/test/kotlin/no/nav/lumi/sensitive/UrlRedactorTest.kt
+++ b/apps/lumi-api/src/test/kotlin/no/nav/lumi/sensitive/UrlRedactorTest.kt
@@ -32,9 +32,26 @@ class UrlRedactorTest : FunSpec({
             result.wasRedacted shouldBe true
         }
 
-        test("preserves fragment") {
+        test("preserves clean fragment") {
             val result = redactor.redactUrl("https://nav.no/sok?q=01020349294#section")
             result.redactedUrl shouldBe "https://nav.no/sok?q=%5BF%C3%98DSELSNUMMER+FJERNET%5D#section"
+            result.wasRedacted shouldBe true
+        }
+
+        test("redacts PII in fragment") {
+            val result = redactor.redactUrl("https://nav.no/page#fnr=01020349294")
+            result.wasRedacted shouldBe true
+            result.redactedUrl shouldBe "https://nav.no/page#fnr=[FØDSELSNUMMER FJERNET]"
+        }
+
+        test("redacts PII in query param key") {
+            val result = redactor.redactUrl("https://nav.no/sok?01020349294=value")
+            result.wasRedacted shouldBe true
+            result.redactedUrl shouldBe "https://nav.no/sok?%5BF%C3%98DSELSNUMMER+FJERNET%5D=value"
+        }
+
+        test("redacts bare query token without equals") {
+            val result = redactor.redactUrl("https://nav.no/sok?01020349294")
             result.wasRedacted shouldBe true
         }
 

--- a/apps/lumi-api/src/test/kotlin/no/nav/lumi/sensitive/UrlRedactorTest.kt
+++ b/apps/lumi-api/src/test/kotlin/no/nav/lumi/sensitive/UrlRedactorTest.kt
@@ -84,6 +84,7 @@ class UrlRedactorTest : FunSpec({
             // %2530%2531... → %30%31... → 01020349294
             val result = redactor.redactUrl("https://nav.no/sok?q=%2530%2531%2530%2532%2530%2533%2534%2539%2532%2539%2534")
             result.wasRedacted shouldBe true
+            result.redactedUrl shouldBe "https://nav.no/sok?q=%5BF%C3%98DSELSNUMMER+FJERNET%5D"
         }
 
         test("URL-encoded PII in fragment is decoded and redacted") {
@@ -95,6 +96,7 @@ class UrlRedactorTest : FunSpec({
         test("URL-encoded PII in path is decoded and redacted") {
             val result = redactor.redactUrl("https://nav.no/bruker/%30%31%30%32%30%33%34%39%32%39%34/status")
             result.wasRedacted shouldBe true
+            result.redactedUrl shouldBe "https://nav.no/bruker/[FØDSELSNUMMER FJERNET]/status"
         }
     }
 
@@ -136,6 +138,7 @@ class UrlRedactorTest : FunSpec({
             // %2B should decode to + once and stay there, not degrade to space
             val result = redactor.redactUrl("https://nav.no/sok?email=ola%2Balias@nav.no")
             result.wasRedacted shouldBe true
+            result.redactedUrl shouldBe "https://nav.no/sok?email=%5BE-POST+FJERNET%5D"
         }
 
         test("literal plus in path is preserved when no PII") {

--- a/apps/lumi-api/src/test/kotlin/no/nav/lumi/sensitive/UrlRedactorTest.kt
+++ b/apps/lumi-api/src/test/kotlin/no/nav/lumi/sensitive/UrlRedactorTest.kt
@@ -79,6 +79,23 @@ class UrlRedactorTest : FunSpec({
             result.wasRedacted shouldBe true
             result.redactedUrl shouldBe "https://nav.no/sok?q=%5BF%C3%98DSELSNUMMER+FJERNET%5D"
         }
+
+        test("double URL-encoded PII is caught via iterative decode") {
+            // %2530%2531... → %30%31... → 01020349294
+            val result = redactor.redactUrl("https://nav.no/sok?q=%2530%2531%2530%2532%2530%2533%2534%2539%2532%2539%2534")
+            result.wasRedacted shouldBe true
+        }
+
+        test("URL-encoded PII in fragment is decoded and redacted") {
+            val result = redactor.redactUrl("https://nav.no/page#user=%30%31%30%32%30%33%34%39%32%39%34")
+            result.wasRedacted shouldBe true
+            result.redactedUrl shouldBe "https://nav.no/page#user=[FØDSELSNUMMER FJERNET]"
+        }
+
+        test("URL-encoded PII in path is decoded and redacted") {
+            val result = redactor.redactUrl("https://nav.no/bruker/%30%31%30%32%30%33%34%39%32%39%34/status")
+            result.wasRedacted shouldBe true
+        }
     }
 
     context("PII in URL path (fallback full-string redaction)") {

--- a/apps/lumi-api/src/test/kotlin/no/nav/lumi/sensitive/UrlRedactorTest.kt
+++ b/apps/lumi-api/src/test/kotlin/no/nav/lumi/sensitive/UrlRedactorTest.kt
@@ -144,6 +144,13 @@ class UrlRedactorTest : FunSpec({
         test("lone percent in path does not prevent PII detection") {
             val result = redactor.redactUrl("https://nav.no/bruker/01020349294/100%")
             result.wasRedacted shouldBe true
+            result.redactedUrl shouldBe "https://nav.no/bruker/%5BF%C3%98DSELSNUMMER%20FJERNET%5D/100%25"
+        }
+
+        test("existing valid percent-encoding is preserved when path also contains redacted PII") {
+            val result = redactor.redactUrl("https://nav.no/status%20ok/01020349294")
+            result.wasRedacted shouldBe true
+            result.redactedUrl shouldBe "https://nav.no/status%20ok/%5BF%C3%98DSELSNUMMER%20FJERNET%5D"
         }
     }
 

--- a/apps/lumi-api/src/test/kotlin/no/nav/lumi/sensitive/UrlRedactorTest.kt
+++ b/apps/lumi-api/src/test/kotlin/no/nav/lumi/sensitive/UrlRedactorTest.kt
@@ -128,6 +128,25 @@ class UrlRedactorTest : FunSpec({
         }
     }
 
+    context("malformed percent-encoding") {
+        test("trailing percent does not abort decode of valid encoded PII") {
+            // The trailing % is malformed, but the encoded fnr should still be decoded and caught
+            val result = redactor.redactUrl("https://nav.no/sok?q=%30%31%30%32%30%33%34%39%32%39%34%")
+            result.wasRedacted shouldBe true
+        }
+
+        test("incomplete percent sequence does not abort decode") {
+            // %z is not valid hex — should not prevent decoding of the rest
+            val result = redactor.redactUrl("https://nav.no/sok?q=%30%31%30%32%30%33%34%39%32%39%34&x=%zz")
+            result.wasRedacted shouldBe true
+        }
+
+        test("lone percent in path does not prevent PII detection") {
+            val result = redactor.redactUrl("https://nav.no/bruker/01020349294/100%")
+            result.wasRedacted shouldBe true
+        }
+    }
+
     context("plus-sign preservation") {
         test("plus-alias email in query param is redacted") {
             val result = redactor.redactUrl("https://nav.no/sok?email=ola+alias@nav.no")

--- a/apps/lumi-api/src/test/kotlin/no/nav/lumi/sensitive/UrlRedactorTest.kt
+++ b/apps/lumi-api/src/test/kotlin/no/nav/lumi/sensitive/UrlRedactorTest.kt
@@ -41,7 +41,7 @@ class UrlRedactorTest : FunSpec({
         test("redacts PII in fragment") {
             val result = redactor.redactUrl("https://nav.no/page#fnr=01020349294")
             result.wasRedacted shouldBe true
-            result.redactedUrl shouldBe "https://nav.no/page#fnr=[FØDSELSNUMMER FJERNET]"
+            result.redactedUrl shouldBe "https://nav.no/page#fnr=%5BF%C3%98DSELSNUMMER%20FJERNET%5D"
         }
 
         test("redacts PII in query param key") {
@@ -90,20 +90,20 @@ class UrlRedactorTest : FunSpec({
         test("URL-encoded PII in fragment is decoded and redacted") {
             val result = redactor.redactUrl("https://nav.no/page#user=%30%31%30%32%30%33%34%39%32%39%34")
             result.wasRedacted shouldBe true
-            result.redactedUrl shouldBe "https://nav.no/page#user=[FØDSELSNUMMER FJERNET]"
+            result.redactedUrl shouldBe "https://nav.no/page#user=%5BF%C3%98DSELSNUMMER%20FJERNET%5D"
         }
 
         test("URL-encoded PII in path is decoded and redacted") {
             val result = redactor.redactUrl("https://nav.no/bruker/%30%31%30%32%30%33%34%39%32%39%34/status")
             result.wasRedacted shouldBe true
-            result.redactedUrl shouldBe "https://nav.no/bruker/[FØDSELSNUMMER FJERNET]/status"
+            result.redactedUrl shouldBe "https://nav.no/bruker/%5BF%C3%98DSELSNUMMER%20FJERNET%5D/status"
         }
     }
 
     context("PII in URL path (fallback full-string redaction)") {
         test("redacts fødselsnummer in path") {
             val result = redactor.redactUrl("https://nav.no/bruker/01020349294/status")
-            result.redactedUrl shouldBe "https://nav.no/bruker/[FØDSELSNUMMER FJERNET]/status"
+            result.redactedUrl shouldBe "https://nav.no/bruker/%5BF%C3%98DSELSNUMMER%20FJERNET%5D/status"
             result.wasRedacted shouldBe true
         }
 
@@ -111,7 +111,7 @@ class UrlRedactorTest : FunSpec({
             val result = redactor.redactUrl("https://nav.no/bruker/01020349294?email=test@nav.no")
             result.wasRedacted shouldBe true
             // Path PII redacted by full-string pass, query PII by param-level
-            result.redactedUrl shouldBe "https://nav.no/bruker/[FØDSELSNUMMER FJERNET]?email=%5BE-POST+FJERNET%5D"
+            result.redactedUrl shouldBe "https://nav.no/bruker/%5BF%C3%98DSELSNUMMER%20FJERNET%5D?email=%5BE-POST+FJERNET%5D"
         }
     }
 

--- a/apps/lumi-api/src/test/kotlin/no/nav/lumi/sensitive/UrlRedactorTest.kt
+++ b/apps/lumi-api/src/test/kotlin/no/nav/lumi/sensitive/UrlRedactorTest.kt
@@ -125,4 +125,23 @@ class UrlRedactorTest : FunSpec({
             result.wasRedacted shouldBe true
         }
     }
+
+    context("plus-sign preservation") {
+        test("plus-alias email in query param is redacted") {
+            val result = redactor.redactUrl("https://nav.no/sok?email=ola+alias@nav.no")
+            result.wasRedacted shouldBe true
+        }
+
+        test("percent-encoded plus in email survives multi-pass decode") {
+            // %2B should decode to + once and stay there, not degrade to space
+            val result = redactor.redactUrl("https://nav.no/sok?email=ola%2Balias@nav.no")
+            result.wasRedacted shouldBe true
+        }
+
+        test("literal plus in path is preserved when no PII") {
+            val result = redactor.redactUrl("https://nav.no/c++/docs")
+            result.wasRedacted shouldBe false
+            result.redactedUrl shouldBe "https://nav.no/c++/docs"
+        }
+    }
 })

--- a/apps/lumi-api/src/test/kotlin/no/nav/lumi/service/FeedbackServiceTest.kt
+++ b/apps/lumi-api/src/test/kotlin/no/nav/lumi/service/FeedbackServiceTest.kt
@@ -128,7 +128,7 @@ class FeedbackServiceTest : FunSpec({
             val id = service.save(feedbackJson, "flex", "test-app")
             val saved = repository.findRawById(id, "flex").shouldNotBeNull()
             saved.feedbackJson shouldNotContain "01020349294"
-            saved.feedbackJson shouldContain "[FØDSELSNUMMER FJERNET]"
+            saved.feedbackJson shouldContain "%5BF%C3%98DSELSNUMMER%20FJERNET%5D"
         }
 
         test("redacts PII in tag values") {

--- a/apps/lumi-api/src/test/kotlin/no/nav/lumi/service/FeedbackServiceTest.kt
+++ b/apps/lumi-api/src/test/kotlin/no/nav/lumi/service/FeedbackServiceTest.kt
@@ -93,6 +93,133 @@ class FeedbackServiceTest : FunSpec({
             saved.feedbackJson shouldContain "\"userAgent\": \"botMozilla\""
             saved.feedbackJson shouldContain "\"segment\": \"intern\""
         }
+
+        test("redacts fødselsnummer in URL query parameter") {
+            val feedbackJson = """
+                {
+                    "context": {
+                        "url": "https://nav.no/sok?soek=01020349294&page=1"
+                    },
+                    "answers": []
+                }
+            """.trimIndent()
+
+            val id = service.save(feedbackJson, "flex", "test-app")
+            val saved = repository.findRawById(id, "flex").shouldNotBeNull()
+
+            saved.feedbackJson shouldNotContain "01020349294"
+            saved.feedbackJson shouldContain "soek="
+
+            val savedJson = Json.parseToJsonElement(saved.feedbackJson).jsonObject
+            savedJson["sensitiveDataRedacted"]?.jsonPrimitive?.content shouldBe "true"
+        }
+
+        test("redacts fødselsnummer in URL path") {
+            val feedbackJson = """
+                {
+                    "context": {
+                        "url": "https://nav.no/bruker/01020349294/status"
+                    },
+                    "answers": []
+                }
+            """.trimIndent()
+
+            val id = service.save(feedbackJson, "flex", "test-app")
+            val saved = repository.findRawById(id, "flex").shouldNotBeNull()
+            saved.feedbackJson shouldNotContain "01020349294"
+            saved.feedbackJson shouldContain "[FØDSELSNUMMER FJERNET]"
+        }
+
+        test("redacts PII in tag values") {
+            val feedbackJson = """
+                {
+                    "context": {
+                        "tags": {
+                            "team": "flex",
+                            "bruker": "01020349294"
+                        }
+                    },
+                    "answers": []
+                }
+            """.trimIndent()
+
+            val id = service.save(feedbackJson, "flex", "test-app")
+            val saved = repository.findRawById(id, "flex").shouldNotBeNull()
+            saved.feedbackJson shouldNotContain "01020349294"
+            saved.feedbackJson shouldContain "[FØDSELSNUMMER FJERNET]"
+            saved.feedbackJson shouldContain "\"team\""
+            saved.feedbackJson shouldContain "\"flex\""
+
+            val savedJson = Json.parseToJsonElement(saved.feedbackJson).jsonObject
+            savedJson["sensitiveDataRedacted"]?.jsonPrimitive?.content shouldBe "true"
+        }
+
+        test("redacts PII in tag keys") {
+            val feedbackJson = """
+                {
+                    "context": {
+                        "tags": {
+                            "01020349294": "ja"
+                        }
+                    },
+                    "answers": []
+                }
+            """.trimIndent()
+
+            val id = service.save(feedbackJson, "flex", "test-app")
+            val saved = repository.findRawById(id, "flex").shouldNotBeNull()
+            saved.feedbackJson shouldNotContain "01020349294"
+            saved.feedbackJson shouldContain "REDACTED_KEY"
+
+            val savedJson = Json.parseToJsonElement(saved.feedbackJson).jsonObject
+            savedJson["sensitiveDataRedacted"]?.jsonPrimitive?.content shouldBe "true"
+        }
+
+        test("redacts PII in debug recursively") {
+            val feedbackJson = """
+                {
+                    "context": {
+                        "debug": {
+                            "nested": {
+                                "value": "ring 98765432"
+                            }
+                        }
+                    },
+                    "answers": []
+                }
+            """.trimIndent()
+
+            val id = service.save(feedbackJson, "flex", "test-app")
+            val saved = repository.findRawById(id, "flex").shouldNotBeNull()
+            saved.feedbackJson shouldNotContain "98765432"
+            saved.feedbackJson shouldContain "[TELEFON FJERNET]"
+
+            val savedJson = Json.parseToJsonElement(saved.feedbackJson).jsonObject
+            savedJson["sensitiveDataRedacted"]?.jsonPrimitive?.content shouldBe "true"
+        }
+
+        test("no redaction leaves sensitiveDataRedacted as false") {
+            val feedbackJson = """
+                {
+                    "context": {
+                        "url": "https://nav.no/arbeid",
+                        "tags": {"team": "flex"}
+                    },
+                    "answers": [
+                        {
+                            "fieldId": "q1",
+                            "value": {"type": "text", "text": "Alt er bra"}
+                        }
+                    ]
+                }
+            """.trimIndent()
+
+            val id = service.save(feedbackJson, "flex", "test-app")
+            val saved = repository.findRawById(id, "flex").shouldNotBeNull()
+
+            val savedJson = Json.parseToJsonElement(saved.feedbackJson).jsonObject
+            savedJson["sensitiveDataRedacted"]?.jsonPrimitive?.content shouldBe "false"
+        }
     }
 
     context("delete") {

--- a/apps/lumi-api/src/test/kotlin/no/nav/lumi/service/FeedbackServiceTest.kt
+++ b/apps/lumi-api/src/test/kotlin/no/nav/lumi/service/FeedbackServiceTest.kt
@@ -220,6 +220,29 @@ class FeedbackServiceTest : FunSpec({
             val savedJson = Json.parseToJsonElement(saved.feedbackJson).jsonObject
             savedJson["sensitiveDataRedacted"]?.jsonPrimitive?.content shouldBe "false"
         }
+
+        test("redacts PII in debug JsonArray") {
+            val feedbackJson = """
+                {
+                    "context": {
+                        "debug": [
+                            {"fnr": "01020349294"},
+                            {"clean": "ok"}
+                        ]
+                    },
+                    "answers": []
+                }
+            """.trimIndent()
+
+            val id = service.save(feedbackJson, "flex", "test-app")
+            val saved = repository.findRawById(id, "flex").shouldNotBeNull()
+            saved.feedbackJson shouldNotContain "01020349294"
+            saved.feedbackJson shouldContain "[FØDSELSNUMMER FJERNET]"
+            saved.feedbackJson shouldContain "\"clean\""
+
+            val savedJson = Json.parseToJsonElement(saved.feedbackJson).jsonObject
+            savedJson["sensitiveDataRedacted"]?.jsonPrimitive?.content shouldBe "true"
+        }
     }
 
     context("delete") {

--- a/apps/lumi-api/src/test/kotlin/no/nav/lumi/service/FeedbackServiceTest.kt
+++ b/apps/lumi-api/src/test/kotlin/no/nav/lumi/service/FeedbackServiceTest.kt
@@ -1,5 +1,6 @@
 package no.nav.lumi.service
 
+import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.collections.shouldContain as collectionShouldContain
@@ -11,6 +12,7 @@ import kotlinx.serialization.json.jsonObject
 import kotlinx.serialization.json.jsonPrimitive
 import no.nav.lumi.TestDatabase
 import no.nav.lumi.config.DatabaseHolder
+import no.nav.lumi.config.exception.ApiErrorException
 import no.nav.lumi.insertTestFeedback
 import no.nav.lumi.insertTestFeedbackWithJson
 import no.nav.lumi.repository.FeedbackRepository
@@ -282,6 +284,47 @@ class FeedbackServiceTest : FunSpec({
             val values = tags.values.map { it.jsonPrimitive.content }
             values collectionShouldContain "flex"
             values collectionShouldContain "dagpenger"
+        }
+
+        test("blank tag keys after HTML stripping are replaced with unique redaction key") {
+            val feedbackJson = """
+                {
+                    "context": {
+                        "tags": {
+                            "<b></b>": "skjult",
+                            "team": "flex"
+                        }
+                    },
+                    "answers": []
+                }
+            """.trimIndent()
+
+            val id = service.save(feedbackJson, "flex", "test-app")
+            val saved = repository.findRawById(id, "flex").shouldNotBeNull()
+            val savedJson = Json.parseToJsonElement(saved.feedbackJson).jsonObject
+            val tags = savedJson["context"]?.jsonObject?.get("tags")?.jsonObject
+            tags.shouldNotBeNull()
+
+            tags.keys.any { it.isBlank() } shouldBe false
+            tags.keys.any { it.startsWith("[REDACTED_KEY_") } shouldBe true
+            tags.values.map { it.jsonPrimitive.content } collectionShouldContain "skjult"
+            savedJson["sensitiveDataRedacted"]?.jsonPrimitive?.content shouldBe "true"
+        }
+
+        test("answer redaction failure fails closed with internal server error") {
+            val feedbackJson = """
+                {
+                    "answers": [
+                        "ugyldig-svar"
+                    ]
+                }
+            """.trimIndent()
+
+            val exception = shouldThrow<ApiErrorException.InternalServerErrorException> {
+                service.save(feedbackJson, "flex", "test-app")
+            }
+
+            exception.message shouldBe "Failed to redact feedback JSON"
         }
     }
 

--- a/apps/lumi-api/src/test/kotlin/no/nav/lumi/service/FeedbackServiceTest.kt
+++ b/apps/lumi-api/src/test/kotlin/no/nav/lumi/service/FeedbackServiceTest.kt
@@ -2,6 +2,7 @@ package no.nav.lumi.service
 
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.shouldBe
+import io.kotest.matchers.collections.shouldContain as collectionShouldContain
 import io.kotest.matchers.string.shouldContain
 import io.kotest.matchers.string.shouldNotContain
 import io.kotest.matchers.nulls.shouldNotBeNull
@@ -242,6 +243,45 @@ class FeedbackServiceTest : FunSpec({
 
             val savedJson = Json.parseToJsonElement(saved.feedbackJson).jsonObject
             savedJson["sensitiveDataRedacted"]?.jsonPrimitive?.content shouldBe "true"
+        }
+        test("redacts percent-encoded fødselsnummer in pathname") {
+            val feedbackJson = """
+                {
+                    "context": {
+                        "pathname": "/bruker/%30%31%30%32%30%33%34%39%32%39%34/status"
+                    },
+                    "answers": []
+                }
+            """.trimIndent()
+
+            val id = service.save(feedbackJson, "flex", "test-app")
+            val saved = repository.findRawById(id, "flex").shouldNotBeNull()
+            saved.feedbackJson shouldNotContain "01020349294"
+            saved.feedbackJson shouldContain "[FØDSELSNUMMER FJERNET]"
+        }
+
+        test("HTML-stripped tag keys that collide do not overwrite each other") {
+            val feedbackJson = """
+                {
+                    "context": {
+                        "tags": {
+                            "team": "flex",
+                            "<b>team</b>": "dagpenger"
+                        }
+                    },
+                    "answers": []
+                }
+            """.trimIndent()
+
+            val id = service.save(feedbackJson, "flex", "test-app")
+            val saved = repository.findRawById(id, "flex").shouldNotBeNull()
+            val savedJson = Json.parseToJsonElement(saved.feedbackJson).jsonObject
+            val tags = savedJson["context"]?.jsonObject?.get("tags")?.jsonObject
+            tags.shouldNotBeNull()
+            // Both values should be present (no data loss)
+            val values = tags.values.map { it.jsonPrimitive.content }
+            values collectionShouldContain "flex"
+            values collectionShouldContain "dagpenger"
         }
     }
 


### PR DESCRIPTION
## Beskrivelse

Utvider PII-redaksjon fra kun tekst-svar til å dekke alle kontekst-felt der team utilsiktet kan sende personopplysninger.

### Nye filer
- `sensitive/UrlRedactor.kt` — Dekomponerer URL, redakterer query-params individuelt + full-string fallback for PII i path
- `sensitive/JsonRedactor.kt` — Rekursiv JSON-walk som redakterer string-verdier og nøkler med PII

### Endrede filer
- `service/FeedbackService.kt` — `sanitizeAndRedactContext()` erstatter `sanitizeContext()`
- Tester utvidet med 6 nye integrasjonstester + 2 nye unit-test-klasser

### Hva redakteres nå

| Felt | Før | Etter |
|------|-----|-------|
| `answers[*].value.text` | ✅ PII-redaktert | ✅ Uendret |
| `context.url` | Bare HTML-strip | ✅ HTML-strip + PII per query-param + path-fallback |
| `context.pathname` | Bare HTML-strip | ✅ HTML-strip + PII-redaksjon |
| `context.tags` (verdier) | Bare HTML-strip | ✅ HTML-strip + PII-redaksjon |
| `context.tags` (nøkler) | Ingen | ✅ PII → `[REDACTED_KEY_n]` |
| `context.debug` | Ingen | ✅ Rekursiv PII-redaksjon |
| `sensitiveDataRedacted`-flagg | Kun tekst-svar | ✅ Alle felt |

### Utenfor scope
- `metadata` og `deduplicationKey` — feltene eksisterer ikke i `FeedbackSubmissionV1` ennå
- Tas som del av egne issues når feltene legges til i modellen

### Verifisering
- `./gradlew test` ✅ (full suite, inkl. DB-tester)
- Ingen regresjoner i eksisterende tester

Closes #273
Del av epic: #270