### PR TITLE
fix(docs): allow esbuild build script

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -154,12 +154,15 @@ jobs:
       contents: read
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
-      - uses: pnpm/action-setup@903f9c1a6ebcba6cf41d87230be49611ac97822e # v6.0.3
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e
         with:
           node-version: 22
           cache: pnpm
           cache-dependency-path: docs/pnpm-lock.yaml
+      - name: Setup pnpm
+        run: |
+          corepack enable
+          corepack prepare pnpm@10.32.1 --activate
       - name: Install docs deps
         working-directory: docs
         run: pnpm install --frozen-lockfile --ignore-workspace

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -155,6 +155,8 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
       - uses: pnpm/action-setup@903f9c1a6ebcba6cf41d87230be49611ac97822e # v6.0.3
+        with:
+          version: 10.32.1
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e
         with:
           node-version: 22

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -158,12 +158,6 @@ jobs:
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e
         with:
           node-version: 22
-          cache: pnpm
-          cache-dependency-path: docs/pnpm-lock.yaml
-      - name: Setup pnpm
-        run: |
-          corepack enable
-          corepack prepare pnpm@10.32.1 --activate
       - name: Install docs deps
         working-directory: docs
         run: pnpm install --frozen-lockfile --ignore-workspace

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -162,7 +162,7 @@ jobs:
           cache-dependency-path: docs/pnpm-lock.yaml
       - name: Install docs deps
         working-directory: docs
-        run: pnpm install --config.strictDepBuilds=false --frozen-lockfile --ignore-workspace
+        run: pnpm install --frozen-lockfile --ignore-workspace
         env:
           NPM_AUTH_TOKEN: ${{ secrets.READER_TOKEN }}
       - name: Build docs

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -154,6 +154,7 @@ jobs:
       contents: read
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+      - uses: pnpm/action-setup@903f9c1a6ebcba6cf41d87230be49611ac97822e # v6.0.3
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e
         with:
           node-version: 22

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -162,7 +162,7 @@ jobs:
           cache-dependency-path: docs/pnpm-lock.yaml
       - name: Install docs deps
         working-directory: docs
-        run: pnpm install --frozen-lockfile --ignore-workspace
+        run: pnpm install --config.strictDepBuilds=false --frozen-lockfile --ignore-workspace
         env:
           NPM_AUTH_TOKEN: ${{ secrets.READER_TOKEN }}
       - name: Build docs

--- a/docs/package.json
+++ b/docs/package.json
@@ -7,6 +7,11 @@
     "build": "vitepress build",
     "preview": "vitepress preview"
   },
+  "pnpm": {
+    "onlyBuiltDependencies": [
+      "esbuild"
+    ]
+  },
   "devDependencies": {
     "mermaid": "^11.14.0",
     "vitepress": "^1.6.4",


### PR DESCRIPTION
## Beskrivelse

Følger opp #287 med en smal docs-fiks for merge queue. `docs/package.json` godkjenner kun `esbuild` som nødvendig build dependency, og docs-jobben bruker nå én pnpm-setup via `pnpm/action-setup` med repoets pnpm-versjon. Den tidligere cache/post-step-feilen er fjernet ved å ikke bruke `setup-node`-cache i docs-jobben.

## Endringer

- `docs/package.json`: godkjenner kun `esbuild` via `pnpm.onlyBuiltDependencies`
- `.github/workflows/ci.yaml`: fjerner det brede `strictDepBuilds=false`-flagget fra docs-install
- `.github/workflows/ci.yaml`: bruker kun `pnpm/action-setup` i docs-jobben og pinner `pnpm@10.32.1`
- `.github/workflows/ci.yaml`: fjerner `setup-node`-cache i docs-jobben slik at post-job ikke kan feile på cache-save

## Issue

Ingen egen issue. Oppfølging av #287 og docs-feilene som blokkerer #281-#285 i merge queue.

## Sjekkliste

- [x] Koden kompilerer og linter uten feil
- [x] Endringene er testet (manuelt eller automatisk)
- [x] Ingen sensitiv data eksponert (tokens, credentials, PII)

## Verifisering

- `pnpm --dir docs install --frozen-lockfile --ignore-workspace`
- `pnpm --dir docs --ignore-workspace run build`
- `pnpm run lint` (består med eksisterende urelaterte warnings i dashboard CSS og `scripts/tanstack-mcp.mjs`)
- `pnpm run typecheck`
- GitHub Actions: `CI / Build docs` grønn på commit `0e36493`
