### PR TITLE
ci(docs): relax strict dep builds in docs CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -162,7 +162,7 @@ jobs:
           cache-dependency-path: docs/pnpm-lock.yaml
       - name: Install docs deps
         working-directory: docs
-        run: pnpm install --frozen-lockfile --ignore-workspace
+        run: pnpm install --config.strictDepBuilds=false --frozen-lockfile --ignore-workspace
         env:
           NPM_AUTH_TOKEN: ${{ secrets.READER_TOKEN }}
       - name: Build docs


### PR DESCRIPTION
## Beskrivelse

Build docs feiler i merge queue på rene GitHub-runnere fordi pnpm stopper `docs`-installasjonen med `ERR_PNPM_IGNORED_BUILDS` for `esbuild@0.21.5` før VitePress-bygget får kjøre.

## Endringer

- `.github/workflows/ci.yaml`: setter `strictDepBuilds=false` kun for den standalone docs-installasjonen som kjører med `--ignore-workspace`, slik at merge-queue-jobben kan installere og bygge docs uten å endre app- eller API-atferd

## Issue

Ingen eksisterende issue. Denne PR-en fikser merge-queue-feil i `Build docs` for Dependabot-oppdateringer.

## Sjekkliste

- [x] Koden kompilerer og linter uten feil
- [x] Endringene er testet (manuelt eller automatisk)
- [x] Ingen sensitiv data eksponert (tokens, credentials, PII)

## Verifisering

- `cd docs && pnpm install --config.strictDepBuilds=false --frozen-lockfile --ignore-workspace`
- `cd docs && pnpm --ignore-workspace run build`
- `pnpm run lint`
- `pnpm run typecheck`

`pnpm run lint` ga kun to eksisterende Biome-advarsler uten feil i urelatert kode.