### PR TITLE
feat(api): deduplicate feedback submissions

### DIFF
--- a/apps/lumi-api/src/main/kotlin/no/nav/lumi/domain/SaveResult.kt
+++ b/apps/lumi-api/src/main/kotlin/no/nav/lumi/domain/SaveResult.kt
@@ -1,0 +1,9 @@
+package no.nav.lumi.domain
+
+sealed interface SaveResult {
+    val id: String
+
+    data class Created(override val id: String) : SaveResult
+
+    data class Duplicate(override val id: String) : SaveResult
+}

--- a/apps/lumi-api/src/main/kotlin/no/nav/lumi/domain/SubmissionV1.kt
+++ b/apps/lumi-api/src/main/kotlin/no/nav/lumi/domain/SubmissionV1.kt
@@ -38,6 +38,7 @@ data class FeedbackSubmissionV1(
     val submittedAt: String,
     val startedAt: String? = null,
     val timeToCompleteMs: Long? = null,
+    val deduplicationKey: String? = null,
     val context: SubmissionContextV1? = null,
     val answers: List<Answer>
 )

--- a/apps/lumi-api/src/main/kotlin/no/nav/lumi/repository/FeedbackRepository.kt
+++ b/apps/lumi-api/src/main/kotlin/no/nav/lumi/repository/FeedbackRepository.kt
@@ -4,6 +4,7 @@ import no.nav.lumi.config.exception.ApiErrorException
 import no.nav.lumi.domain.*
 import org.jetbrains.exposed.v1.core.*
 import org.jetbrains.exposed.v1.jdbc.*
+import org.jetbrains.exposed.v1.jdbc.transactions.TransactionManager
 import org.slf4j.LoggerFactory
 import java.time.Instant
 import java.util.*
@@ -35,6 +36,30 @@ class FeedbackRepository(
         }
     }
 
+    suspend fun findIdByDeduplicationKeyHash(team: String, surveyId: String, deduplicationKeyHash: String): String? {
+        return dbQuery {
+            findIdByDeduplicationKeyHashInCurrentTransaction(team, surveyId, deduplicationKeyHash)
+        }
+    }
+
+    suspend fun <T> withScopedDeduplicationLock(
+        team: String,
+        surveyId: String,
+        deduplicationKeyHash: String,
+        block: suspend () -> T
+    ): T {
+        return dbQuery {
+            val conn = TransactionManager.current().connection.connection as java.sql.Connection
+            conn.prepareStatement("SELECT pg_advisory_xact_lock(hashtext(?), hashtext(?))").use { stmt ->
+                stmt.setString(1, "$team:$surveyId")
+                stmt.setString(2, deduplicationKeyHash)
+                stmt.execute()
+            }
+
+            block()
+        }
+    }
+
     suspend fun save(
         feedbackJson: String,
         team: String,
@@ -42,51 +67,72 @@ class FeedbackRepository(
         surveyId: String? = null,
         definitionHash: String? = null,
         deduplicationKeyHash: String? = null
-    ): String {
+    ): SaveResult {
+        return dbQuery {
+            saveInCurrentTransaction(feedbackJson, team, app, surveyId, definitionHash, deduplicationKeyHash)
+        }
+    }
+
+    internal fun findIdByDeduplicationKeyHashInCurrentTransaction(
+        team: String,
+        surveyId: String,
+        deduplicationKeyHash: String
+    ): String? {
+        return FeedbackTable.select(FeedbackTable.id)
+            .where {
+                (FeedbackTable.team eq team) and
+                    (FeedbackTable.surveyId eq surveyId) and
+                    (FeedbackTable.deduplicationKeyHash eq deduplicationKeyHash)
+            }
+            .singleOrNull()
+            ?.get(FeedbackTable.id)
+    }
+
+    internal fun saveInCurrentTransaction(
+        feedbackJson: String,
+        team: String,
+        app: String,
+        surveyId: String? = null,
+        definitionHash: String? = null,
+        deduplicationKeyHash: String? = null
+    ): SaveResult {
         val id = UUID.randomUUID().toString()
 
-        return dbQuery {
-            if (surveyId != null && deduplicationKeyHash != null) {
-                val inserted = FeedbackTable.insertIgnore {
-                    it[FeedbackTable.id] = id
-                    it[FeedbackTable.opprettet] = Instant.now()
-                    it[FeedbackTable.feedbackJson] = feedbackJson
-                    it[FeedbackTable.team] = team
-                    it[FeedbackTable.app] = app
-                    it[FeedbackTable.surveyId] = surveyId
-                    it[FeedbackTable.definitionHash] = definitionHash
-                    it[FeedbackTable.deduplicationKeyHash] = deduplicationKeyHash
-                }.insertedCount > 0
+        return if (surveyId != null && deduplicationKeyHash != null) {
+            val inserted = FeedbackTable.insertIgnore {
+                it[FeedbackTable.id] = id
+                it[FeedbackTable.opprettet] = Instant.now()
+                it[FeedbackTable.feedbackJson] = feedbackJson
+                it[FeedbackTable.team] = team
+                it[FeedbackTable.app] = app
+                it[FeedbackTable.surveyId] = surveyId
+                it[FeedbackTable.definitionHash] = definitionHash
+                it[FeedbackTable.deduplicationKeyHash] = deduplicationKeyHash
+            }.insertedCount > 0
 
-                if (inserted) {
-                    id
-                } else {
-                    FeedbackTable.select(FeedbackTable.id)
-                        .where {
-                            (FeedbackTable.team eq team) and
-                                (FeedbackTable.surveyId eq surveyId) and
-                                (FeedbackTable.deduplicationKeyHash eq deduplicationKeyHash)
-                        }
-                        .singleOrNull()
-                        ?.get(FeedbackTable.id)
-                        ?: throw ApiErrorException.InternalServerErrorException(
-                            "Duplicate deduplication key detected but existing feedback row was not found"
-                        )
-                }
+            if (inserted) {
+                SaveResult.Created(id)
             } else {
-                FeedbackTable.insert {
-                    it[FeedbackTable.id] = id
-                    it[FeedbackTable.opprettet] = Instant.now()
-                    it[FeedbackTable.feedbackJson] = feedbackJson
-                    it[FeedbackTable.team] = team
-                    it[FeedbackTable.app] = app
-                    it[FeedbackTable.surveyId] = surveyId
-                    it[FeedbackTable.definitionHash] = definitionHash
-                    it[FeedbackTable.deduplicationKeyHash] = deduplicationKeyHash
-                }
+                val existingId = findIdByDeduplicationKeyHashInCurrentTransaction(team, surveyId, deduplicationKeyHash)
+                    ?: throw ApiErrorException.InternalServerErrorException(
+                        "Duplicate deduplication key detected but existing feedback row was not found"
+                    )
 
-                id
+                SaveResult.Duplicate(existingId)
             }
+        } else {
+            FeedbackTable.insert {
+                it[FeedbackTable.id] = id
+                it[FeedbackTable.opprettet] = Instant.now()
+                it[FeedbackTable.feedbackJson] = feedbackJson
+                it[FeedbackTable.team] = team
+                it[FeedbackTable.app] = app
+                it[FeedbackTable.surveyId] = surveyId
+                it[FeedbackTable.definitionHash] = definitionHash
+                it[FeedbackTable.deduplicationKeyHash] = deduplicationKeyHash
+            }
+
+            SaveResult.Created(id)
         }
     }
 

--- a/apps/lumi-api/src/main/kotlin/no/nav/lumi/repository/SurveyDefinitionRepository.kt
+++ b/apps/lumi-api/src/main/kotlin/no/nav/lumi/repository/SurveyDefinitionRepository.kt
@@ -19,17 +19,7 @@ class SurveyDefinitionRepository {
 
     suspend fun findByTeamAndSurveyId(team: String, surveyId: String): StoredSurveyDefinition? {
         return dbQuery {
-            SurveyDefinitionTable.selectAll()
-                .where { (SurveyDefinitionTable.team eq team) and (SurveyDefinitionTable.surveyId eq surveyId) }
-                .singleOrNull()
-                ?.let { row ->
-                    StoredSurveyDefinition(
-                        team = row[SurveyDefinitionTable.team],
-                        surveyId = row[SurveyDefinitionTable.surveyId],
-                        definitionHash = row[SurveyDefinitionTable.definitionHash],
-                        definition = json.decodeFromString(row[SurveyDefinitionTable.definition])
-                    )
-                }
+            findByTeamAndSurveyIdInCurrentTransaction(team, surveyId)
         }
     }
 
@@ -52,34 +42,7 @@ class SurveyDefinitionRepository {
         maxDefinitions: Int
     ): Int {
         return dbQuery {
-            val definitionJson = json.encodeToString(definition)
-            val transaction = org.jetbrains.exposed.v1.jdbc.transactions.TransactionManager.current()
-            val conn = transaction.connection.connection as java.sql.Connection
-
-            // Acquire transaction-scoped advisory lock keyed on team name hash.
-            // This serializes concurrent inserts for the same team so the count
-            // check is consistent. Lock is auto-released on commit/rollback.
-            conn.prepareStatement("SELECT pg_advisory_xact_lock(hashtext(?))").use { lock ->
-                lock.setString(1, team)
-                lock.execute()
-            }
-
-            val sql = """
-                INSERT INTO survey_definitions (id, team, survey_id, definition_hash, definition)
-                SELECT gen_random_uuid(), ?, ?, ?, ?::jsonb
-                WHERE (SELECT count(*) FROM survey_definitions WHERE team = ?) < ?
-                ON CONFLICT (team, survey_id) DO NOTHING
-            """.trimIndent()
-
-            conn.prepareStatement(sql).use { stmt ->
-                stmt.setString(1, team)
-                stmt.setString(2, definition.surveyId)
-                stmt.setString(3, definitionHash)
-                stmt.setString(4, definitionJson)
-                stmt.setString(5, team)
-                stmt.setInt(6, maxDefinitions)
-                stmt.executeUpdate()
-            }
+            insertIfUnderLimitInCurrentTransaction(team, definition, definitionHash, maxDefinitions)
         }
     }
 
@@ -91,16 +54,79 @@ class SurveyDefinitionRepository {
         newDefinitionHash: String
     ): Boolean {
         return dbQuery {
-            val definitionJson = json.encodeToString(definition)
-            SurveyDefinitionTable.update({
-                (SurveyDefinitionTable.team eq team) and
-                    (SurveyDefinitionTable.surveyId eq surveyId) and
-                    (SurveyDefinitionTable.definitionHash eq expectedDefinitionHash)
-            }) {
-                it[SurveyDefinitionTable.definitionHash] = newDefinitionHash
-                it[SurveyDefinitionTable.definition] = definitionJson
-                it[SurveyDefinitionTable.updatedAt] = Instant.now()
-            } > 0
+            updateDefinitionIfHashMatchesInCurrentTransaction(
+                team = team,
+                surveyId = surveyId,
+                expectedDefinitionHash = expectedDefinitionHash,
+                definition = definition,
+                newDefinitionHash = newDefinitionHash
+            )
         }
+    }
+
+    internal fun findByTeamAndSurveyIdInCurrentTransaction(team: String, surveyId: String): StoredSurveyDefinition? {
+        return SurveyDefinitionTable.selectAll()
+            .where { (SurveyDefinitionTable.team eq team) and (SurveyDefinitionTable.surveyId eq surveyId) }
+            .singleOrNull()
+            ?.let { row ->
+                StoredSurveyDefinition(
+                    team = row[SurveyDefinitionTable.team],
+                    surveyId = row[SurveyDefinitionTable.surveyId],
+                    definitionHash = row[SurveyDefinitionTable.definitionHash],
+                    definition = json.decodeFromString(row[SurveyDefinitionTable.definition])
+                )
+            }
+    }
+
+    internal fun insertIfUnderLimitInCurrentTransaction(
+        team: String,
+        definition: SurveyDefinition,
+        definitionHash: String,
+        maxDefinitions: Int
+    ): Int {
+        val definitionJson = json.encodeToString(definition)
+        val transaction = org.jetbrains.exposed.v1.jdbc.transactions.TransactionManager.current()
+        val conn = transaction.connection.connection as java.sql.Connection
+
+        conn.prepareStatement("SELECT pg_advisory_xact_lock(hashtext(?))").use { lock ->
+            lock.setString(1, team)
+            lock.execute()
+        }
+
+        val sql = """
+            INSERT INTO survey_definitions (id, team, survey_id, definition_hash, definition)
+            SELECT gen_random_uuid(), ?, ?, ?, ?::jsonb
+            WHERE (SELECT count(*) FROM survey_definitions WHERE team = ?) < ?
+            ON CONFLICT (team, survey_id) DO NOTHING
+        """.trimIndent()
+
+        return conn.prepareStatement(sql).use { stmt ->
+            stmt.setString(1, team)
+            stmt.setString(2, definition.surveyId)
+            stmt.setString(3, definitionHash)
+            stmt.setString(4, definitionJson)
+            stmt.setString(5, team)
+            stmt.setInt(6, maxDefinitions)
+            stmt.executeUpdate()
+        }
+    }
+
+    internal fun updateDefinitionIfHashMatchesInCurrentTransaction(
+        team: String,
+        surveyId: String,
+        expectedDefinitionHash: String,
+        definition: SurveyDefinition,
+        newDefinitionHash: String
+    ): Boolean {
+        val definitionJson = json.encodeToString(definition)
+        return SurveyDefinitionTable.update({
+            (SurveyDefinitionTable.team eq team) and
+                (SurveyDefinitionTable.surveyId eq surveyId) and
+                (SurveyDefinitionTable.definitionHash eq expectedDefinitionHash)
+        }) {
+            it[SurveyDefinitionTable.definitionHash] = newDefinitionHash
+            it[SurveyDefinitionTable.definition] = definitionJson
+            it[SurveyDefinitionTable.updatedAt] = Instant.now()
+        } > 0
     }
 }

--- a/apps/lumi-api/src/main/kotlin/no/nav/lumi/routes/InternalSubmissionRoutes.kt
+++ b/apps/lumi-api/src/main/kotlin/no/nav/lumi/routes/InternalSubmissionRoutes.kt
@@ -5,10 +5,13 @@ import io.ktor.server.request.*
 import io.ktor.server.response.*
 import io.ktor.server.routing.*
 import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.put
 import no.nav.lumi.config.auth.CallerIdentityKey
 import no.nav.lumi.config.auth.parseCallerIdentity
 import no.nav.lumi.config.exception.ApiErrorException
 import no.nav.lumi.service.FeedbackService
+import no.nav.lumi.service.SubmissionService
 import no.nav.lumi.service.SurveyDefinitionService
 import no.nav.lumi.validation.SubmissionValidator
 import org.slf4j.LoggerFactory
@@ -16,6 +19,7 @@ import io.ktor.utils.io.core.readText
 import io.ktor.utils.io.readRemaining
 import kotlinx.serialization.SerializationException
 import no.nav.lumi.domain.FeedbackSubmissionV1
+import no.nav.lumi.domain.SaveResult
 import java.security.MessageDigest
 
 private val log = LoggerFactory.getLogger("InternalSubmissionRoutes")
@@ -40,6 +44,7 @@ private val strictJson = Json {
 fun Route.internalSubmissionRoutes(
     feedbackService: FeedbackService = FeedbackService(),
     surveyDefinitionService: SurveyDefinitionService = SurveyDefinitionService(),
+    submissionService: SubmissionService = SubmissionService(feedbackService, surveyDefinitionService),
     submissionKey: String? = System.getenv("LUMI_INTERNAL_SUBMISSION_KEY")
 ) {
     if (submissionKey.isNullOrBlank()) {
@@ -75,7 +80,9 @@ fun Route.internalSubmissionRoutes(
             val jsonElement = try {
                 strictJson.parseToJsonElement(body)
             } catch (e: Exception) {
-                log.warn("Internal submission: invalid JSON from ${identity.team}/${identity.app}", e)
+                log.warn(
+                    "Internal submission: invalid JSON from ${identity.team}/${identity.app} parseErrorType=${e::class.simpleName}"
+                )
                 throw ApiErrorException.BadRequestException("Invalid JSON")
             }
 
@@ -86,21 +93,33 @@ fun Route.internalSubmissionRoutes(
             }
 
             SubmissionValidator.validateSubmissionV1(submission)
-            val definitionResult = surveyDefinitionService.registerOrValidate(identity.team, submission)
-
-            val id = feedbackService.save(
+            val submissionOutcome = submissionService.submit(
                 feedbackJson = body,
                 team = identity.team,
                 app = identity.app,
-                surveyId = definitionResult.surveyId,
-                definitionHash = definitionResult.definitionHash,
-                deduplicationKeyHash = null
+                submission = submission
             )
 
-            log.info(
-                "Internal submission: saved feedback id=$id team=${identity.team} app=${identity.app} surveyId=${submission.surveyId} definitionHash=${definitionResult.definitionHash}"
-            )
-            call.respond(HttpStatusCode.Created, mapOf("id" to id))
+            when (val saveResult = submissionOutcome.saveResult) {
+                is SaveResult.Created -> {
+                    log.info(
+                        "Internal submission: saved feedback id=${saveResult.id} team=${identity.team} app=${identity.app} surveyId=${submission.surveyId} definitionHash=${submissionOutcome.definitionHash}"
+                    )
+                    call.respond(HttpStatusCode.Created, mapOf("id" to saveResult.id))
+                }
+                is SaveResult.Duplicate -> {
+                    log.info(
+                        "Internal submission: deduplicated feedback id=${saveResult.id} team=${identity.team} app=${identity.app} surveyId=${submission.surveyId}"
+                    )
+                    call.respond(
+                        HttpStatusCode.OK,
+                        buildJsonObject {
+                            put("id", saveResult.id)
+                            put("duplicate", true)
+                        }
+                    )
+                }
+            }
         }
     }
 }

--- a/apps/lumi-api/src/main/kotlin/no/nav/lumi/routes/SubmissionRoutes.kt
+++ b/apps/lumi-api/src/main/kotlin/no/nav/lumi/routes/SubmissionRoutes.kt
@@ -6,6 +6,8 @@ import io.ktor.server.request.*
 import io.ktor.server.response.*
 import io.ktor.server.routing.*
 import kotlinx.serialization.SerializationException
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.put
 import kotlinx.serialization.json.Json
 import no.nav.lumi.config.SubmissionRateLimit
 import no.nav.lumi.config.UserSubmissionRateLimit
@@ -14,7 +16,9 @@ import no.nav.lumi.config.auth.TokenXSubmissionAuthPlugin
 import no.nav.lumi.config.auth.getCallerIdentity
 import no.nav.lumi.config.exception.ApiErrorException
 import no.nav.lumi.domain.FeedbackSubmissionV1
+import no.nav.lumi.domain.SaveResult
 import no.nav.lumi.service.FeedbackService
+import no.nav.lumi.service.SubmissionService
 import no.nav.lumi.service.SurveyDefinitionService
 import no.nav.lumi.validation.SubmissionValidator
 import org.slf4j.LoggerFactory
@@ -49,13 +53,14 @@ private val strictJson = Json {
  */
 fun Route.submissionRoutes(
     feedbackService: FeedbackService = defaultFeedbackService,
-    surveyDefinitionService: SurveyDefinitionService = defaultSurveyDefinitionService
+    surveyDefinitionService: SurveyDefinitionService = defaultSurveyDefinitionService,
+    submissionService: SubmissionService = SubmissionService(feedbackService, surveyDefinitionService)
 ) {
     route("/api/tokenx") {
         install(TokenXSubmissionAuthPlugin)
         rateLimit(SubmissionRateLimit) {
             rateLimit(UserSubmissionRateLimit) {
-                post("/v1/feedback") { handleSubmissionV1(call, feedbackService, surveyDefinitionService) }
+                post("/v1/feedback") { handleSubmissionV1(call, submissionService) }
             }
         }
     }
@@ -64,7 +69,7 @@ fun Route.submissionRoutes(
         install(AzureSubmissionAuthPlugin)
         rateLimit(SubmissionRateLimit) {
             rateLimit(UserSubmissionRateLimit) {
-                post("/v1/feedback") { handleSubmissionV1(call, feedbackService, surveyDefinitionService) }
+                post("/v1/feedback") { handleSubmissionV1(call, submissionService) }
             }
         }
     }
@@ -72,8 +77,7 @@ fun Route.submissionRoutes(
 
 private suspend fun handleSubmissionV1(
     call: io.ktor.server.application.ApplicationCall,
-    feedbackService: FeedbackService,
-    surveyDefinitionService: SurveyDefinitionService
+    submissionService: SubmissionService
 ) {
     val identity = call.getCallerIdentity()
     val body = receiveTextWithLimit(call)
@@ -81,7 +85,9 @@ private suspend fun handleSubmissionV1(
     val jsonElement = try {
         strictJson.parseToJsonElement(body)
     } catch (e: Exception) {
-        log.warn("Invalid JSON in feedback submission from team=${identity.team} app=${identity.app}", e)
+        log.warn(
+            "Invalid JSON in feedback submission from team=${identity.team} app=${identity.app} parseErrorType=${e::class.simpleName}"
+        )
         throw ApiErrorException.BadRequestException("Invalid JSON")
     }
 
@@ -92,21 +98,33 @@ private suspend fun handleSubmissionV1(
     }
 
     SubmissionValidator.validateSubmissionV1(submission)
-    val definitionResult = surveyDefinitionService.registerOrValidate(identity.team, submission)
-
-    val id = feedbackService.save(
+    val submissionOutcome = submissionService.submit(
         feedbackJson = body,
         team = identity.team,
         app = identity.app,
-        surveyId = definitionResult.surveyId,
-        definitionHash = definitionResult.definitionHash,
-        deduplicationKeyHash = null // Dedup wiring planned for #274 (widget v2)
+        submission = submission
     )
 
-    log.info(
-        "Saved feedback id=$id team=${identity.team} app=${identity.app} surveyId=${submission.surveyId} definitionHash=${definitionResult.definitionHash}"
-    )
-    call.respond(HttpStatusCode.Created, mapOf("id" to id))
+    when (val saveResult = submissionOutcome.saveResult) {
+        is SaveResult.Created -> {
+            log.info(
+                "Saved feedback id=${saveResult.id} team=${identity.team} app=${identity.app} surveyId=${submission.surveyId} definitionHash=${submissionOutcome.definitionHash}"
+            )
+            call.respond(HttpStatusCode.Created, mapOf("id" to saveResult.id))
+        }
+        is SaveResult.Duplicate -> {
+            log.info(
+                "Deduplicated feedback id=${saveResult.id} team=${identity.team} app=${identity.app} surveyId=${submission.surveyId}"
+            )
+            call.respond(
+                HttpStatusCode.OK,
+                buildJsonObject {
+                    put("id", saveResult.id)
+                    put("duplicate", true)
+                }
+            )
+        }
+    }
 }
 
 private suspend fun receiveTextWithLimit(call: io.ktor.server.application.ApplicationCall): String {

--- a/apps/lumi-api/src/main/kotlin/no/nav/lumi/service/DeduplicationHash.kt
+++ b/apps/lumi-api/src/main/kotlin/no/nav/lumi/service/DeduplicationHash.kt
@@ -1,0 +1,19 @@
+package no.nav.lumi.service
+
+import java.nio.ByteBuffer
+import java.security.MessageDigest
+
+internal fun computeDeduplicationKeyHash(team: String, surveyId: String, deduplicationKey: String): String {
+    val digest = MessageDigest.getInstance("SHA-256")
+    digest.updateLengthPrefixed("lumi-feedback-dedup-v1")
+    digest.updateLengthPrefixed(team)
+    digest.updateLengthPrefixed(surveyId)
+    digest.updateLengthPrefixed(deduplicationKey)
+    return digest.digest().joinToString("") { byte -> "%02x".format(byte.toInt() and 0xff) }
+}
+
+private fun MessageDigest.updateLengthPrefixed(value: String) {
+    val bytes = value.toByteArray(Charsets.UTF_8)
+    update(ByteBuffer.allocate(Int.SIZE_BYTES).putInt(bytes.size).array())
+    update(bytes)
+}

--- a/apps/lumi-api/src/main/kotlin/no/nav/lumi/service/FeedbackService.kt
+++ b/apps/lumi-api/src/main/kotlin/no/nav/lumi/service/FeedbackService.kt
@@ -4,12 +4,14 @@ import kotlinx.serialization.json.*
 import no.nav.lumi.config.exception.ApiErrorException
 import no.nav.lumi.domain.FeedbackDto
 import no.nav.lumi.domain.FeedbackQuery
+import no.nav.lumi.domain.SaveResult
 import no.nav.lumi.repository.FeedbackRepository
 import no.nav.lumi.sensitive.HtmlSanitizer
 import no.nav.lumi.sensitive.JsonRedactor
 import no.nav.lumi.sensitive.SensitiveDataFilter
 import no.nav.lumi.sensitive.UrlRedactor
 import no.nav.lumi.sensitive.generateUniqueKey
+import no.nav.lumi.validation.DeduplicationKeyValidator
 import org.slf4j.LoggerFactory
 
 class FeedbackService(
@@ -26,6 +28,19 @@ class FeedbackService(
 
     suspend fun findById(id: String, team: String) = repository.findById(id, team)
 
+    suspend fun findDuplicateSubmissionId(team: String, surveyId: String?, deduplicationKey: String?): String? {
+        if (deduplicationKey == null) {
+            return null
+        }
+        if (surveyId == null) {
+            throw ApiErrorException.BadRequestException("Invalid payload: deduplicationKey requires surveyId")
+        }
+
+        DeduplicationKeyValidator.validate(deduplicationKey)
+        val deduplicationKeyHash = computeDeduplicationKeyHash(team, surveyId, deduplicationKey)
+        return repository.findIdByDeduplicationKeyHash(team, surveyId, deduplicationKeyHash)
+    }
+
     suspend fun findAllTags(team: String) = repository.findAllTags(team)
 
     suspend fun findDistinctApps(team: String) = repository.findDistinctApps(team)
@@ -35,11 +50,26 @@ class FeedbackService(
         team: String,
         app: String,
         surveyId: String? = null,
-        definitionHash: String? = null,
-        deduplicationKeyHash: String? = null
-    ): String {
-        val sanitizedJson = redactFeedbackJson(feedbackJson)
-        return repository.save(sanitizedJson, team, app, surveyId, definitionHash, deduplicationKeyHash)
+        definitionHash: String? = null
+    ): SaveResult {
+        val prepared = prepareForSave(feedbackJson, team, surveyId)
+
+        return repository.save(
+            feedbackJson = prepared.feedbackJson,
+            team = team,
+            app = app,
+            surveyId = surveyId,
+            definitionHash = definitionHash,
+            deduplicationKeyHash = prepared.deduplicationKeyHash
+        )
+    }
+
+    internal fun prepareForSave(feedbackJson: String, team: String, surveyId: String?): PreparedFeedbackSave {
+        val prepared = redactFeedbackJson(feedbackJson)
+        return PreparedFeedbackSave(
+            feedbackJson = prepared.feedbackJson,
+            deduplicationKeyHash = deduplicationKeyHash(team, surveyId, prepared.deduplicationKey)
+        )
     }
 
     suspend fun addTag(id: String, team: String, tag: String) = repository.addTag(id, team, tag)
@@ -77,17 +107,21 @@ class FeedbackService(
      * 2. Context URL — PII redacted per query-param + full-string fallback for path
      * 3. Context tags — PII redacted in both keys and values
      * 4. Context debug — recursive PII redaction of all string values and keys
-     * 5. Text answers — PII redacted, but HTML preserved (React escapes at render)
-     * 6. Metadata fields (question.label, options[].label etc.) — NOT sanitized
+     * 5. Root deduplicationKey — removed before persistence; only the scoped hash is retained
+     *    in the dedicated database column when deduplication is requested.
+     * 6. Text answers — PII redacted, but HTML preserved (React escapes at render)
+     * 7. Metadata fields (question.label, options[].label etc.) — NOT sanitized
      *    These are survey-defined by the team admin, not user-authored free text.
      *    SubmissionValidator enforces length limits on all metadata fields.
      *    React escapes all output, so stored HTML is inert in the dashboard.
      */
-    private fun redactFeedbackJson(feedbackJson: String): String {
+    private fun redactFeedbackJson(feedbackJson: String): PreparedFeedbackJson {
         return try {
             val jsonElement = json.parseToJsonElement(feedbackJson)
             val jsonObj = jsonElement.jsonObject.toMutableMap()
             var hasRedactions = false
+            val deduplicationKey = extractDeduplicationKey(jsonObj)
+            jsonObj.remove("deduplicationKey")
 
             val context = jsonObj["context"] as? JsonObject
             if (context != null) {
@@ -122,12 +156,46 @@ class FeedbackService(
 
             // Persist a robust signal for redaction. Always set by backend based on actual redaction.
             jsonObj["sensitiveDataRedacted"] = JsonPrimitive(hasRedactions)
-            
-            json.encodeToString(JsonObject.serializer(), JsonObject(jsonObj))
+
+            PreparedFeedbackJson(
+                feedbackJson = json.encodeToString(JsonObject.serializer(), JsonObject(jsonObj)),
+                deduplicationKey = deduplicationKey
+            )
+        } catch (e: ApiErrorException) {
+            throw e
         } catch (e: Exception) {
-            log.error("Failed to redact feedback JSON, rejecting submission to avoid storing unredacted data", e)
-            throw ApiErrorException.InternalServerErrorException("Failed to redact feedback JSON", e)
+            if (feedbackJson.contains("\"deduplicationKey\"")) {
+                log.error(
+                    "Failed to redact feedback JSON with deduplication key, rejecting submission. errorType={}",
+                    e::class.simpleName
+                )
+            } else {
+                log.error(
+                    "Failed to redact feedback JSON, rejecting submission to avoid storing unredacted data. errorType={}",
+                    e::class.simpleName
+                )
+            }
+            throw ApiErrorException.InternalServerErrorException("Failed to redact feedback JSON")
         }
+    }
+
+    private fun extractDeduplicationKey(jsonObj: MutableMap<String, JsonElement>): String? {
+        val rawElement = jsonObj["deduplicationKey"] ?: return null
+        if (rawElement is JsonNull) {
+            return null
+        }
+        val primitive = rawElement as? JsonPrimitive
+            ?: throw ApiErrorException.BadRequestException(
+                "Invalid payload: deduplicationKey must be 16-128 characters and contain only letters, digits, '.', '_', ':', or '-'"
+            )
+
+        if (!primitive.isString) {
+            throw ApiErrorException.BadRequestException(
+                "Invalid payload: deduplicationKey must be 16-128 characters and contain only letters, digits, '.', '_', ':', or '-'"
+            )
+        }
+
+        return primitive.contentOrNull?.also(DeduplicationKeyValidator::validate)
     }
 
     /**
@@ -226,5 +294,26 @@ class FeedbackService(
     private fun sanitizeStringField(container: MutableMap<String, JsonElement>, fieldName: String) {
         val rawValue = container[fieldName]?.jsonPrimitive?.contentOrNull ?: return
         container[fieldName] = JsonPrimitive(htmlSanitizer.stripTags(rawValue))
+    }
+
+    private data class PreparedFeedbackJson(
+        val feedbackJson: String,
+        val deduplicationKey: String?
+    )
+
+    internal data class PreparedFeedbackSave(
+        val feedbackJson: String,
+        val deduplicationKeyHash: String?
+    )
+
+    private fun deduplicationKeyHash(team: String, surveyId: String?, deduplicationKey: String?): String? {
+        if (deduplicationKey == null) {
+            return null
+        }
+        if (surveyId == null) {
+            throw ApiErrorException.BadRequestException("Invalid payload: deduplicationKey requires surveyId")
+        }
+
+        return computeDeduplicationKeyHash(team, surveyId, deduplicationKey)
     }
 }

--- a/apps/lumi-api/src/main/kotlin/no/nav/lumi/service/FeedbackService.kt
+++ b/apps/lumi-api/src/main/kotlin/no/nav/lumi/service/FeedbackService.kt
@@ -164,6 +164,8 @@ class FeedbackService(
         } catch (e: ApiErrorException) {
             throw e
         } catch (e: Exception) {
+            // Do not log or propagate the throwable here. kotlinx.serialization parse exceptions can embed
+            // raw JSON input (including deduplicationKey), and upstream exception logging must never leak it.
             if (feedbackJson.contains("\"deduplicationKey\"")) {
                 log.error(
                     "Failed to redact feedback JSON with deduplication key, rejecting submission. errorType={}",
@@ -186,12 +188,12 @@ class FeedbackService(
         }
         val primitive = rawElement as? JsonPrimitive
             ?: throw ApiErrorException.BadRequestException(
-                "Invalid payload: deduplicationKey must be 16-128 characters and contain only letters, digits, '.', '_', ':', or '-'"
+                DeduplicationKeyValidator.ERROR_MESSAGE
             )
 
         if (!primitive.isString) {
             throw ApiErrorException.BadRequestException(
-                "Invalid payload: deduplicationKey must be 16-128 characters and contain only letters, digits, '.', '_', ':', or '-'"
+                DeduplicationKeyValidator.ERROR_MESSAGE
             )
         }
 

--- a/apps/lumi-api/src/main/kotlin/no/nav/lumi/service/SubmissionService.kt
+++ b/apps/lumi-api/src/main/kotlin/no/nav/lumi/service/SubmissionService.kt
@@ -1,0 +1,78 @@
+package no.nav.lumi.service
+
+import no.nav.lumi.domain.FeedbackSubmissionV1
+import no.nav.lumi.domain.SaveResult
+import no.nav.lumi.repository.FeedbackRepository
+
+data class SubmissionOutcome(
+    val saveResult: SaveResult,
+    val definitionHash: String? = null
+)
+
+class SubmissionService(
+    private val feedbackService: FeedbackService = FeedbackService(),
+    private val surveyDefinitionService: SurveyDefinitionService = SurveyDefinitionService(),
+    private val feedbackRepository: FeedbackRepository = FeedbackRepository(),
+    internal val afterScopedDeduplicationLockAcquired: suspend () -> Unit = {}
+) {
+    suspend fun submit(
+        feedbackJson: String,
+        team: String,
+        app: String,
+        submission: FeedbackSubmissionV1
+    ): SubmissionOutcome {
+        if (submission.deduplicationKey == null) {
+            val definitionResult = surveyDefinitionService.registerOrValidate(team, submission)
+            val saveResult = feedbackService.save(
+                feedbackJson = feedbackJson,
+                team = team,
+                app = app,
+                surveyId = definitionResult.surveyId,
+                definitionHash = definitionResult.definitionHash
+            )
+            return SubmissionOutcome(saveResult, definitionResult.definitionHash)
+        }
+
+        val duplicateId = feedbackService.findDuplicateSubmissionId(
+            team = team,
+            surveyId = submission.surveyId,
+            deduplicationKey = submission.deduplicationKey
+        )
+        if (duplicateId != null) {
+            return SubmissionOutcome(SaveResult.Duplicate(duplicateId))
+        }
+
+        val prepared = feedbackService.prepareForSave(feedbackJson, team, submission.surveyId)
+        val deduplicationKeyHash = requireNotNull(prepared.deduplicationKeyHash) {
+            "Expected deduplication key hash for submission with deduplicationKey"
+        }
+
+        return feedbackRepository.withScopedDeduplicationLock(team, submission.surveyId, deduplicationKeyHash) {
+            afterScopedDeduplicationLockAcquired()
+
+            val existingId = feedbackRepository.findIdByDeduplicationKeyHashInCurrentTransaction(
+                team = team,
+                surveyId = submission.surveyId,
+                deduplicationKeyHash = deduplicationKeyHash
+            )
+            if (existingId != null) {
+                return@withScopedDeduplicationLock SubmissionOutcome(SaveResult.Duplicate(existingId))
+            }
+
+            val definitionResult = surveyDefinitionService.registerOrValidateInCurrentTransaction(team, submission)
+            val saveResult = feedbackRepository.saveInCurrentTransaction(
+                feedbackJson = prepared.feedbackJson,
+                team = team,
+                app = app,
+                surveyId = definitionResult.surveyId,
+                definitionHash = definitionResult.definitionHash,
+                deduplicationKeyHash = deduplicationKeyHash
+            )
+
+            SubmissionOutcome(
+                saveResult = saveResult,
+                definitionHash = definitionResult.definitionHash.takeIf { saveResult is SaveResult.Created }
+            )
+        }
+    }
+}

--- a/apps/lumi-api/src/main/kotlin/no/nav/lumi/service/SurveyDefinitionService.kt
+++ b/apps/lumi-api/src/main/kotlin/no/nav/lumi/service/SurveyDefinitionService.kt
@@ -22,39 +22,68 @@ class SurveyDefinitionService(
     private val repository: SurveyDefinitionRepository = SurveyDefinitionRepository()
 ) {
     suspend fun registerOrValidate(team: String, submission: FeedbackSubmissionV1): RegistrationResult {
+        return registerOrValidate(
+            team = team,
+            submission = submission,
+            findStored = repository::findByTeamAndSurveyId,
+            insertDefinition = repository::insertIfUnderLimit,
+            updateDefinition = repository::updateDefinitionIfHashMatches
+        )
+    }
+
+    internal suspend fun registerOrValidateInCurrentTransaction(
+        team: String,
+        submission: FeedbackSubmissionV1
+    ): RegistrationResult {
+        return registerOrValidate(
+            team = team,
+            submission = submission,
+            findStored = repository::findByTeamAndSurveyIdInCurrentTransaction,
+            insertDefinition = repository::insertIfUnderLimitInCurrentTransaction,
+            updateDefinition = repository::updateDefinitionIfHashMatchesInCurrentTransaction
+        )
+    }
+
+    private suspend fun registerOrValidate(
+        team: String,
+        submission: FeedbackSubmissionV1,
+        findStored: suspend (String, String) -> StoredSurveyDefinition?,
+        insertDefinition: suspend (String, SurveyDefinition, String, Int) -> Int,
+        updateDefinition: suspend (String, String, String, SurveyDefinition, String) -> Boolean
+    ): RegistrationResult {
         val incomingDefinition = SurveyDefinition.fromSubmission(submission)
         validateDefinitionConsistency(incomingDefinition)
         validateAnswersAgainstIncomingDefinition(incomingDefinition, submission)
         val incomingHash = incomingDefinition.computeHash()
 
         repeat(MAX_REGISTRATION_ATTEMPTS) {
-            val stored = repository.findByTeamAndSurveyId(team, submission.surveyId)
+            val stored = findStored(team, submission.surveyId)
             if (stored != null) {
-                when (val result = handleExistingDefinition(team, stored, incomingDefinition)) {
+                when (val result = handleExistingDefinition(team, stored, incomingDefinition, updateDefinition)) {
                     is ExistingDefinitionResult.Resolved -> return result.registrationResult
                     ExistingDefinitionResult.Retry -> return@repeat
                 }
             }
 
-            val insertedCount = repository.insertIfUnderLimit(
-                team = team,
-                definition = incomingDefinition,
-                definitionHash = incomingHash,
-                maxDefinitions = MAX_DEFINITIONS_PER_TEAM
+            val insertedCount = insertDefinition(
+                team,
+                incomingDefinition,
+                incomingHash,
+                MAX_DEFINITIONS_PER_TEAM
             )
 
             if (insertedCount == 1) {
                 return RegistrationResult(submission.surveyId, incomingHash)
             }
 
-            val existingAfterRace = repository.findByTeamAndSurveyId(team, submission.surveyId)
+            val existingAfterRace = findStored(team, submission.surveyId)
             if (existingAfterRace == null) {
                 throw ApiErrorException.TooManyRequestsException(
                     "Definition limit exceeded for team=$team (max=$MAX_DEFINITIONS_PER_TEAM)"
                 )
             }
 
-            when (val result = handleExistingDefinition(team, existingAfterRace, incomingDefinition)) {
+            when (val result = handleExistingDefinition(team, existingAfterRace, incomingDefinition, updateDefinition)) {
                 is ExistingDefinitionResult.Resolved -> return result.registrationResult
                 ExistingDefinitionResult.Retry -> return@repeat
             }
@@ -86,7 +115,8 @@ class SurveyDefinitionService(
     private suspend fun handleExistingDefinition(
         team: String,
         stored: StoredSurveyDefinition,
-        incomingDefinition: SurveyDefinition
+        incomingDefinition: SurveyDefinition,
+        updateDefinition: suspend (String, String, String, SurveyDefinition, String) -> Boolean
     ): ExistingDefinitionResult {
         val mergedDefinition = stored.definition.mergeWith(incomingDefinition)
         val definitionDiff = diff(stored.definition, mergedDefinition)
@@ -107,13 +137,7 @@ class SurveyDefinitionService(
             )
         }
 
-        val updated = repository.updateDefinitionIfHashMatches(
-            team = team,
-            surveyId = stored.surveyId,
-            expectedDefinitionHash = stored.definitionHash,
-            definition = mergedDefinition,
-            newDefinitionHash = mergedHash
-        )
+        val updated = updateDefinition(team, stored.surveyId, stored.definitionHash, mergedDefinition, mergedHash)
 
         return if (updated) {
             ExistingDefinitionResult.Resolved(

--- a/apps/lumi-api/src/main/kotlin/no/nav/lumi/validation/DeduplicationKeyValidator.kt
+++ b/apps/lumi-api/src/main/kotlin/no/nav/lumi/validation/DeduplicationKeyValidator.kt
@@ -6,7 +6,7 @@ object DeduplicationKeyValidator {
     private const val MIN_DEDUPLICATION_KEY_LENGTH = 16
     private const val MAX_DEDUPLICATION_KEY_LENGTH = 128
     private val DEDUPLICATION_KEY_PATTERN = Regex("^[A-Za-z0-9._:-]+$")
-    private const val ERROR_MESSAGE =
+    internal const val ERROR_MESSAGE =
         "Invalid payload: deduplicationKey must be 16-128 characters and contain only letters, digits, '.', '_', ':', or '-'"
 
     fun validate(deduplicationKey: String?) {

--- a/apps/lumi-api/src/main/kotlin/no/nav/lumi/validation/DeduplicationKeyValidator.kt
+++ b/apps/lumi-api/src/main/kotlin/no/nav/lumi/validation/DeduplicationKeyValidator.kt
@@ -1,0 +1,21 @@
+package no.nav.lumi.validation
+
+import no.nav.lumi.config.exception.ApiErrorException
+
+object DeduplicationKeyValidator {
+    private const val MIN_DEDUPLICATION_KEY_LENGTH = 16
+    private const val MAX_DEDUPLICATION_KEY_LENGTH = 128
+    private val DEDUPLICATION_KEY_PATTERN = Regex("^[A-Za-z0-9._:-]+$")
+    private const val ERROR_MESSAGE =
+        "Invalid payload: deduplicationKey must be 16-128 characters and contain only letters, digits, '.', '_', ':', or '-'"
+
+    fun validate(deduplicationKey: String?) {
+        if (deduplicationKey == null) return
+        if (
+            deduplicationKey.length !in MIN_DEDUPLICATION_KEY_LENGTH..MAX_DEDUPLICATION_KEY_LENGTH ||
+            !DEDUPLICATION_KEY_PATTERN.matches(deduplicationKey)
+        ) {
+            throw ApiErrorException.BadRequestException(ERROR_MESSAGE)
+        }
+    }
+}

--- a/apps/lumi-api/src/main/kotlin/no/nav/lumi/validation/SubmissionValidator.kt
+++ b/apps/lumi-api/src/main/kotlin/no/nav/lumi/validation/SubmissionValidator.kt
@@ -46,6 +46,8 @@ object SubmissionValidator {
             )
         }
 
+        DeduplicationKeyValidator.validate(submission.deduplicationKey)
+
         runCatching { Instant.parse(submission.submittedAt) }
             .getOrElse { throw ApiErrorException.BadRequestException("Invalid payload: submittedAt must be an ISO instant") }
 

--- a/apps/lumi-api/src/test/kotlin/no/nav/lumi/TestUtils.kt
+++ b/apps/lumi-api/src/test/kotlin/no/nav/lumi/TestUtils.kt
@@ -16,6 +16,7 @@ import no.nav.lumi.config.configureSerialization
 import no.nav.lumi.config.configureStatusPages
 import no.nav.lumi.config.configureRateLimiting
 import no.nav.lumi.config.DatabaseHolder
+import no.nav.lumi.domain.SaveResult
 import no.nav.lumi.integrations.valkey.InMemoryStatsCache
 import no.nav.lumi.repository.FeedbackRepository
 import no.nav.lumi.routes.feedbackRoutes
@@ -35,6 +36,11 @@ import no.nav.lumi.service.StatsService
 import no.nav.lumi.service.ExportService
 import java.time.OffsetDateTime
 import java.util.UUID
+
+fun SaveResult.createdId(): String = when (this) {
+    is SaveResult.Created -> id
+    is SaveResult.Duplicate -> error("Expected created save result, got duplicate")
+}
 
 /**
  * Creates a test client configured with JSON serialization

--- a/apps/lumi-api/src/test/kotlin/no/nav/lumi/repository/FeedbackRepositoryTest.kt
+++ b/apps/lumi-api/src/test/kotlin/no/nav/lumi/repository/FeedbackRepositoryTest.kt
@@ -7,6 +7,10 @@ import io.kotest.matchers.collections.shouldHaveSize
 import io.kotest.matchers.nulls.shouldBeNull
 import io.kotest.matchers.nulls.shouldNotBeNull
 import io.kotest.matchers.shouldBe
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.async
+import kotlinx.coroutines.awaitAll
+import kotlinx.coroutines.coroutineScope
 import no.nav.lumi.TestDatabase
 import no.nav.lumi.config.DatabaseHolder
 import no.nav.lumi.domain.Answer
@@ -16,6 +20,7 @@ import no.nav.lumi.domain.FeedbackDto
 import no.nav.lumi.domain.FeedbackQuery
 import no.nav.lumi.domain.PhraseFilter
 import no.nav.lumi.domain.Question
+import no.nav.lumi.domain.SaveResult
 import no.nav.lumi.domain.SubmissionContext
 import no.nav.lumi.domain.StatsQuery
 import no.nav.lumi.insertTestFeedback
@@ -40,7 +45,7 @@ class FeedbackRepositoryTest : FunSpec({
     }
 
     context("save") {
-        test("returns existing id for duplicate deduplication key") {
+        test("returns created first and duplicate with existing id for same deduplication key") {
             val feedbackJson = """
                 {
                     "schemaVersion": 1,
@@ -58,7 +63,16 @@ class FeedbackRepositoryTest : FunSpec({
                 }
             """.trimIndent()
 
-            val firstId = repository.save(
+            val first = repository.save(
+                feedbackJson = feedbackJson,
+                team = "team-test",
+                app = "app-test",
+                surveyId = "survey-dedup",
+                definitionHash = "a".repeat(64),
+                deduplicationKeyHash = "b".repeat(64)
+            ) as SaveResult.Created
+
+            val second = repository.save(
                 feedbackJson = feedbackJson,
                 team = "team-test",
                 app = "app-test",
@@ -67,20 +81,170 @@ class FeedbackRepositoryTest : FunSpec({
                 deduplicationKeyHash = "b".repeat(64)
             )
 
-            val secondId = repository.save(
-                feedbackJson = feedbackJson,
-                team = "team-test",
-                app = "app-test",
-                surveyId = "survey-dedup",
-                definitionHash = "a".repeat(64),
-                deduplicationKeyHash = "b".repeat(64)
-            )
-
-            firstId shouldBe secondId
+            second shouldBe SaveResult.Duplicate(first.id)
 
             val (content, total, _) = repository.findPaginated(FeedbackQuery(team = "team-test"))
             total shouldBe 1
-            content.single().id shouldBe firstId
+            content.single().id shouldBe first.id
+        }
+
+        test("returns duplicate existing id even when payload differs") {
+            val first = repository.save(
+                feedbackJson = """{"answers":[{"fieldId":"q1","fieldType":"TEXT","question":{"label":"Hvorfor?"},"value":{"type":"text","text":"første"}}]}""",
+                team = "team-test",
+                app = "app-test",
+                surveyId = "survey-dedup",
+                definitionHash = "a".repeat(64),
+                deduplicationKeyHash = "c".repeat(64)
+            ) as SaveResult.Created
+
+            val second = repository.save(
+                feedbackJson = """{"answers":[{"fieldId":"q1","fieldType":"TEXT","question":{"label":"Hvorfor?"},"value":{"type":"text","text":"andre"}}]}""",
+                team = "team-test",
+                app = "app-test",
+                surveyId = "survey-dedup",
+                definitionHash = "a".repeat(64),
+                deduplicationKeyHash = "c".repeat(64)
+            )
+
+            second shouldBe SaveResult.Duplicate(first.id)
+
+            val (content, total, _) = repository.findPaginated(FeedbackQuery(team = "team-test"))
+            total shouldBe 1
+            content.single().id shouldBe first.id
+        }
+
+        test("stores same deduplication key hash separately for different surveys and teams") {
+            val first = repository.save(
+                feedbackJson = """{"answers":[{"fieldId":"q1","fieldType":"TEXT","question":{"label":"Hvorfor?"},"value":{"type":"text","text":"første"}}]}""",
+                team = "team-a",
+                app = "app-test",
+                surveyId = "survey-a",
+                definitionHash = "a".repeat(64),
+                deduplicationKeyHash = "d".repeat(64)
+            ) as SaveResult.Created
+
+            val second = repository.save(
+                feedbackJson = """{"answers":[{"fieldId":"q1","fieldType":"TEXT","question":{"label":"Hvorfor?"},"value":{"type":"text","text":"andre"}}]}""",
+                team = "team-a",
+                app = "app-test",
+                surveyId = "survey-b",
+                definitionHash = "a".repeat(64),
+                deduplicationKeyHash = "d".repeat(64)
+            ) as SaveResult.Created
+
+            val third = repository.save(
+                feedbackJson = """{"answers":[{"fieldId":"q1","fieldType":"TEXT","question":{"label":"Hvorfor?"},"value":{"type":"text","text":"tredje"}}]}""",
+                team = "team-b",
+                app = "app-test",
+                surveyId = "survey-a",
+                definitionHash = "a".repeat(64),
+                deduplicationKeyHash = "d".repeat(64)
+            ) as SaveResult.Created
+
+            (second.id == first.id) shouldBe false
+            (third.id == first.id) shouldBe false
+        }
+
+        test("does not deduplicate when deduplication key hash is absent") {
+            val first = repository.save(
+                feedbackJson = """{"answers":[{"fieldId":"q1","fieldType":"TEXT","question":{"label":"Hvorfor?"},"value":{"type":"text","text":"første"}}]}""",
+                team = "team-test",
+                app = "app-test",
+                surveyId = "survey-dedup",
+                definitionHash = "a".repeat(64),
+                deduplicationKeyHash = null
+            ) as SaveResult.Created
+
+            val second = repository.save(
+                feedbackJson = """{"answers":[{"fieldId":"q1","fieldType":"TEXT","question":{"label":"Hvorfor?"},"value":{"type":"text","text":"første"}}]}""",
+                team = "team-test",
+                app = "app-test",
+                surveyId = "survey-dedup",
+                definitionHash = "a".repeat(64),
+                deduplicationKeyHash = null
+            ) as SaveResult.Created
+
+            (second.id == first.id) shouldBe false
+
+            val (_, total, _) = repository.findPaginated(FeedbackQuery(team = "team-test"))
+            total shouldBe 2
+        }
+
+        test("deduplicates across apps for the same team survey and key") {
+            val first = repository.save(
+                feedbackJson = """{"answers":[{"fieldId":"q1","fieldType":"TEXT","question":{"label":"Hvorfor?"},"value":{"type":"text","text":"første"}}]}""",
+                team = "team-test",
+                app = "app-a",
+                surveyId = "survey-dedup",
+                definitionHash = "a".repeat(64),
+                deduplicationKeyHash = "f".repeat(64)
+            ) as SaveResult.Created
+
+            val second = repository.save(
+                feedbackJson = """{"answers":[{"fieldId":"q1","fieldType":"TEXT","question":{"label":"Hvorfor?"},"value":{"type":"text","text":"andre"}}]}""",
+                team = "team-test",
+                app = "app-b",
+                surveyId = "survey-dedup",
+                definitionHash = "a".repeat(64),
+                deduplicationKeyHash = "f".repeat(64)
+            )
+
+            second shouldBe SaveResult.Duplicate(first.id)
+
+            val (content, total, _) = repository.findPaginated(FeedbackQuery(team = "team-test"))
+            total shouldBe 1
+            content.single().app shouldBe "app-a"
+        }
+
+        test("handles concurrent duplicate inserts without creating duplicate rows") {
+            val results = coroutineScope {
+                (1..8).map { index ->
+                    async(Dispatchers.Default) {
+                        repository.save(
+                            feedbackJson = """{"answers":[{"fieldId":"q1","fieldType":"TEXT","question":{"label":"Hvorfor?"},"value":{"type":"text","text":"payload-$index"}}]}""",
+                            team = "team-test",
+                            app = "app-test",
+                            surveyId = "survey-dedup",
+                            definitionHash = "a".repeat(64),
+                            deduplicationKeyHash = "e".repeat(64)
+                        )
+                    }
+                }.awaitAll()
+            }
+
+            results.count { it is SaveResult.Created } shouldBe 1
+            val createdId = (results.first { it is SaveResult.Created } as SaveResult.Created).id
+            results.filterIsInstance<SaveResult.Duplicate>().forEach { duplicate ->
+                duplicate.id shouldBe createdId
+            }
+
+            val (content, total, _) = repository.findPaginated(FeedbackQuery(team = "team-test"))
+            total shouldBe 1
+            content.single().id shouldBe createdId
+        }
+
+        test("finds existing id by scoped deduplication key hash") {
+            val created = repository.save(
+                feedbackJson = """{"answers":[{"fieldId":"q1","fieldType":"TEXT","question":{"label":"Hvorfor?"},"value":{"type":"text","text":"første"}}]}""",
+                team = "team-test",
+                app = "app-test",
+                surveyId = "survey-dedup",
+                definitionHash = "a".repeat(64),
+                deduplicationKeyHash = "f".repeat(64)
+            ) as SaveResult.Created
+
+            repository.findIdByDeduplicationKeyHash(
+                team = "team-test",
+                surveyId = "survey-dedup",
+                deduplicationKeyHash = "f".repeat(64)
+            ) shouldBe created.id
+
+            repository.findIdByDeduplicationKeyHash(
+                team = "team-test",
+                surveyId = "survey-other",
+                deduplicationKeyHash = "f".repeat(64)
+            ) shouldBe null
         }
     }
 

--- a/apps/lumi-api/src/test/kotlin/no/nav/lumi/repository/FeedbackSecurityTest.kt
+++ b/apps/lumi-api/src/test/kotlin/no/nav/lumi/repository/FeedbackSecurityTest.kt
@@ -13,8 +13,14 @@ import kotlinx.serialization.json.jsonObject
 import kotlinx.serialization.json.jsonPrimitive
 import kotlinx.serialization.json.int
 import no.nav.lumi.TestDatabase
+import no.nav.lumi.domain.SaveResult
 import no.nav.lumi.service.FeedbackService
 import org.slf4j.LoggerFactory
+
+private fun SaveResult.createdId(): String = when (this) {
+    is SaveResult.Created -> id
+    is SaveResult.Duplicate -> error("Expected created save result, got duplicate")
+}
 
 class FeedbackSecurityTest : DescribeSpec({
 
@@ -157,7 +163,7 @@ class FeedbackSecurityTest : DescribeSpec({
                 }
             """.trimIndent()
             
-            val saved = service.save(feedbackJson, "team-test", "test-app")
+            val saved = service.save(feedbackJson, "team-test", "test-app").createdId()
             val retrieved = repository.findRawById(saved, "team-test")
             
             retrieved?.feedbackJson shouldNotContain "01020349294"
@@ -181,7 +187,7 @@ class FeedbackSecurityTest : DescribeSpec({
                 }
             """.trimIndent()
 
-            val saved = service.save(feedbackJson, "team-test", "test-app")
+            val saved = service.save(feedbackJson, "team-test", "test-app").createdId()
             val retrieved = repository.findRawById(saved, "team-test")
 
             retrieved?.feedbackJson shouldNotContain digits
@@ -207,7 +213,7 @@ class FeedbackSecurityTest : DescribeSpec({
                 }
             """.trimIndent()
             
-            val saved = service.save(feedbackJson, "team-test", "test-app")
+            val saved = service.save(feedbackJson, "team-test", "test-app").createdId()
             val retrieved = repository.findRawById(saved, "team-test")
             
             retrieved?.feedbackJson shouldNotContain "test.user@example.com"
@@ -230,7 +236,7 @@ class FeedbackSecurityTest : DescribeSpec({
                 }
             """.trimIndent()
 
-            val saved = service.save(feedbackJson, "team-test", "test-app")
+            val saved = service.save(feedbackJson, "team-test", "test-app").createdId()
             val retrieved = repository.findRawById(saved, "team-test")
 
             // HTML-like content is preserved as plain text in stored payload (contextual escaping happens at sink/UI).
@@ -256,7 +262,7 @@ class FeedbackSecurityTest : DescribeSpec({
                 }
             """.trimIndent()
             
-            val saved = service.save(feedbackJson, "team-test", "test-app")
+            val saved = service.save(feedbackJson, "team-test", "test-app").createdId()
             val retrieved = repository.findRawById(saved, "team-test")
             
             retrieved?.feedbackJson shouldNotContain "98765432"
@@ -279,7 +285,7 @@ class FeedbackSecurityTest : DescribeSpec({
                 }
             """.trimIndent()
             
-            val saved = service.save(feedbackJson, "team-test", "test-app")
+            val saved = service.save(feedbackJson, "team-test", "test-app").createdId()
             val retrieved = repository.findRawById(saved, "team-test")
 
             val body = Json.parseToJsonElement(retrieved?.feedbackJson ?: "").jsonObject
@@ -295,7 +301,7 @@ class FeedbackSecurityTest : DescribeSpec({
         it("should handle JSON without answers gracefully") {
             val feedbackJson = """{"surveyId": "simple"}"""
             
-            val saved = repository.save(feedbackJson, "team-test", "test-app")
+            val saved = repository.save(feedbackJson, "team-test", "test-app").createdId()
             val retrieved = repository.findRawById(saved, "team-test")
             
             retrieved?.feedbackJson shouldContain "simple"
@@ -308,10 +314,10 @@ class FeedbackSecurityTest : DescribeSpec({
 
         it("should isolate tags between teams") {
             // Seed data for two teams
-            val idA = service.save("""{"surveyId":"A","answers":[{"fieldId":"f","value":{"type":"text","text":"..."}}]}""", "team-A", "app")
+            val idA = service.save("""{"surveyId":"A","answers":[{"fieldId":"f","value":{"type":"text","text":"..."}}]}""", "team-A", "app").createdId()
             service.addTag(idA, "team-A", "tag-A")
             
-            val idB = service.save("""{"surveyId":"B","answers":[{"fieldId":"f","value":{"type":"text","text":"..."}}]}""", "team-B", "app")
+            val idB = service.save("""{"surveyId":"B","answers":[{"fieldId":"f","value":{"type":"text","text":"..."}}]}""", "team-B", "app").createdId()
             service.addTag(idB, "team-B", "tag-B")
 
             // Verify team-A only sees its tags
@@ -320,8 +326,8 @@ class FeedbackSecurityTest : DescribeSpec({
         }
 
         it("should isolate distinct apps between teams") {
-            service.save("""{"surveyId":"A"}""", "team-A", "app-A")
-            service.save("""{"surveyId":"B"}""", "team-B", "app-B")
+            service.save("""{"surveyId":"A"}""", "team-A", "app-A").createdId()
+            service.save("""{"surveyId":"B"}""", "team-B", "app-B").createdId()
 
             repository.findDistinctApps("team-A") shouldBe listOf("app-A")
             repository.findDistinctApps("team-B") shouldBe listOf("app-B")
@@ -331,8 +337,8 @@ class FeedbackSecurityTest : DescribeSpec({
             val feedbackA = """{"surveyId":"S","context":{"tags":{"key-A":"val-A"}},"answers":[{"fieldId":"f","value":{"type":"text","text":"..."}}]}"""
             val feedbackB = """{"surveyId":"S","context":{"tags":{"key-B":"val-B"}},"answers":[{"fieldId":"f","value":{"type":"text","text":"..."}}]}"""
             
-            service.save(feedbackA, "team-A", "app")
-            service.save(feedbackB, "team-B", "app")
+            service.save(feedbackA, "team-A", "app").createdId()
+            service.save(feedbackB, "team-B", "app").createdId()
 
             val keysA = repository.findMetadataKeysForSurvey("S", "team-A")
             keysA.keys shouldBe setOf("key-A")
@@ -343,7 +349,7 @@ class FeedbackSecurityTest : DescribeSpec({
         }
 
         it("should deny access to feedback from another team") {
-            val idA = service.save("""{"surveyId":"S","answers":[{"fieldId":"f","value":{"type":"text","text":"..."}}]}""", "team-A", "app")
+            val idA = service.save("""{"surveyId":"S","answers":[{"fieldId":"f","value":{"type":"text","text":"..."}}]}""", "team-A", "app").createdId()
             
             // Should be found by authorized team
             service.findById(idA, "team-A")?.id shouldBe idA

--- a/apps/lumi-api/src/test/kotlin/no/nav/lumi/repository/FeedbackSecurityTest.kt
+++ b/apps/lumi-api/src/test/kotlin/no/nav/lumi/repository/FeedbackSecurityTest.kt
@@ -13,14 +13,9 @@ import kotlinx.serialization.json.jsonObject
 import kotlinx.serialization.json.jsonPrimitive
 import kotlinx.serialization.json.int
 import no.nav.lumi.TestDatabase
-import no.nav.lumi.domain.SaveResult
+import no.nav.lumi.createdId
 import no.nav.lumi.service.FeedbackService
 import org.slf4j.LoggerFactory
-
-private fun SaveResult.createdId(): String = when (this) {
-    is SaveResult.Created -> id
-    is SaveResult.Duplicate -> error("Expected created save result, got duplicate")
-}
 
 class FeedbackSecurityTest : DescribeSpec({
 

--- a/apps/lumi-api/src/test/kotlin/no/nav/lumi/routes/InternalSubmissionRoutesTest.kt
+++ b/apps/lumi-api/src/test/kotlin/no/nav/lumi/routes/InternalSubmissionRoutesTest.kt
@@ -2,19 +2,32 @@ package no.nav.lumi.routes
 
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.shouldBe
+import io.kotest.matchers.string.shouldNotContain
 import io.ktor.client.request.*
 import io.ktor.client.statement.*
 import io.ktor.http.*
 import io.ktor.server.routing.*
 import io.ktor.server.testing.*
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.async
+import kotlinx.coroutines.awaitAll
+import kotlinx.coroutines.coroutineScope
 import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.boolean
 import kotlinx.serialization.json.jsonObject
 import kotlinx.serialization.json.jsonPrimitive
 import no.nav.lumi.TestDatabase
 import no.nav.lumi.config.DatabaseHolder
 import no.nav.lumi.config.configureSerialization
 import no.nav.lumi.config.configureStatusPages
+import no.nav.lumi.domain.FeedbackQuery
+import no.nav.lumi.repository.FeedbackRepository
+import no.nav.lumi.repository.SurveyDefinitionRepository
 import no.nav.lumi.service.FeedbackService
+import no.nav.lumi.service.SubmissionService
+import no.nav.lumi.service.SurveyDefinitionService
+import java.util.concurrent.atomic.AtomicInteger
 
 private const val TEST_PSK = "test-internal-submission-key"
 private const val VALID_IDENTITY = "dev-gcp:teamsykefravr:syfomodiaperson"
@@ -31,6 +44,28 @@ private val validPayload = """
       "fieldType": "RATING",
       "question": { "label": "Hvor fornøyd er du?" },
       "value": { "type": "rating", "rating": 4, "ratingVariant": "emoji", "ratingScale": 5 }
+    }
+  ]
+}
+""".trimIndent()
+
+private fun validPayloadWithDedup(
+    deduplicationKey: String,
+    submittedAt: String = "2026-01-10T12:00:12Z",
+    text: String = "Bra"
+) = """
+{
+  "schemaVersion": 1,
+  "surveyId": "modia-feedback",
+  "surveyType": "rating",
+  "submittedAt": "$submittedAt",
+  "deduplicationKey": "$deduplicationKey",
+  "answers": [
+    {
+      "fieldId": "feedback",
+      "fieldType": "TEXT",
+      "question": { "label": "Hvorfor?" },
+      "value": { "type": "text", "text": "$text" }
     }
   ]
 }
@@ -359,6 +394,473 @@ class InternalSubmissionRoutesTest : FunSpec({
             }
 
             response.status shouldBe HttpStatusCode.NotFound
+        }
+    }
+
+    test("should return 200 duplicate with existing id and never persist raw deduplicationKey") {
+        val repository = FeedbackRepository()
+
+        testApplication {
+            application {
+                configureSerialization()
+                configureStatusPages()
+                routing {
+                    internalSubmissionRoutes(
+                        feedbackService = FeedbackService(),
+                        submissionKey = TEST_PSK
+                    )
+                }
+            }
+
+            val firstResponse = client.post("/api/internal/v1/feedback") {
+                contentType(ContentType.Application.Json)
+                header("X-Lumi-Submission-Key", TEST_PSK)
+                header("X-Lumi-Caller-Identity", VALID_IDENTITY)
+                setBody(validPayloadWithDedup("client-key-123456"))
+            }
+
+            firstResponse.status shouldBe HttpStatusCode.Created
+            val firstBody = Json.parseToJsonElement(firstResponse.bodyAsText()).jsonObject
+            val id = firstBody["id"]?.jsonPrimitive?.content!!
+
+            val secondResponse = client.post("/api/internal/v1/feedback") {
+                contentType(ContentType.Application.Json)
+                header("X-Lumi-Submission-Key", TEST_PSK)
+                header("X-Lumi-Caller-Identity", VALID_IDENTITY)
+                setBody(validPayloadWithDedup("client-key-123456", submittedAt = "2026-01-10T12:01:12Z", text = "Annen tekst"))
+            }
+
+            secondResponse.status shouldBe HttpStatusCode.OK
+            val secondBody = Json.parseToJsonElement(secondResponse.bodyAsText()).jsonObject
+            secondBody["id"]?.jsonPrimitive?.content shouldBe id
+            secondBody["duplicate"]?.jsonPrimitive?.boolean shouldBe true
+
+            val saved = repository.findRawById(id, "teamsykefravr")
+            saved?.feedbackJson?.contains("deduplicationKey") shouldBe false
+            saved?.feedbackJson?.contains("Bra") shouldBe true
+            saved?.feedbackJson?.contains("Annen tekst") shouldBe false
+
+            val (_, total, _) = repository.findPaginated(FeedbackQuery(team = "teamsykefravr"))
+            total shouldBe 1
+        }
+    }
+
+    test("should return 200 duplicate without mutating survey definition when duplicate adds a new field") {
+        val feedbackRepository = FeedbackRepository()
+        val surveyDefinitionRepository = SurveyDefinitionRepository()
+
+        testApplication {
+            application {
+                configureSerialization()
+                configureStatusPages()
+                routing {
+                    internalSubmissionRoutes(
+                        feedbackService = FeedbackService(),
+                        submissionKey = TEST_PSK
+                    )
+                }
+            }
+
+            val firstResponse = client.post("/api/internal/v1/feedback") {
+                contentType(ContentType.Application.Json)
+                header("X-Lumi-Submission-Key", TEST_PSK)
+                header("X-Lumi-Caller-Identity", VALID_IDENTITY)
+                setBody(
+                    """
+                    {
+                      "schemaVersion": 1,
+                      "surveyId": "modia-dedup-extension-survey",
+                      "surveyType": "rating",
+                      "submittedAt": "2026-01-10T12:00:12Z",
+                      "deduplicationKey": "client-key-123456",
+                      "answers": [
+                        {
+                          "fieldId": "feedback",
+                          "fieldType": "TEXT",
+                          "question": { "label": "Hvorfor?" },
+                          "value": { "type": "text", "text": "Første payload" }
+                        }
+                      ]
+                    }
+                    """.trimIndent()
+                )
+            }
+
+            firstResponse.status shouldBe HttpStatusCode.Created
+            val existingId = Json.parseToJsonElement(firstResponse.bodyAsText()).jsonObject["id"]?.jsonPrimitive?.content!!
+
+            val storedBefore = surveyDefinitionRepository.findByTeamAndSurveyId("teamsykefravr", "modia-dedup-extension-survey")!!
+
+            val duplicateResponse = client.post("/api/internal/v1/feedback") {
+                contentType(ContentType.Application.Json)
+                header("X-Lumi-Submission-Key", TEST_PSK)
+                header("X-Lumi-Caller-Identity", VALID_IDENTITY)
+                setBody(
+                    """
+                    {
+                      "schemaVersion": 1,
+                      "surveyId": "modia-dedup-extension-survey",
+                      "surveyType": "rating",
+                      "submittedAt": "2026-01-10T12:01:12Z",
+                      "deduplicationKey": "client-key-123456",
+                      "answers": [
+                        {
+                          "fieldId": "feedback",
+                          "fieldType": "TEXT",
+                          "question": { "label": "Hvorfor?" },
+                          "value": { "type": "text", "text": "Andre payload" }
+                        },
+                        {
+                          "fieldId": "followup",
+                          "fieldType": "TEXT",
+                          "question": { "label": "Hva kunne vært bedre?" },
+                          "value": { "type": "text", "text": "Mer hjelp" }
+                        }
+                      ]
+                    }
+                    """.trimIndent()
+                )
+            }
+
+            duplicateResponse.status shouldBe HttpStatusCode.OK
+            val duplicateBody = Json.parseToJsonElement(duplicateResponse.bodyAsText()).jsonObject
+            duplicateBody["id"]?.jsonPrimitive?.content shouldBe existingId
+            duplicateBody["duplicate"]?.jsonPrimitive?.boolean shouldBe true
+
+            val storedAfter = surveyDefinitionRepository.findByTeamAndSurveyId("teamsykefravr", "modia-dedup-extension-survey")!!
+            storedAfter.definitionHash shouldBe storedBefore.definitionHash
+            storedAfter.definition.fields.map { it.fieldId } shouldBe listOf("feedback")
+
+            val (_, total, _) = feedbackRepository.findPaginated(FeedbackQuery(team = "teamsykefravr"))
+            total shouldBe 1
+        }
+    }
+
+    test("should return 200 duplicate instead of 409 for concurrent conflicting definition on internal route") {
+        val feedbackRepository = FeedbackRepository()
+        val surveyDefinitionRepository = SurveyDefinitionRepository()
+        val feedbackService = FeedbackService(feedbackRepository)
+        val surveyDefinitionService = SurveyDefinitionService(surveyDefinitionRepository)
+        val lockAcquired = CompletableDeferred<Unit>()
+        val releaseFirstRequest = CompletableDeferred<Unit>()
+        val lockInvocationCount = AtomicInteger(0)
+        val submissionService = SubmissionService(
+            feedbackService = feedbackService,
+            surveyDefinitionService = surveyDefinitionService,
+            feedbackRepository = feedbackRepository,
+            afterScopedDeduplicationLockAcquired = {
+                if (lockInvocationCount.incrementAndGet() == 1) {
+                    lockAcquired.complete(Unit)
+                    releaseFirstRequest.await()
+                }
+            }
+        )
+
+        testApplication {
+            application {
+                configureSerialization()
+                configureStatusPages()
+                routing {
+                    internalSubmissionRoutes(
+                        feedbackService = feedbackService,
+                        surveyDefinitionService = surveyDefinitionService,
+                        submissionService = submissionService,
+                        submissionKey = TEST_PSK
+                    )
+                }
+            }
+
+            val responses = coroutineScope {
+                val first = async(Dispatchers.Default) {
+                    client.post("/api/internal/v1/feedback") {
+                        contentType(ContentType.Application.Json)
+                        header("X-Lumi-Submission-Key", TEST_PSK)
+                        header("X-Lumi-Caller-Identity", VALID_IDENTITY)
+                        setBody(
+                            """
+                            {
+                              "schemaVersion": 1,
+                              "surveyId": "modia-dedup-race-conflict-survey",
+                              "surveyType": "topTasks",
+                              "submittedAt": "2026-01-10T12:00:12Z",
+                              "deduplicationKey": "client-key-123456",
+                              "answers": [
+                                {
+                                  "fieldId": "task",
+                                  "fieldType": "SINGLE_CHOICE",
+                                  "question": {
+                                    "label": "Hva gjorde du?",
+                                    "options": [{ "id": "apply", "label": "Søknad" }]
+                                  },
+                                  "value": { "type": "singleChoice", "selectedOptionId": "apply" }
+                                }
+                              ]
+                            }
+                            """.trimIndent()
+                        )
+                    }
+                }
+                lockAcquired.await()
+                val second = async(Dispatchers.Default) {
+                    client.post("/api/internal/v1/feedback") {
+                        contentType(ContentType.Application.Json)
+                        header("X-Lumi-Submission-Key", TEST_PSK)
+                        header("X-Lumi-Caller-Identity", VALID_IDENTITY)
+                        setBody(
+                            """
+                            {
+                              "schemaVersion": 1,
+                              "surveyId": "modia-dedup-race-conflict-survey",
+                              "surveyType": "topTasks",
+                              "submittedAt": "2026-01-10T12:01:12Z",
+                              "deduplicationKey": "client-key-123456",
+                              "answers": [
+                                {
+                                  "fieldId": "task",
+                                  "fieldType": "SINGLE_CHOICE",
+                                  "question": {
+                                    "label": "Hva gjorde du?",
+                                    "options": [
+                                      { "id": "apply", "label": "Søknad" },
+                                      { "id": "follow-up", "label": "Oppfølging" }
+                                    ]
+                                  },
+                                  "value": { "type": "singleChoice", "selectedOptionId": "apply" }
+                                }
+                              ]
+                            }
+                            """.trimIndent()
+                        )
+                    }
+                }
+                releaseFirstRequest.complete(Unit)
+                awaitAll(first, second)
+            }
+
+            responses.count { it.status == HttpStatusCode.Created } shouldBe 1
+            responses.count { it.status == HttpStatusCode.OK } shouldBe 1
+            responses.any { it.status == HttpStatusCode.Conflict } shouldBe false
+
+            val createdId = Json.parseToJsonElement(
+                responses.single { it.status == HttpStatusCode.Created }.bodyAsText()
+            ).jsonObject["id"]?.jsonPrimitive?.content!!
+            val duplicateBody = Json.parseToJsonElement(
+                responses.single { it.status == HttpStatusCode.OK }.bodyAsText()
+            ).jsonObject
+            duplicateBody["id"]?.jsonPrimitive?.content shouldBe createdId
+            duplicateBody["duplicate"]?.jsonPrimitive?.boolean shouldBe true
+
+            val stored = surveyDefinitionRepository.findByTeamAndSurveyId("teamsykefravr", "modia-dedup-race-conflict-survey")!!
+            stored.definition.fields.single().optionIds shouldBe listOf("apply")
+
+            val (_, total, _) = feedbackRepository.findPaginated(FeedbackQuery(team = "teamsykefravr"))
+            total shouldBe 1
+        }
+    }
+
+    test("should return 400 for invalid deduplication keys without echoing raw value") {
+        testApplication {
+            application {
+                configureSerialization()
+                configureStatusPages()
+                routing {
+                    internalSubmissionRoutes(
+                        feedbackService = FeedbackService(),
+                        submissionKey = TEST_PSK
+                    )
+                }
+            }
+
+            val response = client.post("/api/internal/v1/feedback") {
+                contentType(ContentType.Application.Json)
+                header("X-Lumi-Submission-Key", TEST_PSK)
+                header("X-Lumi-Caller-Identity", VALID_IDENTITY)
+                setBody(validPayloadWithDedup("bad key with spaces"))
+            }
+
+            response.status shouldBe HttpStatusCode.BadRequest
+            val message = Json.parseToJsonElement(response.bodyAsText()).jsonObject["message"]?.jsonPrimitive?.content!!
+            message.contains("deduplicationKey") shouldBe true
+            message.contains("bad key with spaces") shouldBe false
+        }
+    }
+
+    test("should keep creating new rows when deduplicationKey is absent") {
+        val repository = FeedbackRepository()
+
+        testApplication {
+            application {
+                configureSerialization()
+                configureStatusPages()
+                routing {
+                    internalSubmissionRoutes(
+                        feedbackService = FeedbackService(),
+                        submissionKey = TEST_PSK
+                    )
+                }
+            }
+
+            val firstResponse = client.post("/api/internal/v1/feedback") {
+                contentType(ContentType.Application.Json)
+                header("X-Lumi-Submission-Key", TEST_PSK)
+                header("X-Lumi-Caller-Identity", VALID_IDENTITY)
+                setBody(validPayload)
+            }
+
+            val secondResponse = client.post("/api/internal/v1/feedback") {
+                contentType(ContentType.Application.Json)
+                header("X-Lumi-Submission-Key", TEST_PSK)
+                header("X-Lumi-Caller-Identity", VALID_IDENTITY)
+                setBody(validPayload.replace("12:00:12Z", "12:01:12Z"))
+            }
+
+            firstResponse.status shouldBe HttpStatusCode.Created
+            secondResponse.status shouldBe HttpStatusCode.Created
+
+            val firstId = Json.parseToJsonElement(firstResponse.bodyAsText()).jsonObject["id"]?.jsonPrimitive?.content
+            val secondId = Json.parseToJsonElement(secondResponse.bodyAsText()).jsonObject["id"]?.jsonPrimitive?.content
+            (firstId == secondId) shouldBe false
+
+            val (_, total, _) = repository.findPaginated(FeedbackQuery(team = "teamsykefravr"))
+            total shouldBe 2
+        }
+    }
+
+    test("should treat same deduplicationKey on different teams as separate submissions") {
+        val repository = FeedbackRepository()
+
+        testApplication {
+            application {
+                configureSerialization()
+                configureStatusPages()
+                routing {
+                    internalSubmissionRoutes(
+                        feedbackService = FeedbackService(),
+                        submissionKey = TEST_PSK
+                    )
+                }
+            }
+
+            val firstResponse = client.post("/api/internal/v1/feedback") {
+                contentType(ContentType.Application.Json)
+                header("X-Lumi-Submission-Key", TEST_PSK)
+                header("X-Lumi-Caller-Identity", VALID_IDENTITY)
+                setBody(validPayloadWithDedup("client-key-123456"))
+            }
+
+            val secondResponse = client.post("/api/internal/v1/feedback") {
+                contentType(ContentType.Application.Json)
+                header("X-Lumi-Submission-Key", TEST_PSK)
+                header("X-Lumi-Caller-Identity", "dev-gcp:flex:syfomodiaperson")
+                setBody(validPayloadWithDedup("client-key-123456", submittedAt = "2026-01-10T12:01:12Z"))
+            }
+
+            firstResponse.status shouldBe HttpStatusCode.Created
+            secondResponse.status shouldBe HttpStatusCode.Created
+
+            val (_, teamOneTotal, _) = repository.findPaginated(FeedbackQuery(team = "teamsykefravr"))
+            val (_, teamTwoTotal, _) = repository.findPaginated(FeedbackQuery(team = "flex"))
+            teamOneTotal shouldBe 1
+            teamTwoTotal shouldBe 1
+        }
+    }
+
+    test("should not persist malformed json with root deduplicationKey") {
+        val repository = FeedbackRepository()
+
+        testApplication {
+            application {
+                configureSerialization()
+                configureStatusPages()
+                routing {
+                    internalSubmissionRoutes(
+                        feedbackService = FeedbackService(),
+                        submissionKey = TEST_PSK
+                    )
+                }
+            }
+
+            val response = client.post("/api/internal/v1/feedback") {
+                contentType(ContentType.Application.Json)
+                header("X-Lumi-Submission-Key", TEST_PSK)
+                header("X-Lumi-Caller-Identity", VALID_IDENTITY)
+                setBody(
+                    """
+                    {
+                      "schemaVersion": 1,
+                      "surveyId": "modia-feedback",
+                      "surveyType": "rating",
+                      "deduplicationKey": "client-key-123456",
+                      "answers": [
+                    }
+                    """.trimIndent()
+                )
+            }
+
+            response.status shouldBe HttpStatusCode.BadRequest
+            response.bodyAsText() shouldNotContain "client-key-123456"
+
+            val (_, total, _) = repository.findPaginated(FeedbackQuery(team = "teamsykefravr"))
+            total shouldBe 0
+        }
+    }
+
+    test("should accept explicit deduplicationKey null as absent") {
+        val repository = FeedbackRepository()
+
+        testApplication {
+            application {
+                configureSerialization()
+                configureStatusPages()
+                routing {
+                    internalSubmissionRoutes(
+                        feedbackService = FeedbackService(),
+                        submissionKey = TEST_PSK
+                    )
+                }
+            }
+
+            val payload = """
+                {
+                  "schemaVersion": 1,
+                  "surveyId": "modia-feedback",
+                  "surveyType": "rating",
+                  "submittedAt": "2026-01-10T12:00:12Z",
+                  "deduplicationKey": null,
+                  "answers": [
+                    {
+                      "fieldId": "feedback",
+                      "fieldType": "TEXT",
+                      "question": { "label": "Hvorfor?" },
+                      "value": { "type": "text", "text": "Lik payload" }
+                    }
+                  ]
+                }
+            """.trimIndent()
+
+            val firstResponse = client.post("/api/internal/v1/feedback") {
+                contentType(ContentType.Application.Json)
+                header("X-Lumi-Submission-Key", TEST_PSK)
+                header("X-Lumi-Caller-Identity", VALID_IDENTITY)
+                setBody(payload)
+            }
+
+            val secondResponse = client.post("/api/internal/v1/feedback") {
+                contentType(ContentType.Application.Json)
+                header("X-Lumi-Submission-Key", TEST_PSK)
+                header("X-Lumi-Caller-Identity", VALID_IDENTITY)
+                setBody(payload.replace("12:00:12Z", "12:01:12Z"))
+            }
+
+            firstResponse.status shouldBe HttpStatusCode.Created
+            secondResponse.status shouldBe HttpStatusCode.Created
+
+            val firstId = Json.parseToJsonElement(firstResponse.bodyAsText()).jsonObject["id"]?.jsonPrimitive?.content!!
+            val secondId = Json.parseToJsonElement(secondResponse.bodyAsText()).jsonObject["id"]?.jsonPrimitive?.content!!
+            (firstId == secondId) shouldBe false
+
+            repository.findRawById(firstId, "teamsykefravr")?.feedbackJson shouldNotContain "deduplicationKey"
+            repository.findRawById(secondId, "teamsykefravr")?.feedbackJson shouldNotContain "deduplicationKey"
         }
     }
 })

--- a/apps/lumi-api/src/test/kotlin/no/nav/lumi/routes/SubmissionRoutesTest.kt
+++ b/apps/lumi-api/src/test/kotlin/no/nav/lumi/routes/SubmissionRoutesTest.kt
@@ -2,17 +2,58 @@ package no.nav.lumi.routes
 
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.shouldBe
+import io.kotest.matchers.string.shouldNotContain
 import io.ktor.client.request.*
 import io.ktor.client.statement.*
 import io.ktor.http.*
+import io.ktor.server.routing.*
 import io.ktor.server.testing.*
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.async
+import kotlinx.coroutines.awaitAll
+import kotlinx.coroutines.coroutineScope
 import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.boolean
 import kotlinx.serialization.json.jsonObject
 import kotlinx.serialization.json.jsonPrimitive
 import no.nav.lumi.TestDatabase
 import no.nav.lumi.config.DatabaseHolder
+import no.nav.lumi.config.configureRateLimiting
+import no.nav.lumi.config.configureSerialization
+import no.nav.lumi.config.configureStatusPages
 import no.nav.lumi.createTestClient
+import no.nav.lumi.domain.FeedbackQuery
+import no.nav.lumi.repository.FeedbackRepository
+import no.nav.lumi.repository.SurveyDefinitionRepository
+import no.nav.lumi.routes.submissionRoutes
+import no.nav.lumi.service.FeedbackService
+import no.nav.lumi.service.SubmissionService
+import no.nav.lumi.service.SurveyDefinitionService
 import no.nav.lumi.testModule
+import java.util.concurrent.atomic.AtomicInteger
+
+private fun submissionPayloadWithDedup(
+    deduplicationKey: String,
+    submittedAt: String = "2026-01-10T12:00:12Z",
+    text: String = "Bra"
+) = """
+    {
+      "schemaVersion": 1,
+      "surveyId": "dp-feedback",
+      "surveyType": "rating",
+      "submittedAt": "$submittedAt",
+      "deduplicationKey": "$deduplicationKey",
+      "answers": [
+        {
+          "fieldId": "feedback",
+          "fieldType": "TEXT",
+          "question": { "label": "Hvorfor?" },
+          "value": { "type": "text", "text": "$text" }
+        }
+      ]
+    }
+""".trimIndent()
 
 class SubmissionRoutesTest : FunSpec({
     beforeSpec {
@@ -1187,6 +1228,710 @@ class SubmissionRoutesTest : FunSpec({
             response.status shouldBe HttpStatusCode.BadRequest
             val message = Json.parseToJsonElement(response.bodyAsText()).jsonObject["message"]?.jsonPrimitive?.content
             (message?.contains("selectedOptionIds max length", ignoreCase = true) == true) shouldBe true
+        }
+    }
+
+    test("should return 200 duplicate with existing id when deduplicationKey is reused") {
+        val repository = FeedbackRepository()
+
+        testApplication {
+            application { testModule() }
+            val client = createTestClient()
+
+            val firstResponse = client.post("/api/tokenx/v1/feedback") {
+                contentType(ContentType.Application.Json)
+                setBody(submissionPayloadWithDedup("client-key-123456"))
+            }
+
+            firstResponse.status shouldBe HttpStatusCode.Created
+            val firstBody = Json.parseToJsonElement(firstResponse.bodyAsText()).jsonObject
+            val id = firstBody["id"]?.jsonPrimitive?.content!!
+
+            val secondResponse = client.post("/api/tokenx/v1/feedback") {
+                contentType(ContentType.Application.Json)
+                setBody(
+                    submissionPayloadWithDedup(
+                        deduplicationKey = "client-key-123456",
+                        submittedAt = "2026-01-10T12:01:12Z",
+                        text = "Annen tekst"
+                    )
+                )
+            }
+
+            secondResponse.status shouldBe HttpStatusCode.OK
+            val secondBody = Json.parseToJsonElement(secondResponse.bodyAsText()).jsonObject
+            secondBody["id"]?.jsonPrimitive?.content shouldBe id
+            secondBody["duplicate"]?.jsonPrimitive?.boolean shouldBe true
+
+            val saved = repository.findRawById(id, "local-dev")
+            saved?.feedbackJson?.contains("deduplicationKey") shouldBe false
+            saved?.feedbackJson?.contains("Bra") shouldBe true
+            saved?.feedbackJson?.contains("Annen tekst") shouldBe false
+
+            val (_, total, _) = repository.findPaginated(FeedbackQuery(team = "local-dev"))
+            total shouldBe 1
+        }
+    }
+
+    test("should return 200 duplicate instead of 409 when same deduplicationKey reuses conflicting survey definition") {
+        val feedbackRepository = FeedbackRepository()
+        val surveyDefinitionRepository = SurveyDefinitionRepository()
+
+        testApplication {
+            application { testModule() }
+            val client = createTestClient()
+
+            val firstResponse = client.post("/api/tokenx/v1/feedback") {
+                contentType(ContentType.Application.Json)
+                setBody(
+                    """
+                    {
+                      "schemaVersion": 1,
+                      "surveyId": "dedup-conflict-survey",
+                      "surveyType": "topTasks",
+                      "submittedAt": "2026-01-10T12:00:12Z",
+                      "deduplicationKey": "client-key-123456",
+                      "answers": [
+                        {
+                          "fieldId": "task",
+                          "fieldType": "SINGLE_CHOICE",
+                          "question": {
+                            "label": "Hva gjorde du?",
+                            "options": [{ "id": "apply", "label": "Søknad" }]
+                          },
+                          "value": { "type": "singleChoice", "selectedOptionId": "apply" }
+                        }
+                      ]
+                    }
+                    """.trimIndent()
+                )
+            }
+
+            firstResponse.status shouldBe HttpStatusCode.Created
+            val existingId = Json.parseToJsonElement(firstResponse.bodyAsText()).jsonObject["id"]?.jsonPrimitive?.content!!
+
+            val storedBefore = surveyDefinitionRepository.findByTeamAndSurveyId("local-dev", "dedup-conflict-survey")!!
+
+            val duplicateResponse = client.post("/api/tokenx/v1/feedback") {
+                contentType(ContentType.Application.Json)
+                setBody(
+                    """
+                    {
+                      "schemaVersion": 1,
+                      "surveyId": "dedup-conflict-survey",
+                      "surveyType": "topTasks",
+                      "submittedAt": "2026-01-10T12:01:12Z",
+                      "deduplicationKey": "client-key-123456",
+                      "answers": [
+                        {
+                          "fieldId": "task",
+                          "fieldType": "SINGLE_CHOICE",
+                          "question": {
+                            "label": "Hva gjorde du?",
+                            "options": [
+                              { "id": "apply", "label": "Søknad" },
+                              { "id": "follow-up", "label": "Oppfølging" }
+                            ]
+                          },
+                          "value": { "type": "singleChoice", "selectedOptionId": "apply" }
+                        }
+                      ]
+                    }
+                    """.trimIndent()
+                )
+            }
+
+            duplicateResponse.status shouldBe HttpStatusCode.OK
+            val duplicateBody = Json.parseToJsonElement(duplicateResponse.bodyAsText()).jsonObject
+            duplicateBody["id"]?.jsonPrimitive?.content shouldBe existingId
+            duplicateBody["duplicate"]?.jsonPrimitive?.boolean shouldBe true
+
+            val storedAfter = surveyDefinitionRepository.findByTeamAndSurveyId("local-dev", "dedup-conflict-survey")!!
+            storedAfter.definitionHash shouldBe storedBefore.definitionHash
+            storedAfter.definition.fields.single().optionIds shouldBe listOf("apply")
+
+            val (_, total, _) = feedbackRepository.findPaginated(FeedbackQuery(team = "local-dev"))
+            total shouldBe 1
+        }
+    }
+
+    test("should still return 409 when a new deduplicationKey sends a conflicting survey definition") {
+        testApplication {
+            application { testModule() }
+            val client = createTestClient()
+
+            client.post("/api/tokenx/v1/feedback") {
+                contentType(ContentType.Application.Json)
+                setBody(
+                    """
+                    {
+                      "schemaVersion": 1,
+                      "surveyId": "dedup-new-key-conflict-survey",
+                      "surveyType": "topTasks",
+                      "submittedAt": "2026-01-10T12:00:12Z",
+                      "deduplicationKey": "client-key-123456",
+                      "answers": [
+                        {
+                          "fieldId": "task",
+                          "fieldType": "SINGLE_CHOICE",
+                          "question": {
+                            "label": "Hva gjorde du?",
+                            "options": [{ "id": "apply", "label": "Søknad" }]
+                          },
+                          "value": { "type": "singleChoice", "selectedOptionId": "apply" }
+                        }
+                      ]
+                    }
+                    """.trimIndent()
+                )
+            }.status shouldBe HttpStatusCode.Created
+
+            val conflictResponse = client.post("/api/tokenx/v1/feedback") {
+                contentType(ContentType.Application.Json)
+                setBody(
+                    """
+                    {
+                      "schemaVersion": 1,
+                      "surveyId": "dedup-new-key-conflict-survey",
+                      "surveyType": "topTasks",
+                      "submittedAt": "2026-01-10T12:01:12Z",
+                      "deduplicationKey": "client-key-654321",
+                      "answers": [
+                        {
+                          "fieldId": "task",
+                          "fieldType": "SINGLE_CHOICE",
+                          "question": {
+                            "label": "Hva gjorde du?",
+                            "options": [
+                              { "id": "apply", "label": "Søknad" },
+                              { "id": "follow-up", "label": "Oppfølging" }
+                            ]
+                          },
+                          "value": { "type": "singleChoice", "selectedOptionId": "apply" }
+                        }
+                      ]
+                    }
+                    """.trimIndent()
+                )
+            }
+
+            conflictResponse.status shouldBe HttpStatusCode.Conflict
+        }
+    }
+
+    test("should still extend survey definition when deduplicationKey is new") {
+        val feedbackRepository = FeedbackRepository()
+        val surveyDefinitionRepository = SurveyDefinitionRepository()
+
+        testApplication {
+            application { testModule() }
+            val client = createTestClient()
+
+            client.post("/api/tokenx/v1/feedback") {
+                contentType(ContentType.Application.Json)
+                setBody(
+                    """
+                    {
+                      "schemaVersion": 1,
+                      "surveyId": "dedup-extension-survey",
+                      "surveyType": "rating",
+                      "submittedAt": "2026-01-10T12:00:12Z",
+                      "deduplicationKey": "client-key-123456",
+                      "answers": [
+                        {
+                          "fieldId": "feedback",
+                          "fieldType": "TEXT",
+                          "question": { "label": "Hvorfor?" },
+                          "value": { "type": "text", "text": "Første payload" }
+                        }
+                      ]
+                    }
+                    """.trimIndent()
+                )
+            }.status shouldBe HttpStatusCode.Created
+
+            val secondResponse = client.post("/api/tokenx/v1/feedback") {
+                contentType(ContentType.Application.Json)
+                setBody(
+                    """
+                    {
+                      "schemaVersion": 1,
+                      "surveyId": "dedup-extension-survey",
+                      "surveyType": "rating",
+                      "submittedAt": "2026-01-10T12:01:12Z",
+                      "deduplicationKey": "client-key-654321",
+                      "answers": [
+                        {
+                          "fieldId": "feedback",
+                          "fieldType": "TEXT",
+                          "question": { "label": "Hvorfor?" },
+                          "value": { "type": "text", "text": "Andre payload" }
+                        },
+                        {
+                          "fieldId": "followup",
+                          "fieldType": "TEXT",
+                          "question": { "label": "Hva kunne vært bedre?" },
+                          "value": { "type": "text", "text": "Mer hjelp" }
+                        }
+                      ]
+                    }
+                    """.trimIndent()
+                )
+            }
+
+            secondResponse.status shouldBe HttpStatusCode.Created
+
+            val stored = surveyDefinitionRepository.findByTeamAndSurveyId("local-dev", "dedup-extension-survey")!!
+            stored.definition.fields.map { it.fieldId } shouldBe listOf("feedback", "followup")
+
+            val (_, total, _) = feedbackRepository.findPaginated(FeedbackQuery(team = "local-dev"))
+            total shouldBe 2
+        }
+    }
+
+    test("should return 400 for invalid deduplication keys without echoing raw value") {
+        testApplication {
+            application { testModule() }
+            val client = createTestClient()
+
+            val response = client.post("/api/tokenx/v1/feedback") {
+                contentType(ContentType.Application.Json)
+                setBody(submissionPayloadWithDedup("bad key with spaces"))
+            }
+
+            response.status shouldBe HttpStatusCode.BadRequest
+            val message = Json.parseToJsonElement(response.bodyAsText()).jsonObject["message"]?.jsonPrimitive?.content!!
+            message.contains("deduplicationKey") shouldBe true
+            message.contains("bad key with spaces") shouldBe false
+        }
+    }
+
+    test("should keep creating new rows when deduplicationKey is absent") {
+        val repository = FeedbackRepository()
+
+        testApplication {
+            application { testModule() }
+            val client = createTestClient()
+
+            val payload = """
+                {
+                  "schemaVersion": 1,
+                  "surveyId": "dp-feedback",
+                  "surveyType": "rating",
+                  "submittedAt": "2026-01-10T12:00:12Z",
+                  "answers": [
+                    {
+                      "fieldId": "feedback",
+                      "fieldType": "TEXT",
+                      "question": { "label": "Hvorfor?" },
+                      "value": { "type": "text", "text": "Lik payload" }
+                    }
+                  ]
+                }
+            """.trimIndent()
+
+            val firstResponse = client.post("/api/tokenx/v1/feedback") {
+                contentType(ContentType.Application.Json)
+                setBody(payload)
+            }
+
+            val secondResponse = client.post("/api/tokenx/v1/feedback") {
+                contentType(ContentType.Application.Json)
+                setBody(payload.replace("12:00:12Z", "12:01:12Z"))
+            }
+
+            firstResponse.status shouldBe HttpStatusCode.Created
+            secondResponse.status shouldBe HttpStatusCode.Created
+
+            val firstId = Json.parseToJsonElement(firstResponse.bodyAsText()).jsonObject["id"]?.jsonPrimitive?.content
+            val secondId = Json.parseToJsonElement(secondResponse.bodyAsText()).jsonObject["id"]?.jsonPrimitive?.content
+            (firstId == secondId) shouldBe false
+
+            val (_, total, _) = repository.findPaginated(FeedbackQuery(team = "local-dev"))
+            total shouldBe 2
+        }
+    }
+
+    test("should not persist malformed json with root deduplicationKey") {
+        val repository = FeedbackRepository()
+
+        testApplication {
+            application { testModule() }
+            val client = createTestClient()
+
+            val response = client.post("/api/tokenx/v1/feedback") {
+                contentType(ContentType.Application.Json)
+                setBody(
+                    """
+                    {
+                      "schemaVersion": 1,
+                      "surveyId": "dp-feedback",
+                      "surveyType": "rating",
+                      "deduplicationKey": "client-key-123456",
+                      "answers": [
+                    }
+                    """.trimIndent()
+                )
+            }
+
+            response.status shouldBe HttpStatusCode.BadRequest
+            response.bodyAsText() shouldNotContain "client-key-123456"
+
+            val (_, total, _) = repository.findPaginated(FeedbackQuery(team = "local-dev"))
+            total shouldBe 0
+        }
+    }
+
+    test("should accept explicit deduplicationKey null as absent") {
+        val repository = FeedbackRepository()
+
+        testApplication {
+            application { testModule() }
+            val client = createTestClient()
+
+            val payload = """
+                {
+                  "schemaVersion": 1,
+                  "surveyId": "dp-feedback",
+                  "surveyType": "rating",
+                  "submittedAt": "2026-01-10T12:00:12Z",
+                  "deduplicationKey": null,
+                  "answers": [
+                    {
+                      "fieldId": "feedback",
+                      "fieldType": "TEXT",
+                      "question": { "label": "Hvorfor?" },
+                      "value": { "type": "text", "text": "Lik payload" }
+                    }
+                  ]
+                }
+            """.trimIndent()
+
+            val firstResponse = client.post("/api/tokenx/v1/feedback") {
+                contentType(ContentType.Application.Json)
+                setBody(payload)
+            }
+
+            val secondResponse = client.post("/api/tokenx/v1/feedback") {
+                contentType(ContentType.Application.Json)
+                setBody(payload.replace("12:00:12Z", "12:01:12Z"))
+            }
+
+            firstResponse.status shouldBe HttpStatusCode.Created
+            secondResponse.status shouldBe HttpStatusCode.Created
+
+            val firstId = Json.parseToJsonElement(firstResponse.bodyAsText()).jsonObject["id"]?.jsonPrimitive?.content!!
+            val secondId = Json.parseToJsonElement(secondResponse.bodyAsText()).jsonObject["id"]?.jsonPrimitive?.content!!
+            (firstId == secondId) shouldBe false
+
+            repository.findRawById(firstId, "local-dev")?.feedbackJson shouldNotContain "deduplicationKey"
+            repository.findRawById(secondId, "local-dev")?.feedbackJson shouldNotContain "deduplicationKey"
+        }
+    }
+
+    test("should treat same deduplicationKey on different surveyIds as separate submissions") {
+        val repository = FeedbackRepository()
+
+        testApplication {
+            application { testModule() }
+            val client = createTestClient()
+
+            val firstResponse = client.post("/api/tokenx/v1/feedback") {
+                contentType(ContentType.Application.Json)
+                setBody(submissionPayloadWithDedup("client-key-123456"))
+            }
+
+            val secondResponse = client.post("/api/tokenx/v1/feedback") {
+                contentType(ContentType.Application.Json)
+                setBody(submissionPayloadWithDedup("client-key-123456").replace("\"dp-feedback\"", "\"dp-feedback-2\""))
+            }
+
+            firstResponse.status shouldBe HttpStatusCode.Created
+            secondResponse.status shouldBe HttpStatusCode.Created
+
+            val (_, total, _) = repository.findPaginated(FeedbackQuery(team = "local-dev"))
+            total shouldBe 2
+        }
+    }
+
+    test("should handle concurrent duplicate submissions without 500 and persist one row") {
+        val repository = FeedbackRepository()
+
+        testApplication {
+            application { testModule() }
+            val client = createTestClient()
+
+            val responses = coroutineScope {
+                (1..4).map { index ->
+                    async(Dispatchers.Default) {
+                        client.post("/api/tokenx/v1/feedback") {
+                            contentType(ContentType.Application.Json)
+                            setBody(
+                                submissionPayloadWithDedup(
+                                    deduplicationKey = "client-key-123456",
+                                    submittedAt = "2026-01-10T12:0${index}:12Z",
+                                    text = "payload-$index"
+                                )
+                            )
+                        }
+                    }
+                }.awaitAll()
+            }
+
+            responses.count { it.status == HttpStatusCode.Created } shouldBe 1
+            responses.count { it.status == HttpStatusCode.OK } shouldBe 3
+
+            val ids = responses.map { response ->
+                Json.parseToJsonElement(response.bodyAsText()).jsonObject["id"]?.jsonPrimitive?.content
+            }.toSet()
+            ids.size shouldBe 1
+
+            val duplicateFlags = responses
+                .filter { it.status == HttpStatusCode.OK }
+                .map { Json.parseToJsonElement(it.bodyAsText()).jsonObject["duplicate"]?.jsonPrimitive?.boolean }
+            duplicateFlags.all { it == true } shouldBe true
+
+            val (_, total, _) = repository.findPaginated(FeedbackQuery(team = "local-dev"))
+            total shouldBe 1
+        }
+    }
+
+    test("should return duplicate instead of 409 for concurrent conflicting definition with same deduplicationKey") {
+        val feedbackRepository = FeedbackRepository()
+        val surveyDefinitionRepository = SurveyDefinitionRepository()
+        val feedbackService = FeedbackService(feedbackRepository)
+        val surveyDefinitionService = SurveyDefinitionService(surveyDefinitionRepository)
+        val lockAcquired = CompletableDeferred<Unit>()
+        val releaseFirstRequest = CompletableDeferred<Unit>()
+        val lockInvocationCount = AtomicInteger(0)
+        val submissionService = SubmissionService(
+            feedbackService = feedbackService,
+            surveyDefinitionService = surveyDefinitionService,
+            feedbackRepository = feedbackRepository,
+            afterScopedDeduplicationLockAcquired = {
+                if (lockInvocationCount.incrementAndGet() == 1) {
+                    lockAcquired.complete(Unit)
+                    releaseFirstRequest.await()
+                }
+            }
+        )
+
+        testApplication {
+            application {
+                configureSerialization()
+                configureStatusPages()
+                configureRateLimiting()
+                routing {
+                    submissionRoutes(
+                        feedbackService = feedbackService,
+                        surveyDefinitionService = surveyDefinitionService,
+                        submissionService = submissionService
+                    )
+                }
+            }
+            val client = createTestClient()
+
+            val responses = coroutineScope {
+                val first = async(Dispatchers.Default) {
+                    client.post("/api/tokenx/v1/feedback") {
+                        contentType(ContentType.Application.Json)
+                        setBody(
+                            """
+                            {
+                              "schemaVersion": 1,
+                              "surveyId": "dedup-race-conflict-survey",
+                              "surveyType": "topTasks",
+                              "submittedAt": "2026-01-10T12:00:12Z",
+                              "deduplicationKey": "client-key-123456",
+                              "answers": [
+                                {
+                                  "fieldId": "task",
+                                  "fieldType": "SINGLE_CHOICE",
+                                  "question": {
+                                    "label": "Hva gjorde du?",
+                                    "options": [{ "id": "apply", "label": "Søknad" }]
+                                  },
+                                  "value": { "type": "singleChoice", "selectedOptionId": "apply" }
+                                }
+                              ]
+                            }
+                            """.trimIndent()
+                        )
+                    }
+                }
+                lockAcquired.await()
+                val second = async(Dispatchers.Default) {
+                    client.post("/api/tokenx/v1/feedback") {
+                        contentType(ContentType.Application.Json)
+                        setBody(
+                            """
+                            {
+                              "schemaVersion": 1,
+                              "surveyId": "dedup-race-conflict-survey",
+                              "surveyType": "topTasks",
+                              "submittedAt": "2026-01-10T12:01:12Z",
+                              "deduplicationKey": "client-key-123456",
+                              "answers": [
+                                {
+                                  "fieldId": "task",
+                                  "fieldType": "SINGLE_CHOICE",
+                                  "question": {
+                                    "label": "Hva gjorde du?",
+                                    "options": [
+                                      { "id": "apply", "label": "Søknad" },
+                                      { "id": "follow-up", "label": "Oppfølging" }
+                                    ]
+                                  },
+                                  "value": { "type": "singleChoice", "selectedOptionId": "apply" }
+                                }
+                              ]
+                            }
+                            """.trimIndent()
+                        )
+                    }
+                }
+                releaseFirstRequest.complete(Unit)
+                awaitAll(first, second)
+            }
+
+            responses.count { it.status == HttpStatusCode.Created } shouldBe 1
+            responses.count { it.status == HttpStatusCode.OK } shouldBe 1
+            responses.any { it.status == HttpStatusCode.Conflict } shouldBe false
+
+            val createdId = Json.parseToJsonElement(
+                responses.single { it.status == HttpStatusCode.Created }.bodyAsText()
+            ).jsonObject["id"]?.jsonPrimitive?.content!!
+            val duplicateBody = Json.parseToJsonElement(
+                responses.single { it.status == HttpStatusCode.OK }.bodyAsText()
+            ).jsonObject
+            duplicateBody["id"]?.jsonPrimitive?.content shouldBe createdId
+            duplicateBody["duplicate"]?.jsonPrimitive?.boolean shouldBe true
+
+            val stored = surveyDefinitionRepository.findByTeamAndSurveyId("local-dev", "dedup-race-conflict-survey")!!
+            stored.definition.fields.single().optionIds shouldBe listOf("apply")
+
+            val (_, total, _) = feedbackRepository.findPaginated(FeedbackQuery(team = "local-dev"))
+            total shouldBe 1
+        }
+    }
+
+    test("should not mutate survey definition for concurrent duplicate extension with same deduplicationKey") {
+        val feedbackRepository = FeedbackRepository()
+        val surveyDefinitionRepository = SurveyDefinitionRepository()
+        val feedbackService = FeedbackService(feedbackRepository)
+        val surveyDefinitionService = SurveyDefinitionService(surveyDefinitionRepository)
+        val lockAcquired = CompletableDeferred<Unit>()
+        val releaseFirstRequest = CompletableDeferred<Unit>()
+        val lockInvocationCount = AtomicInteger(0)
+        val submissionService = SubmissionService(
+            feedbackService = feedbackService,
+            surveyDefinitionService = surveyDefinitionService,
+            feedbackRepository = feedbackRepository,
+            afterScopedDeduplicationLockAcquired = {
+                if (lockInvocationCount.incrementAndGet() == 1) {
+                    lockAcquired.complete(Unit)
+                    releaseFirstRequest.await()
+                }
+            }
+        )
+
+        testApplication {
+            application {
+                configureSerialization()
+                configureStatusPages()
+                configureRateLimiting()
+                routing {
+                    submissionRoutes(
+                        feedbackService = feedbackService,
+                        surveyDefinitionService = surveyDefinitionService,
+                        submissionService = submissionService
+                    )
+                }
+            }
+            val client = createTestClient()
+
+            val responses = coroutineScope {
+                val first = async(Dispatchers.Default) {
+                    client.post("/api/tokenx/v1/feedback") {
+                        contentType(ContentType.Application.Json)
+                        setBody(
+                            """
+                            {
+                              "schemaVersion": 1,
+                              "surveyId": "dedup-race-extension-survey",
+                              "surveyType": "rating",
+                              "submittedAt": "2026-01-10T12:00:12Z",
+                              "deduplicationKey": "client-key-123456",
+                              "answers": [
+                                {
+                                  "fieldId": "feedback",
+                                  "fieldType": "TEXT",
+                                  "question": { "label": "Hvorfor?" },
+                                  "value": { "type": "text", "text": "Første payload" }
+                                }
+                              ]
+                            }
+                            """.trimIndent()
+                        )
+                    }
+                }
+                lockAcquired.await()
+                val second = async(Dispatchers.Default) {
+                    client.post("/api/tokenx/v1/feedback") {
+                        contentType(ContentType.Application.Json)
+                        setBody(
+                            """
+                            {
+                              "schemaVersion": 1,
+                              "surveyId": "dedup-race-extension-survey",
+                              "surveyType": "rating",
+                              "submittedAt": "2026-01-10T12:01:12Z",
+                              "deduplicationKey": "client-key-123456",
+                              "answers": [
+                                {
+                                  "fieldId": "feedback",
+                                  "fieldType": "TEXT",
+                                  "question": { "label": "Hvorfor?" },
+                                  "value": { "type": "text", "text": "Andre payload" }
+                                },
+                                {
+                                  "fieldId": "followup",
+                                  "fieldType": "TEXT",
+                                  "question": { "label": "Hva kunne vært bedre?" },
+                                  "value": { "type": "text", "text": "Mer hjelp" }
+                                }
+                              ]
+                            }
+                            """.trimIndent()
+                        )
+                    }
+                }
+                releaseFirstRequest.complete(Unit)
+                awaitAll(first, second)
+            }
+
+            responses.count { it.status == HttpStatusCode.Created } shouldBe 1
+            responses.count { it.status == HttpStatusCode.OK } shouldBe 1
+
+            val createdId = Json.parseToJsonElement(
+                responses.single { it.status == HttpStatusCode.Created }.bodyAsText()
+            ).jsonObject["id"]?.jsonPrimitive?.content!!
+            val duplicateBody = Json.parseToJsonElement(
+                responses.single { it.status == HttpStatusCode.OK }.bodyAsText()
+            ).jsonObject
+            duplicateBody["id"]?.jsonPrimitive?.content shouldBe createdId
+            duplicateBody["duplicate"]?.jsonPrimitive?.boolean shouldBe true
+
+            val stored = surveyDefinitionRepository.findByTeamAndSurveyId("local-dev", "dedup-race-extension-survey")!!
+            stored.definition.fields.map { it.fieldId } shouldBe listOf("feedback")
+
+            val saved = feedbackRepository.findRawById(createdId, "local-dev")
+            saved?.feedbackJson?.contains("Første payload") shouldBe true
+            saved?.feedbackJson?.contains("Andre payload") shouldBe false
+            saved?.feedbackJson?.contains("followup") shouldBe false
+
+            val (_, total, _) = feedbackRepository.findPaginated(FeedbackQuery(team = "local-dev"))
+            total shouldBe 1
         }
     }
 })

--- a/apps/lumi-api/src/test/kotlin/no/nav/lumi/service/FeedbackServiceTest.kt
+++ b/apps/lumi-api/src/test/kotlin/no/nav/lumi/service/FeedbackServiceTest.kt
@@ -13,10 +13,17 @@ import kotlinx.serialization.json.jsonPrimitive
 import no.nav.lumi.TestDatabase
 import no.nav.lumi.config.DatabaseHolder
 import no.nav.lumi.config.exception.ApiErrorException
+import no.nav.lumi.domain.SaveResult
 import no.nav.lumi.insertTestFeedback
 import no.nav.lumi.insertTestFeedbackWithJson
 import no.nav.lumi.repository.FeedbackRepository
+import no.nav.lumi.service.computeDeduplicationKeyHash
 import java.util.UUID
+
+private fun SaveResult.createdId(): String = when (this) {
+    is SaveResult.Created -> id
+    is SaveResult.Duplicate -> error("Expected created save result, got duplicate")
+}
 
 class FeedbackServiceTest : FunSpec({
 
@@ -48,7 +55,7 @@ class FeedbackServiceTest : FunSpec({
                 }
             """.trimIndent()
             
-            val id = service.save(feedbackJson, "flex", "test-app")
+            val id = service.save(feedbackJson, "flex", "test-app").createdId()
             
             val saved = repository.findRawById(id, "flex").shouldNotBeNull()
             saved.feedbackJson shouldNotContain "01020349294"
@@ -86,7 +93,7 @@ class FeedbackServiceTest : FunSpec({
                 }
             """.trimIndent()
 
-            val id = service.save(feedbackJson, "flex", "test-app")
+            val id = service.save(feedbackJson, "flex", "test-app").createdId()
             val saved = repository.findRawById(id, "flex").shouldNotBeNull()
 
             saved.feedbackJson shouldContain "Hei <b>team</b>"
@@ -107,7 +114,7 @@ class FeedbackServiceTest : FunSpec({
                 }
             """.trimIndent()
 
-            val id = service.save(feedbackJson, "flex", "test-app")
+            val id = service.save(feedbackJson, "flex", "test-app").createdId()
             val saved = repository.findRawById(id, "flex").shouldNotBeNull()
 
             saved.feedbackJson shouldNotContain "01020349294"
@@ -127,7 +134,7 @@ class FeedbackServiceTest : FunSpec({
                 }
             """.trimIndent()
 
-            val id = service.save(feedbackJson, "flex", "test-app")
+            val id = service.save(feedbackJson, "flex", "test-app").createdId()
             val saved = repository.findRawById(id, "flex").shouldNotBeNull()
             saved.feedbackJson shouldNotContain "01020349294"
             saved.feedbackJson shouldContain "%5BF%C3%98DSELSNUMMER%20FJERNET%5D"
@@ -146,7 +153,7 @@ class FeedbackServiceTest : FunSpec({
                 }
             """.trimIndent()
 
-            val id = service.save(feedbackJson, "flex", "test-app")
+            val id = service.save(feedbackJson, "flex", "test-app").createdId()
             val saved = repository.findRawById(id, "flex").shouldNotBeNull()
             saved.feedbackJson shouldNotContain "01020349294"
             saved.feedbackJson shouldContain "[FØDSELSNUMMER FJERNET]"
@@ -169,7 +176,7 @@ class FeedbackServiceTest : FunSpec({
                 }
             """.trimIndent()
 
-            val id = service.save(feedbackJson, "flex", "test-app")
+            val id = service.save(feedbackJson, "flex", "test-app").createdId()
             val saved = repository.findRawById(id, "flex").shouldNotBeNull()
             saved.feedbackJson shouldNotContain "01020349294"
             saved.feedbackJson shouldContain "REDACTED_KEY"
@@ -192,7 +199,7 @@ class FeedbackServiceTest : FunSpec({
                 }
             """.trimIndent()
 
-            val id = service.save(feedbackJson, "flex", "test-app")
+            val id = service.save(feedbackJson, "flex", "test-app").createdId()
             val saved = repository.findRawById(id, "flex").shouldNotBeNull()
             saved.feedbackJson shouldNotContain "98765432"
             saved.feedbackJson shouldContain "[TELEFON FJERNET]"
@@ -217,7 +224,7 @@ class FeedbackServiceTest : FunSpec({
                 }
             """.trimIndent()
 
-            val id = service.save(feedbackJson, "flex", "test-app")
+            val id = service.save(feedbackJson, "flex", "test-app").createdId()
             val saved = repository.findRawById(id, "flex").shouldNotBeNull()
 
             val savedJson = Json.parseToJsonElement(saved.feedbackJson).jsonObject
@@ -237,7 +244,7 @@ class FeedbackServiceTest : FunSpec({
                 }
             """.trimIndent()
 
-            val id = service.save(feedbackJson, "flex", "test-app")
+            val id = service.save(feedbackJson, "flex", "test-app").createdId()
             val saved = repository.findRawById(id, "flex").shouldNotBeNull()
             saved.feedbackJson shouldNotContain "01020349294"
             saved.feedbackJson shouldContain "[FØDSELSNUMMER FJERNET]"
@@ -256,7 +263,7 @@ class FeedbackServiceTest : FunSpec({
                 }
             """.trimIndent()
 
-            val id = service.save(feedbackJson, "flex", "test-app")
+            val id = service.save(feedbackJson, "flex", "test-app").createdId()
             val saved = repository.findRawById(id, "flex").shouldNotBeNull()
             saved.feedbackJson shouldNotContain "01020349294"
             saved.feedbackJson shouldContain "[FØDSELSNUMMER FJERNET]"
@@ -275,7 +282,7 @@ class FeedbackServiceTest : FunSpec({
                 }
             """.trimIndent()
 
-            val id = service.save(feedbackJson, "flex", "test-app")
+            val id = service.save(feedbackJson, "flex", "test-app").createdId()
             val saved = repository.findRawById(id, "flex").shouldNotBeNull()
             val savedJson = Json.parseToJsonElement(saved.feedbackJson).jsonObject
             val tags = savedJson["context"]?.jsonObject?.get("tags")?.jsonObject
@@ -299,7 +306,7 @@ class FeedbackServiceTest : FunSpec({
                 }
             """.trimIndent()
 
-            val id = service.save(feedbackJson, "flex", "test-app")
+            val id = service.save(feedbackJson, "flex", "test-app").createdId()
             val saved = repository.findRawById(id, "flex").shouldNotBeNull()
             val savedJson = Json.parseToJsonElement(saved.feedbackJson).jsonObject
             val tags = savedJson["context"]?.jsonObject?.get("tags")?.jsonObject
@@ -325,6 +332,280 @@ class FeedbackServiceTest : FunSpec({
             }
 
             exception.message shouldBe "Failed to redact feedback JSON"
+        }
+
+        test("computes scoped deduplication hash with length-prefixed sha-256") {
+            computeDeduplicationKeyHash(
+                team = "flex",
+                surveyId = "survey-123",
+                deduplicationKey = "dedup-key-123456"
+            ) shouldBe "1eea9655aab33d16947b8a6c4a2abbf641df30ebcc38c453ec6b2b835e5d9e02"
+        }
+
+        test("strips deduplicationKey before persistence and returns duplicate for same team survey and key") {
+            val firstPayload = """
+                {
+                    "schemaVersion": 1,
+                    "surveyId": "survey-dedup",
+                    "surveyType": "rating",
+                    "submittedAt": "2026-01-10T12:00:12Z",
+                    "deduplicationKey": "client-key-123456",
+                    "answers": [
+                        {
+                            "fieldId": "feedback",
+                            "fieldType": "TEXT",
+                            "question": { "label": "Hvorfor?" },
+                            "value": { "type": "text", "text": "Første payload" }
+                        }
+                    ]
+                }
+            """.trimIndent()
+            val secondPayload = """
+                {
+                    "schemaVersion": 1,
+                    "surveyId": "survey-dedup",
+                    "surveyType": "rating",
+                    "submittedAt": "2026-01-10T12:01:12Z",
+                    "deduplicationKey": "client-key-123456",
+                    "answers": [
+                        {
+                            "fieldId": "feedback",
+                            "fieldType": "TEXT",
+                            "question": { "label": "Hvorfor?" },
+                            "value": { "type": "text", "text": "Andre payload" }
+                        }
+                    ]
+                }
+            """.trimIndent()
+
+            val firstId = service.save(
+                feedbackJson = firstPayload,
+                team = "flex",
+                app = "test-app",
+                surveyId = "survey-dedup",
+                definitionHash = "a".repeat(64)
+            ).createdId()
+
+            val second = service.save(
+                feedbackJson = secondPayload,
+                team = "flex",
+                app = "test-app",
+                surveyId = "survey-dedup",
+                definitionHash = "a".repeat(64)
+            )
+
+            second shouldBe SaveResult.Duplicate(firstId)
+
+            val saved = repository.findRawById(firstId, "flex").shouldNotBeNull()
+            saved.feedbackJson shouldNotContain "deduplicationKey"
+            saved.feedbackJson shouldContain "Første payload"
+            saved.feedbackJson shouldNotContain "Andre payload"
+        }
+
+        test("uses provided surveyId for dedup scope when payload surveyId differs") {
+            val payload = """
+                {
+                    "schemaVersion": 1,
+                    "surveyId": "payload-survey",
+                    "surveyType": "rating",
+                    "submittedAt": "2026-01-10T12:00:12Z",
+                    "deduplicationKey": "client-key-123456",
+                    "answers": [
+                        {
+                            "fieldId": "feedback",
+                            "fieldType": "TEXT",
+                            "question": { "label": "Hvorfor?" },
+                            "value": { "type": "text", "text": "Payload" }
+                        }
+                    ]
+                }
+            """.trimIndent()
+
+            val first = service.save(
+                feedbackJson = payload,
+                team = "flex",
+                app = "test-app",
+                surveyId = "service-scope-a",
+                definitionHash = "a".repeat(64)
+            ).createdId()
+
+            val second = service.save(
+                feedbackJson = payload.replace("12:00:12Z", "12:01:12Z"),
+                team = "flex",
+                app = "test-app",
+                surveyId = "service-scope-b",
+                definitionHash = "a".repeat(64)
+            ).createdId()
+
+            (first == second) shouldBe false
+
+            val firstSaved = repository.findRawById(first, "flex").shouldNotBeNull()
+            val secondSaved = repository.findRawById(second, "flex").shouldNotBeNull()
+            firstSaved.feedbackJson shouldNotContain "deduplicationKey"
+            secondSaved.feedbackJson shouldNotContain "deduplicationKey"
+
+            val (_, total, _) = repository.findPaginated(no.nav.lumi.domain.FeedbackQuery(team = "flex"))
+            total shouldBe 2
+        }
+
+        test("fails closed when malformed json contains deduplicationKey and persists nothing") {
+            val malformedPayload = """
+                {
+                    "schemaVersion": 1,
+                    "surveyId": "survey-dedup",
+                    "surveyType": "rating",
+                    "deduplicationKey": "client-key-123456",
+                    "answers": [
+                }
+            """.trimIndent()
+
+            val exception = shouldThrow<ApiErrorException.InternalServerErrorException> {
+                service.save(
+                    feedbackJson = malformedPayload,
+                    team = "flex",
+                    app = "test-app",
+                    surveyId = "survey-dedup",
+                    definitionHash = "a".repeat(64)
+                )
+            }
+
+            exception.message shouldBe "Failed to redact feedback JSON"
+            exception.cause shouldBe null
+            val (_, total, _) = repository.findPaginated(no.nav.lumi.domain.FeedbackQuery(team = "flex"))
+            total shouldBe 0
+        }
+
+        test("treats explicit deduplicationKey null as absent and does not persist the raw field") {
+            val payload = """
+                {
+                    "schemaVersion": 1,
+                    "surveyId": "survey-dedup",
+                    "surveyType": "rating",
+                    "submittedAt": "2026-01-10T12:00:12Z",
+                    "deduplicationKey": null,
+                    "answers": [
+                        {
+                            "fieldId": "feedback",
+                            "fieldType": "TEXT",
+                            "question": { "label": "Hvorfor?" },
+                            "value": { "type": "text", "text": "Payload" }
+                        }
+                    ]
+                }
+            """.trimIndent()
+
+            val firstId = service.save(
+                feedbackJson = payload,
+                team = "flex",
+                app = "test-app",
+                surveyId = "survey-dedup",
+                definitionHash = "a".repeat(64)
+            ).createdId()
+
+            val secondId = service.save(
+                feedbackJson = payload.replace("12:00:12Z", "12:01:12Z"),
+                team = "flex",
+                app = "test-app",
+                surveyId = "survey-dedup",
+                definitionHash = "a".repeat(64)
+            ).createdId()
+
+            (firstId == secondId) shouldBe false
+
+            val firstSaved = repository.findRawById(firstId, "flex").shouldNotBeNull()
+            val secondSaved = repository.findRawById(secondId, "flex").shouldNotBeNull()
+            firstSaved.feedbackJson shouldNotContain "deduplicationKey"
+            secondSaved.feedbackJson shouldNotContain "deduplicationKey"
+        }
+
+        test("rejects invalid deduplicationKey format at service boundary without echoing raw value") {
+            val payload = """
+                {
+                    "schemaVersion": 1,
+                    "surveyId": "survey-dedup",
+                    "surveyType": "rating",
+                    "submittedAt": "2026-01-10T12:00:12Z",
+                    "deduplicationKey": "bad key with spaces",
+                    "answers": []
+                }
+            """.trimIndent()
+
+            val exception = shouldThrow<ApiErrorException.BadRequestException> {
+                service.save(
+                    feedbackJson = payload,
+                    team = "flex",
+                    app = "test-app",
+                    surveyId = "survey-dedup",
+                    definitionHash = "a".repeat(64)
+                )
+            }
+
+            exception.message shouldContain "deduplicationKey"
+            exception.message shouldNotContain "bad key with spaces"
+        }
+
+        test("rejects deduplicationKey when surveyId is missing and persists nothing") {
+            val payload = """
+                {
+                    "schemaVersion": 1,
+                    "surveyType": "rating",
+                    "submittedAt": "2026-01-10T12:00:12Z",
+                    "deduplicationKey": "client-key-123456",
+                    "answers": []
+                }
+            """.trimIndent()
+
+            val exception = shouldThrow<ApiErrorException.BadRequestException> {
+                service.save(
+                    feedbackJson = payload,
+                    team = "flex",
+                    app = "test-app"
+                )
+            }
+
+            exception.message shouldBe "Invalid payload: deduplicationKey requires surveyId"
+            val (_, total, _) = repository.findPaginated(no.nav.lumi.domain.FeedbackQuery(team = "flex"))
+            total shouldBe 0
+        }
+
+        test("finds existing duplicate submission id before definition handling") {
+            val payload = """
+                {
+                    "schemaVersion": 1,
+                    "surveyId": "survey-dedup",
+                    "surveyType": "rating",
+                    "submittedAt": "2026-01-10T12:00:12Z",
+                    "deduplicationKey": "client-key-123456",
+                    "answers": []
+                }
+            """.trimIndent()
+
+            val id = service.save(
+                feedbackJson = payload,
+                team = "flex",
+                app = "test-app",
+                surveyId = "survey-dedup",
+                definitionHash = "a".repeat(64)
+            ).createdId()
+
+            service.findDuplicateSubmissionId(
+                team = "flex",
+                surveyId = "survey-dedup",
+                deduplicationKey = "client-key-123456"
+            ) shouldBe id
+        }
+
+        test("findDuplicateSubmissionId rejects invalid deduplicationKey without echoing raw value") {
+            val exception = shouldThrow<ApiErrorException.BadRequestException> {
+                service.findDuplicateSubmissionId(
+                    team = "flex",
+                    surveyId = "survey-dedup",
+                    deduplicationKey = "bad key with spaces"
+                )
+            }
+
+            exception.message shouldContain "deduplicationKey"
+            exception.message shouldNotContain "bad key with spaces"
         }
     }
 

--- a/apps/lumi-api/src/test/kotlin/no/nav/lumi/service/FeedbackServiceTest.kt
+++ b/apps/lumi-api/src/test/kotlin/no/nav/lumi/service/FeedbackServiceTest.kt
@@ -14,16 +14,12 @@ import no.nav.lumi.TestDatabase
 import no.nav.lumi.config.DatabaseHolder
 import no.nav.lumi.config.exception.ApiErrorException
 import no.nav.lumi.domain.SaveResult
+import no.nav.lumi.createdId
 import no.nav.lumi.insertTestFeedback
 import no.nav.lumi.insertTestFeedbackWithJson
 import no.nav.lumi.repository.FeedbackRepository
 import no.nav.lumi.service.computeDeduplicationKeyHash
 import java.util.UUID
-
-private fun SaveResult.createdId(): String = when (this) {
-    is SaveResult.Created -> id
-    is SaveResult.Duplicate -> error("Expected created save result, got duplicate")
-}
 
 class FeedbackServiceTest : FunSpec({
 


### PR DESCRIPTION
## Beskrivelse

Implementerer backend-deduplisering av feedback-innsendinger for å hindre duplikater fra browser-retries og nettverksfeil.

Deduplisering er scoped til `team + surveyId + deduplicationKey`. Første innsending lagres som før, mens senere innsendinger med samme scoped nøkkel returnerer eksisterende id med `duplicate: true` uten å opprette ny rad.

## Endringer

- `FeedbackSubmissionV1`: legger til valgfri `deduplicationKey`
- `FeedbackService` / `DeduplicationHash`: validerer, hasher og stripper rå deduplicationKey før persistering
- `SubmissionService`: felles submit-orchestrering for ekstern og intern rute
- `FeedbackRepository`: lookup/save med `SaveResult.Created` / `SaveResult.Duplicate` og scoped advisory lock for concurrent duplicates
- `SurveyDefinitionService` / `SurveyDefinitionRepository`: transaksjonsvennlige varianter for race-safe dedup-before-definition
- `SubmissionRoutes` / `InternalSubmissionRoutes`: `201 Created` for ny innsending og `200 OK` med `duplicate: true` for duplicate
- Tester: omfattende service-, repository- og route-/integrasjonstester for duplicate, race, sikker stripping, malformed JSON, no-key path og survey-definition-interaksjon

## Viktige kontrakter og avklaringer

- Duplicate/idempotency gjelder etter at requesten er en gyldig V1-payload. Ugyldig payload kan fortsatt gi `400`, selv med eksisterende deduplicationKey.
- For gyldige requests vinner duplicate/idempotency før survey-definition-sideeffekter, også under concurrency.
- Rå `deduplicationKey` lagres ikke i `feedback_json`, logges ikke og returneres ikke.
- Klienter må ikke begynne å sende `deduplicationKey` før backend-rollout er ferdig. Shared TS-/widget-kontrakter følger i #275.

## Issue

Closes #274
Del av epic: #270

## Verifisering

- [x] `pnpm run api:test`
- [x] `pnpm run lint`
- [x] `pnpm run typecheck`
- [x] Målrettede route/service/repository-tester for deduplisering og race-scenarioer
- [x] Dobbel inspeksjon
- [x] Grill/stress-test etter inspeksjon

## Sjekkliste

- [x] Koden kompilerer og linter uten feil
- [x] Endringene er testet (manuelt eller automatisk)
- [x] Ingen sensitiv data eksponert (tokens, credentials, PII)
