### PR TITLE
feat(submission): support schema v2 survey definitions

### DIFF
--- a/.github/skills/lumi-survey/SKILL.md
+++ b/.github/skills/lumi-survey/SKILL.md
@@ -1,11 +1,22 @@
 ---
 name: lumi-survey
-description: Integrer @navikt/lumi-survey tilbakemeldingswidget i en Nav-frontendapplikasjon
+description: Integrer og konfigurer @navikt/lumi-survey med survey-design, v2-payload, transport, auth, NAIS accessPolicy og validering. Brukes når en agent skal lage, endre eller feilsøke Lumi Survey-widgeter, surveyId-strategi, feedback-endepunkt eller tilhørende NAIS-oppsett i en Nav-app.
 ---
 
 # Lumi Survey-integrasjon
 
 Legg til en Lumi Survey-widget i applikasjonen din. Dekker installasjon, survey-konfigurasjon, backend-transportendepunkt og NAIS-oppsett.
+
+## Agent-defaults
+
+- Bruk alltid ny widget-kontrakt: `submission.transportPayload` sender `schemaVersion: 2`, `definition` og `deduplicationKey`.
+- Utvikleren skal ikke fylle ut `deduplicationKey` eller `definition`; widgeten lager dette.
+- Bruk ny `surveyId` når spørsmål legges til, fjernes, får nytt navn eller endrer type/options. Eksempel: `min-flate-feedback-v2`.
+- Backend/BFF skal videresende payloaden uten å endre JSON-strukturen. Ikke bygg egen payload hvis du kan sende `submission.transportPayload`.
+- `deduplicationKey` brukes bare for nytt forsøk etter transportfeil. Etter vellykket innsending eller reset får neste innsending ny nøkkel.
+- `localStorage`/consent-storage styrer kun UX-state (vist/lukket/sendt), ikke deduplication.
+- Ikke legg PII i `context.tags`, `context.debug`, `surveyId`, `fieldId` eller option values.
+- Lag survey-konfig med stabile, maskinvennlige `id`/`value`-er: bokstaver/tall/`_`/`-`, maks 200 tegn. Ikke bruk punktum, slash, mellomrom eller brukerdata i id-er.
 
 ## Fase 1: Kartlegging
 
@@ -332,6 +343,8 @@ import { survey } from "./survey";
 
 Velg en unik `surveyId` — bruk appnavnet som prefiks (f.eks. `"sykepengesoknad-feedback"`, `"modia-satisfaction"`). Denne ID-en identifiserer surveyen i Lumi-dashboardet.
 
+Når du endrer survey-strukturen senere, skal du lage ny `surveyId`. Gjelder også når du legger til nye spørsmål.
+
 ### 4d. Valgfritt: Kontekst-tags for segmentering
 
 Send med metadata for å muliggjøre filtrering i Lumi-dashboardet:
@@ -387,6 +400,7 @@ Etter implementasjon, verifiser hele flyten:
 - [ ] Aksel v8+ bekreftet (`@navikt/ds-react` ≥ 8.0.0)
 - [ ] `LumiSurveyDock` rendres i appen med en unik `surveyId`
 - [ ] Survey-konfigurasjon bruker `satisfies LumiSurveyConfig`
+- [ ] Spørsmåls-ID-er og option values er stabile og uten PII
 - [ ] Transport sin `submit`-funksjon kaller ditt backend-endepunkt
 - [ ] Backend-endepunkt utveksler token og videresender til Lumi API via `LUMI_FEEDBACK_PATH`
 - [ ] NAIS-manifest har `LUMI_API_HOST`, `LUMI_AUDIENCE`, `LUMI_FEEDBACK_PATH` og `accessPolicy`
@@ -395,6 +409,8 @@ Etter implementasjon, verifiser hele flyten:
 - [ ] Ingen personopplysninger i kontekst-tags
 - [ ] Lagringsstrategi matcher app-type (consent for offentlige, localStorage for interne)
 - [ ] Surveyen dukker opp i riktig Lumi-dashboard etter testinnsending (dev: https://lumi-dashboard.ansatt.dev.nav.no, prod: https://lumi-dashboard.ansatt.nav.no/)
+- [ ] Feilet transport + nytt forsøk gir ikke duplikat
+- [ ] Ny `surveyId` brukes hvis survey-strukturen er endret
 
 ## Hurtigstart: Forhåndsdefinerte surveys
 

--- a/.github/skills/lumi-survey/SKILL.md
+++ b/.github/skills/lumi-survey/SKILL.md
@@ -1,22 +1,11 @@
 ---
 name: lumi-survey
-description: Integrer og konfigurer @navikt/lumi-survey med survey-design, v2-payload, transport, auth, NAIS accessPolicy og validering. Brukes når en agent skal lage, endre eller feilsøke Lumi Survey-widgeter, surveyId-strategi, feedback-endepunkt eller tilhørende NAIS-oppsett i en Nav-app.
+description: Integrer @navikt/lumi-survey tilbakemeldingswidget i en Nav-frontendapplikasjon
 ---
 
 # Lumi Survey-integrasjon
 
 Legg til en Lumi Survey-widget i applikasjonen din. Dekker installasjon, survey-konfigurasjon, backend-transportendepunkt og NAIS-oppsett.
-
-## Agent-defaults
-
-- Bruk alltid ny widget-kontrakt: `submission.transportPayload` sender `schemaVersion: 2`, `definition` og `deduplicationKey`.
-- Utvikleren skal ikke fylle ut `deduplicationKey` eller `definition`; widgeten lager dette.
-- Bruk ny `surveyId` når spørsmål legges til, fjernes, får nytt navn eller endrer type/options. Eksempel: `min-flate-feedback-v2`.
-- Backend/BFF skal videresende payloaden uten å endre JSON-strukturen. Ikke bygg egen payload hvis du kan sende `submission.transportPayload`.
-- `deduplicationKey` brukes bare for nytt forsøk etter transportfeil. Etter vellykket innsending eller reset får neste innsending ny nøkkel.
-- `localStorage`/consent-storage styrer kun UX-state (vist/lukket/sendt), ikke deduplication.
-- Ikke legg PII i `context.tags`, `context.debug`, `surveyId`, `fieldId` eller option values.
-- Lag survey-konfig med stabile, maskinvennlige `id`/`value`-er: bokstaver/tall/`_`/`-`, maks 200 tegn. Ikke bruk punktum, slash, mellomrom eller brukerdata i id-er.
 
 ## Fase 1: Kartlegging
 
@@ -343,8 +332,6 @@ import { survey } from "./survey";
 
 Velg en unik `surveyId` — bruk appnavnet som prefiks (f.eks. `"sykepengesoknad-feedback"`, `"modia-satisfaction"`). Denne ID-en identifiserer surveyen i Lumi-dashboardet.
 
-Når du endrer survey-strukturen senere, skal du lage ny `surveyId`. Gjelder også når du legger til nye spørsmål.
-
 ### 4d. Valgfritt: Kontekst-tags for segmentering
 
 Send med metadata for å muliggjøre filtrering i Lumi-dashboardet:
@@ -400,7 +387,6 @@ Etter implementasjon, verifiser hele flyten:
 - [ ] Aksel v8+ bekreftet (`@navikt/ds-react` ≥ 8.0.0)
 - [ ] `LumiSurveyDock` rendres i appen med en unik `surveyId`
 - [ ] Survey-konfigurasjon bruker `satisfies LumiSurveyConfig`
-- [ ] Spørsmåls-ID-er og option values er stabile og uten PII
 - [ ] Transport sin `submit`-funksjon kaller ditt backend-endepunkt
 - [ ] Backend-endepunkt utveksler token og videresender til Lumi API via `LUMI_FEEDBACK_PATH`
 - [ ] NAIS-manifest har `LUMI_API_HOST`, `LUMI_AUDIENCE`, `LUMI_FEEDBACK_PATH` og `accessPolicy`
@@ -409,8 +395,6 @@ Etter implementasjon, verifiser hele flyten:
 - [ ] Ingen personopplysninger i kontekst-tags
 - [ ] Lagringsstrategi matcher app-type (consent for offentlige, localStorage for interne)
 - [ ] Surveyen dukker opp i riktig Lumi-dashboard etter testinnsending (dev: https://lumi-dashboard.ansatt.dev.nav.no, prod: https://lumi-dashboard.ansatt.nav.no/)
-- [ ] Feilet transport + nytt forsøk gir ikke duplikat
-- [ ] Ny `surveyId` brukes hvis survey-strukturen er endret
 
 ## Hurtigstart: Forhåndsdefinerte surveys
 

--- a/.github/skills/lumi-survey/references/backend-transport.md
+++ b/.github/skills/lumi-survey/references/backend-transport.md
@@ -19,7 +19,7 @@ export async function POST(request: Request) {
   const obo = await requestOboToken(token, process.env.LUMI_AUDIENCE!);
   if (!obo.ok) return new Response("Token exchange failed", { status: 502 });
 
-  const body = await request.text();
+  const body = await request.json();
 
   // Endepunkt settes via LUMI_FEEDBACK_PATH (se Fase 6a)
   const response = await fetch(`${process.env.LUMI_API_HOST}${process.env.LUMI_FEEDBACK_PATH}`, {
@@ -28,15 +28,13 @@ export async function POST(request: Request) {
       "Content-Type": "application/json",
       Authorization: `Bearer ${obo.token}`,
     },
-    body,
+    body: JSON.stringify(body),
   });
 
   if (!response.ok) return new Response("Lumi API error", { status: response.status });
   return new Response(null, { status: 204 });
 }
 ```
-
-Videresend rå JSON-tekst. Ikke parse og bygg payloaden på nytt i BFF-en; widgeten har allerede laget `schemaVersion: 2`, `definition` og `deduplicationKey`.
 
 ### Kotlin backend (Ktor / Spring Boot BFF)
 

--- a/.github/skills/lumi-survey/references/backend-transport.md
+++ b/.github/skills/lumi-survey/references/backend-transport.md
@@ -19,7 +19,7 @@ export async function POST(request: Request) {
   const obo = await requestOboToken(token, process.env.LUMI_AUDIENCE!);
   if (!obo.ok) return new Response("Token exchange failed", { status: 502 });
 
-  const body = await request.json();
+  const body = await request.text();
 
   // Endepunkt settes via LUMI_FEEDBACK_PATH (se Fase 6a)
   const response = await fetch(`${process.env.LUMI_API_HOST}${process.env.LUMI_FEEDBACK_PATH}`, {
@@ -28,13 +28,15 @@ export async function POST(request: Request) {
       "Content-Type": "application/json",
       Authorization: `Bearer ${obo.token}`,
     },
-    body: JSON.stringify(body),
+    body,
   });
 
   if (!response.ok) return new Response("Lumi API error", { status: response.status });
   return new Response(null, { status: 204 });
 }
 ```
+
+Videresend rå JSON-tekst. Ikke parse og bygg payloaden på nytt i BFF-en; widgeten har allerede laget `schemaVersion: 2`, `definition` og `deduplicationKey`.
 
 ### Kotlin backend (Ktor / Spring Boot BFF)
 

--- a/apps/lumi-api/src/main/kotlin/no/nav/lumi/domain/DefinitionHash.kt
+++ b/apps/lumi-api/src/main/kotlin/no/nav/lumi/domain/DefinitionHash.kt
@@ -73,13 +73,41 @@ data class DefinitionDiff(
     val removedFields: List<String>,
     val changedFields: List<FieldChange>
 ) {
+    fun hasChanges(): Boolean = addedFields.isNotEmpty() || removedFields.isNotEmpty() || changedFields.isNotEmpty()
+
     fun describe(): String {
+        return describeInternal(redactIdentifiers = false)
+    }
+
+    fun describeRedacted(): String {
+        return describeInternal(redactIdentifiers = true)
+    }
+
+    private fun describeInternal(redactIdentifiers: Boolean): String {
+        val fieldAliases = if (redactIdentifiers) {
+            (addedFields + removedFields + changedFields.map { it.fieldId })
+                .filterNot { it == "_surveyType" }
+                .distinct()
+                .sorted()
+                .mapIndexed { index, fieldId -> fieldId to "field_${index + 1}" }
+                .toMap()
+        } else {
+            emptyMap()
+        }
+
+        fun redactFieldId(fieldId: String): String = fieldAliases[fieldId] ?: fieldId
+
+        fun redactChange(change: String): String {
+            if (!redactIdentifiers) return change
+            return change.replace(Regex("""optionIds \[[^\]]*] -> \[[^\]]*]"""), "optionIds [REDACTED] -> [REDACTED]")
+        }
+
         val parts = buildList {
-            if (addedFields.isNotEmpty()) add("addedFields=$addedFields")
-            if (removedFields.isNotEmpty()) add("removedFields=$removedFields")
+            if (addedFields.isNotEmpty()) add("addedFields=${addedFields.map(::redactFieldId)}")
+            if (removedFields.isNotEmpty()) add("removedFields=${removedFields.map(::redactFieldId)}")
             if (changedFields.isNotEmpty()) {
                 add(
-                    "changedFields=${changedFields.map { "${it.fieldId}: ${it.change}" }}"
+                    "changedFields=${changedFields.map { "${redactFieldId(it.fieldId)}: ${redactChange(it.change)}" }}"
                 )
             }
         }

--- a/apps/lumi-api/src/main/kotlin/no/nav/lumi/domain/DefinitionHash.kt
+++ b/apps/lumi-api/src/main/kotlin/no/nav/lumi/domain/DefinitionHash.kt
@@ -99,7 +99,10 @@ data class DefinitionDiff(
 
         fun redactChange(change: String): String {
             if (!redactIdentifiers) return change
-            return change.replace(Regex("""optionIds \[[^\]]*] -> \[[^\]]*]"""), "optionIds [REDACTED] -> [REDACTED]")
+            return change.replace(
+                Regex("""optionIds (null|\[[^\]]*]) -> (null|\[[^\]]*])"""),
+                "optionIds [REDACTED] -> [REDACTED]"
+            )
         }
 
         val parts = buildList {

--- a/apps/lumi-api/src/main/kotlin/no/nav/lumi/domain/Models.kt
+++ b/apps/lumi-api/src/main/kotlin/no/nav/lumi/domain/Models.kt
@@ -79,7 +79,7 @@ enum class RatingVariant {
         )
 
         /** Get the fixed scale for a variant */
-        fun getScale(variant: RatingVariant): Int = fixedScales[variant] ?: 5
+        fun getScale(variant: RatingVariant): Int = fixedScales.getValue(variant)
     }
 }
 

--- a/apps/lumi-api/src/main/kotlin/no/nav/lumi/domain/SurveyDefinitionPayload.kt
+++ b/apps/lumi-api/src/main/kotlin/no/nav/lumi/domain/SurveyDefinitionPayload.kt
@@ -1,0 +1,48 @@
+package no.nav.lumi.domain
+
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class SurveyDefinitionPayload(
+    val surveyType: SurveyType,
+    val fields: List<SubmissionFieldDefinitionPayload>
+) {
+    fun toSurveyDefinition(surveyId: String): SurveyDefinition {
+        return SurveyDefinition(
+            surveyId = surveyId,
+            surveyType = surveyType,
+            fields = fields.map { field ->
+                FieldDefinition(
+                    fieldId = field.fieldId,
+                    fieldType = field.fieldType,
+                    ratingVariant = field.ratingVariant,
+                    ratingScale = field.ratingScale,
+                    optionIds = field.optionIds
+                )
+            }
+        )
+    }
+}
+
+@Serializable
+data class SubmissionFieldDefinitionPayload(
+    val fieldId: String,
+    val fieldType: FieldType,
+    val ratingVariant: RatingVariant? = null,
+    val ratingScale: Int? = null,
+    val optionIds: List<String>? = null
+)
+
+@Serializable
+data class FeedbackSubmissionV2(
+    val schemaVersion: Int,
+    val surveyId: String,
+    val surveyType: SurveyType,
+    val submittedAt: String,
+    val startedAt: String? = null,
+    val timeToCompleteMs: Long? = null,
+    val deduplicationKey: String,
+    val definition: SurveyDefinitionPayload,
+    val context: SubmissionContextV1? = null,
+    val answers: List<Answer>
+)

--- a/apps/lumi-api/src/main/kotlin/no/nav/lumi/repository/SurveyDefinitionRepository.kt
+++ b/apps/lumi-api/src/main/kotlin/no/nav/lumi/repository/SurveyDefinitionRepository.kt
@@ -11,8 +11,14 @@ data class StoredSurveyDefinition(
     val team: String,
     val surveyId: String,
     val definitionHash: String,
-    val definition: SurveyDefinition
+    val definition: SurveyDefinition,
+    val source: String = SurveyDefinitionSource.AUTO
 )
+
+object SurveyDefinitionSource {
+    const val AUTO = "auto"
+    const val API = "api"
+}
 
 class SurveyDefinitionRepository {
     private val json = Json { ignoreUnknownKeys = true }
@@ -46,6 +52,23 @@ class SurveyDefinitionRepository {
         }
     }
 
+    suspend fun insertApiDefinitionIfUnderLimit(
+        team: String,
+        definition: SurveyDefinition,
+        definitionHash: String,
+        maxDefinitions: Int
+    ): Int {
+        return dbQuery {
+            insertIfUnderLimitInCurrentTransaction(
+                team = team,
+                definition = definition,
+                definitionHash = definitionHash,
+                maxDefinitions = maxDefinitions,
+                source = SurveyDefinitionSource.API
+            )
+        }
+    }
+
     suspend fun updateDefinitionIfHashMatches(
         team: String,
         surveyId: String,
@@ -64,6 +87,25 @@ class SurveyDefinitionRepository {
         }
     }
 
+    suspend fun updateApiDefinitionIfHashMatches(
+        team: String,
+        surveyId: String,
+        expectedDefinitionHash: String,
+        definition: SurveyDefinition,
+        newDefinitionHash: String
+    ): Boolean {
+        return dbQuery {
+            updateDefinitionIfHashMatchesInCurrentTransaction(
+                team = team,
+                surveyId = surveyId,
+                expectedDefinitionHash = expectedDefinitionHash,
+                definition = definition,
+                newDefinitionHash = newDefinitionHash,
+                source = SurveyDefinitionSource.API
+            )
+        }
+    }
+
     internal fun findByTeamAndSurveyIdInCurrentTransaction(team: String, surveyId: String): StoredSurveyDefinition? {
         return SurveyDefinitionTable.selectAll()
             .where { (SurveyDefinitionTable.team eq team) and (SurveyDefinitionTable.surveyId eq surveyId) }
@@ -73,7 +115,8 @@ class SurveyDefinitionRepository {
                     team = row[SurveyDefinitionTable.team],
                     surveyId = row[SurveyDefinitionTable.surveyId],
                     definitionHash = row[SurveyDefinitionTable.definitionHash],
-                    definition = json.decodeFromString(row[SurveyDefinitionTable.definition])
+                    definition = json.decodeFromString(row[SurveyDefinitionTable.definition]),
+                    source = row[SurveyDefinitionTable.dbSource]
                 )
             }
     }
@@ -82,7 +125,8 @@ class SurveyDefinitionRepository {
         team: String,
         definition: SurveyDefinition,
         definitionHash: String,
-        maxDefinitions: Int
+        maxDefinitions: Int,
+        source: String = SurveyDefinitionSource.AUTO
     ): Int {
         val definitionJson = json.encodeToString(definition)
         val transaction = org.jetbrains.exposed.v1.jdbc.transactions.TransactionManager.current()
@@ -94,8 +138,8 @@ class SurveyDefinitionRepository {
         }
 
         val sql = """
-            INSERT INTO survey_definitions (id, team, survey_id, definition_hash, definition)
-            SELECT gen_random_uuid(), ?, ?, ?, ?::jsonb
+            INSERT INTO survey_definitions (id, team, survey_id, definition_hash, definition, source)
+            SELECT gen_random_uuid(), ?, ?, ?, ?::jsonb, ?
             WHERE (SELECT count(*) FROM survey_definitions WHERE team = ?) < ?
             ON CONFLICT (team, survey_id) DO NOTHING
         """.trimIndent()
@@ -105,10 +149,26 @@ class SurveyDefinitionRepository {
             stmt.setString(2, definition.surveyId)
             stmt.setString(3, definitionHash)
             stmt.setString(4, definitionJson)
-            stmt.setString(5, team)
-            stmt.setInt(6, maxDefinitions)
+            stmt.setString(5, source)
+            stmt.setString(6, team)
+            stmt.setInt(7, maxDefinitions)
             stmt.executeUpdate()
         }
+    }
+
+    internal fun insertApiDefinitionIfUnderLimitInCurrentTransaction(
+        team: String,
+        definition: SurveyDefinition,
+        definitionHash: String,
+        maxDefinitions: Int
+    ): Int {
+        return insertIfUnderLimitInCurrentTransaction(
+            team = team,
+            definition = definition,
+            definitionHash = definitionHash,
+            maxDefinitions = maxDefinitions,
+            source = SurveyDefinitionSource.API
+        )
     }
 
     internal fun updateDefinitionIfHashMatchesInCurrentTransaction(
@@ -116,7 +176,8 @@ class SurveyDefinitionRepository {
         surveyId: String,
         expectedDefinitionHash: String,
         definition: SurveyDefinition,
-        newDefinitionHash: String
+        newDefinitionHash: String,
+        source: String? = null
     ): Boolean {
         val definitionJson = json.encodeToString(definition)
         return SurveyDefinitionTable.update({
@@ -126,7 +187,27 @@ class SurveyDefinitionRepository {
         }) {
             it[SurveyDefinitionTable.definitionHash] = newDefinitionHash
             it[SurveyDefinitionTable.definition] = definitionJson
+            if (source != null) {
+                it[SurveyDefinitionTable.dbSource] = source
+            }
             it[SurveyDefinitionTable.updatedAt] = Instant.now()
         } > 0
+    }
+
+    internal fun updateApiDefinitionIfHashMatchesInCurrentTransaction(
+        team: String,
+        surveyId: String,
+        expectedDefinitionHash: String,
+        definition: SurveyDefinition,
+        newDefinitionHash: String
+    ): Boolean {
+        return updateDefinitionIfHashMatchesInCurrentTransaction(
+            team = team,
+            surveyId = surveyId,
+            expectedDefinitionHash = expectedDefinitionHash,
+            definition = definition,
+            newDefinitionHash = newDefinitionHash,
+            source = SurveyDefinitionSource.API
+        )
     }
 }

--- a/apps/lumi-api/src/main/kotlin/no/nav/lumi/routes/InternalSubmissionRoutes.kt
+++ b/apps/lumi-api/src/main/kotlin/no/nav/lumi/routes/InternalSubmissionRoutes.kt
@@ -4,7 +4,6 @@ import io.ktor.http.*
 import io.ktor.server.request.*
 import io.ktor.server.response.*
 import io.ktor.server.routing.*
-import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.buildJsonObject
 import kotlinx.serialization.json.put
 import no.nav.lumi.config.auth.CallerIdentityKey
@@ -13,12 +12,7 @@ import no.nav.lumi.config.exception.ApiErrorException
 import no.nav.lumi.service.FeedbackService
 import no.nav.lumi.service.SubmissionService
 import no.nav.lumi.service.SurveyDefinitionService
-import no.nav.lumi.validation.SubmissionValidator
 import org.slf4j.LoggerFactory
-import io.ktor.utils.io.core.readText
-import io.ktor.utils.io.readRemaining
-import kotlinx.serialization.SerializationException
-import no.nav.lumi.domain.FeedbackSubmissionV1
 import no.nav.lumi.domain.SaveResult
 import java.security.MessageDigest
 
@@ -26,13 +20,6 @@ private val log = LoggerFactory.getLogger("InternalSubmissionRoutes")
 
 private const val SUBMISSION_KEY_HEADER = "X-Lumi-Submission-Key"
 private const val CALLER_IDENTITY_HEADER = "X-Lumi-Caller-Identity"
-private const val MAX_SUBMISSION_BYTES = 1_048_576L
-
-private val strictJson = Json {
-    ignoreUnknownKeys = false
-    isLenient = false
-    encodeDefaults = true
-}
 
 /**
  * Internal submission route for cross-tenant proxy forwarding in dev.
@@ -78,7 +65,7 @@ fun Route.internalSubmissionRoutes(
             val body = receiveTextWithLimit(call)
 
             val jsonElement = try {
-                strictJson.parseToJsonElement(body)
+                strictSubmissionJson.parseToJsonElement(body)
             } catch (e: Exception) {
                 log.warn(
                     "Internal submission: invalid JSON from ${identity.team}/${identity.app} parseErrorType=${e::class.simpleName}"
@@ -86,18 +73,14 @@ fun Route.internalSubmissionRoutes(
                 throw ApiErrorException.BadRequestException("Invalid JSON")
             }
 
-            val submission = try {
-                strictJson.decodeFromJsonElement(FeedbackSubmissionV1.serializer(), jsonElement)
-            } catch (e: SerializationException) {
-                throw ApiErrorException.BadRequestException("Invalid payload")
-            }
-
-            SubmissionValidator.validateSubmissionV1(submission)
+            val parsedSubmission = decodeValidatedSubmission(jsonElement)
+            val submission = parsedSubmission.submission
             val submissionOutcome = submissionService.submit(
                 feedbackJson = body,
                 team = identity.team,
                 app = identity.app,
-                submission = submission
+                submission = submission,
+                definition = parsedSubmission.definition
             )
 
             when (val saveResult = submissionOutcome.saveResult) {
@@ -122,19 +105,4 @@ fun Route.internalSubmissionRoutes(
             }
         }
     }
-}
-
-private suspend fun receiveTextWithLimit(call: io.ktor.server.application.ApplicationCall): String {
-    val contentLength = call.request.headers[HttpHeaders.ContentLength]?.toLongOrNull()
-    if (contentLength != null && contentLength > MAX_SUBMISSION_BYTES) {
-        throw ApiErrorException.PayloadTooLargeException("Payload too large")
-    }
-
-    val packet = call.receiveChannel().readRemaining(MAX_SUBMISSION_BYTES + 1)
-    val text = packet.readText()
-    if (text.toByteArray().size > MAX_SUBMISSION_BYTES) {
-        throw ApiErrorException.PayloadTooLargeException("Payload too large")
-    }
-
-    return text
 }

--- a/apps/lumi-api/src/main/kotlin/no/nav/lumi/routes/SubmissionRouteParsing.kt
+++ b/apps/lumi-api/src/main/kotlin/no/nav/lumi/routes/SubmissionRouteParsing.kt
@@ -1,0 +1,129 @@
+package no.nav.lumi.routes
+
+import io.ktor.http.HttpHeaders
+import io.ktor.server.application.ApplicationCall
+import io.ktor.server.request.receiveChannel
+import io.ktor.utils.io.core.readText
+import io.ktor.utils.io.readRemaining
+import kotlinx.serialization.MissingFieldException
+import kotlinx.serialization.SerializationException
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonElement
+import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.intOrNull
+import kotlinx.serialization.json.jsonObject
+import no.nav.lumi.config.exception.ApiErrorException
+import no.nav.lumi.domain.FeedbackSubmissionV1
+import no.nav.lumi.domain.FeedbackSubmissionV2
+import no.nav.lumi.domain.SurveyDefinition
+import no.nav.lumi.validation.SubmissionV2Validator
+import no.nav.lumi.validation.SubmissionValidator
+
+internal const val MAX_SUBMISSION_BYTES = 1_048_576L
+
+internal val strictSubmissionJson = Json {
+    ignoreUnknownKeys = false
+    isLenient = false
+    encodeDefaults = true
+}
+
+internal data class ParsedSubmission(
+    val submission: FeedbackSubmissionV1,
+    val definition: SurveyDefinition? = null
+)
+
+internal fun decodeValidatedSubmission(jsonElement: JsonElement): ParsedSubmission {
+    val schemaVersion = extractSchemaVersion(jsonElement)
+
+    return when (schemaVersion) {
+        1 -> {
+            val submission = decodeSubmissionV1(jsonElement)
+            SubmissionValidator.validateSubmissionV1(submission)
+            ParsedSubmission(submission = submission)
+        }
+
+        2 -> {
+            val submission = decodeSubmissionV2(jsonElement)
+            SubmissionV2Validator.validateSubmissionV2(submission)
+            ParsedSubmission(
+                submission = submission.toV1CompatibleSubmission(),
+                definition = submission.definition.toSurveyDefinition(submission.surveyId)
+            )
+        }
+
+        else -> throw ApiErrorException.BadRequestException(
+            "UNSUPPORTED_SCHEMA: schemaVersion=$schemaVersion is not supported"
+        )
+    }
+}
+
+internal suspend fun receiveTextWithLimit(call: ApplicationCall): String {
+    val contentLength = call.request.headers[HttpHeaders.ContentLength]?.toLongOrNull()
+    if (contentLength != null && contentLength > MAX_SUBMISSION_BYTES) {
+        throw ApiErrorException.PayloadTooLargeException("Payload too large")
+    }
+
+    val packet = call.receiveChannel().readRemaining(MAX_SUBMISSION_BYTES + 1)
+    val text = packet.readText()
+    if (text.toByteArray().size > MAX_SUBMISSION_BYTES) {
+        throw ApiErrorException.PayloadTooLargeException("Payload too large")
+    }
+
+    return text
+}
+
+private fun extractSchemaVersion(jsonElement: JsonElement): Int {
+    val jsonObject = runCatching { jsonElement.jsonObject }
+        .getOrElse { throw ApiErrorException.BadRequestException("Invalid payload") }
+
+    val rawSchemaVersion = jsonObject["schemaVersion"]
+        ?: throw ApiErrorException.BadRequestException("Invalid payload: schemaVersion is required")
+
+    val schemaVersion = rawSchemaVersion as? JsonPrimitive
+        ?: throw ApiErrorException.BadRequestException("Invalid payload: schemaVersion must be an integer")
+
+    return schemaVersion.intOrNull
+        ?: throw ApiErrorException.BadRequestException("Invalid payload: schemaVersion must be an integer")
+}
+
+private fun decodeSubmissionV1(jsonElement: JsonElement): FeedbackSubmissionV1 {
+    return try {
+        strictSubmissionJson.decodeFromJsonElement(FeedbackSubmissionV1.serializer(), jsonElement)
+    } catch (_: SerializationException) {
+        throw ApiErrorException.BadRequestException("Invalid payload")
+    }
+}
+
+@OptIn(kotlinx.serialization.ExperimentalSerializationApi::class)
+private fun decodeSubmissionV2(jsonElement: JsonElement): FeedbackSubmissionV2 {
+    return try {
+        strictSubmissionJson.decodeFromJsonElement(FeedbackSubmissionV2.serializer(), jsonElement)
+    } catch (e: MissingFieldException) {
+        when {
+            e.missingFields.contains("definition") -> {
+                throw ApiErrorException.BadRequestException("Invalid payload: definition is required for schemaVersion=2")
+            }
+
+            e.missingFields.contains("deduplicationKey") -> {
+                throw ApiErrorException.BadRequestException("Invalid payload: deduplicationKey is required for schemaVersion=2")
+            }
+        }
+        throw ApiErrorException.BadRequestException("Invalid payload")
+    } catch (_: SerializationException) {
+        throw ApiErrorException.BadRequestException("Invalid payload")
+    }
+}
+
+private fun FeedbackSubmissionV2.toV1CompatibleSubmission(): FeedbackSubmissionV1 {
+    return FeedbackSubmissionV1(
+        schemaVersion = schemaVersion,
+        surveyId = surveyId,
+        surveyType = surveyType,
+        submittedAt = submittedAt,
+        startedAt = startedAt,
+        timeToCompleteMs = timeToCompleteMs,
+        deduplicationKey = deduplicationKey,
+        context = context,
+        answers = answers
+    )
+}

--- a/apps/lumi-api/src/main/kotlin/no/nav/lumi/routes/SubmissionRouteParsing.kt
+++ b/apps/lumi-api/src/main/kotlin/no/nav/lumi/routes/SubmissionRouteParsing.kt
@@ -82,7 +82,7 @@ private fun extractSchemaVersion(jsonElement: JsonElement): Int {
     val schemaVersion = rawSchemaVersion as? JsonPrimitive
         ?: throw ApiErrorException.BadRequestException("Invalid payload: schemaVersion must be an integer")
 
-    if (schemaVersion.toString().startsWith("\"")) {
+    if (schemaVersion.isString) {
         throw ApiErrorException.BadRequestException("Invalid payload: schemaVersion must be an integer")
     }
 

--- a/apps/lumi-api/src/main/kotlin/no/nav/lumi/routes/SubmissionRouteParsing.kt
+++ b/apps/lumi-api/src/main/kotlin/no/nav/lumi/routes/SubmissionRouteParsing.kt
@@ -82,6 +82,10 @@ private fun extractSchemaVersion(jsonElement: JsonElement): Int {
     val schemaVersion = rawSchemaVersion as? JsonPrimitive
         ?: throw ApiErrorException.BadRequestException("Invalid payload: schemaVersion must be an integer")
 
+    if (schemaVersion.toString().startsWith("\"")) {
+        throw ApiErrorException.BadRequestException("Invalid payload: schemaVersion must be an integer")
+    }
+
     return schemaVersion.intOrNull
         ?: throw ApiErrorException.BadRequestException("Invalid payload: schemaVersion must be an integer")
 }

--- a/apps/lumi-api/src/main/kotlin/no/nav/lumi/routes/SubmissionRoutes.kt
+++ b/apps/lumi-api/src/main/kotlin/no/nav/lumi/routes/SubmissionRoutes.kt
@@ -5,14 +5,8 @@ import io.ktor.server.plugins.ratelimit.*
 import io.ktor.server.request.*
 import io.ktor.server.response.*
 import io.ktor.server.routing.*
-import kotlinx.serialization.MissingFieldException
-import kotlinx.serialization.SerializationException
-import kotlinx.serialization.json.JsonPrimitive
 import kotlinx.serialization.json.buildJsonObject
-import kotlinx.serialization.json.intOrNull
-import kotlinx.serialization.json.jsonObject
 import kotlinx.serialization.json.put
-import kotlinx.serialization.json.Json
 import no.nav.lumi.config.SubmissionRateLimit
 import no.nav.lumi.config.UserSubmissionRateLimit
 import no.nav.lumi.config.auth.AzureSubmissionAuthPlugin
@@ -20,28 +14,15 @@ import no.nav.lumi.config.auth.TokenXSubmissionAuthPlugin
 import no.nav.lumi.config.auth.getCallerIdentity
 import no.nav.lumi.config.exception.ApiErrorException
 import no.nav.lumi.domain.FeedbackSubmissionV1
-import no.nav.lumi.domain.FeedbackSubmissionV2
 import no.nav.lumi.domain.SaveResult
 import no.nav.lumi.service.FeedbackService
 import no.nav.lumi.service.SubmissionService
 import no.nav.lumi.service.SurveyDefinitionService
-import no.nav.lumi.validation.SubmissionValidator
-import no.nav.lumi.validation.SubmissionV2Validator
 import org.slf4j.LoggerFactory
-import io.ktor.utils.io.core.readText
-import io.ktor.utils.io.readRemaining
 
 private val log = LoggerFactory.getLogger("SubmissionRoutes")
 private val defaultFeedbackService = FeedbackService()
 private val defaultSurveyDefinitionService = SurveyDefinitionService()
-
-private const val MAX_SUBMISSION_BYTES = 1_048_576L
-
-private val strictJson = Json {
-    ignoreUnknownKeys = false
-    isLenient = false
-    encodeDefaults = true
-}
 
 /**
  * Submission routes for feedback collection.
@@ -89,7 +70,7 @@ private suspend fun handleSubmission(
     val body = receiveTextWithLimit(call)
 
     val jsonElement = try {
-        strictJson.parseToJsonElement(body)
+        strictSubmissionJson.parseToJsonElement(body)
     } catch (e: Exception) {
         log.warn(
             "Invalid JSON in feedback submission from team=${identity.team} app=${identity.app} parseErrorType=${e::class.simpleName}"
@@ -97,100 +78,20 @@ private suspend fun handleSubmission(
         throw ApiErrorException.BadRequestException("Invalid JSON")
     }
 
-    val schemaVersion = extractSchemaVersion(jsonElement)
+    val parsedSubmission = decodeValidatedSubmission(jsonElement)
 
-    when (schemaVersion) {
-        1 -> {
-            val submission = decodeSubmissionV1(jsonElement)
-            SubmissionValidator.validateSubmissionV1(submission)
-            respondWithSubmissionResult(
-                call = call,
-                identity = identity,
-                submission = submission,
-                submissionOutcome = submissionService.submit(
-                    feedbackJson = body,
-                    team = identity.team,
-                    app = identity.app,
-                    submission = submission
-                )
-            )
-        }
-
-        2 -> {
-            val submission = decodeSubmissionV2(jsonElement)
-            SubmissionV2Validator.validateSubmissionV2(submission)
-            val v1CompatibleSubmission = FeedbackSubmissionV1(
-                schemaVersion = submission.schemaVersion,
-                surveyId = submission.surveyId,
-                surveyType = submission.surveyType,
-                submittedAt = submission.submittedAt,
-                startedAt = submission.startedAt,
-                timeToCompleteMs = submission.timeToCompleteMs,
-                deduplicationKey = submission.deduplicationKey,
-                context = submission.context,
-                answers = submission.answers
-            )
-            respondWithSubmissionResult(
-                call = call,
-                identity = identity,
-                submission = v1CompatibleSubmission,
-                submissionOutcome = submissionService.submit(
-                    feedbackJson = body,
-                    team = identity.team,
-                    app = identity.app,
-                    submission = v1CompatibleSubmission,
-                    definition = submission.definition.toSurveyDefinition(submission.surveyId),
-                    allowDefinitionExpansion = false
-                )
-            )
-        }
-
-        else -> throw ApiErrorException.BadRequestException(
-            "UNSUPPORTED_SCHEMA: schemaVersion=$schemaVersion is not supported"
+    respondWithSubmissionResult(
+        call = call,
+        identity = identity,
+        submission = parsedSubmission.submission,
+        submissionOutcome = submissionService.submit(
+            feedbackJson = body,
+            team = identity.team,
+            app = identity.app,
+            submission = parsedSubmission.submission,
+            definition = parsedSubmission.definition
         )
-    }
-}
-
-private fun extractSchemaVersion(jsonElement: kotlinx.serialization.json.JsonElement): Int {
-    val jsonObject = runCatching { jsonElement.jsonObject }
-        .getOrElse { throw ApiErrorException.BadRequestException("Invalid payload") }
-
-    val rawSchemaVersion = jsonObject["schemaVersion"]
-        ?: throw ApiErrorException.BadRequestException("Invalid payload: schemaVersion is required")
-
-    val schemaVersion = rawSchemaVersion as? JsonPrimitive
-        ?: throw ApiErrorException.BadRequestException("Invalid payload: schemaVersion must be an integer")
-
-    return schemaVersion.intOrNull
-        ?: throw ApiErrorException.BadRequestException("Invalid payload: schemaVersion must be an integer")
-}
-
-private fun decodeSubmissionV1(jsonElement: kotlinx.serialization.json.JsonElement): FeedbackSubmissionV1 {
-    return try {
-        strictJson.decodeFromJsonElement(FeedbackSubmissionV1.serializer(), jsonElement)
-    } catch (e: SerializationException) {
-        throw ApiErrorException.BadRequestException("Invalid payload")
-    }
-}
-
-@OptIn(kotlinx.serialization.ExperimentalSerializationApi::class)
-private fun decodeSubmissionV2(jsonElement: kotlinx.serialization.json.JsonElement): FeedbackSubmissionV2 {
-    return try {
-        strictJson.decodeFromJsonElement(FeedbackSubmissionV2.serializer(), jsonElement)
-    } catch (e: MissingFieldException) {
-        when {
-            e.missingFields.contains("definition") -> {
-                throw ApiErrorException.BadRequestException("Invalid payload: definition is required for schemaVersion=2")
-            }
-
-            e.missingFields.contains("deduplicationKey") -> {
-                throw ApiErrorException.BadRequestException("Invalid payload: deduplicationKey is required for schemaVersion=2")
-            }
-        }
-        throw ApiErrorException.BadRequestException("Invalid payload")
-    } catch (e: SerializationException) {
-        throw ApiErrorException.BadRequestException("Invalid payload")
-    }
+    )
 }
 
 private suspend fun respondWithSubmissionResult(
@@ -220,19 +121,4 @@ private suspend fun respondWithSubmissionResult(
             )
         }
     }
-}
-
-private suspend fun receiveTextWithLimit(call: io.ktor.server.application.ApplicationCall): String {
-    val contentLength = call.request.headers[HttpHeaders.ContentLength]?.toLongOrNull()
-    if (contentLength != null && contentLength > MAX_SUBMISSION_BYTES) {
-        throw ApiErrorException.PayloadTooLargeException("Payload too large")
-    }
-
-    val packet = call.receiveChannel().readRemaining(MAX_SUBMISSION_BYTES + 1)
-    val text = packet.readText()
-    if (text.toByteArray().size > MAX_SUBMISSION_BYTES) {
-        throw ApiErrorException.PayloadTooLargeException("Payload too large")
-    }
-
-    return text
 }

--- a/apps/lumi-api/src/main/kotlin/no/nav/lumi/routes/SubmissionRoutes.kt
+++ b/apps/lumi-api/src/main/kotlin/no/nav/lumi/routes/SubmissionRoutes.kt
@@ -178,8 +178,14 @@ private fun decodeSubmissionV2(jsonElement: kotlinx.serialization.json.JsonEleme
     return try {
         strictJson.decodeFromJsonElement(FeedbackSubmissionV2.serializer(), jsonElement)
     } catch (e: MissingFieldException) {
-        if (e.missingFields.contains("definition")) {
-            throw ApiErrorException.BadRequestException("Invalid payload: definition is required for schemaVersion=2")
+        when {
+            e.missingFields.contains("definition") -> {
+                throw ApiErrorException.BadRequestException("Invalid payload: definition is required for schemaVersion=2")
+            }
+
+            e.missingFields.contains("deduplicationKey") -> {
+                throw ApiErrorException.BadRequestException("Invalid payload: deduplicationKey is required for schemaVersion=2")
+            }
         }
         throw ApiErrorException.BadRequestException("Invalid payload")
     } catch (e: SerializationException) {

--- a/apps/lumi-api/src/main/kotlin/no/nav/lumi/routes/SubmissionRoutes.kt
+++ b/apps/lumi-api/src/main/kotlin/no/nav/lumi/routes/SubmissionRoutes.kt
@@ -5,8 +5,12 @@ import io.ktor.server.plugins.ratelimit.*
 import io.ktor.server.request.*
 import io.ktor.server.response.*
 import io.ktor.server.routing.*
+import kotlinx.serialization.MissingFieldException
 import kotlinx.serialization.SerializationException
 import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.intOrNull
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
 import kotlinx.serialization.json.put
 import kotlinx.serialization.json.Json
 import no.nav.lumi.config.SubmissionRateLimit
@@ -16,11 +20,13 @@ import no.nav.lumi.config.auth.TokenXSubmissionAuthPlugin
 import no.nav.lumi.config.auth.getCallerIdentity
 import no.nav.lumi.config.exception.ApiErrorException
 import no.nav.lumi.domain.FeedbackSubmissionV1
+import no.nav.lumi.domain.FeedbackSubmissionV2
 import no.nav.lumi.domain.SaveResult
 import no.nav.lumi.service.FeedbackService
 import no.nav.lumi.service.SubmissionService
 import no.nav.lumi.service.SurveyDefinitionService
 import no.nav.lumi.validation.SubmissionValidator
+import no.nav.lumi.validation.SubmissionV2Validator
 import org.slf4j.LoggerFactory
 import io.ktor.utils.io.core.readText
 import io.ktor.utils.io.readRemaining
@@ -60,7 +66,7 @@ fun Route.submissionRoutes(
         install(TokenXSubmissionAuthPlugin)
         rateLimit(SubmissionRateLimit) {
             rateLimit(UserSubmissionRateLimit) {
-                post("/v1/feedback") { handleSubmissionV1(call, submissionService) }
+                post("/v1/feedback") { handleSubmission(call, submissionService) }
             }
         }
     }
@@ -69,13 +75,13 @@ fun Route.submissionRoutes(
         install(AzureSubmissionAuthPlugin)
         rateLimit(SubmissionRateLimit) {
             rateLimit(UserSubmissionRateLimit) {
-                post("/v1/feedback") { handleSubmissionV1(call, submissionService) }
+                post("/v1/feedback") { handleSubmission(call, submissionService) }
             }
         }
     }
 }
 
-private suspend fun handleSubmissionV1(
+private suspend fun handleSubmission(
     call: io.ktor.server.application.ApplicationCall,
     submissionService: SubmissionService
 ) {
@@ -91,20 +97,99 @@ private suspend fun handleSubmissionV1(
         throw ApiErrorException.BadRequestException("Invalid JSON")
     }
 
-    val submission = try {
+    val schemaVersion = extractSchemaVersion(jsonElement)
+
+    when (schemaVersion) {
+        1 -> {
+            val submission = decodeSubmissionV1(jsonElement)
+            SubmissionValidator.validateSubmissionV1(submission)
+            respondWithSubmissionResult(
+                call = call,
+                identity = identity,
+                submission = submission,
+                submissionOutcome = submissionService.submit(
+                    feedbackJson = body,
+                    team = identity.team,
+                    app = identity.app,
+                    submission = submission
+                )
+            )
+        }
+
+        2 -> {
+            val submission = decodeSubmissionV2(jsonElement)
+            SubmissionV2Validator.validateSubmissionV2(submission)
+            val v1CompatibleSubmission = FeedbackSubmissionV1(
+                schemaVersion = submission.schemaVersion,
+                surveyId = submission.surveyId,
+                surveyType = submission.surveyType,
+                submittedAt = submission.submittedAt,
+                startedAt = submission.startedAt,
+                timeToCompleteMs = submission.timeToCompleteMs,
+                deduplicationKey = submission.deduplicationKey,
+                context = submission.context,
+                answers = submission.answers
+            )
+            respondWithSubmissionResult(
+                call = call,
+                identity = identity,
+                submission = v1CompatibleSubmission,
+                submissionOutcome = submissionService.submit(
+                    feedbackJson = body,
+                    team = identity.team,
+                    app = identity.app,
+                    submission = v1CompatibleSubmission,
+                    definition = submission.definition.toSurveyDefinition(submission.surveyId),
+                    allowDefinitionExpansion = false
+                )
+            )
+        }
+
+        else -> throw ApiErrorException.BadRequestException(
+            "UNSUPPORTED_SCHEMA: schemaVersion=$schemaVersion is not supported"
+        )
+    }
+}
+
+private fun extractSchemaVersion(jsonElement: kotlinx.serialization.json.JsonElement): Int {
+    val jsonObject = runCatching { jsonElement.jsonObject }
+        .getOrElse { throw ApiErrorException.BadRequestException("Invalid payload") }
+
+    val rawSchemaVersion = jsonObject["schemaVersion"]
+        ?: throw ApiErrorException.BadRequestException("Invalid payload: schemaVersion is required")
+
+    return rawSchemaVersion.jsonPrimitive.intOrNull
+        ?: throw ApiErrorException.BadRequestException("Invalid payload: schemaVersion must be an integer")
+}
+
+private fun decodeSubmissionV1(jsonElement: kotlinx.serialization.json.JsonElement): FeedbackSubmissionV1 {
+    return try {
         strictJson.decodeFromJsonElement(FeedbackSubmissionV1.serializer(), jsonElement)
     } catch (e: SerializationException) {
         throw ApiErrorException.BadRequestException("Invalid payload")
     }
+}
 
-    SubmissionValidator.validateSubmissionV1(submission)
-    val submissionOutcome = submissionService.submit(
-        feedbackJson = body,
-        team = identity.team,
-        app = identity.app,
-        submission = submission
-    )
+@OptIn(kotlinx.serialization.ExperimentalSerializationApi::class)
+private fun decodeSubmissionV2(jsonElement: kotlinx.serialization.json.JsonElement): FeedbackSubmissionV2 {
+    return try {
+        strictJson.decodeFromJsonElement(FeedbackSubmissionV2.serializer(), jsonElement)
+    } catch (e: MissingFieldException) {
+        if (e.missingFields.contains("definition")) {
+            throw ApiErrorException.BadRequestException("Invalid payload: definition is required for schemaVersion=2")
+        }
+        throw ApiErrorException.BadRequestException("Invalid payload")
+    } catch (e: SerializationException) {
+        throw ApiErrorException.BadRequestException("Invalid payload")
+    }
+}
 
+private suspend fun respondWithSubmissionResult(
+    call: io.ktor.server.application.ApplicationCall,
+    identity: no.nav.lumi.config.auth.CallerIdentity,
+    submission: FeedbackSubmissionV1,
+    submissionOutcome: no.nav.lumi.service.SubmissionOutcome
+) {
     when (val saveResult = submissionOutcome.saveResult) {
         is SaveResult.Created -> {
             log.info(
@@ -112,6 +197,7 @@ private suspend fun handleSubmissionV1(
             )
             call.respond(HttpStatusCode.Created, mapOf("id" to saveResult.id))
         }
+
         is SaveResult.Duplicate -> {
             log.info(
                 "Deduplicated feedback id=${saveResult.id} team=${identity.team} app=${identity.app} surveyId=${submission.surveyId}"

--- a/apps/lumi-api/src/main/kotlin/no/nav/lumi/routes/SubmissionRoutes.kt
+++ b/apps/lumi-api/src/main/kotlin/no/nav/lumi/routes/SubmissionRoutes.kt
@@ -7,10 +7,10 @@ import io.ktor.server.response.*
 import io.ktor.server.routing.*
 import kotlinx.serialization.MissingFieldException
 import kotlinx.serialization.SerializationException
+import kotlinx.serialization.json.JsonPrimitive
 import kotlinx.serialization.json.buildJsonObject
 import kotlinx.serialization.json.intOrNull
 import kotlinx.serialization.json.jsonObject
-import kotlinx.serialization.json.jsonPrimitive
 import kotlinx.serialization.json.put
 import kotlinx.serialization.json.Json
 import no.nav.lumi.config.SubmissionRateLimit
@@ -158,7 +158,10 @@ private fun extractSchemaVersion(jsonElement: kotlinx.serialization.json.JsonEle
     val rawSchemaVersion = jsonObject["schemaVersion"]
         ?: throw ApiErrorException.BadRequestException("Invalid payload: schemaVersion is required")
 
-    return rawSchemaVersion.jsonPrimitive.intOrNull
+    val schemaVersion = rawSchemaVersion as? JsonPrimitive
+        ?: throw ApiErrorException.BadRequestException("Invalid payload: schemaVersion must be an integer")
+
+    return schemaVersion.intOrNull
         ?: throw ApiErrorException.BadRequestException("Invalid payload: schemaVersion must be an integer")
 }
 

--- a/apps/lumi-api/src/main/kotlin/no/nav/lumi/service/FeedbackService.kt
+++ b/apps/lumi-api/src/main/kotlin/no/nav/lumi/service/FeedbackService.kt
@@ -122,6 +122,7 @@ class FeedbackService(
             var hasRedactions = false
             val deduplicationKey = extractDeduplicationKey(jsonObj)
             jsonObj.remove("deduplicationKey")
+            jsonObj.remove("definition")
 
             val context = jsonObj["context"] as? JsonObject
             if (context != null) {

--- a/apps/lumi-api/src/main/kotlin/no/nav/lumi/service/SubmissionService.kt
+++ b/apps/lumi-api/src/main/kotlin/no/nav/lumi/service/SubmissionService.kt
@@ -99,11 +99,11 @@ class SubmissionService(
         inCurrentTransaction: Boolean
     ): RegistrationResult {
         return when {
-            definition == null && inCurrentTransaction ->
-                surveyDefinitionService.registerOrValidateInCurrentTransaction(team, submission)
+            definition != null && inCurrentTransaction ->
+                surveyDefinitionService.registerOrValidateV2InCurrentTransaction(team, submission, definition)
 
-            definition == null ->
-                surveyDefinitionService.registerOrValidate(team, submission)
+            definition != null ->
+                surveyDefinitionService.registerOrValidateV2(team, submission, definition)
 
             allowDefinitionExpansion && inCurrentTransaction ->
                 surveyDefinitionService.registerOrValidateInCurrentTransaction(team, submission)
@@ -112,10 +112,10 @@ class SubmissionService(
                 surveyDefinitionService.registerOrValidate(team, submission)
 
             inCurrentTransaction ->
-                surveyDefinitionService.registerOrValidateV2InCurrentTransaction(team, submission, definition)
+                surveyDefinitionService.registerOrValidateInCurrentTransaction(team, submission)
 
             else ->
-                surveyDefinitionService.registerOrValidateV2(team, submission, definition)
+                surveyDefinitionService.registerOrValidate(team, submission)
         }
     }
 }

--- a/apps/lumi-api/src/main/kotlin/no/nav/lumi/service/SubmissionService.kt
+++ b/apps/lumi-api/src/main/kotlin/no/nav/lumi/service/SubmissionService.kt
@@ -21,15 +21,13 @@ class SubmissionService(
         team: String,
         app: String,
         submission: FeedbackSubmissionV1,
-        definition: SurveyDefinition? = null,
-        allowDefinitionExpansion: Boolean = definition == null
+        definition: SurveyDefinition? = null
     ): SubmissionOutcome {
         if (submission.deduplicationKey == null) {
             val definitionResult = registerDefinition(
                 team = team,
                 submission = submission,
                 definition = definition,
-                allowDefinitionExpansion = allowDefinitionExpansion,
                 inCurrentTransaction = false
             )
             val saveResult = feedbackService.save(
@@ -72,7 +70,6 @@ class SubmissionService(
                 team = team,
                 submission = submission,
                 definition = definition,
-                allowDefinitionExpansion = allowDefinitionExpansion,
                 inCurrentTransaction = true
             )
             val saveResult = feedbackRepository.saveInCurrentTransaction(
@@ -95,7 +92,6 @@ class SubmissionService(
         team: String,
         submission: FeedbackSubmissionV1,
         definition: SurveyDefinition?,
-        allowDefinitionExpansion: Boolean,
         inCurrentTransaction: Boolean
     ): RegistrationResult {
         return when {
@@ -104,12 +100,6 @@ class SubmissionService(
 
             definition != null ->
                 surveyDefinitionService.registerOrValidateV2(team, submission, definition)
-
-            allowDefinitionExpansion && inCurrentTransaction ->
-                surveyDefinitionService.registerOrValidateInCurrentTransaction(team, submission)
-
-            allowDefinitionExpansion ->
-                surveyDefinitionService.registerOrValidate(team, submission)
 
             inCurrentTransaction ->
                 surveyDefinitionService.registerOrValidateInCurrentTransaction(team, submission)

--- a/apps/lumi-api/src/main/kotlin/no/nav/lumi/service/SubmissionService.kt
+++ b/apps/lumi-api/src/main/kotlin/no/nav/lumi/service/SubmissionService.kt
@@ -2,6 +2,7 @@ package no.nav.lumi.service
 
 import no.nav.lumi.domain.FeedbackSubmissionV1
 import no.nav.lumi.domain.SaveResult
+import no.nav.lumi.domain.SurveyDefinition
 import no.nav.lumi.repository.FeedbackRepository
 
 data class SubmissionOutcome(
@@ -19,10 +20,18 @@ class SubmissionService(
         feedbackJson: String,
         team: String,
         app: String,
-        submission: FeedbackSubmissionV1
+        submission: FeedbackSubmissionV1,
+        definition: SurveyDefinition? = null,
+        allowDefinitionExpansion: Boolean = definition == null
     ): SubmissionOutcome {
         if (submission.deduplicationKey == null) {
-            val definitionResult = surveyDefinitionService.registerOrValidate(team, submission)
+            val definitionResult = registerDefinition(
+                team = team,
+                submission = submission,
+                definition = definition,
+                allowDefinitionExpansion = allowDefinitionExpansion,
+                inCurrentTransaction = false
+            )
             val saveResult = feedbackService.save(
                 feedbackJson = feedbackJson,
                 team = team,
@@ -59,7 +68,13 @@ class SubmissionService(
                 return@withScopedDeduplicationLock SubmissionOutcome(SaveResult.Duplicate(existingId))
             }
 
-            val definitionResult = surveyDefinitionService.registerOrValidateInCurrentTransaction(team, submission)
+            val definitionResult = registerDefinition(
+                team = team,
+                submission = submission,
+                definition = definition,
+                allowDefinitionExpansion = allowDefinitionExpansion,
+                inCurrentTransaction = true
+            )
             val saveResult = feedbackRepository.saveInCurrentTransaction(
                 feedbackJson = prepared.feedbackJson,
                 team = team,
@@ -73,6 +88,34 @@ class SubmissionService(
                 saveResult = saveResult,
                 definitionHash = definitionResult.definitionHash.takeIf { saveResult is SaveResult.Created }
             )
+        }
+    }
+
+    private suspend fun registerDefinition(
+        team: String,
+        submission: FeedbackSubmissionV1,
+        definition: SurveyDefinition?,
+        allowDefinitionExpansion: Boolean,
+        inCurrentTransaction: Boolean
+    ): RegistrationResult {
+        return when {
+            definition == null && inCurrentTransaction ->
+                surveyDefinitionService.registerOrValidateInCurrentTransaction(team, submission)
+
+            definition == null ->
+                surveyDefinitionService.registerOrValidate(team, submission)
+
+            allowDefinitionExpansion && inCurrentTransaction ->
+                surveyDefinitionService.registerOrValidateInCurrentTransaction(team, submission)
+
+            allowDefinitionExpansion ->
+                surveyDefinitionService.registerOrValidate(team, submission)
+
+            inCurrentTransaction ->
+                surveyDefinitionService.registerOrValidateV2InCurrentTransaction(team, submission, definition)
+
+            else ->
+                surveyDefinitionService.registerOrValidateV2(team, submission, definition)
         }
     }
 }

--- a/apps/lumi-api/src/main/kotlin/no/nav/lumi/service/SurveyDefinitionService.kt
+++ b/apps/lumi-api/src/main/kotlin/no/nav/lumi/service/SurveyDefinitionService.kt
@@ -271,7 +271,7 @@ class SurveyDefinitionService(
         throw ApiErrorException.ConflictException(
             "Survey definition conflict for surveyId=$surveyId: ${
                 if (redactIdentifiers) definitionDiff.describeRedacted() else definitionDiff.describe()
-            }"
+            }. Use a new surveyId for structural changes."
         )
     }
 

--- a/apps/lumi-api/src/main/kotlin/no/nav/lumi/service/SurveyDefinitionService.kt
+++ b/apps/lumi-api/src/main/kotlin/no/nav/lumi/service/SurveyDefinitionService.kt
@@ -9,6 +9,7 @@ import no.nav.lumi.domain.diff
 import no.nav.lumi.domain.mergeWith
 import no.nav.lumi.repository.StoredSurveyDefinition
 import no.nav.lumi.repository.SurveyDefinitionRepository
+import no.nav.lumi.repository.SurveyDefinitionSource
 import no.nav.lumi.validation.SurveyDefinitionValidator
 
 data class RegistrationResult(
@@ -25,6 +26,7 @@ class SurveyDefinitionService(
             submission = submission,
             incomingDefinition = SurveyDefinition.fromSubmission(submission),
             allowDefinitionExpansion = true,
+            incomingSource = SurveyDefinitionSource.AUTO,
             findStored = repository::findByTeamAndSurveyId,
             insertDefinition = repository::insertIfUnderLimit,
             updateDefinition = repository::updateDefinitionIfHashMatches
@@ -41,9 +43,10 @@ class SurveyDefinitionService(
             submission = submission,
             incomingDefinition = definition,
             allowDefinitionExpansion = false,
+            incomingSource = SurveyDefinitionSource.API,
             findStored = repository::findByTeamAndSurveyId,
-            insertDefinition = repository::insertIfUnderLimit,
-            updateDefinition = repository::updateDefinitionIfHashMatches
+            insertDefinition = repository::insertApiDefinitionIfUnderLimit,
+            updateDefinition = repository::updateApiDefinitionIfHashMatches
         )
     }
 
@@ -56,9 +59,20 @@ class SurveyDefinitionService(
             submission = submission,
             incomingDefinition = SurveyDefinition.fromSubmission(submission),
             allowDefinitionExpansion = true,
+            incomingSource = SurveyDefinitionSource.AUTO,
             findStored = repository::findByTeamAndSurveyIdInCurrentTransaction,
-            insertDefinition = repository::insertIfUnderLimitInCurrentTransaction,
-            updateDefinition = repository::updateDefinitionIfHashMatchesInCurrentTransaction
+            insertDefinition = { team, definition, definitionHash, maxDefinitions ->
+                repository.insertIfUnderLimitInCurrentTransaction(team, definition, definitionHash, maxDefinitions)
+            },
+            updateDefinition = { team, surveyId, expectedHash, definition, newHash ->
+                repository.updateDefinitionIfHashMatchesInCurrentTransaction(
+                    team,
+                    surveyId,
+                    expectedHash,
+                    definition,
+                    newHash
+                )
+            }
         )
     }
 
@@ -72,9 +86,10 @@ class SurveyDefinitionService(
             submission = submission,
             incomingDefinition = definition,
             allowDefinitionExpansion = false,
+            incomingSource = SurveyDefinitionSource.API,
             findStored = repository::findByTeamAndSurveyIdInCurrentTransaction,
-            insertDefinition = repository::insertIfUnderLimitInCurrentTransaction,
-            updateDefinition = repository::updateDefinitionIfHashMatchesInCurrentTransaction
+            insertDefinition = repository::insertApiDefinitionIfUnderLimitInCurrentTransaction,
+            updateDefinition = repository::updateApiDefinitionIfHashMatchesInCurrentTransaction
         )
     }
 
@@ -83,6 +98,7 @@ class SurveyDefinitionService(
         submission: FeedbackSubmissionV1,
         incomingDefinition: SurveyDefinition,
         allowDefinitionExpansion: Boolean,
+        incomingSource: String,
         findStored: suspend (String, String) -> StoredSurveyDefinition?,
         insertDefinition: suspend (String, SurveyDefinition, String, Int) -> Int,
         updateDefinition: suspend (String, String, String, SurveyDefinition, String) -> Boolean
@@ -100,6 +116,7 @@ class SurveyDefinitionService(
                         stored = stored,
                         incomingDefinition = incomingDefinition,
                         allowDefinitionExpansion = allowDefinitionExpansion,
+                        incomingSource = incomingSource,
                         updateDefinition = updateDefinition
                     )
                 ) {
@@ -132,6 +149,7 @@ class SurveyDefinitionService(
                     stored = existingAfterRace,
                     incomingDefinition = incomingDefinition,
                     allowDefinitionExpansion = allowDefinitionExpansion,
+                    incomingSource = incomingSource,
                     updateDefinition = updateDefinition
                 )
             ) {
@@ -166,12 +184,40 @@ class SurveyDefinitionService(
         stored: StoredSurveyDefinition,
         incomingDefinition: SurveyDefinition,
         allowDefinitionExpansion: Boolean,
+        incomingSource: String,
         updateDefinition: suspend (String, String, String, SurveyDefinition, String) -> Boolean
     ): ExistingDefinitionResult {
         if (!allowDefinitionExpansion) {
             val definitionDiff = diff(stored.definition, incomingDefinition)
+            if (stored.source == SurveyDefinitionSource.AUTO && incomingSource == SurveyDefinitionSource.API) {
+                if (definitionDiff.changedFields.isNotEmpty() || definitionDiff.removedFields.isNotEmpty()) {
+                    throwDefinitionConflict(stored.surveyId, definitionDiff, redactIdentifiers = true)
+                }
+
+                val incomingHash = incomingDefinition.computeHash()
+                val updated = updateDefinition(team, stored.surveyId, stored.definitionHash, incomingDefinition, incomingHash)
+                return if (updated) {
+                    ExistingDefinitionResult.Resolved(
+                        RegistrationResult(stored.surveyId, incomingHash)
+                    )
+                } else {
+                    ExistingDefinitionResult.Retry
+                }
+            }
+
             if (definitionDiff.hasChanges()) {
                 throwDefinitionConflict(stored.surveyId, definitionDiff, redactIdentifiers = true)
+            }
+
+            return ExistingDefinitionResult.Resolved(
+                RegistrationResult(stored.surveyId, stored.definitionHash)
+            )
+        }
+
+        if (stored.source == SurveyDefinitionSource.API) {
+            val definitionDiff = diff(stored.definition, incomingDefinition)
+            if (definitionDiff.changedFields.isNotEmpty() || definitionDiff.addedFields.isNotEmpty()) {
+                throwDefinitionConflict(stored.surveyId, definitionDiff)
             }
 
             return ExistingDefinitionResult.Resolved(

--- a/apps/lumi-api/src/main/kotlin/no/nav/lumi/service/SurveyDefinitionService.kt
+++ b/apps/lumi-api/src/main/kotlin/no/nav/lumi/service/SurveyDefinitionService.kt
@@ -1,17 +1,15 @@
 package no.nav.lumi.service
 
 import no.nav.lumi.config.exception.ApiErrorException
-import no.nav.lumi.domain.AnswerValue
 import no.nav.lumi.domain.DefinitionDiff
 import no.nav.lumi.domain.FeedbackSubmissionV1
-import no.nav.lumi.domain.FieldType
 import no.nav.lumi.domain.SurveyDefinition
 import no.nav.lumi.domain.computeHash
 import no.nav.lumi.domain.diff
 import no.nav.lumi.domain.mergeWith
 import no.nav.lumi.repository.StoredSurveyDefinition
 import no.nav.lumi.repository.SurveyDefinitionRepository
-import no.nav.lumi.repository.isSafeChoiceValue
+import no.nav.lumi.validation.SurveyDefinitionValidator
 
 data class RegistrationResult(
     val surveyId: String,
@@ -25,6 +23,24 @@ class SurveyDefinitionService(
         return registerOrValidate(
             team = team,
             submission = submission,
+            incomingDefinition = SurveyDefinition.fromSubmission(submission),
+            allowDefinitionExpansion = true,
+            findStored = repository::findByTeamAndSurveyId,
+            insertDefinition = repository::insertIfUnderLimit,
+            updateDefinition = repository::updateDefinitionIfHashMatches
+        )
+    }
+
+    suspend fun registerOrValidateV2(
+        team: String,
+        submission: FeedbackSubmissionV1,
+        definition: SurveyDefinition
+    ): RegistrationResult {
+        return registerOrValidate(
+            team = team,
+            submission = submission,
+            incomingDefinition = definition,
+            allowDefinitionExpansion = false,
             findStored = repository::findByTeamAndSurveyId,
             insertDefinition = repository::insertIfUnderLimit,
             updateDefinition = repository::updateDefinitionIfHashMatches
@@ -38,6 +54,24 @@ class SurveyDefinitionService(
         return registerOrValidate(
             team = team,
             submission = submission,
+            incomingDefinition = SurveyDefinition.fromSubmission(submission),
+            allowDefinitionExpansion = true,
+            findStored = repository::findByTeamAndSurveyIdInCurrentTransaction,
+            insertDefinition = repository::insertIfUnderLimitInCurrentTransaction,
+            updateDefinition = repository::updateDefinitionIfHashMatchesInCurrentTransaction
+        )
+    }
+
+    internal suspend fun registerOrValidateV2InCurrentTransaction(
+        team: String,
+        submission: FeedbackSubmissionV1,
+        definition: SurveyDefinition
+    ): RegistrationResult {
+        return registerOrValidate(
+            team = team,
+            submission = submission,
+            incomingDefinition = definition,
+            allowDefinitionExpansion = false,
             findStored = repository::findByTeamAndSurveyIdInCurrentTransaction,
             insertDefinition = repository::insertIfUnderLimitInCurrentTransaction,
             updateDefinition = repository::updateDefinitionIfHashMatchesInCurrentTransaction
@@ -47,11 +81,12 @@ class SurveyDefinitionService(
     private suspend fun registerOrValidate(
         team: String,
         submission: FeedbackSubmissionV1,
+        incomingDefinition: SurveyDefinition,
+        allowDefinitionExpansion: Boolean,
         findStored: suspend (String, String) -> StoredSurveyDefinition?,
         insertDefinition: suspend (String, SurveyDefinition, String, Int) -> Int,
         updateDefinition: suspend (String, String, String, SurveyDefinition, String) -> Boolean
     ): RegistrationResult {
-        val incomingDefinition = SurveyDefinition.fromSubmission(submission)
         validateDefinitionConsistency(incomingDefinition)
         validateAnswersAgainstIncomingDefinition(incomingDefinition, submission)
         val incomingHash = incomingDefinition.computeHash()
@@ -59,7 +94,15 @@ class SurveyDefinitionService(
         repeat(MAX_REGISTRATION_ATTEMPTS) {
             val stored = findStored(team, submission.surveyId)
             if (stored != null) {
-                when (val result = handleExistingDefinition(team, stored, incomingDefinition, updateDefinition)) {
+                when (
+                    val result = handleExistingDefinition(
+                        team = team,
+                        stored = stored,
+                        incomingDefinition = incomingDefinition,
+                        allowDefinitionExpansion = allowDefinitionExpansion,
+                        updateDefinition = updateDefinition
+                    )
+                ) {
                     is ExistingDefinitionResult.Resolved -> return result.registrationResult
                     ExistingDefinitionResult.Retry -> return@repeat
                 }
@@ -83,7 +126,15 @@ class SurveyDefinitionService(
                 )
             }
 
-            when (val result = handleExistingDefinition(team, existingAfterRace, incomingDefinition, updateDefinition)) {
+            when (
+                val result = handleExistingDefinition(
+                    team = team,
+                    stored = existingAfterRace,
+                    incomingDefinition = incomingDefinition,
+                    allowDefinitionExpansion = allowDefinitionExpansion,
+                    updateDefinition = updateDefinition
+                )
+            ) {
                 is ExistingDefinitionResult.Resolved -> return result.registrationResult
                 ExistingDefinitionResult.Retry -> return@repeat
             }
@@ -103,21 +154,31 @@ class SurveyDefinitionService(
         definition: SurveyDefinition,
         submission: FeedbackSubmissionV1
     ) {
-        val synthetic = StoredSurveyDefinition(
-            team = "",
-            surveyId = definition.surveyId,
-            definitionHash = "",
-            definition = definition
+        SurveyDefinitionValidator.validateAnswersAgainstDefinition(
+            definition = definition,
+            answers = submission.answers,
+            surveyId = definition.surveyId
         )
-        validateAnswersAgainstStoredDefinition(synthetic, submission)
     }
 
     private suspend fun handleExistingDefinition(
         team: String,
         stored: StoredSurveyDefinition,
         incomingDefinition: SurveyDefinition,
+        allowDefinitionExpansion: Boolean,
         updateDefinition: suspend (String, String, String, SurveyDefinition, String) -> Boolean
     ): ExistingDefinitionResult {
+        if (!allowDefinitionExpansion) {
+            val definitionDiff = diff(stored.definition, incomingDefinition)
+            if (definitionDiff.hasChanges()) {
+                throwDefinitionConflict(stored.surveyId, definitionDiff, redactIdentifiers = true)
+            }
+
+            return ExistingDefinitionResult.Resolved(
+                RegistrationResult(stored.surveyId, stored.definitionHash)
+            )
+        }
+
         val mergedDefinition = stored.definition.mergeWith(incomingDefinition)
         val definitionDiff = diff(stored.definition, mergedDefinition)
         if (definitionDiff.changedFields.isNotEmpty()) {
@@ -148,163 +209,24 @@ class SurveyDefinitionService(
         }
     }
 
-    private fun validateAnswersAgainstStoredDefinition(
-        stored: StoredSurveyDefinition,
-        submission: FeedbackSubmissionV1
-    ) {
-        val storedFieldsById = stored.definition.fields.associateBy { it.fieldId }
-
-        submission.answers.forEach { answer ->
-            val storedField = storedFieldsById[answer.fieldId]
-                ?: throw ApiErrorException.BadRequestException(
-                    "Invalid payload: unknown fieldId=${answer.fieldId} for surveyId=${stored.surveyId}"
-                )
-
-            if (storedField.fieldType != answer.fieldType) {
-                throw ApiErrorException.BadRequestException(
-                    "Invalid payload: fieldId=${answer.fieldId} has fieldType=${answer.fieldType}, expected ${storedField.fieldType}"
-                )
-            }
-
-            val expectedFieldType = expectedFieldType(answer.value)
-            if (storedField.fieldType != expectedFieldType) {
-                throw ApiErrorException.BadRequestException(
-                    "Invalid payload: fieldId=${answer.fieldId} has fieldType=${storedField.fieldType}, expected $expectedFieldType"
-                )
-            }
-
-            when (val value = answer.value) {
-                is AnswerValue.Rating -> {
-                    if (storedField.ratingVariant != value.ratingVariant || storedField.ratingScale != value.ratingScale) {
-                        throw ApiErrorException.BadRequestException(
-                            "Invalid payload: rating config for fieldId=${answer.fieldId} does not match stored definition"
-                        )
-                    }
-                }
-
-                is AnswerValue.SingleChoice -> {
-                    val optionIds = storedField.optionIds.orEmpty()
-                    if (value.selectedOptionId !in optionIds) {
-                        throw ApiErrorException.BadRequestException(
-                            "Invalid payload: selectedOptionId=${value.selectedOptionId} is not valid for fieldId=${answer.fieldId}"
-                        )
-                    }
-                }
-
-                is AnswerValue.MultiChoice -> {
-                    val duplicateSelections = value.selectedOptionIds.groupBy { it }.filter { it.value.size > 1 }.keys
-                    if (duplicateSelections.isNotEmpty()) {
-                        throw ApiErrorException.BadRequestException(
-                            "Invalid payload: duplicate selectedOptionIds=$duplicateSelections for fieldId=${answer.fieldId}"
-                        )
-                    }
-                    val optionIds = storedField.optionIds.orEmpty().toSet()
-                    val invalidIds = value.selectedOptionIds.filterNot(optionIds::contains)
-                    if (invalidIds.isNotEmpty()) {
-                        throw ApiErrorException.BadRequestException(
-                            "Invalid payload: selectedOptionIds=$invalidIds are not valid for fieldId=${answer.fieldId}"
-                        )
-                    }
-                }
-
-                is AnswerValue.Text, is AnswerValue.DateValue -> Unit
-            }
-        }
-    }
-
-    private fun expectedFieldType(value: AnswerValue): FieldType {
-        return when (value) {
-            is AnswerValue.Rating -> FieldType.RATING
-            is AnswerValue.Text -> FieldType.TEXT
-            is AnswerValue.SingleChoice -> FieldType.SINGLE_CHOICE
-            is AnswerValue.MultiChoice -> FieldType.MULTI_CHOICE
-            is AnswerValue.DateValue -> FieldType.DATE
-        }
-    }
-
     /**
      * Validate structural consistency of a definition before first registration.
      * Prevents a malformed first submission from permanently locking an invalid structure.
      */
     private fun validateDefinitionConsistency(definition: SurveyDefinition) {
-        val duplicateIds = definition.fields.groupBy { it.fieldId }.filter { it.value.size > 1 }.keys
-        if (duplicateIds.isNotEmpty()) {
-            throw ApiErrorException.BadRequestException(
-                "Invalid payload: duplicate fieldIds=$duplicateIds"
-            )
-        }
-
-        definition.fields.forEach { field ->
-            validateFieldId(field.fieldId)
-
-            when (field.fieldType) {
-                FieldType.SINGLE_CHOICE, FieldType.MULTI_CHOICE -> {
-                    if (field.optionIds.isNullOrEmpty()) {
-                        throw ApiErrorException.BadRequestException(
-                            "Invalid payload: fieldId=${field.fieldId} (${field.fieldType}) requires at least one option"
-                        )
-                    }
-                    field.optionIds.forEach { validateOptionId(it, field.fieldId) }
-                    val duplicates = field.optionIds.groupBy { it }.filter { it.value.size > 1 }.keys
-                    if (duplicates.isNotEmpty()) {
-                        throw ApiErrorException.BadRequestException(
-                            "Invalid payload: fieldId=${field.fieldId} has duplicate optionIds=$duplicates"
-                        )
-                    }
-                }
-
-                FieldType.RATING -> {
-                    if (field.ratingVariant == null || field.ratingScale == null) {
-                        throw ApiErrorException.BadRequestException(
-                            "Invalid payload: fieldId=${field.fieldId} (RATING) requires ratingVariant and ratingScale"
-                        )
-                    }
-                }
-
-                else -> { /* TEXT, DATE — no structural requirements */ }
-            }
-        }
+        SurveyDefinitionValidator.validateDefinition(definition)
     }
 
-    private fun throwDefinitionConflict(surveyId: String, definitionDiff: DefinitionDiff): Nothing {
+    private fun throwDefinitionConflict(
+        surveyId: String,
+        definitionDiff: DefinitionDiff,
+        redactIdentifiers: Boolean = false
+    ): Nothing {
         throw ApiErrorException.ConflictException(
-            "Survey definition conflict for surveyId=$surveyId: ${definitionDiff.describe()}"
+            "Survey definition conflict for surveyId=$surveyId: ${
+                if (redactIdentifiers) definitionDiff.describeRedacted() else definitionDiff.describe()
+            }"
         )
-    }
-
-    /** fieldId: alphanumeric + hyphen + underscore, max 200 chars */
-    private fun validateFieldId(fieldId: String) {
-        if (fieldId.isBlank()) {
-            throw ApiErrorException.BadRequestException("Invalid payload: fieldId must be non-blank")
-        }
-        if (fieldId.length > MAX_IDENTIFIER_LENGTH) {
-            throw ApiErrorException.BadRequestException(
-                "Invalid payload: fieldId exceeds max length $MAX_IDENTIFIER_LENGTH"
-            )
-        }
-        if (!fieldId.all { it.isLetterOrDigit() || it == '-' || it == '_' }) {
-            throw ApiErrorException.BadRequestException(
-                "Invalid payload: fieldId=$fieldId contains illegal characters (allowed: alphanumeric, hyphen, underscore)"
-            )
-        }
-    }
-
-    private fun validateOptionId(optionId: String, fieldId: String) {
-        if (optionId.isBlank()) {
-            throw ApiErrorException.BadRequestException(
-                "Invalid payload: fieldId=$fieldId has blank optionIds"
-            )
-        }
-        if (optionId.length > MAX_IDENTIFIER_LENGTH) {
-            throw ApiErrorException.BadRequestException(
-                "Invalid payload: fieldId=$fieldId has optionId exceeding max length $MAX_IDENTIFIER_LENGTH"
-            )
-        }
-        if (!isSafeChoiceValue(optionId)) {
-            throw ApiErrorException.BadRequestException(
-                "Invalid payload: fieldId=$fieldId has optionId containing illegal characters"
-            )
-        }
     }
 
     private sealed interface ExistingDefinitionResult {
@@ -314,7 +236,6 @@ class SurveyDefinitionService(
 
     private companion object {
         const val MAX_DEFINITIONS_PER_TEAM = 500
-        const val MAX_IDENTIFIER_LENGTH = 200
         const val MAX_REGISTRATION_ATTEMPTS = 5
     }
 }

--- a/apps/lumi-api/src/main/kotlin/no/nav/lumi/validation/SubmissionV2Validator.kt
+++ b/apps/lumi-api/src/main/kotlin/no/nav/lumi/validation/SubmissionV2Validator.kt
@@ -1,0 +1,42 @@
+package no.nav.lumi.validation
+
+import no.nav.lumi.config.exception.ApiErrorException
+import no.nav.lumi.domain.FeedbackSubmissionV2
+
+object SubmissionV2Validator {
+    fun validateSubmissionV2(submission: FeedbackSubmissionV2) {
+        SubmissionValidator.validateCommonSubmission(
+            schemaVersion = submission.schemaVersion,
+            expectedSchemaVersion = 2,
+            surveyId = submission.surveyId,
+            submittedAt = submission.submittedAt,
+            startedAt = submission.startedAt,
+            deduplicationKey = submission.deduplicationKey,
+            context = submission.context,
+            answers = submission.answers
+        )
+
+        if (submission.surveyType != submission.definition.surveyType) {
+            throw ApiErrorException.BadRequestException(
+                "Invalid payload: surveyType must match definition.surveyType"
+            )
+        }
+
+        val definition = submission.definition.toSurveyDefinition(submission.surveyId)
+        SurveyDefinitionValidator.validateDefinition(definition)
+
+        val fieldIds = definition.fields.map { it.fieldId }.toSet()
+        val invalidFieldIds = submission.answers.map { it.fieldId }.filterNot(fieldIds::contains)
+        if (invalidFieldIds.isNotEmpty()) {
+            throw ApiErrorException.BadRequestException(
+                "Invalid payload: answers.fieldId must exist in definition.fields"
+            )
+        }
+
+        SurveyDefinitionValidator.validateAnswersAgainstDefinition(
+            definition = definition,
+            answers = submission.answers,
+            surveyId = submission.surveyId
+        )
+    }
+}

--- a/apps/lumi-api/src/main/kotlin/no/nav/lumi/validation/SubmissionValidator.kt
+++ b/apps/lumi-api/src/main/kotlin/no/nav/lumi/validation/SubmissionValidator.kt
@@ -4,9 +4,11 @@ import kotlinx.serialization.json.JsonElement
 import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.contentOrNull
 import no.nav.lumi.config.exception.ApiErrorException
+import no.nav.lumi.domain.Answer
 import no.nav.lumi.domain.AnswerValue
 import no.nav.lumi.domain.FeedbackSubmissionV1
 import no.nav.lumi.domain.RatingVariant
+import no.nav.lumi.domain.SubmissionContextV1
 import java.net.URI
 import java.time.Instant
 
@@ -31,48 +33,70 @@ object SubmissionValidator {
     private const val MAX_CONTEXT_DEBUG_KEYS = 50
 
     fun validateSubmissionV1(submission: FeedbackSubmissionV1) {
-        if (submission.schemaVersion != 1) {
+        validateCommonSubmission(
+            schemaVersion = submission.schemaVersion,
+            expectedSchemaVersion = 1,
+            surveyId = submission.surveyId,
+            submittedAt = submission.submittedAt,
+            startedAt = submission.startedAt,
+            deduplicationKey = submission.deduplicationKey,
+            context = submission.context,
+            answers = submission.answers
+        )
+    }
+
+    internal fun validateCommonSubmission(
+        schemaVersion: Int,
+        expectedSchemaVersion: Int,
+        surveyId: String,
+        submittedAt: String,
+        startedAt: String?,
+        deduplicationKey: String?,
+        context: SubmissionContextV1?,
+        answers: List<Answer>
+    ) {
+        if (schemaVersion != expectedSchemaVersion) {
             throw ApiErrorException.BadRequestException(
-                "UNSUPPORTED_SCHEMA: schemaVersion=${submission.schemaVersion} is not supported"
+                "UNSUPPORTED_SCHEMA: schemaVersion=$schemaVersion is not supported"
             )
         }
 
-        if (submission.surveyId.isBlank()) {
+        if (surveyId.isBlank()) {
             throw ApiErrorException.BadRequestException("Invalid payload: surveyId must be non-blank")
         }
-        if (submission.surveyId.length > MAX_SURVEY_ID_LENGTH) {
+        if (surveyId.length > MAX_SURVEY_ID_LENGTH) {
             throw ApiErrorException.BadRequestException(
                 "Invalid payload: surveyId max length is $MAX_SURVEY_ID_LENGTH"
             )
         }
 
-        DeduplicationKeyValidator.validate(submission.deduplicationKey)
+        DeduplicationKeyValidator.validate(deduplicationKey)
 
-        runCatching { Instant.parse(submission.submittedAt) }
+        runCatching { Instant.parse(submittedAt) }
             .getOrElse { throw ApiErrorException.BadRequestException("Invalid payload: submittedAt must be an ISO instant") }
 
-        if (submission.startedAt != null) {
-            runCatching { Instant.parse(submission.startedAt) }
+        if (startedAt != null) {
+            runCatching { Instant.parse(startedAt) }
                 .getOrElse { throw ApiErrorException.BadRequestException("Invalid payload: startedAt must be an ISO instant") }
         }
 
-        if (submission.answers.isEmpty()) {
+        if (answers.isEmpty()) {
             throw ApiErrorException.BadRequestException("Invalid payload: answers must be non-empty")
         }
-        if (submission.answers.size > MAX_ANSWERS_PER_SUBMISSION) {
+        if (answers.size > MAX_ANSWERS_PER_SUBMISSION) {
             throw ApiErrorException.BadRequestException(
                 "Invalid payload: answers max count is $MAX_ANSWERS_PER_SUBMISSION"
             )
         }
 
-        val uniqueFieldIds = submission.answers.map { it.fieldId }.toSet().size
-        if (uniqueFieldIds != submission.answers.size) {
+        val uniqueFieldIds = answers.map { it.fieldId }.toSet().size
+        if (uniqueFieldIds != answers.size) {
             throw ApiErrorException.BadRequestException(
                 "Invalid payload: answers.fieldId must be unique"
             )
         }
 
-        submission.context?.let { context ->
+        context?.let { context ->
             context.url?.let { url ->
                 if (url.length > MAX_CONTEXT_URL_LENGTH) {
                     throw ApiErrorException.BadRequestException(
@@ -171,7 +195,7 @@ object SubmissionValidator {
             }
         }
 
-        submission.answers.forEach { answer ->
+        answers.forEach { answer ->
             if (answer.fieldId.isBlank()) {
                 throw ApiErrorException.BadRequestException("Invalid payload: answers.fieldId must be non-blank")
             }

--- a/apps/lumi-api/src/main/kotlin/no/nav/lumi/validation/SurveyDefinitionValidator.kt
+++ b/apps/lumi-api/src/main/kotlin/no/nav/lumi/validation/SurveyDefinitionValidator.kt
@@ -1,0 +1,219 @@
+package no.nav.lumi.validation
+
+import no.nav.lumi.config.exception.ApiErrorException
+import no.nav.lumi.domain.Answer
+import no.nav.lumi.domain.AnswerValue
+import no.nav.lumi.domain.FieldType
+import no.nav.lumi.domain.RatingVariant
+import no.nav.lumi.domain.SurveyDefinition
+import no.nav.lumi.repository.isSafeChoiceValue
+
+object SurveyDefinitionValidator {
+    fun validateDefinition(definition: SurveyDefinition) {
+        if (definition.fields.size > MAX_FIELDS_PER_DEFINITION) {
+            throw ApiErrorException.BadRequestException(
+                "Invalid payload: definition.fields max count is $MAX_FIELDS_PER_DEFINITION"
+            )
+        }
+
+        val duplicateIds = definition.fields.groupBy { it.fieldId }.filter { it.value.size > 1 }.keys
+        if (duplicateIds.isNotEmpty()) {
+            throw ApiErrorException.BadRequestException(
+                "Invalid payload: duplicate fieldIds=$duplicateIds"
+            )
+        }
+
+        definition.fields.forEach { field ->
+            validateFieldId(field.fieldId)
+
+            when (field.fieldType) {
+                FieldType.RATING -> {
+                    val variant = field.ratingVariant
+                        ?: throw ApiErrorException.BadRequestException(
+                            "Invalid payload: fieldId=${field.fieldId} (RATING) requires ratingVariant and ratingScale"
+                        )
+                    val scale = field.ratingScale
+                        ?: throw ApiErrorException.BadRequestException(
+                            "Invalid payload: fieldId=${field.fieldId} (RATING) requires ratingVariant and ratingScale"
+                        )
+
+                    val expectedScale = RatingVariant.getScale(variant)
+                    if (scale != expectedScale) {
+                        throw ApiErrorException.BadRequestException(
+                            "Invalid payload: fieldId=${field.fieldId} ratingScale=$scale does not match ratingVariant=$variant (expected $expectedScale)"
+                        )
+                    }
+                    if (field.optionIds != null) {
+                        throw ApiErrorException.BadRequestException(
+                            "Invalid payload: fieldId=${field.fieldId} (RATING) must not include optionIds"
+                        )
+                    }
+                }
+
+                FieldType.SINGLE_CHOICE, FieldType.MULTI_CHOICE -> {
+                    if (field.optionIds.isNullOrEmpty()) {
+                        throw ApiErrorException.BadRequestException(
+                            "Invalid payload: fieldId=${field.fieldId} (${field.fieldType}) requires at least one option"
+                        )
+                    }
+                    field.optionIds.forEach { validateOptionId(it, field.fieldId) }
+                    val duplicates = field.optionIds.groupBy { it }.filter { it.value.size > 1 }.keys
+                    if (duplicates.isNotEmpty()) {
+                        throw ApiErrorException.BadRequestException(
+                            "Invalid payload: fieldId=${field.fieldId} has duplicate optionIds=$duplicates"
+                        )
+                    }
+                    if (field.ratingVariant != null || field.ratingScale != null) {
+                        throw ApiErrorException.BadRequestException(
+                            "Invalid payload: fieldId=${field.fieldId} (${field.fieldType}) must not include ratingVariant or ratingScale"
+                        )
+                    }
+                }
+
+                else -> {
+                    if (field.ratingVariant != null || field.ratingScale != null) {
+                        throw ApiErrorException.BadRequestException(
+                            "Invalid payload: fieldId=${field.fieldId} (${field.fieldType}) must not include ratingVariant or ratingScale"
+                        )
+                    }
+                    if (field.optionIds != null) {
+                        throw ApiErrorException.BadRequestException(
+                            "Invalid payload: fieldId=${field.fieldId} (${field.fieldType}) must not include optionIds"
+                        )
+                    }
+                }
+            }
+        }
+    }
+
+    fun validateAnswersAgainstDefinition(
+        definition: SurveyDefinition,
+        answers: List<Answer>,
+        surveyId: String = definition.surveyId
+    ) {
+        val fieldsById = definition.fields.associateBy { it.fieldId }
+
+        answers.forEach { answer ->
+            val field = fieldsById[answer.fieldId]
+                ?: throw ApiErrorException.BadRequestException(
+                    "Invalid payload: unknown fieldId=${answer.fieldId} for surveyId=$surveyId"
+                )
+
+            if (field.fieldType != answer.fieldType) {
+                throw ApiErrorException.BadRequestException(
+                    "Invalid payload: fieldId=${answer.fieldId} has fieldType=${answer.fieldType}, expected ${field.fieldType}"
+                )
+            }
+
+            val expectedFieldType = expectedFieldType(answer.value)
+            if (field.fieldType != expectedFieldType) {
+                throw ApiErrorException.BadRequestException(
+                    "Invalid payload: fieldId=${answer.fieldId} has fieldType=${field.fieldType}, expected $expectedFieldType"
+                )
+            }
+
+            when (val value = answer.value) {
+                is AnswerValue.Rating -> {
+                    if (field.ratingVariant != value.ratingVariant || field.ratingScale != value.ratingScale) {
+                        throw ApiErrorException.BadRequestException(
+                            "Invalid payload: rating config for fieldId=${answer.fieldId} does not match stored definition"
+                        )
+                    }
+                }
+
+                is AnswerValue.SingleChoice -> {
+                    validateChoiceQuestionOptions(answer, field.optionIds.orEmpty())
+                    val optionIds = field.optionIds.orEmpty()
+                    if (value.selectedOptionId !in optionIds) {
+                        throw ApiErrorException.BadRequestException(
+                            "Invalid payload: selectedOptionId=${value.selectedOptionId} is not valid for fieldId=${answer.fieldId}"
+                        )
+                    }
+                }
+
+                is AnswerValue.MultiChoice -> {
+                    validateChoiceQuestionOptions(answer, field.optionIds.orEmpty())
+                    val duplicateSelections = value.selectedOptionIds.groupBy { it }.filter { it.value.size > 1 }.keys
+                    if (duplicateSelections.isNotEmpty()) {
+                        throw ApiErrorException.BadRequestException(
+                            "Invalid payload: duplicate selectedOptionIds=$duplicateSelections for fieldId=${answer.fieldId}"
+                        )
+                    }
+                    val optionIds = field.optionIds.orEmpty().toSet()
+                    val invalidIds = value.selectedOptionIds.filterNot(optionIds::contains)
+                    if (invalidIds.isNotEmpty()) {
+                        throw ApiErrorException.BadRequestException(
+                            "Invalid payload: selectedOptionIds=$invalidIds are not valid for fieldId=${answer.fieldId}"
+                        )
+                    }
+                }
+
+                is AnswerValue.Text, is AnswerValue.DateValue -> Unit
+            }
+        }
+    }
+
+    private fun validateChoiceQuestionOptions(
+        answer: Answer,
+        definitionOptionIds: List<String>
+    ) {
+        val answerOptionIds = answer.question.options?.map { it.id }
+            ?: throw ApiErrorException.BadRequestException(
+                "Invalid payload: choice answer fieldId=${answer.fieldId} must include question.options to match definition.optionIds"
+            )
+
+        if (answerOptionIds != definitionOptionIds) {
+            throw ApiErrorException.BadRequestException(
+                "Invalid payload: choice answer fieldId=${answer.fieldId} question.options must match definition.optionIds"
+            )
+        }
+    }
+
+    private fun expectedFieldType(value: AnswerValue): FieldType {
+        return when (value) {
+            is AnswerValue.Rating -> FieldType.RATING
+            is AnswerValue.Text -> FieldType.TEXT
+            is AnswerValue.SingleChoice -> FieldType.SINGLE_CHOICE
+            is AnswerValue.MultiChoice -> FieldType.MULTI_CHOICE
+            is AnswerValue.DateValue -> FieldType.DATE
+        }
+    }
+
+    /** fieldId: alphanumeric + hyphen + underscore, max 200 chars */
+    private fun validateFieldId(fieldId: String) {
+        if (fieldId.isBlank()) {
+            throw ApiErrorException.BadRequestException("Invalid payload: fieldId must be non-blank")
+        }
+        if (fieldId.length > MAX_IDENTIFIER_LENGTH) {
+            throw ApiErrorException.BadRequestException(
+                "Invalid payload: fieldId exceeds max length $MAX_IDENTIFIER_LENGTH"
+            )
+        }
+        if (!fieldId.all { it.isLetterOrDigit() || it == '-' || it == '_' }) {
+            throw ApiErrorException.BadRequestException(
+                "Invalid payload: fieldId=$fieldId contains illegal characters (allowed: alphanumeric, hyphen, underscore)"
+            )
+        }
+    }
+
+    private fun validateOptionId(optionId: String, fieldId: String) {
+        if (optionId.isBlank()) {
+            throw ApiErrorException.BadRequestException(
+                "Invalid payload: fieldId=$fieldId has blank optionIds"
+            )
+        }
+        if (optionId.length > MAX_IDENTIFIER_LENGTH) {
+            throw ApiErrorException.BadRequestException(
+                "Invalid payload: fieldId=$fieldId has optionId exceeding max length $MAX_IDENTIFIER_LENGTH"
+            )
+        }
+        if (!isSafeChoiceValue(optionId)) {
+            throw ApiErrorException.BadRequestException(
+                "Invalid payload: fieldId=$fieldId has optionId containing illegal characters"
+            )
+        }
+    }
+
+    private const val MAX_FIELDS_PER_DEFINITION = 50
+    private const val MAX_IDENTIFIER_LENGTH = 200
+}

--- a/apps/lumi-api/src/test/kotlin/no/nav/lumi/domain/DefinitionHashTest.kt
+++ b/apps/lumi-api/src/test/kotlin/no/nav/lumi/domain/DefinitionHashTest.kt
@@ -120,6 +120,32 @@ class DefinitionHashTest : FunSpec({
         definitionDiff.changedFields.single().change shouldContain "ratingVariant EMOJI -> NPS"
     }
 
+    test("redacted diff hides optionIds when fieldType changes between option and non-option fields") {
+        val stored = SurveyDefinition(
+            surveyId = "survey-1",
+            surveyType = SurveyType.CUSTOM,
+            fields = listOf(
+                FieldDefinition("category", FieldType.TEXT, null, null, null),
+                FieldDefinition("task", FieldType.SINGLE_CHOICE, null, null, listOf("apply", "follow-up"))
+            )
+        )
+        val incoming = SurveyDefinition(
+            surveyId = "survey-1",
+            surveyType = SurveyType.CUSTOM,
+            fields = listOf(
+                FieldDefinition("category", FieldType.SINGLE_CHOICE, null, null, listOf("private-choice")),
+                FieldDefinition("task", FieldType.TEXT, null, null, null)
+            )
+        )
+
+        val description = diff(stored, incoming).describeRedacted()
+
+        description shouldContain "optionIds [REDACTED] -> [REDACTED]"
+        description.contains("private-choice") shouldBe false
+        description.contains("apply") shouldBe false
+        description.contains("follow-up") shouldBe false
+    }
+
     test("field order does not affect hash (sorted by fieldId)") {
         val definition1 = SurveyDefinition(
             surveyId = "survey-1",

--- a/apps/lumi-api/src/test/kotlin/no/nav/lumi/routes/InternalSubmissionRoutesTest.kt
+++ b/apps/lumi-api/src/test/kotlin/no/nav/lumi/routes/InternalSubmissionRoutesTest.kt
@@ -13,6 +13,9 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.async
 import kotlinx.coroutines.awaitAll
 import kotlinx.coroutines.coroutineScope
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.mockk
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.boolean
 import kotlinx.serialization.json.jsonObject
@@ -22,9 +25,11 @@ import no.nav.lumi.config.DatabaseHolder
 import no.nav.lumi.config.configureSerialization
 import no.nav.lumi.config.configureStatusPages
 import no.nav.lumi.domain.FeedbackQuery
+import no.nav.lumi.domain.SaveResult
 import no.nav.lumi.repository.FeedbackRepository
 import no.nav.lumi.repository.SurveyDefinitionRepository
 import no.nav.lumi.service.FeedbackService
+import no.nav.lumi.service.SubmissionOutcome
 import no.nav.lumi.service.SubmissionService
 import no.nav.lumi.service.SurveyDefinitionService
 import java.util.concurrent.atomic.AtomicInteger
@@ -71,6 +76,36 @@ private fun validPayloadWithDedup(
 }
 """.trimIndent()
 
+private fun validPayloadV2(
+    submittedAt: String = "2026-01-10T12:00:12Z",
+    deduplicationKey: String = "client-key-123456"
+) = """
+{
+  "schemaVersion": 2,
+  "surveyId": "modia-feedback-v2",
+  "surveyType": "rating",
+  "submittedAt": "$submittedAt",
+  "deduplicationKey": "$deduplicationKey",
+  "definition": {
+    "surveyType": "rating",
+    "fields": [
+      {
+        "fieldId": "feedback",
+        "fieldType": "TEXT"
+      }
+    ]
+  },
+  "answers": [
+    {
+      "fieldId": "feedback",
+      "fieldType": "TEXT",
+      "question": { "label": "Hvorfor?" },
+      "value": { "type": "text", "text": "Bra" }
+    }
+  ]
+}
+""".trimIndent()
+
 class InternalSubmissionRoutesTest : FunSpec({
 
     beforeSpec { TestDatabase.initialize() }
@@ -104,6 +139,54 @@ class InternalSubmissionRoutesTest : FunSpec({
             parsed["id"]?.jsonPrimitive?.content?.isNotBlank() shouldBe true
         }
     }
+
+    test("should accept valid schemaVersion 2 payload on internal route") {
+        val submissionService = mockk<SubmissionService>()
+        coEvery {
+            submissionService.submit(any(), any(), any(), any(), any())
+        } returns SubmissionOutcome(SaveResult.Created("created-v2"), "hash-v2")
+
+        testApplication {
+            application {
+                configureSerialization()
+                configureStatusPages()
+                routing {
+                    internalSubmissionRoutes(
+                        submissionService = submissionService,
+                        submissionKey = TEST_PSK
+                    )
+                }
+            }
+
+            val response = client.post("/api/internal/v1/feedback") {
+                contentType(ContentType.Application.Json)
+                header("X-Lumi-Submission-Key", TEST_PSK)
+                header("X-Lumi-Caller-Identity", VALID_IDENTITY)
+                setBody(validPayloadV2())
+            }
+
+            response.status shouldBe HttpStatusCode.Created
+            Json.parseToJsonElement(response.bodyAsText()).jsonObject["id"]?.jsonPrimitive?.content shouldBe "created-v2"
+            coVerify(exactly = 1) {
+                submissionService.submit(
+                    any(),
+                    "teamsykefravr",
+                    "syfomodiaperson",
+                    match {
+                        it.schemaVersion == 2 &&
+                            it.surveyId == "modia-feedback-v2" &&
+                            it.deduplicationKey == "client-key-123456"
+                    },
+                    match {
+                        it.surveyId == "modia-feedback-v2" &&
+                            it.surveyType.name == "RATING" &&
+                            it.fields.map { field -> field.fieldId } == listOf("feedback")
+                    }
+                )
+            }
+        }
+    }
+
 
     test("should apply immutable definition validation on internal route") {
         testApplication {

--- a/apps/lumi-api/src/test/kotlin/no/nav/lumi/routes/SubmissionV2RoutesTest.kt
+++ b/apps/lumi-api/src/test/kotlin/no/nav/lumi/routes/SubmissionV2RoutesTest.kt
@@ -201,6 +201,91 @@ class SubmissionV2RoutesTest : FunSpec({
             }
 
             response.status shouldBe HttpStatusCode.BadRequest
+            Json.parseToJsonElement(response.bodyAsText()).jsonObject["message"]?.jsonPrimitive?.content shouldBe
+                "Invalid payload: definition is required for schemaVersion=2"
+            coVerify(exactly = 0) { submissionService.submit(any(), any(), any(), any(), any(), any()) }
+        }
+    }
+
+    test("v2 without deduplicationKey returns specific 400") {
+        val submissionService = mockk<SubmissionService>()
+
+        testApplication {
+            application { submissionRoutesTestModule(submissionService) }
+            val client = createTestClient()
+
+            val response = client.post("/api/tokenx/v1/feedback") {
+                contentType(ContentType.Application.Json)
+                setBody(
+                    """
+                    {
+                      "schemaVersion": 2,
+                      "surveyId": "dp-feedback-v2",
+                      "surveyType": "rating",
+                      "submittedAt": "2026-01-10T12:00:12Z",
+                      "definition": {
+                        "surveyType": "rating",
+                        "fields": [
+                          {
+                            "fieldId": "feedback",
+                            "fieldType": "TEXT"
+                          }
+                        ]
+                      },
+                      "answers": [
+                        {
+                          "fieldId": "feedback",
+                          "fieldType": "TEXT",
+                          "question": { "label": "Hvorfor?" },
+                          "value": { "type": "text", "text": "Bra" }
+                        }
+                      ]
+                    }
+                    """.trimIndent()
+                )
+            }
+
+            response.status shouldBe HttpStatusCode.BadRequest
+            Json.parseToJsonElement(response.bodyAsText()).jsonObject["message"]?.jsonPrimitive?.content shouldBe
+                "Invalid payload: deduplicationKey is required for schemaVersion=2"
+            coVerify(exactly = 0) { submissionService.submit(any(), any(), any(), any(), any(), any()) }
+        }
+    }
+
+    test("v2 without answers returns generic invalid payload") {
+        val submissionService = mockk<SubmissionService>()
+
+        testApplication {
+            application { submissionRoutesTestModule(submissionService) }
+            val client = createTestClient()
+
+            val response = client.post("/api/tokenx/v1/feedback") {
+                contentType(ContentType.Application.Json)
+                setBody(
+                    """
+                    {
+                      "schemaVersion": 2,
+                      "surveyId": "dp-feedback-v2",
+                      "surveyType": "rating",
+                      "submittedAt": "2026-01-10T12:00:12Z",
+                      "deduplicationKey": "client-key-123456",
+                      "definition": {
+                        "surveyType": "rating",
+                        "fields": [
+                          {
+                            "fieldId": "feedback",
+                            "fieldType": "TEXT"
+                          }
+                        ]
+                      }
+                    }
+                    """.trimIndent()
+                )
+            }
+
+            response.status shouldBe HttpStatusCode.BadRequest
+            Json.parseToJsonElement(response.bodyAsText()).jsonObject["message"]?.jsonPrimitive?.content shouldBe
+                "Invalid payload"
             coVerify(exactly = 0) { submissionService.submit(any(), any(), any(), any(), any(), any()) }
         }
     }

--- a/apps/lumi-api/src/test/kotlin/no/nav/lumi/routes/SubmissionV2RoutesTest.kt
+++ b/apps/lumi-api/src/test/kotlin/no/nav/lumi/routes/SubmissionV2RoutesTest.kt
@@ -101,7 +101,7 @@ class SubmissionV2RoutesTest : FunSpec({
     test("v1 still works on existing submission endpoint") {
         val submissionService = mockk<SubmissionService>()
         coEvery {
-            submissionService.submit(any(), any(), any(), any(), any(), any())
+            submissionService.submit(any(), any(), any(), any(), any())
         } returns SubmissionOutcome(SaveResult.Created("created-v1"), "hash-v1")
 
         testApplication {
@@ -132,7 +132,7 @@ class SubmissionV2RoutesTest : FunSpec({
 
             response.status shouldBe HttpStatusCode.Created
             coVerify(exactly = 1) {
-                submissionService.submit(any(), "local-dev", "local-app", any(), null, true)
+                submissionService.submit(any(), "local-dev", "local-app", any(), null)
             }
         }
     }
@@ -140,7 +140,7 @@ class SubmissionV2RoutesTest : FunSpec({
     test("v2 accepts complete definition on existing submission endpoint") {
         val submissionService = mockk<SubmissionService>()
         coEvery {
-            submissionService.submit(any(), any(), any(), any(), any(), any())
+            submissionService.submit(any(), any(), any(), any(), any())
         } returns SubmissionOutcome(SaveResult.Created("created-v2"), "hash-v2")
 
         testApplication {
@@ -163,8 +163,7 @@ class SubmissionV2RoutesTest : FunSpec({
                         it.surveyId == "dp-feedback-v2" &&
                             it.surveyType.name == "RATING" &&
                             it.fields.map { field -> field.fieldId } == listOf("feedback")
-                    },
-                    false
+                    }
                 )
             }
         }
@@ -203,7 +202,7 @@ class SubmissionV2RoutesTest : FunSpec({
             response.status shouldBe HttpStatusCode.BadRequest
             Json.parseToJsonElement(response.bodyAsText()).jsonObject["message"]?.jsonPrimitive?.content shouldBe
                 "Invalid payload: definition is required for schemaVersion=2"
-            coVerify(exactly = 0) { submissionService.submit(any(), any(), any(), any(), any(), any()) }
+            coVerify(exactly = 0) { submissionService.submit(any(), any(), any(), any(), any()) }
         }
     }
 
@@ -248,7 +247,7 @@ class SubmissionV2RoutesTest : FunSpec({
             response.status shouldBe HttpStatusCode.BadRequest
             Json.parseToJsonElement(response.bodyAsText()).jsonObject["message"]?.jsonPrimitive?.content shouldBe
                 "Invalid payload: deduplicationKey is required for schemaVersion=2"
-            coVerify(exactly = 0) { submissionService.submit(any(), any(), any(), any(), any(), any()) }
+            coVerify(exactly = 0) { submissionService.submit(any(), any(), any(), any(), any()) }
         }
     }
 
@@ -286,7 +285,7 @@ class SubmissionV2RoutesTest : FunSpec({
             response.status shouldBe HttpStatusCode.BadRequest
             Json.parseToJsonElement(response.bodyAsText()).jsonObject["message"]?.jsonPrimitive?.content shouldBe
                 "Invalid payload"
-            coVerify(exactly = 0) { submissionService.submit(any(), any(), any(), any(), any(), any()) }
+            coVerify(exactly = 0) { submissionService.submit(any(), any(), any(), any(), any()) }
         }
     }
 
@@ -331,7 +330,7 @@ class SubmissionV2RoutesTest : FunSpec({
 
             response.status shouldBe HttpStatusCode.BadRequest
             response.bodyAsText() shouldContain "schemaVersion must be an integer"
-            coVerify(exactly = 0) { submissionService.submit(any(), any(), any(), any(), any(), any()) }
+            coVerify(exactly = 0) { submissionService.submit(any(), any(), any(), any(), any()) }
         }
     }
 
@@ -349,7 +348,7 @@ class SubmissionV2RoutesTest : FunSpec({
 
             response.status shouldBe HttpStatusCode.BadRequest
             response.bodyAsText() shouldContain "surveyType must match definition.surveyType"
-            coVerify(exactly = 0) { submissionService.submit(any(), any(), any(), any(), any(), any()) }
+            coVerify(exactly = 0) { submissionService.submit(any(), any(), any(), any(), any()) }
         }
     }
 
@@ -367,7 +366,7 @@ class SubmissionV2RoutesTest : FunSpec({
 
             response.status shouldBe HttpStatusCode.BadRequest
             response.bodyAsText() shouldContain "answers.fieldId"
-            coVerify(exactly = 0) { submissionService.submit(any(), any(), any(), any(), any(), any()) }
+            coVerify(exactly = 0) { submissionService.submit(any(), any(), any(), any(), any()) }
         }
     }
 
@@ -415,7 +414,7 @@ class SubmissionV2RoutesTest : FunSpec({
 
             response.status shouldBe HttpStatusCode.BadRequest
             response.bodyAsText() shouldContain "must not include optionIds"
-            coVerify(exactly = 0) { submissionService.submit(any(), any(), any(), any(), any(), any()) }
+            coVerify(exactly = 0) { submissionService.submit(any(), any(), any(), any(), any()) }
         }
     }
 
@@ -460,7 +459,7 @@ class SubmissionV2RoutesTest : FunSpec({
 
             response.status shouldBe HttpStatusCode.BadRequest
             response.bodyAsText() shouldContain "fieldType=SINGLE_CHOICE, expected TEXT"
-            coVerify(exactly = 0) { submissionService.submit(any(), any(), any(), any(), any(), any()) }
+            coVerify(exactly = 0) { submissionService.submit(any(), any(), any(), any(), any()) }
         }
     }
 
@@ -492,7 +491,7 @@ class SubmissionV2RoutesTest : FunSpec({
 
             response.status shouldBe HttpStatusCode.BadRequest
             response.bodyAsText() shouldContain "definition.fields max count"
-            coVerify(exactly = 0) { submissionService.submit(any(), any(), any(), any(), any(), any()) }
+            coVerify(exactly = 0) { submissionService.submit(any(), any(), any(), any(), any()) }
         }
     }
 
@@ -532,7 +531,7 @@ class SubmissionV2RoutesTest : FunSpec({
 
             response.status shouldBe HttpStatusCode.BadRequest
             response.bodyAsText() shouldContain "question.options"
-            coVerify(exactly = 0) { submissionService.submit(any(), any(), any(), any(), any(), any()) }
+            coVerify(exactly = 0) { submissionService.submit(any(), any(), any(), any(), any()) }
         }
     }
 
@@ -579,14 +578,14 @@ class SubmissionV2RoutesTest : FunSpec({
 
             response.status shouldBe HttpStatusCode.BadRequest
             response.bodyAsText() shouldContain "definition.optionIds"
-            coVerify(exactly = 0) { submissionService.submit(any(), any(), any(), any(), any(), any()) }
+            coVerify(exactly = 0) { submissionService.submit(any(), any(), any(), any(), any()) }
         }
     }
 
     test("v2 accepts choice answer when question options match definition") {
         val submissionService = mockk<SubmissionService>()
         coEvery {
-            submissionService.submit(any(), any(), any(), any(), any(), any())
+            submissionService.submit(any(), any(), any(), any(), any())
         } returns SubmissionOutcome(SaveResult.Created("created-choice"), "hash-choice")
 
         testApplication {
@@ -628,7 +627,7 @@ class SubmissionV2RoutesTest : FunSpec({
 
             response.status shouldBe HttpStatusCode.Created
             coVerify(exactly = 1) {
-                submissionService.submit(any(), any(), any(), any(), any(), any())
+                submissionService.submit(any(), any(), any(), any(), any())
             }
         }
     }
@@ -636,7 +635,7 @@ class SubmissionV2RoutesTest : FunSpec({
     test("v2 returns 409 when full definition structure changes for same surveyId") {
         val submissionService = mockk<SubmissionService>()
         coEvery {
-            submissionService.submit(any(), any(), any(), any(), any(), any())
+            submissionService.submit(any(), any(), any(), any(), any())
         } answers {
             if (firstArg<String>().contains("followup")) {
                 throw ApiErrorException.ConflictException(
@@ -701,7 +700,7 @@ class SubmissionV2RoutesTest : FunSpec({
     test("v2 deduplicates retry with same deduplicationKey") {
         val submissionService = mockk<SubmissionService>()
         coEvery {
-            submissionService.submit(any(), any(), any(), any(), any(), any())
+            submissionService.submit(any(), any(), any(), any(), any())
         } returnsMany listOf(
             SubmissionOutcome(SaveResult.Created("created-v2"), "hash-v2"),
             SubmissionOutcome(SaveResult.Duplicate("created-v2"))

--- a/apps/lumi-api/src/test/kotlin/no/nav/lumi/routes/SubmissionV2RoutesTest.kt
+++ b/apps/lumi-api/src/test/kotlin/no/nav/lumi/routes/SubmissionV2RoutesTest.kt
@@ -334,6 +334,51 @@ class SubmissionV2RoutesTest : FunSpec({
         }
     }
 
+    test("string schemaVersion returns specific 400") {
+        val submissionService = mockk<SubmissionService>()
+
+        testApplication {
+            application { submissionRoutesTestModule(submissionService) }
+            val client = createTestClient()
+
+            val response = client.post("/api/tokenx/v1/feedback") {
+                contentType(ContentType.Application.Json)
+                setBody(
+                    """
+                    {
+                      "schemaVersion": "2",
+                      "surveyId": "dp-feedback-v2",
+                      "surveyType": "rating",
+                      "submittedAt": "2026-01-10T12:00:12Z",
+                      "deduplicationKey": "client-key-123456",
+                      "definition": {
+                        "surveyType": "rating",
+                        "fields": [
+                          {
+                            "fieldId": "feedback",
+                            "fieldType": "TEXT"
+                          }
+                        ]
+                      },
+                      "answers": [
+                        {
+                          "fieldId": "feedback",
+                          "fieldType": "TEXT",
+                          "question": { "label": "Hvorfor?" },
+                          "value": { "type": "text", "text": "Bra" }
+                        }
+                      ]
+                    }
+                    """.trimIndent()
+                )
+            }
+
+            response.status shouldBe HttpStatusCode.BadRequest
+            response.bodyAsText() shouldContain "schemaVersion must be an integer"
+            coVerify(exactly = 0) { submissionService.submit(any(), any(), any(), any(), any()) }
+        }
+    }
+
     test("v2 rejects surveyType mismatch between top-level and definition") {
         val submissionService = mockk<SubmissionService>()
 

--- a/apps/lumi-api/src/test/kotlin/no/nav/lumi/routes/SubmissionV2RoutesTest.kt
+++ b/apps/lumi-api/src/test/kotlin/no/nav/lumi/routes/SubmissionV2RoutesTest.kt
@@ -205,6 +205,51 @@ class SubmissionV2RoutesTest : FunSpec({
         }
     }
 
+    test("non-primitive schemaVersion returns 400") {
+        val submissionService = mockk<SubmissionService>()
+
+        testApplication {
+            application { submissionRoutesTestModule(submissionService) }
+            val client = createTestClient()
+
+            val response = client.post("/api/tokenx/v1/feedback") {
+                contentType(ContentType.Application.Json)
+                setBody(
+                    """
+                    {
+                      "schemaVersion": { "value": 2 },
+                      "surveyId": "dp-feedback-v2",
+                      "surveyType": "rating",
+                      "submittedAt": "2026-01-10T12:00:12Z",
+                      "deduplicationKey": "client-key-123456",
+                      "definition": {
+                        "surveyType": "rating",
+                        "fields": [
+                          {
+                            "fieldId": "feedback",
+                            "fieldType": "TEXT"
+                          }
+                        ]
+                      },
+                      "answers": [
+                        {
+                          "fieldId": "feedback",
+                          "fieldType": "TEXT",
+                          "question": { "label": "Hvorfor?" },
+                          "value": { "type": "text", "text": "Bra" }
+                        }
+                      ]
+                    }
+                    """.trimIndent()
+                )
+            }
+
+            response.status shouldBe HttpStatusCode.BadRequest
+            response.bodyAsText() shouldContain "schemaVersion must be an integer"
+            coVerify(exactly = 0) { submissionService.submit(any(), any(), any(), any(), any(), any()) }
+        }
+    }
+
     test("v2 rejects surveyType mismatch between top-level and definition") {
         val submissionService = mockk<SubmissionService>()
 

--- a/apps/lumi-api/src/test/kotlin/no/nav/lumi/routes/SubmissionV2RoutesTest.kt
+++ b/apps/lumi-api/src/test/kotlin/no/nav/lumi/routes/SubmissionV2RoutesTest.kt
@@ -1,0 +1,603 @@
+package no.nav.lumi.routes
+
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.string.shouldContain
+import io.kotest.matchers.string.shouldNotContain
+import io.ktor.client.request.*
+import io.ktor.client.statement.*
+import io.ktor.http.*
+import io.ktor.server.application.*
+import io.ktor.server.routing.*
+import io.ktor.server.testing.testApplication
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.mockk
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.boolean
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
+import no.nav.lumi.config.configureRateLimiting
+import no.nav.lumi.config.configureSerialization
+import no.nav.lumi.config.configureStatusPages
+import no.nav.lumi.config.exception.ApiErrorException
+import no.nav.lumi.createTestClient
+import no.nav.lumi.domain.SaveResult
+import no.nav.lumi.service.SubmissionOutcome
+import no.nav.lumi.service.SubmissionService
+
+private fun Application.submissionRoutesTestModule(submissionService: SubmissionService) {
+    configureSerialization()
+    configureStatusPages()
+    configureRateLimiting()
+    routing {
+        submissionRoutes(submissionService = submissionService)
+    }
+}
+
+private fun submissionPayloadV2(
+    submittedAt: String = "2026-01-10T12:00:12Z",
+    deduplicationKey: String = "client-key-123456",
+    surveyType: String = "rating",
+    definitionSurveyType: String = surveyType,
+    definitionFieldId: String = "feedback",
+    answerFieldId: String = definitionFieldId
+) = """
+    {
+      "schemaVersion": 2,
+      "surveyId": "dp-feedback-v2",
+      "surveyType": "$surveyType",
+      "submittedAt": "$submittedAt",
+      "deduplicationKey": "$deduplicationKey",
+      "definition": {
+        "surveyType": "$definitionSurveyType",
+        "fields": [
+          {
+            "fieldId": "$definitionFieldId",
+            "fieldType": "TEXT"
+          }
+        ]
+      },
+      "answers": [
+        {
+          "fieldId": "$answerFieldId",
+          "fieldType": "TEXT",
+          "question": { "label": "Hvorfor?" },
+          "value": { "type": "text", "text": "Bra" }
+        }
+      ]
+    }
+""".trimIndent()
+
+private fun submissionPayloadV2Raw(
+    definitionFieldsJson: String,
+    answersJson: String
+) = """
+    {
+      "schemaVersion": 2,
+      "surveyId": "dp-feedback-v2",
+      "surveyType": "rating",
+      "submittedAt": "2026-01-10T12:00:12Z",
+      "deduplicationKey": "client-key-123456",
+      "definition": {
+        "surveyType": "rating",
+        "fields": $definitionFieldsJson
+      },
+      "answers": $answersJson
+    }
+""".trimIndent()
+
+private fun repeatedTextFieldsJson(count: Int): String =
+    (1..count).joinToString(prefix = "[", postfix = "]") { index ->
+        """
+        {
+          "fieldId": "field_$index",
+          "fieldType": "TEXT"
+        }
+        """.trimIndent()
+    }
+
+class SubmissionV2RoutesTest : FunSpec({
+    test("v1 still works on existing submission endpoint") {
+        val submissionService = mockk<SubmissionService>()
+        coEvery {
+            submissionService.submit(any(), any(), any(), any(), any(), any())
+        } returns SubmissionOutcome(SaveResult.Created("created-v1"), "hash-v1")
+
+        testApplication {
+            application { submissionRoutesTestModule(submissionService) }
+            val client = createTestClient()
+
+            val response = client.post("/api/tokenx/v1/feedback") {
+                contentType(ContentType.Application.Json)
+                setBody(
+                    """
+                    {
+                      "schemaVersion": 1,
+                      "surveyId": "dp-feedback-v1",
+                      "surveyType": "rating",
+                      "submittedAt": "2026-01-10T12:00:12Z",
+                      "answers": [
+                        {
+                          "fieldId": "feedback",
+                          "fieldType": "TEXT",
+                          "question": { "label": "Hvorfor?" },
+                          "value": { "type": "text", "text": "Bra" }
+                        }
+                      ]
+                    }
+                    """.trimIndent()
+                )
+            }
+
+            response.status shouldBe HttpStatusCode.Created
+            coVerify(exactly = 1) {
+                submissionService.submit(any(), "local-dev", "local-app", any(), null, true)
+            }
+        }
+    }
+
+    test("v2 accepts complete definition on existing submission endpoint") {
+        val submissionService = mockk<SubmissionService>()
+        coEvery {
+            submissionService.submit(any(), any(), any(), any(), any(), any())
+        } returns SubmissionOutcome(SaveResult.Created("created-v2"), "hash-v2")
+
+        testApplication {
+            application { submissionRoutesTestModule(submissionService) }
+            val client = createTestClient()
+
+            val response = client.post("/api/tokenx/v1/feedback") {
+                contentType(ContentType.Application.Json)
+                setBody(submissionPayloadV2())
+            }
+
+            response.status shouldBe HttpStatusCode.Created
+            coVerify(exactly = 1) {
+                submissionService.submit(
+                    any(),
+                    "local-dev",
+                    "local-app",
+                    match { it.schemaVersion == 2 && it.deduplicationKey == "client-key-123456" },
+                    match {
+                        it.surveyId == "dp-feedback-v2" &&
+                            it.surveyType.name == "RATING" &&
+                            it.fields.map { field -> field.fieldId } == listOf("feedback")
+                    },
+                    false
+                )
+            }
+        }
+    }
+
+    test("v2 without definition returns 400") {
+        val submissionService = mockk<SubmissionService>()
+
+        testApplication {
+            application { submissionRoutesTestModule(submissionService) }
+            val client = createTestClient()
+
+            val response = client.post("/api/tokenx/v1/feedback") {
+                contentType(ContentType.Application.Json)
+                setBody(
+                    """
+                    {
+                      "schemaVersion": 2,
+                      "surveyId": "dp-feedback-v2",
+                      "surveyType": "rating",
+                      "submittedAt": "2026-01-10T12:00:12Z",
+                      "deduplicationKey": "client-key-123456",
+                      "answers": [
+                        {
+                          "fieldId": "feedback",
+                          "fieldType": "TEXT",
+                          "question": { "label": "Hvorfor?" },
+                          "value": { "type": "text", "text": "Bra" }
+                        }
+                      ]
+                    }
+                    """.trimIndent()
+                )
+            }
+
+            response.status shouldBe HttpStatusCode.BadRequest
+            coVerify(exactly = 0) { submissionService.submit(any(), any(), any(), any(), any(), any()) }
+        }
+    }
+
+    test("v2 rejects surveyType mismatch between top-level and definition") {
+        val submissionService = mockk<SubmissionService>()
+
+        testApplication {
+            application { submissionRoutesTestModule(submissionService) }
+            val client = createTestClient()
+
+            val response = client.post("/api/tokenx/v1/feedback") {
+                contentType(ContentType.Application.Json)
+                setBody(submissionPayloadV2(surveyType = "rating", definitionSurveyType = "topTasks"))
+            }
+
+            response.status shouldBe HttpStatusCode.BadRequest
+            response.bodyAsText() shouldContain "surveyType must match definition.surveyType"
+            coVerify(exactly = 0) { submissionService.submit(any(), any(), any(), any(), any(), any()) }
+        }
+    }
+
+    test("v2 rejects answers whose fieldId is missing from definition") {
+        val submissionService = mockk<SubmissionService>()
+
+        testApplication {
+            application { submissionRoutesTestModule(submissionService) }
+            val client = createTestClient()
+
+            val response = client.post("/api/tokenx/v1/feedback") {
+                contentType(ContentType.Application.Json)
+                setBody(submissionPayloadV2(definitionFieldId = "defined-field", answerFieldId = "other-field"))
+            }
+
+            response.status shouldBe HttpStatusCode.BadRequest
+            response.bodyAsText() shouldContain "answers.fieldId"
+            coVerify(exactly = 0) { submissionService.submit(any(), any(), any(), any(), any(), any()) }
+        }
+    }
+
+    test("v2 rejects malformed rating definition before submit") {
+        val submissionService = mockk<SubmissionService>()
+
+        testApplication {
+            application { submissionRoutesTestModule(submissionService) }
+            val client = createTestClient()
+
+            val response = client.post("/api/tokenx/v1/feedback") {
+                contentType(ContentType.Application.Json)
+                setBody(
+                    """
+                    {
+                      "schemaVersion": 2,
+                      "surveyId": "dp-feedback-v2",
+                      "surveyType": "rating",
+                      "submittedAt": "2026-01-10T12:00:12Z",
+                      "deduplicationKey": "client-key-123456",
+                      "definition": {
+                        "surveyType": "rating",
+                        "fields": [
+                          {
+                            "fieldId": "rating",
+                            "fieldType": "RATING",
+                            "ratingVariant": "emoji",
+                            "ratingScale": 5,
+                            "optionIds": ["unexpected"]
+                          }
+                        ]
+                      },
+                      "answers": [
+                        {
+                          "fieldId": "rating",
+                          "fieldType": "RATING",
+                          "question": { "label": "Hvor fornøyd er du?" },
+                          "value": { "type": "rating", "rating": 4, "ratingVariant": "emoji", "ratingScale": 5 }
+                        }
+                      ]
+                    }
+                    """.trimIndent()
+                )
+            }
+
+            response.status shouldBe HttpStatusCode.BadRequest
+            response.bodyAsText() shouldContain "must not include optionIds"
+            coVerify(exactly = 0) { submissionService.submit(any(), any(), any(), any(), any(), any()) }
+        }
+    }
+
+    test("v2 rejects answers that conflict with definition before submit") {
+        val submissionService = mockk<SubmissionService>()
+
+        testApplication {
+            application { submissionRoutesTestModule(submissionService) }
+            val client = createTestClient()
+
+            val response = client.post("/api/tokenx/v1/feedback") {
+                contentType(ContentType.Application.Json)
+                setBody(
+                    """
+                    {
+                      "schemaVersion": 2,
+                      "surveyId": "dp-feedback-v2",
+                      "surveyType": "rating",
+                      "submittedAt": "2026-01-10T12:00:12Z",
+                      "deduplicationKey": "client-key-123456",
+                      "definition": {
+                        "surveyType": "rating",
+                        "fields": [
+                          {
+                            "fieldId": "feedback",
+                            "fieldType": "TEXT"
+                          }
+                        ]
+                      },
+                      "answers": [
+                        {
+                          "fieldId": "feedback",
+                          "fieldType": "SINGLE_CHOICE",
+                          "question": { "label": "Hvorfor?" },
+                          "value": { "type": "singleChoice", "selectedOptionId": "a" }
+                        }
+                      ]
+                    }
+                    """.trimIndent()
+                )
+            }
+
+            response.status shouldBe HttpStatusCode.BadRequest
+            response.bodyAsText() shouldContain "fieldType=SINGLE_CHOICE, expected TEXT"
+            coVerify(exactly = 0) { submissionService.submit(any(), any(), any(), any(), any(), any()) }
+        }
+    }
+
+    test("v2 rejects definition with too many fields before submit") {
+        val submissionService = mockk<SubmissionService>()
+
+        testApplication {
+            application { submissionRoutesTestModule(submissionService) }
+            val client = createTestClient()
+
+            val response = client.post("/api/tokenx/v1/feedback") {
+                contentType(ContentType.Application.Json)
+                setBody(
+                    submissionPayloadV2Raw(
+                        definitionFieldsJson = repeatedTextFieldsJson(51),
+                        answersJson = """
+                        [
+                          {
+                            "fieldId": "field_1",
+                            "fieldType": "TEXT",
+                            "question": { "label": "Hvorfor?" },
+                            "value": { "type": "text", "text": "Bra" }
+                          }
+                        ]
+                        """.trimIndent()
+                    )
+                )
+            }
+
+            response.status shouldBe HttpStatusCode.BadRequest
+            response.bodyAsText() shouldContain "definition.fields max count"
+            coVerify(exactly = 0) { submissionService.submit(any(), any(), any(), any(), any(), any()) }
+        }
+    }
+
+    test("v2 rejects single choice answer when question options are missing") {
+        val submissionService = mockk<SubmissionService>()
+
+        testApplication {
+            application { submissionRoutesTestModule(submissionService) }
+            val client = createTestClient()
+
+            val response = client.post("/api/tokenx/v1/feedback") {
+                contentType(ContentType.Application.Json)
+                setBody(
+                    submissionPayloadV2Raw(
+                        definitionFieldsJson = """
+                        [
+                          {
+                            "fieldId": "category",
+                            "fieldType": "SINGLE_CHOICE",
+                            "optionIds": ["bug", "feature"]
+                          }
+                        ]
+                        """.trimIndent(),
+                        answersJson = """
+                        [
+                          {
+                            "fieldId": "category",
+                            "fieldType": "SINGLE_CHOICE",
+                            "question": { "label": "Kategori?" },
+                            "value": { "type": "singleChoice", "selectedOptionId": "bug" }
+                          }
+                        ]
+                        """.trimIndent()
+                    )
+                )
+            }
+
+            response.status shouldBe HttpStatusCode.BadRequest
+            response.bodyAsText() shouldContain "question.options"
+            coVerify(exactly = 0) { submissionService.submit(any(), any(), any(), any(), any(), any()) }
+        }
+    }
+
+    test("v2 rejects multi choice answer when question options differ from definition") {
+        val submissionService = mockk<SubmissionService>()
+
+        testApplication {
+            application { submissionRoutesTestModule(submissionService) }
+            val client = createTestClient()
+
+            val response = client.post("/api/tokenx/v1/feedback") {
+                contentType(ContentType.Application.Json)
+                setBody(
+                    submissionPayloadV2Raw(
+                        definitionFieldsJson = """
+                        [
+                          {
+                            "fieldId": "category",
+                            "fieldType": "MULTI_CHOICE",
+                            "optionIds": ["bug", "feature"]
+                          }
+                        ]
+                        """.trimIndent(),
+                        answersJson = """
+                        [
+                          {
+                            "fieldId": "category",
+                            "fieldType": "MULTI_CHOICE",
+                            "question": {
+                              "label": "Kategori?",
+                              "options": [
+                                { "id": "bug", "label": "Bug" },
+                                { "id": "feature", "label": "Feature" },
+                                { "id": "other", "label": "Other" }
+                              ]
+                            },
+                            "value": { "type": "multiChoice", "selectedOptionIds": ["bug", "feature"] }
+                          }
+                        ]
+                        """.trimIndent()
+                    )
+                )
+            }
+
+            response.status shouldBe HttpStatusCode.BadRequest
+            response.bodyAsText() shouldContain "definition.optionIds"
+            coVerify(exactly = 0) { submissionService.submit(any(), any(), any(), any(), any(), any()) }
+        }
+    }
+
+    test("v2 accepts choice answer when question options match definition") {
+        val submissionService = mockk<SubmissionService>()
+        coEvery {
+            submissionService.submit(any(), any(), any(), any(), any(), any())
+        } returns SubmissionOutcome(SaveResult.Created("created-choice"), "hash-choice")
+
+        testApplication {
+            application { submissionRoutesTestModule(submissionService) }
+            val client = createTestClient()
+
+            val response = client.post("/api/tokenx/v1/feedback") {
+                contentType(ContentType.Application.Json)
+                setBody(
+                    submissionPayloadV2Raw(
+                        definitionFieldsJson = """
+                        [
+                          {
+                            "fieldId": "category",
+                            "fieldType": "SINGLE_CHOICE",
+                            "optionIds": ["bug", "feature"]
+                          }
+                        ]
+                        """.trimIndent(),
+                        answersJson = """
+                        [
+                          {
+                            "fieldId": "category",
+                            "fieldType": "SINGLE_CHOICE",
+                            "question": {
+                              "label": "Kategori?",
+                              "options": [
+                                { "id": "bug", "label": "Bug" },
+                                { "id": "feature", "label": "Feature" }
+                              ]
+                            },
+                            "value": { "type": "singleChoice", "selectedOptionId": "feature" }
+                          }
+                        ]
+                        """.trimIndent()
+                    )
+                )
+            }
+
+            response.status shouldBe HttpStatusCode.Created
+            coVerify(exactly = 1) {
+                submissionService.submit(any(), any(), any(), any(), any(), any())
+            }
+        }
+    }
+
+    test("v2 returns 409 when full definition structure changes for same surveyId") {
+        val submissionService = mockk<SubmissionService>()
+        coEvery {
+            submissionService.submit(any(), any(), any(), any(), any(), any())
+        } answers {
+            if (firstArg<String>().contains("followup")) {
+                throw ApiErrorException.ConflictException(
+                    "Survey definition conflict for surveyId=dp-feedback-v2: addedFields=[field_1]"
+                )
+            }
+            SubmissionOutcome(SaveResult.Created("created-v2"), "hash-v2")
+        }
+
+        testApplication {
+            application { submissionRoutesTestModule(submissionService) }
+            val client = createTestClient()
+
+            client.post("/api/tokenx/v1/feedback") {
+                contentType(ContentType.Application.Json)
+                setBody(submissionPayloadV2())
+            }.status shouldBe HttpStatusCode.Created
+
+            val response = client.post("/api/tokenx/v1/feedback") {
+                contentType(ContentType.Application.Json)
+                setBody(
+                    """
+                    {
+                      "schemaVersion": 2,
+                      "surveyId": "dp-feedback-v2",
+                      "surveyType": "rating",
+                      "submittedAt": "2026-01-10T12:01:12Z",
+                      "deduplicationKey": "client-key-654321",
+                      "definition": {
+                        "surveyType": "rating",
+                        "fields": [
+                          {
+                            "fieldId": "feedback",
+                            "fieldType": "TEXT"
+                          },
+                          {
+                            "fieldId": "followup",
+                            "fieldType": "TEXT"
+                          }
+                        ]
+                      },
+                      "answers": [
+                        {
+                          "fieldId": "feedback",
+                          "fieldType": "TEXT",
+                          "question": { "label": "Hvorfor?" },
+                          "value": { "type": "text", "text": "Bra" }
+                        }
+                      ]
+                    }
+                    """.trimIndent()
+                )
+            }
+
+            response.status shouldBe HttpStatusCode.Conflict
+            response.bodyAsText() shouldContain "addedFields=[field_1]"
+            response.bodyAsText() shouldNotContain "followup"
+            response.bodyAsText() shouldNotContain "Hvorfor?"
+        }
+    }
+
+    test("v2 deduplicates retry with same deduplicationKey") {
+        val submissionService = mockk<SubmissionService>()
+        coEvery {
+            submissionService.submit(any(), any(), any(), any(), any(), any())
+        } returnsMany listOf(
+            SubmissionOutcome(SaveResult.Created("created-v2"), "hash-v2"),
+            SubmissionOutcome(SaveResult.Duplicate("created-v2"))
+        )
+
+        testApplication {
+            application { submissionRoutesTestModule(submissionService) }
+            val client = createTestClient()
+
+            val firstResponse = client.post("/api/tokenx/v1/feedback") {
+                contentType(ContentType.Application.Json)
+                setBody(submissionPayloadV2())
+            }
+
+            val secondResponse = client.post("/api/tokenx/v1/feedback") {
+                contentType(ContentType.Application.Json)
+                setBody(submissionPayloadV2(submittedAt = "2026-01-10T12:01:12Z"))
+            }
+
+            firstResponse.status shouldBe HttpStatusCode.Created
+            secondResponse.status shouldBe HttpStatusCode.OK
+
+            val firstId = Json.parseToJsonElement(firstResponse.bodyAsText()).jsonObject["id"]?.jsonPrimitive?.content!!
+            val secondBody = Json.parseToJsonElement(secondResponse.bodyAsText()).jsonObject
+            secondBody["id"]?.jsonPrimitive?.content shouldBe firstId
+            secondBody["duplicate"]?.jsonPrimitive?.boolean shouldBe true
+        }
+    }
+})

--- a/apps/lumi-api/src/test/kotlin/no/nav/lumi/service/FeedbackServicePrepareForSaveTest.kt
+++ b/apps/lumi-api/src/test/kotlin/no/nav/lumi/service/FeedbackServicePrepareForSaveTest.kt
@@ -1,0 +1,49 @@
+package no.nav.lumi.service
+
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.string.shouldContain
+import io.kotest.matchers.string.shouldNotContain
+
+class FeedbackServicePrepareForSaveTest : FunSpec({
+    test("prepareForSave strips definition and raw deduplicationKey from schemaVersion=2 payload") {
+        val service = FeedbackService()
+        val payload = """
+            {
+                "schemaVersion": 2,
+                "surveyId": "survey-v2",
+                "surveyType": "rating",
+                "submittedAt": "2026-01-10T12:00:12Z",
+                "deduplicationKey": "client-key-123456",
+                "definition": {
+                    "surveyType": "rating",
+                    "fields": [
+                        {
+                            "fieldId": "feedback",
+                            "fieldType": "TEXT"
+                        }
+                    ]
+                },
+                "answers": [
+                    {
+                        "fieldId": "feedback",
+                        "fieldType": "TEXT",
+                        "question": { "label": "Hvorfor?" },
+                        "value": { "type": "text", "text": "Payload" }
+                    }
+                ]
+            }
+        """.trimIndent()
+
+        val prepared = service.prepareForSave(
+            feedbackJson = payload,
+            team = "flex",
+            surveyId = "survey-v2"
+        )
+
+        prepared.feedbackJson shouldNotContain "\"definition\""
+        prepared.feedbackJson shouldNotContain "deduplicationKey"
+        prepared.feedbackJson shouldContain "\"surveyType\":\"rating\""
+        (prepared.deduplicationKeyHash?.isNotBlank()) shouldBe true
+    }
+})

--- a/apps/lumi-api/src/test/kotlin/no/nav/lumi/service/FeedbackServiceTest.kt
+++ b/apps/lumi-api/src/test/kotlin/no/nav/lumi/service/FeedbackServiceTest.kt
@@ -437,7 +437,8 @@ class FeedbackServiceTest : FunSpec({
             val saved = repository.findRawById(id, "flex").shouldNotBeNull()
             saved.feedbackJson shouldNotContain "deduplicationKey"
             saved.feedbackJson shouldNotContain "\"definition\""
-            saved.feedbackJson shouldContain "\"surveyType\":\"rating\""
+            val savedJson = Json.parseToJsonElement(saved.feedbackJson).jsonObject
+            savedJson["surveyType"]?.jsonPrimitive?.content shouldBe "rating"
         }
 
         test("uses provided surveyId for dedup scope when payload surveyId differs") {

--- a/apps/lumi-api/src/test/kotlin/no/nav/lumi/service/FeedbackServiceTest.kt
+++ b/apps/lumi-api/src/test/kotlin/no/nav/lumi/service/FeedbackServiceTest.kt
@@ -398,6 +398,48 @@ class FeedbackServiceTest : FunSpec({
             saved.feedbackJson shouldNotContain "Andre payload"
         }
 
+        test("strips definition and deduplicationKey before persisting schemaVersion=2 payload") {
+            val payload = """
+                {
+                    "schemaVersion": 2,
+                    "surveyId": "survey-v2",
+                    "surveyType": "rating",
+                    "submittedAt": "2026-01-10T12:00:12Z",
+                    "deduplicationKey": "client-key-123456",
+                    "definition": {
+                        "surveyType": "rating",
+                        "fields": [
+                            {
+                                "fieldId": "feedback",
+                                "fieldType": "TEXT"
+                            }
+                        ]
+                    },
+                    "answers": [
+                        {
+                            "fieldId": "feedback",
+                            "fieldType": "TEXT",
+                            "question": { "label": "Hvorfor?" },
+                            "value": { "type": "text", "text": "Payload" }
+                        }
+                    ]
+                }
+            """.trimIndent()
+
+            val id = service.save(
+                feedbackJson = payload,
+                team = "flex",
+                app = "test-app",
+                surveyId = "survey-v2",
+                definitionHash = "a".repeat(64)
+            ).createdId()
+
+            val saved = repository.findRawById(id, "flex").shouldNotBeNull()
+            saved.feedbackJson shouldNotContain "deduplicationKey"
+            saved.feedbackJson shouldNotContain "\"definition\""
+            saved.feedbackJson shouldContain "\"surveyType\":\"rating\""
+        }
+
         test("uses provided surveyId for dedup scope when payload surveyId differs") {
             val payload = """
                 {

--- a/apps/lumi-api/src/test/kotlin/no/nav/lumi/service/SubmissionServiceTest.kt
+++ b/apps/lumi-api/src/test/kotlin/no/nav/lumi/service/SubmissionServiceTest.kt
@@ -19,7 +19,7 @@ import no.nav.lumi.domain.SurveyType
 import no.nav.lumi.repository.FeedbackRepository
 
 class SubmissionServiceTest : FunSpec({
-    test("provided definition uses v2 registration even when definition expansion is allowed") {
+    test("provided definition uses v2 registration") {
         val feedbackService = mockk<FeedbackService>()
         val surveyDefinitionService = mockk<SurveyDefinitionService>()
         val feedbackRepository = mockk<FeedbackRepository>()
@@ -38,8 +38,7 @@ class SubmissionServiceTest : FunSpec({
                 team = "team-a",
                 app = "app-a",
                 submission = submission,
-                definition = definition,
-                allowDefinitionExpansion = true
+                definition = definition
             )
         }
 
@@ -50,7 +49,7 @@ class SubmissionServiceTest : FunSpec({
         coVerify(exactly = 0) { surveyDefinitionService.registerOrValidateV2InCurrentTransaction(any(), any(), any()) }
     }
 
-    test("provided definition uses v2 registration in current transaction even when definition expansion is allowed") {
+    test("provided definition uses v2 registration in current transaction") {
         val feedbackService = mockk<FeedbackService>()
         val surveyDefinitionService = mockk<SurveyDefinitionService>()
         val feedbackRepository = mockk<FeedbackRepository>()
@@ -96,8 +95,7 @@ class SubmissionServiceTest : FunSpec({
                 team = "team-a",
                 app = "app-a",
                 submission = submission,
-                definition = definition,
-                allowDefinitionExpansion = true
+                definition = definition
             )
         }
 

--- a/apps/lumi-api/src/test/kotlin/no/nav/lumi/service/SubmissionServiceTest.kt
+++ b/apps/lumi-api/src/test/kotlin/no/nav/lumi/service/SubmissionServiceTest.kt
@@ -1,0 +1,141 @@
+package no.nav.lumi.service
+
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.every
+import io.mockk.mockk
+import no.nav.lumi.domain.Answer
+import no.nav.lumi.domain.AnswerValue
+import no.nav.lumi.domain.FeedbackSubmissionV1
+import no.nav.lumi.domain.FieldDefinition
+import no.nav.lumi.domain.FieldType
+import no.nav.lumi.domain.Question
+import no.nav.lumi.domain.RatingVariant
+import no.nav.lumi.domain.SaveResult
+import no.nav.lumi.domain.SurveyDefinition
+import no.nav.lumi.domain.SurveyType
+import no.nav.lumi.repository.FeedbackRepository
+
+class SubmissionServiceTest : FunSpec({
+    test("provided definition uses v2 registration even when definition expansion is allowed") {
+        val feedbackService = mockk<FeedbackService>()
+        val surveyDefinitionService = mockk<SurveyDefinitionService>()
+        val feedbackRepository = mockk<FeedbackRepository>()
+        val service = SubmissionService(feedbackService, surveyDefinitionService, feedbackRepository)
+        val submission = ratingSubmission()
+        val definition = expandedDefinition()
+        val registrationResult = RegistrationResult("survey-1", "definition-hash-v2")
+        val saveResult = SaveResult.Created("feedback-1")
+
+        coEvery { surveyDefinitionService.registerOrValidateV2("team-a", submission, definition) } returns registrationResult
+        coEvery { feedbackService.save("{}", "team-a", "app-a", "survey-1", "definition-hash-v2") } returns saveResult
+
+        val result = runSubmission {
+            service.submit(
+                feedbackJson = "{}",
+                team = "team-a",
+                app = "app-a",
+                submission = submission,
+                definition = definition,
+                allowDefinitionExpansion = true
+            )
+        }
+
+        result shouldBe SubmissionOutcome(saveResult, "definition-hash-v2")
+        coVerify(exactly = 1) { surveyDefinitionService.registerOrValidateV2("team-a", submission, definition) }
+        coVerify(exactly = 0) { surveyDefinitionService.registerOrValidate("team-a", submission) }
+        coVerify(exactly = 0) { surveyDefinitionService.registerOrValidateInCurrentTransaction(any(), any()) }
+        coVerify(exactly = 0) { surveyDefinitionService.registerOrValidateV2InCurrentTransaction(any(), any(), any()) }
+    }
+
+    test("provided definition uses v2 registration in current transaction even when definition expansion is allowed") {
+        val feedbackService = mockk<FeedbackService>()
+        val surveyDefinitionService = mockk<SurveyDefinitionService>()
+        val feedbackRepository = mockk<FeedbackRepository>()
+        val service = SubmissionService(feedbackService, surveyDefinitionService, feedbackRepository)
+        val submission = ratingSubmission(deduplicationKey = "client-key-123456")
+        val definition = expandedDefinition()
+        val registrationResult = RegistrationResult("survey-1", "definition-hash-v2")
+        val saveResult = SaveResult.Created("feedback-1")
+        val prepared = FeedbackService.PreparedFeedbackSave("redacted-json", "dedup-hash")
+
+        coEvery { feedbackService.findDuplicateSubmissionId("team-a", "survey-1", "client-key-123456") } returns null
+        every { feedbackService.prepareForSave("{}", "team-a", "survey-1") } returns prepared
+        coEvery {
+            feedbackRepository.withScopedDeduplicationLock(
+                "team-a",
+                "survey-1",
+                "dedup-hash",
+                any<suspend () -> SubmissionOutcome>()
+            )
+        } coAnswers {
+            arg<suspend () -> SubmissionOutcome>(3).invoke()
+        }
+        every {
+            feedbackRepository.findIdByDeduplicationKeyHashInCurrentTransaction("team-a", "survey-1", "dedup-hash")
+        } returns null
+        coEvery {
+            surveyDefinitionService.registerOrValidateV2InCurrentTransaction("team-a", submission, definition)
+        } returns registrationResult
+        every {
+            feedbackRepository.saveInCurrentTransaction(
+                "redacted-json",
+                "team-a",
+                "app-a",
+                "survey-1",
+                "definition-hash-v2",
+                "dedup-hash"
+            )
+        } returns saveResult
+
+        val result = runSubmission {
+            service.submit(
+                feedbackJson = "{}",
+                team = "team-a",
+                app = "app-a",
+                submission = submission,
+                definition = definition,
+                allowDefinitionExpansion = true
+            )
+        }
+
+        result shouldBe SubmissionOutcome(saveResult, "definition-hash-v2")
+        coVerify(exactly = 1) {
+            surveyDefinitionService.registerOrValidateV2InCurrentTransaction("team-a", submission, definition)
+        }
+        coVerify(exactly = 0) { surveyDefinitionService.registerOrValidateInCurrentTransaction("team-a", submission) }
+        coVerify(exactly = 0) { surveyDefinitionService.registerOrValidate("team-a", submission) }
+        coVerify(exactly = 0) { surveyDefinitionService.registerOrValidateV2("team-a", submission, definition) }
+    }
+})
+
+private fun ratingSubmission(deduplicationKey: String? = null) = FeedbackSubmissionV1(
+    schemaVersion = 2,
+    surveyId = "survey-1",
+    surveyType = SurveyType.RATING,
+    submittedAt = "2026-01-10T12:00:12Z",
+    deduplicationKey = deduplicationKey,
+    answers = listOf(
+        Answer(
+            fieldId = "rating",
+            fieldType = FieldType.RATING,
+            question = Question(label = "Hvor fornøyd er du?"),
+            value = AnswerValue.Rating(rating = 4, ratingVariant = RatingVariant.EMOJI, ratingScale = 5)
+        )
+    )
+)
+
+private fun expandedDefinition() = SurveyDefinition(
+    surveyId = "survey-1",
+    surveyType = SurveyType.RATING,
+    fields = listOf(
+        FieldDefinition("rating", FieldType.RATING, RatingVariant.EMOJI, 5, null),
+        FieldDefinition("followup", FieldType.TEXT, null, null, null)
+    )
+)
+
+private fun runSubmission(block: suspend () -> SubmissionOutcome): SubmissionOutcome {
+    return kotlinx.coroutines.runBlocking { block() }
+}

--- a/apps/lumi-api/src/test/kotlin/no/nav/lumi/service/SurveyDefinitionServiceTest.kt
+++ b/apps/lumi-api/src/test/kotlin/no/nav/lumi/service/SurveyDefinitionServiceTest.kt
@@ -24,6 +24,7 @@ import no.nav.lumi.domain.SurveyType
 import no.nav.lumi.domain.computeHash
 import no.nav.lumi.repository.StoredSurveyDefinition
 import no.nav.lumi.repository.SurveyDefinitionRepository
+import no.nav.lumi.repository.SurveyDefinitionSource
 
 class SurveyDefinitionServiceTest : FunSpec({
     test("first submission registers definition") {
@@ -141,7 +142,8 @@ class SurveyDefinitionServiceTest : FunSpec({
             team = "team-a",
             surveyId = "survey-1",
             definitionHash = storedDefinition.computeHash(),
-            definition = storedDefinition
+            definition = storedDefinition,
+            source = SurveyDefinitionSource.API
         )
 
         val exception = shouldThrowConflict {
@@ -165,6 +167,126 @@ class SurveyDefinitionServiceTest : FunSpec({
         exception.message shouldContain "Survey definition conflict for surveyId=survey-1"
         exception.message shouldContain "addedFields=[field_1]"
         exception.message shouldNotContain "followup"
+    }
+
+    test("schemaVersion=2 can take over compatible v1-derived partial definition") {
+        val repository = mockk<SurveyDefinitionRepository>()
+        val service = SurveyDefinitionService(repository)
+        val storedDefinition = SurveyDefinition(
+            surveyId = "survey-1",
+            surveyType = SurveyType.RATING,
+            fields = listOf(
+                FieldDefinition("rating", FieldType.RATING, RatingVariant.EMOJI, 5, null)
+            )
+        )
+        val fullDefinition = SurveyDefinition(
+            surveyId = "survey-1",
+            surveyType = SurveyType.RATING,
+            fields = listOf(
+                FieldDefinition("rating", FieldType.RATING, RatingVariant.EMOJI, 5, null),
+                FieldDefinition("followup", FieldType.TEXT, null, null, null)
+            )
+        )
+        val storedHash = storedDefinition.computeHash()
+        val fullHash = fullDefinition.computeHash()
+        val submission = FeedbackSubmissionV1(
+            schemaVersion = 2,
+            surveyId = "survey-1",
+            surveyType = SurveyType.RATING,
+            submittedAt = "2026-01-10T12:00:12Z",
+            deduplicationKey = "client-key-123456",
+            answers = listOf(
+                Answer(
+                    fieldId = "rating",
+                    fieldType = FieldType.RATING,
+                    question = Question(label = "Hvor fornøyd er du?"),
+                    value = AnswerValue.Rating(rating = 4, ratingVariant = RatingVariant.EMOJI, ratingScale = 5)
+                )
+            )
+        )
+
+        coEvery { repository.findByTeamAndSurveyId("team-a", "survey-1") } returns StoredSurveyDefinition(
+            team = "team-a",
+            surveyId = "survey-1",
+            definitionHash = storedHash,
+            definition = storedDefinition,
+            source = SurveyDefinitionSource.AUTO
+        )
+        coEvery {
+            repository.updateApiDefinitionIfHashMatches("team-a", "survey-1", storedHash, fullDefinition, fullHash)
+        } returns true
+
+        val result = service.registerOrValidateV2("team-a", submission, fullDefinition)
+
+        result shouldBe RegistrationResult("survey-1", fullHash)
+    }
+
+    test("v1 answered subset after schemaVersion=2 definition keeps api definition hash") {
+        val repository = mockk<SurveyDefinitionRepository>()
+        val service = SurveyDefinitionService(repository)
+        val storedDefinition = SurveyDefinition(
+            surveyId = "survey-1",
+            surveyType = SurveyType.RATING,
+            fields = listOf(
+                FieldDefinition("rating", FieldType.RATING, RatingVariant.EMOJI, 5, null),
+                FieldDefinition("followup", FieldType.TEXT, null, null, null)
+            )
+        )
+        val storedHash = storedDefinition.computeHash()
+        val submission = ratingSubmission()
+
+        coEvery { repository.findByTeamAndSurveyId("team-a", "survey-1") } returns StoredSurveyDefinition(
+            team = "team-a",
+            surveyId = "survey-1",
+            definitionHash = storedHash,
+            definition = storedDefinition,
+            source = SurveyDefinitionSource.API
+        )
+
+        val result = service.registerOrValidate("team-a", submission)
+
+        result shouldBe RegistrationResult("survey-1", storedHash)
+        coVerify(exactly = 0) { repository.updateDefinitionIfHashMatches(any(), any(), any(), any(), any()) }
+    }
+
+    test("v1 unknown answered field after schemaVersion=2 definition returns 409") {
+        val repository = mockk<SurveyDefinitionRepository>()
+        val service = SurveyDefinitionService(repository)
+        val storedDefinition = SurveyDefinition(
+            surveyId = "survey-1",
+            surveyType = SurveyType.RATING,
+            fields = listOf(
+                FieldDefinition("rating", FieldType.RATING, RatingVariant.EMOJI, 5, null)
+            )
+        )
+        val submission = FeedbackSubmissionV1(
+            schemaVersion = 1,
+            surveyId = "survey-1",
+            surveyType = SurveyType.RATING,
+            submittedAt = "2026-01-10T12:00:12Z",
+            answers = listOf(
+                Answer(
+                    fieldId = "followup",
+                    fieldType = FieldType.TEXT,
+                    question = Question(label = "Hva kunne vært bedre?"),
+                    value = AnswerValue.Text("Mer hjelp")
+                )
+            )
+        )
+
+        coEvery { repository.findByTeamAndSurveyId("team-a", "survey-1") } returns StoredSurveyDefinition(
+            team = "team-a",
+            surveyId = "survey-1",
+            definitionHash = storedDefinition.computeHash(),
+            definition = storedDefinition,
+            source = SurveyDefinitionSource.API
+        )
+
+        val exception = shouldThrowConflict {
+            service.registerOrValidate("team-a", submission)
+        }
+
+        exception.message shouldContain "addedFields=[followup]"
     }
 
     test("schemaVersion=2 rejects rating definition with mismatched fixed scale before persistence") {

--- a/apps/lumi-api/src/test/kotlin/no/nav/lumi/service/SurveyDefinitionServiceTest.kt
+++ b/apps/lumi-api/src/test/kotlin/no/nav/lumi/service/SurveyDefinitionServiceTest.kt
@@ -3,6 +3,7 @@ package no.nav.lumi.service
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.string.shouldContain
+import io.kotest.matchers.string.shouldNotContain
 import io.mockk.coEvery
 import io.mockk.coVerify
 import io.mockk.mockk
@@ -11,10 +12,13 @@ import no.nav.lumi.domain.Answer
 import no.nav.lumi.domain.AnswerValue
 import no.nav.lumi.domain.ChoiceOption
 import no.nav.lumi.domain.FeedbackSubmissionV1
+import no.nav.lumi.domain.FeedbackSubmissionV2
 import no.nav.lumi.domain.FieldDefinition
 import no.nav.lumi.domain.FieldType
 import no.nav.lumi.domain.Question
 import no.nav.lumi.domain.RatingVariant
+import no.nav.lumi.domain.SubmissionFieldDefinitionPayload
+import no.nav.lumi.domain.SurveyDefinitionPayload
 import no.nav.lumi.domain.SurveyDefinition
 import no.nav.lumi.domain.SurveyType
 import no.nav.lumi.domain.computeHash
@@ -95,6 +99,201 @@ class SurveyDefinitionServiceTest : FunSpec({
         val result = service.registerOrValidate("team-a", relabeledSubmission)
 
         result.definitionHash shouldBe storedDefinition.computeHash()
+    }
+
+    test("schemaVersion=2 full definition change returns 409 without additive merge") {
+        val repository = mockk<SurveyDefinitionRepository>()
+        val service = SurveyDefinitionService(repository)
+        val storedSubmission = ratingSubmission()
+        val storedDefinition = SurveyDefinition.fromSubmission(storedSubmission)
+        val incomingSubmission = FeedbackSubmissionV2(
+            schemaVersion = 2,
+            surveyId = "survey-1",
+            surveyType = SurveyType.RATING,
+            submittedAt = "2026-01-10T12:00:12Z",
+            deduplicationKey = "client-key-123456",
+            definition = SurveyDefinitionPayload(
+                surveyType = SurveyType.RATING,
+                fields = listOf(
+                    SubmissionFieldDefinitionPayload(
+                        fieldId = "rating",
+                        fieldType = FieldType.RATING,
+                        ratingVariant = RatingVariant.EMOJI,
+                        ratingScale = 5
+                    ),
+                    SubmissionFieldDefinitionPayload(
+                        fieldId = "followup",
+                        fieldType = FieldType.TEXT
+                    )
+                )
+            ),
+            answers = listOf(
+                Answer(
+                    fieldId = "rating",
+                    fieldType = FieldType.RATING,
+                    question = Question(label = "Hvor fornøyd er du?"),
+                    value = AnswerValue.Rating(rating = 4, ratingVariant = RatingVariant.EMOJI, ratingScale = 5)
+                )
+            )
+        )
+
+        coEvery { repository.findByTeamAndSurveyId("team-a", "survey-1") } returns StoredSurveyDefinition(
+            team = "team-a",
+            surveyId = "survey-1",
+            definitionHash = storedDefinition.computeHash(),
+            definition = storedDefinition
+        )
+
+        val exception = shouldThrowConflict {
+            service.registerOrValidateV2(
+                "team-a",
+                FeedbackSubmissionV1(
+                    schemaVersion = incomingSubmission.schemaVersion,
+                    surveyId = incomingSubmission.surveyId,
+                    surveyType = incomingSubmission.surveyType,
+                    submittedAt = incomingSubmission.submittedAt,
+                    startedAt = incomingSubmission.startedAt,
+                    timeToCompleteMs = incomingSubmission.timeToCompleteMs,
+                    deduplicationKey = incomingSubmission.deduplicationKey,
+                    context = incomingSubmission.context,
+                    answers = incomingSubmission.answers
+                ),
+                incomingSubmission.definition.toSurveyDefinition(incomingSubmission.surveyId)
+            )
+        }
+
+        exception.message shouldContain "Survey definition conflict for surveyId=survey-1"
+        exception.message shouldContain "addedFields=[field_1]"
+        exception.message shouldNotContain "followup"
+    }
+
+    test("schemaVersion=2 rejects rating definition with mismatched fixed scale before persistence") {
+        val repository = mockk<SurveyDefinitionRepository>()
+        val service = SurveyDefinitionService(repository)
+        val submission = FeedbackSubmissionV2(
+            schemaVersion = 2,
+            surveyId = "survey-bad-scale",
+            surveyType = SurveyType.RATING,
+            submittedAt = "2026-01-10T12:00:12Z",
+            deduplicationKey = "client-key-123456",
+            definition = SurveyDefinitionPayload(
+                surveyType = SurveyType.RATING,
+                fields = listOf(
+                    SubmissionFieldDefinitionPayload(
+                        fieldId = "rating",
+                        fieldType = FieldType.RATING,
+                        ratingVariant = RatingVariant.EMOJI,
+                        ratingScale = 4
+                    )
+                )
+            ),
+            answers = listOf(
+                Answer(
+                    fieldId = "rating",
+                    fieldType = FieldType.RATING,
+                    question = Question(label = "Hvor fornøyd er du?"),
+                    value = AnswerValue.Rating(rating = 4, ratingVariant = RatingVariant.EMOJI, ratingScale = 4)
+                )
+            )
+        )
+
+        val exception = shouldThrowBadRequest {
+            service.registerOrValidateV2(
+                "team-a",
+                submission.toV1Submission(),
+                submission.definition.toSurveyDefinition(submission.surveyId)
+            )
+        }
+
+        exception.message shouldContain "ratingScale=4 does not match ratingVariant=EMOJI"
+        coVerify(exactly = 0) { repository.findByTeamAndSurveyId(any(), any()) }
+        coVerify(exactly = 0) { repository.insertIfUnderLimit(any(), any(), any(), any()) }
+    }
+
+    test("schemaVersion=2 rejects choice definition with rating metadata before persistence") {
+        val repository = mockk<SurveyDefinitionRepository>()
+        val service = SurveyDefinitionService(repository)
+        val submission = FeedbackSubmissionV2(
+            schemaVersion = 2,
+            surveyId = "survey-choice-bad",
+            surveyType = SurveyType.TOP_TASKS,
+            submittedAt = "2026-01-10T12:00:12Z",
+            deduplicationKey = "client-key-123456",
+            definition = SurveyDefinitionPayload(
+                surveyType = SurveyType.TOP_TASKS,
+                fields = listOf(
+                    SubmissionFieldDefinitionPayload(
+                        fieldId = "task",
+                        fieldType = FieldType.SINGLE_CHOICE,
+                        ratingVariant = RatingVariant.THUMBS,
+                        ratingScale = 2,
+                        optionIds = listOf("apply", "follow-up")
+                    )
+                )
+            ),
+            answers = listOf(
+                Answer(
+                    fieldId = "task",
+                    fieldType = FieldType.SINGLE_CHOICE,
+                    question = Question(label = "Hva gjorde du?"),
+                    value = AnswerValue.SingleChoice("apply")
+                )
+            )
+        )
+
+        val exception = shouldThrowBadRequest {
+            service.registerOrValidateV2(
+                "team-a",
+                submission.toV1Submission(),
+                submission.definition.toSurveyDefinition(submission.surveyId)
+            )
+        }
+
+        exception.message shouldContain "must not include ratingVariant or ratingScale"
+        coVerify(exactly = 0) { repository.findByTeamAndSurveyId(any(), any()) }
+        coVerify(exactly = 0) { repository.insertIfUnderLimit(any(), any(), any(), any()) }
+    }
+
+    test("schemaVersion=2 rejects text definition with optionIds before persistence") {
+        val repository = mockk<SurveyDefinitionRepository>()
+        val service = SurveyDefinitionService(repository)
+        val submission = FeedbackSubmissionV2(
+            schemaVersion = 2,
+            surveyId = "survey-text-bad",
+            surveyType = SurveyType.CUSTOM,
+            submittedAt = "2026-01-10T12:00:12Z",
+            deduplicationKey = "client-key-123456",
+            definition = SurveyDefinitionPayload(
+                surveyType = SurveyType.CUSTOM,
+                fields = listOf(
+                    SubmissionFieldDefinitionPayload(
+                        fieldId = "comment",
+                        fieldType = FieldType.TEXT,
+                        optionIds = listOf("unexpected")
+                    )
+                )
+            ),
+            answers = listOf(
+                Answer(
+                    fieldId = "comment",
+                    fieldType = FieldType.TEXT,
+                    question = Question(label = "Hvorfor?"),
+                    value = AnswerValue.Text("Bra")
+                )
+            )
+        )
+
+        val exception = shouldThrowBadRequest {
+            service.registerOrValidateV2(
+                "team-a",
+                submission.toV1Submission(),
+                submission.definition.toSurveyDefinition(submission.surveyId)
+            )
+        }
+
+        exception.message shouldContain "must not include optionIds"
+        coVerify(exactly = 0) { repository.findByTeamAndSurveyId(any(), any()) }
+        coVerify(exactly = 0) { repository.insertIfUnderLimit(any(), any(), any(), any()) }
     }
 
     test("overlapping field change returns 409 instead of 400") {
@@ -638,6 +837,18 @@ private fun choiceSubmission(optionLabel: String) = FeedbackSubmissionV1(
             value = AnswerValue.SingleChoice("apply")
         )
     )
+)
+
+private fun FeedbackSubmissionV2.toV1Submission() = FeedbackSubmissionV1(
+    schemaVersion = schemaVersion,
+    surveyId = surveyId,
+    surveyType = surveyType,
+    submittedAt = submittedAt,
+    startedAt = startedAt,
+    timeToCompleteMs = timeToCompleteMs,
+    deduplicationKey = deduplicationKey,
+    context = context,
+    answers = answers
 )
 
 private fun shouldThrowBadRequest(block: suspend () -> Unit): ApiErrorException.BadRequestException {

--- a/apps/lumi-dashboard/app/types/__tests__/submission.contract.test.ts
+++ b/apps/lumi-dashboard/app/types/__tests__/submission.contract.test.ts
@@ -1,0 +1,306 @@
+import { describe, expect, it } from "vitest";
+
+import type { FeedbackSubmission } from "~/types/api";
+import {
+  FeedbackSubmissionSchema,
+  FeedbackSubmissionV1Schema,
+  FeedbackSubmissionV2Schema,
+} from "~/types/schemas";
+
+describe("submission contract", () => {
+  it("accepts valid v1 and v2 payloads in the versioned union schema", () => {
+    const v1: FeedbackSubmission = {
+      schemaVersion: 1,
+      surveyId: "survey-1",
+      surveyType: "rating",
+      submittedAt: "2026-01-21T12:00:00.000Z",
+      answers: [
+        {
+          fieldId: "rating",
+          fieldType: "RATING",
+          question: { label: "How was it?" },
+          value: {
+            type: "rating",
+            rating: 4,
+            ratingVariant: "emoji",
+            ratingScale: 5,
+          },
+        },
+      ],
+    };
+
+    const v2: FeedbackSubmission = {
+      schemaVersion: 2,
+      surveyId: "survey-1",
+      surveyType: "rating",
+      submittedAt: "2026-01-21T12:00:00.000Z",
+      deduplicationKey: "retryable-submit:survey-1",
+      definition: {
+        surveyType: "rating",
+        fields: [
+          {
+            fieldId: "rating",
+            fieldType: "RATING",
+            ratingVariant: "emoji",
+            ratingScale: 5,
+          },
+          {
+            fieldId: "followup",
+            fieldType: "TEXT",
+          },
+        ],
+      },
+      answers: [
+        {
+          fieldId: "rating",
+          fieldType: "RATING",
+          question: { label: "How was it?" },
+          value: {
+            type: "rating",
+            rating: 4,
+            ratingVariant: "emoji",
+            ratingScale: 5,
+          },
+        },
+      ],
+    };
+
+    expect(() => FeedbackSubmissionV1Schema.parse(v1)).not.toThrow();
+    expect(() => FeedbackSubmissionV2Schema.parse(v2)).not.toThrow();
+    expect(() => FeedbackSubmissionSchema.parse(v1)).not.toThrow();
+    expect(() => FeedbackSubmissionSchema.parse(v2)).not.toThrow();
+  });
+
+  it("rejects v2 submissions with empty definition fields", () => {
+    const invalidPayload = {
+      schemaVersion: 2,
+      surveyId: "survey-1",
+      surveyType: "rating",
+      submittedAt: "2026-01-21T12:00:00.000Z",
+      deduplicationKey: "retryable-submit:survey-1",
+      definition: {
+        surveyType: "rating",
+        fields: [],
+      },
+      answers: [
+        {
+          fieldId: "rating",
+          fieldType: "RATING",
+          question: { label: "How was it?" },
+          value: {
+            type: "rating",
+            rating: 4,
+            ratingVariant: "emoji",
+            ratingScale: 5,
+          },
+        },
+      ],
+    };
+
+    expect(() => FeedbackSubmissionV2Schema.parse(invalidPayload)).toThrow();
+  });
+
+  it("rejects v2 definitions with duplicate fieldIds", () => {
+    const invalidPayload = {
+      schemaVersion: 2,
+      surveyId: "survey-1",
+      surveyType: "rating",
+      submittedAt: "2026-01-21T12:00:00.000Z",
+      deduplicationKey: "retryable-submit:survey-1",
+      definition: {
+        surveyType: "rating",
+        fields: [
+          {
+            fieldId: "rating",
+            fieldType: "RATING",
+            ratingVariant: "emoji",
+            ratingScale: 5,
+          },
+          {
+            fieldId: "rating",
+            fieldType: "TEXT",
+          },
+        ],
+      },
+      answers: [
+        {
+          fieldId: "rating",
+          fieldType: "RATING",
+          question: { label: "How was it?" },
+          value: {
+            type: "rating",
+            rating: 4,
+            ratingVariant: "emoji",
+            ratingScale: 5,
+          },
+        },
+      ],
+    };
+
+    expect(() => FeedbackSubmissionV2Schema.parse(invalidPayload)).toThrow(
+      /definition\.fields\.fieldId must be unique/,
+    );
+  });
+
+  it("rejects v2 definitions when rating fields miss rating metadata", () => {
+    const invalidPayload = {
+      schemaVersion: 2,
+      surveyId: "survey-1",
+      surveyType: "rating",
+      submittedAt: "2026-01-21T12:00:00.000Z",
+      deduplicationKey: "retryable-submit:survey-1",
+      definition: {
+        surveyType: "rating",
+        fields: [
+          {
+            fieldId: "rating",
+            fieldType: "RATING",
+          },
+        ],
+      },
+      answers: [
+        {
+          fieldId: "rating",
+          fieldType: "RATING",
+          question: { label: "How was it?" },
+          value: {
+            type: "rating",
+            rating: 4,
+            ratingVariant: "emoji",
+            ratingScale: 5,
+          },
+        },
+      ],
+    };
+
+    expect(() => FeedbackSubmissionV2Schema.parse(invalidPayload)).toThrow();
+  });
+
+  it("rejects v2 choice definitions with empty or duplicate optionIds", () => {
+    const emptyOptionsPayload = {
+      schemaVersion: 2,
+      surveyId: "survey-1",
+      surveyType: "custom",
+      submittedAt: "2026-01-21T12:00:00.000Z",
+      deduplicationKey: "retryable-submit:survey-1",
+      definition: {
+        surveyType: "custom",
+        fields: [
+          {
+            fieldId: "category",
+            fieldType: "SINGLE_CHOICE",
+            optionIds: [],
+          },
+        ],
+      },
+      answers: [
+        {
+          fieldId: "category",
+          fieldType: "SINGLE_CHOICE",
+          question: {
+            label: "Category",
+            options: [{ id: "bug", label: "Bug" }],
+          },
+          value: { type: "singleChoice", selectedOptionId: "bug" },
+        },
+      ],
+    };
+
+    const duplicateOptionsPayload = {
+      ...emptyOptionsPayload,
+      definition: {
+        surveyType: "custom",
+        fields: [
+          {
+            fieldId: "category",
+            fieldType: "SINGLE_CHOICE",
+            optionIds: ["bug", "bug"],
+          },
+        ],
+      },
+    };
+
+    expect(() =>
+      FeedbackSubmissionV2Schema.parse(emptyOptionsPayload),
+    ).toThrow();
+    expect(() =>
+      FeedbackSubmissionV2Schema.parse(duplicateOptionsPayload),
+    ).toThrow(/optionIds must be unique/);
+  });
+
+  it("rejects invalid v2 deduplication keys", () => {
+    const invalidPayload = {
+      schemaVersion: 2,
+      surveyId: "survey-1",
+      surveyType: "rating",
+      submittedAt: "2026-01-21T12:00:00.000Z",
+      deduplicationKey: "not valid!",
+      definition: {
+        surveyType: "rating",
+        fields: [
+          {
+            fieldId: "rating",
+            fieldType: "RATING",
+            ratingVariant: "emoji",
+            ratingScale: 5,
+          },
+        ],
+      },
+      answers: [
+        {
+          fieldId: "rating",
+          fieldType: "RATING",
+          question: { label: "How was it?" },
+          value: {
+            type: "rating",
+            rating: 4,
+            ratingVariant: "emoji",
+            ratingScale: 5,
+          },
+        },
+      ],
+    };
+
+    expect(() => FeedbackSubmissionV2Schema.parse(invalidPayload)).toThrow(
+      /deduplicationKey/,
+    );
+  });
+
+  it("rejects v2 submissions when top-level surveyType mismatches definition", () => {
+    const invalidPayload = {
+      schemaVersion: 2,
+      surveyId: "survey-1",
+      surveyType: "custom",
+      submittedAt: "2026-01-21T12:00:00.000Z",
+      deduplicationKey: "retryable-submit:survey-1",
+      definition: {
+        surveyType: "rating",
+        fields: [
+          {
+            fieldId: "rating",
+            fieldType: "RATING",
+            ratingVariant: "emoji",
+            ratingScale: 5,
+          },
+        ],
+      },
+      answers: [
+        {
+          fieldId: "rating",
+          fieldType: "RATING",
+          question: { label: "How was it?" },
+          value: {
+            type: "rating",
+            rating: 4,
+            ratingVariant: "emoji",
+            ratingScale: 5,
+          },
+        },
+      ],
+    };
+
+    expect(() => FeedbackSubmissionV2Schema.parse(invalidPayload)).toThrow(
+      /surveyType must match definition\.surveyType/,
+    );
+  });
+});

--- a/apps/lumi-dashboard/app/types/__tests__/submission.contract.test.ts
+++ b/apps/lumi-dashboard/app/types/__tests__/submission.contract.test.ts
@@ -540,7 +540,9 @@ describe("submission contract", () => {
       expect(
         () => FeedbackSubmissionV2Schema.parse(invalidPayload),
         `expected non-decimal fieldId "${illegalId}" to be rejected`,
-      ).toThrow(/fieldId must contain only letters, digits, hyphen, or underscore/);
+      ).toThrow(
+        /fieldId must contain only letters, digits, hyphen, or underscore/,
+      );
     }
   });
 

--- a/apps/lumi-dashboard/app/types/__tests__/submission.contract.test.ts
+++ b/apps/lumi-dashboard/app/types/__tests__/submission.contract.test.ts
@@ -745,4 +745,62 @@ describe("submission contract", () => {
 
     expect(() => FeedbackSubmissionV2Schema.parse(payload)).not.toThrow();
   });
+
+  it("accepts v2 definition with exactly 50 fields (backend MAX_FIELDS_PER_DEFINITION)", () => {
+    const fields = Array.from({ length: 50 }, (_, i) => ({
+      fieldId: `field-${i + 1}`,
+      fieldType: "TEXT" as const,
+    }));
+    const payload = {
+      schemaVersion: 2,
+      surveyId: "survey-1",
+      surveyType: "custom",
+      submittedAt: "2026-01-21T12:00:00.000Z",
+      deduplicationKey: "retryable-submit:survey-1",
+      definition: {
+        surveyType: "custom",
+        fields,
+      },
+      answers: [
+        {
+          fieldId: "field-1",
+          fieldType: "TEXT",
+          question: { label: "Q1" },
+          value: { type: "text", text: "answer" },
+        },
+      ],
+    };
+
+    expect(() => FeedbackSubmissionV2Schema.parse(payload)).not.toThrow();
+  });
+
+  it("rejects v2 definition with 51 fields (exceeds backend MAX_FIELDS_PER_DEFINITION = 50)", () => {
+    const fields = Array.from({ length: 51 }, (_, i) => ({
+      fieldId: `field-${i + 1}`,
+      fieldType: "TEXT" as const,
+    }));
+    const invalidPayload = {
+      schemaVersion: 2,
+      surveyId: "survey-1",
+      surveyType: "custom",
+      submittedAt: "2026-01-21T12:00:00.000Z",
+      deduplicationKey: "retryable-submit:survey-1",
+      definition: {
+        surveyType: "custom",
+        fields,
+      },
+      answers: [
+        {
+          fieldId: "field-1",
+          fieldType: "TEXT",
+          question: { label: "Q1" },
+          value: { type: "text", text: "answer" },
+        },
+      ],
+    };
+
+    expect(() => FeedbackSubmissionV2Schema.parse(invalidPayload)).toThrow(
+      /definition\.fields must not exceed 50 fields/,
+    );
+  });
 });

--- a/apps/lumi-dashboard/app/types/__tests__/submission.contract.test.ts
+++ b/apps/lumi-dashboard/app/types/__tests__/submission.contract.test.ts
@@ -407,4 +407,340 @@ describe("submission contract", () => {
       /fieldId must contain only letters, digits, hyphen, or underscore/,
     );
   });
+
+  it("rejects v2 definition fieldId exceeding 200 characters", () => {
+    const longFieldId = "a".repeat(201);
+    const invalidPayload = {
+      schemaVersion: 2,
+      surveyId: "survey-1",
+      surveyType: "rating",
+      submittedAt: "2026-01-21T12:00:00.000Z",
+      deduplicationKey: "retryable-submit:survey-1",
+      definition: {
+        surveyType: "rating",
+        fields: [
+          {
+            fieldId: longFieldId,
+            fieldType: "RATING",
+            ratingVariant: "emoji",
+            ratingScale: 5,
+          },
+        ],
+      },
+      answers: [],
+    };
+
+    expect(() => FeedbackSubmissionV2Schema.parse(invalidPayload)).toThrow(
+      /fieldId must not exceed 200 characters/,
+    );
+  });
+
+  it("accepts v2 definition fieldId of exactly 200 characters", () => {
+    const maxFieldId = "a".repeat(200);
+    const payload = {
+      schemaVersion: 2,
+      surveyId: "survey-1",
+      surveyType: "rating",
+      submittedAt: "2026-01-21T12:00:00.000Z",
+      deduplicationKey: "retryable-submit:survey-1",
+      definition: {
+        surveyType: "rating",
+        fields: [
+          {
+            fieldId: maxFieldId,
+            fieldType: "RATING",
+            ratingVariant: "emoji",
+            ratingScale: 5,
+          },
+        ],
+      },
+      answers: [
+        {
+          fieldId: maxFieldId,
+          fieldType: "RATING",
+          question: { label: "How was it?" },
+          value: {
+            type: "rating",
+            rating: 4,
+            ratingVariant: "emoji",
+            ratingScale: 5,
+          },
+        },
+      ],
+    };
+
+    expect(() => FeedbackSubmissionV2Schema.parse(payload)).not.toThrow();
+  });
+
+  it("accepts Unicode fieldId (e.g. Norwegian letters and digits)", () => {
+    // Backend uses Character.isLetterOrDigit() which allows Unicode letters/digits
+    const payload = {
+      schemaVersion: 2,
+      surveyId: "survey-1",
+      surveyType: "rating",
+      submittedAt: "2026-01-21T12:00:00.000Z",
+      deduplicationKey: "retryable-submit:survey-1",
+      definition: {
+        surveyType: "rating",
+        fields: [
+          {
+            fieldId: "følelse_1",
+            fieldType: "RATING",
+            ratingVariant: "emoji",
+            ratingScale: 5,
+          },
+        ],
+      },
+      answers: [
+        {
+          fieldId: "følelse_1",
+          fieldType: "RATING",
+          question: { label: "Hvordan følte du deg?" },
+          value: {
+            type: "rating",
+            rating: 3,
+            ratingVariant: "emoji",
+            ratingScale: 5,
+          },
+        },
+      ],
+    };
+
+    expect(() => FeedbackSubmissionV2Schema.parse(payload)).not.toThrow();
+  });
+
+  it("rejects v2 definition fieldIds with non-decimal Unicode numeric chars (² and Ⅻ)", () => {
+    // \p{N} matches ALL Unicode number categories (including superscript digits and
+    // Roman numerals), but backend Kotlin isLetterOrDigit() only accepts \p{L} and \p{Nd}.
+    // Superscript TWO (U+00B2) and ROMAN NUMERAL TWELVE (U+216C) are \p{No} / \p{Nl},
+    // not decimal digits, so they must be rejected.
+    const illegalFieldIds = ["field²", "fieldⅫ"];
+
+    for (const illegalId of illegalFieldIds) {
+      const invalidPayload = {
+        schemaVersion: 2,
+        surveyId: "survey-1",
+        surveyType: "rating",
+        submittedAt: "2026-01-21T12:00:00.000Z",
+        deduplicationKey: "retryable-submit:survey-1",
+        definition: {
+          surveyType: "rating",
+          fields: [
+            {
+              fieldId: illegalId,
+              fieldType: "RATING",
+              ratingVariant: "emoji",
+              ratingScale: 5,
+            },
+          ],
+        },
+        answers: [],
+      };
+
+      expect(
+        () => FeedbackSubmissionV2Schema.parse(invalidPayload),
+        `expected non-decimal fieldId "${illegalId}" to be rejected`,
+      ).toThrow(/fieldId must contain only letters, digits, hyphen, or underscore/);
+    }
+  });
+
+  it("rejects v2 definition optionIds that are blank or whitespace-only", () => {
+    // Backend uses optionId.isBlank() to reject whitespace-only strings.
+    // Space (charCode 32) is not a control char and not a JSONPath special char —
+    // so without an explicit blank-check it would previously slip through .min(1).
+    const blankOptionIds = [" ", "   "];
+
+    for (const blankId of blankOptionIds) {
+      const invalidPayload = {
+        schemaVersion: 2,
+        surveyId: "survey-1",
+        surveyType: "custom",
+        submittedAt: "2026-01-21T12:00:00.000Z",
+        deduplicationKey: "retryable-submit:survey-1",
+        definition: {
+          surveyType: "custom",
+          fields: [
+            {
+              fieldId: "category",
+              fieldType: "SINGLE_CHOICE",
+              optionIds: [blankId],
+            },
+          ],
+        },
+        answers: [],
+      };
+
+      expect(
+        () => FeedbackSubmissionV2Schema.parse(invalidPayload),
+        `expected blank optionId "${JSON.stringify(blankId)}" to be rejected`,
+      ).toThrow(/optionId must not be blank/);
+    }
+  });
+
+  it("rejects v2 definition optionId exceeding 200 characters", () => {
+    const longOptionId = "a".repeat(201);
+    const invalidPayload = {
+      schemaVersion: 2,
+      surveyId: "survey-1",
+      surveyType: "custom",
+      submittedAt: "2026-01-21T12:00:00.000Z",
+      deduplicationKey: "retryable-submit:survey-1",
+      definition: {
+        surveyType: "custom",
+        fields: [
+          {
+            fieldId: "category",
+            fieldType: "SINGLE_CHOICE",
+            optionIds: [longOptionId],
+          },
+        ],
+      },
+      answers: [],
+    };
+
+    expect(() => FeedbackSubmissionV2Schema.parse(invalidPayload)).toThrow(
+      /optionId must not exceed 200 characters/,
+    );
+  });
+
+  it("accepts v2 definition optionId of exactly 200 characters", () => {
+    const maxOptionId = "a".repeat(200);
+    const payload = {
+      schemaVersion: 2,
+      surveyId: "survey-1",
+      surveyType: "custom",
+      submittedAt: "2026-01-21T12:00:00.000Z",
+      deduplicationKey: "retryable-submit:survey-1",
+      definition: {
+        surveyType: "custom",
+        fields: [
+          {
+            fieldId: "category",
+            fieldType: "SINGLE_CHOICE",
+            optionIds: [maxOptionId],
+          },
+        ],
+      },
+      answers: [
+        {
+          fieldId: "category",
+          fieldType: "SINGLE_CHOICE",
+          question: {
+            label: "Category",
+            options: [{ id: maxOptionId, label: "Option" }],
+          },
+          value: { type: "singleChoice", selectedOptionId: maxOptionId },
+        },
+      ],
+    };
+
+    expect(() => FeedbackSubmissionV2Schema.parse(payload)).not.toThrow();
+  });
+
+  it("rejects v2 definition optionIds containing JSONPath special characters", () => {
+    // Backend JSON_PATH_SPECIAL_CHARS = {'"', '\\', '$', '@', '?', '(', ')', ','}
+    // '(' is tested via "opt(1", ')' is tested in isolation to ensure both are covered independently.
+    const illegalOptionIds = [
+      'opt"1',
+      "opt\\1",
+      "opt$1",
+      "opt@1",
+      "opt?1",
+      "opt(1",
+      ")",
+      "opt,1",
+    ];
+
+    for (const illegalId of illegalOptionIds) {
+      const invalidPayload = {
+        schemaVersion: 2,
+        surveyId: "survey-1",
+        surveyType: "custom",
+        submittedAt: "2026-01-21T12:00:00.000Z",
+        deduplicationKey: "retryable-submit:survey-1",
+        definition: {
+          surveyType: "custom",
+          fields: [
+            {
+              fieldId: "category",
+              fieldType: "SINGLE_CHOICE",
+              optionIds: [illegalId],
+            },
+          ],
+        },
+        answers: [],
+      };
+
+      expect(
+        () => FeedbackSubmissionV2Schema.parse(invalidPayload),
+        `expected "${illegalId}" to be rejected`,
+      ).toThrow(/optionId contains illegal characters/);
+    }
+  });
+
+  it("rejects v2 definition optionIds containing control characters", () => {
+    // Backend: it.code < 32 is forbidden (includes \n, \r, \t, \0)
+    const controlCharOptionIds = ["opt\n1", "opt\r1", "opt\t1", "opt\x001"];
+
+    for (const illegalId of controlCharOptionIds) {
+      const invalidPayload = {
+        schemaVersion: 2,
+        surveyId: "survey-1",
+        surveyType: "custom",
+        submittedAt: "2026-01-21T12:00:00.000Z",
+        deduplicationKey: "retryable-submit:survey-1",
+        definition: {
+          surveyType: "custom",
+          fields: [
+            {
+              fieldId: "category",
+              fieldType: "SINGLE_CHOICE",
+              optionIds: [illegalId],
+            },
+          ],
+        },
+        answers: [],
+      };
+
+      expect(
+        () => FeedbackSubmissionV2Schema.parse(invalidPayload),
+        `expected control char optionId to be rejected`,
+      ).toThrow(/optionId contains illegal characters/);
+    }
+  });
+
+  it("accepts v2 definition optionIds that are valid per backend rules", () => {
+    // Backend allows: alphanumeric, hyphens, spaces, international chars etc.
+    const validOptionIds = ["opt-1", "Svært ofte", "option_A", "123", "a b c"];
+    const payload = {
+      schemaVersion: 2,
+      surveyId: "survey-1",
+      surveyType: "custom",
+      submittedAt: "2026-01-21T12:00:00.000Z",
+      deduplicationKey: "retryable-submit:survey-1",
+      definition: {
+        surveyType: "custom",
+        fields: [
+          {
+            fieldId: "category",
+            fieldType: "SINGLE_CHOICE",
+            optionIds: validOptionIds,
+          },
+        ],
+      },
+      answers: [
+        {
+          fieldId: "category",
+          fieldType: "SINGLE_CHOICE",
+          question: {
+            label: "Category",
+            options: validOptionIds.map((id) => ({ id, label: id })),
+          },
+          value: { type: "singleChoice", selectedOptionId: "opt-1" },
+        },
+      ],
+    };
+
+    expect(() => FeedbackSubmissionV2Schema.parse(payload)).not.toThrow();
+  });
 });

--- a/apps/lumi-dashboard/app/types/__tests__/submission.contract.test.ts
+++ b/apps/lumi-dashboard/app/types/__tests__/submission.contract.test.ts
@@ -370,6 +370,298 @@ describe("submission contract", () => {
     );
   });
 
+  it("rejects v2 rating answers whose metadata differs from definition", () => {
+    const invalidPayload = {
+      schemaVersion: 2,
+      surveyId: "survey-1",
+      surveyType: "rating",
+      submittedAt: "2026-01-21T12:00:00.000Z",
+      deduplicationKey: "retryable-submit:survey-1",
+      definition: {
+        surveyType: "rating",
+        fields: [
+          {
+            fieldId: "rating",
+            fieldType: "RATING",
+            ratingVariant: "emoji",
+            ratingScale: 5,
+          },
+        ],
+      },
+      answers: [
+        {
+          fieldId: "rating",
+          fieldType: "RATING",
+          question: { label: "How was it?" },
+          value: {
+            type: "rating",
+            rating: 1,
+            ratingVariant: "thumbs",
+            ratingScale: 2,
+          },
+        },
+      ],
+    };
+
+    expect(() => FeedbackSubmissionV2Schema.parse(invalidPayload)).toThrow(
+      /rating config/,
+    );
+  });
+
+  it("rejects v2 choice answers whose options differ from definition", () => {
+    const invalidPayload = {
+      schemaVersion: 2,
+      surveyId: "survey-1",
+      surveyType: "custom",
+      submittedAt: "2026-01-21T12:00:00.000Z",
+      deduplicationKey: "retryable-submit:survey-1",
+      definition: {
+        surveyType: "custom",
+        fields: [
+          {
+            fieldId: "category",
+            fieldType: "SINGLE_CHOICE",
+            optionIds: ["bug", "idea"],
+          },
+        ],
+      },
+      answers: [
+        {
+          fieldId: "category",
+          fieldType: "SINGLE_CHOICE",
+          question: {
+            label: "Category",
+            options: [{ id: "bug", label: "Bug" }],
+          },
+          value: { type: "singleChoice", selectedOptionId: "bug" },
+        },
+      ],
+    };
+
+    expect(() => FeedbackSubmissionV2Schema.parse(invalidPayload)).toThrow(
+      /question\.options must match definition\.optionIds/,
+    );
+  });
+
+  it("rejects v2 single-choice answers with selected option outside definition", () => {
+    const invalidPayload = {
+      schemaVersion: 2,
+      surveyId: "survey-1",
+      surveyType: "custom",
+      submittedAt: "2026-01-21T12:00:00.000Z",
+      deduplicationKey: "retryable-submit:survey-1",
+      definition: {
+        surveyType: "custom",
+        fields: [
+          {
+            fieldId: "category",
+            fieldType: "SINGLE_CHOICE",
+            optionIds: ["bug", "idea"],
+          },
+        ],
+      },
+      answers: [
+        {
+          fieldId: "category",
+          fieldType: "SINGLE_CHOICE",
+          question: {
+            label: "Category",
+            options: [
+              { id: "bug", label: "Bug" },
+              { id: "idea", label: "Idea" },
+            ],
+          },
+          value: { type: "singleChoice", selectedOptionId: "other" },
+        },
+      ],
+    };
+
+    expect(() => FeedbackSubmissionV2Schema.parse(invalidPayload)).toThrow(
+      /selectedOptionId=other is not valid/,
+    );
+  });
+
+  it("rejects v2 multi-choice answers with duplicate or unknown selected options", () => {
+    const invalidPayload = {
+      schemaVersion: 2,
+      surveyId: "survey-1",
+      surveyType: "custom",
+      submittedAt: "2026-01-21T12:00:00.000Z",
+      deduplicationKey: "retryable-submit:survey-1",
+      definition: {
+        surveyType: "custom",
+        fields: [
+          {
+            fieldId: "category",
+            fieldType: "MULTI_CHOICE",
+            optionIds: ["bug", "idea"],
+          },
+        ],
+      },
+      answers: [
+        {
+          fieldId: "category",
+          fieldType: "MULTI_CHOICE",
+          question: {
+            label: "Category",
+            options: [
+              { id: "bug", label: "Bug" },
+              { id: "idea", label: "Idea" },
+            ],
+          },
+          value: {
+            type: "multiChoice",
+            selectedOptionIds: ["bug", "bug", "other"],
+          },
+        },
+      ],
+    };
+
+    expect(() => FeedbackSubmissionV2Schema.parse(invalidPayload)).toThrow(
+      /duplicate selectedOptionIds/,
+    );
+    expect(() => FeedbackSubmissionV2Schema.parse(invalidPayload)).toThrow(
+      /selectedOptionIds=other are not valid/,
+    );
+  });
+
+  it("accepts valid v2 multi-choice answers that match definition", () => {
+    const payload = {
+      schemaVersion: 2,
+      surveyId: "survey-1",
+      surveyType: "custom",
+      submittedAt: "2026-01-21T12:00:00.000Z",
+      deduplicationKey: "retryable-submit:survey-1",
+      definition: {
+        surveyType: "custom",
+        fields: [
+          {
+            fieldId: "category",
+            fieldType: "MULTI_CHOICE",
+            optionIds: ["bug", "idea", "other"],
+          },
+        ],
+      },
+      answers: [
+        {
+          fieldId: "category",
+          fieldType: "MULTI_CHOICE",
+          question: {
+            label: "Category",
+            options: [
+              { id: "bug", label: "Bug" },
+              { id: "idea", label: "Idea" },
+              { id: "other", label: "Other" },
+            ],
+          },
+          value: {
+            type: "multiChoice",
+            selectedOptionIds: ["bug", "other"],
+          },
+        },
+      ],
+    };
+
+    expect(() => FeedbackSubmissionV2Schema.parse(payload)).not.toThrow();
+  });
+
+  it("rejects v2 definitions with backend-forbidden fields for fieldType", () => {
+    const ratingWithOptions = {
+      schemaVersion: 2,
+      surveyId: "survey-1",
+      surveyType: "rating",
+      submittedAt: "2026-01-21T12:00:00.000Z",
+      deduplicationKey: "retryable-submit:survey-1",
+      definition: {
+        surveyType: "rating",
+        fields: [
+          {
+            fieldId: "rating",
+            fieldType: "RATING",
+            ratingVariant: "emoji",
+            ratingScale: 5,
+            optionIds: ["not-allowed"],
+          },
+        ],
+      },
+      answers: [
+        {
+          fieldId: "rating",
+          fieldType: "RATING",
+          question: { label: "How was it?" },
+          value: {
+            type: "rating",
+            rating: 4,
+            ratingVariant: "emoji",
+            ratingScale: 5,
+          },
+        },
+      ],
+    };
+
+    const choiceWithRatingMetadata = {
+      schemaVersion: 2,
+      surveyId: "survey-1",
+      surveyType: "custom",
+      submittedAt: "2026-01-21T12:00:00.000Z",
+      deduplicationKey: "retryable-submit:survey-1",
+      definition: {
+        surveyType: "custom",
+        fields: [
+          {
+            fieldId: "category",
+            fieldType: "SINGLE_CHOICE",
+            optionIds: ["bug"],
+            ratingVariant: "emoji",
+          },
+        ],
+      },
+      answers: [
+        {
+          fieldId: "category",
+          fieldType: "SINGLE_CHOICE",
+          question: {
+            label: "Category",
+            options: [{ id: "bug", label: "Bug" }],
+          },
+          value: { type: "singleChoice", selectedOptionId: "bug" },
+        },
+      ],
+    };
+
+    const textWithOptions = {
+      schemaVersion: 2,
+      surveyId: "survey-1",
+      surveyType: "custom",
+      submittedAt: "2026-01-21T12:00:00.000Z",
+      deduplicationKey: "retryable-submit:survey-1",
+      definition: {
+        surveyType: "custom",
+        fields: [
+          {
+            fieldId: "feedback",
+            fieldType: "TEXT",
+            optionIds: ["not-allowed"],
+          },
+        ],
+      },
+      answers: [
+        {
+          fieldId: "feedback",
+          fieldType: "TEXT",
+          question: { label: "Feedback" },
+          value: { type: "text", text: "Hello" },
+        },
+      ],
+    };
+
+    expect(() => FeedbackSubmissionV2Schema.parse(ratingWithOptions)).toThrow();
+    expect(() =>
+      FeedbackSubmissionV2Schema.parse(choiceWithRatingMetadata),
+    ).toThrow();
+    expect(() => FeedbackSubmissionV2Schema.parse(textWithOptions)).toThrow();
+  });
+
   it("rejects v2 definition fieldIds with backend-illegal characters", () => {
     const invalidPayload = {
       schemaVersion: 2,

--- a/apps/lumi-dashboard/app/types/__tests__/submission.contract.test.ts
+++ b/apps/lumi-dashboard/app/types/__tests__/submission.contract.test.ts
@@ -303,4 +303,108 @@ describe("submission contract", () => {
       /surveyType must match definition\.surveyType/,
     );
   });
+
+  it("rejects v2 answers whose fieldId is missing from definition", () => {
+    const invalidPayload = {
+      schemaVersion: 2,
+      surveyId: "survey-1",
+      surveyType: "rating",
+      submittedAt: "2026-01-21T12:00:00.000Z",
+      deduplicationKey: "retryable-submit:survey-1",
+      definition: {
+        surveyType: "rating",
+        fields: [
+          {
+            fieldId: "rating",
+            fieldType: "RATING",
+            ratingVariant: "emoji",
+            ratingScale: 5,
+          },
+        ],
+      },
+      answers: [
+        {
+          fieldId: "unknown",
+          fieldType: "TEXT",
+          question: { label: "Unknown" },
+          value: { type: "text", text: "No definition" },
+        },
+      ],
+    };
+
+    expect(() => FeedbackSubmissionV2Schema.parse(invalidPayload)).toThrow(
+      /answers\.fieldId must exist in definition\.fields/,
+    );
+  });
+
+  it("rejects v2 answers whose fieldType differs from definition", () => {
+    const invalidPayload = {
+      schemaVersion: 2,
+      surveyId: "survey-1",
+      surveyType: "rating",
+      submittedAt: "2026-01-21T12:00:00.000Z",
+      deduplicationKey: "retryable-submit:survey-1",
+      definition: {
+        surveyType: "rating",
+        fields: [
+          {
+            fieldId: "rating",
+            fieldType: "RATING",
+            ratingVariant: "emoji",
+            ratingScale: 5,
+          },
+        ],
+      },
+      answers: [
+        {
+          fieldId: "rating",
+          fieldType: "TEXT",
+          question: { label: "Rating" },
+          value: { type: "text", text: "Wrong type" },
+        },
+      ],
+    };
+
+    expect(() => FeedbackSubmissionV2Schema.parse(invalidPayload)).toThrow(
+      /answers\.fieldType must match definition fieldType/,
+    );
+  });
+
+  it("rejects v2 definition fieldIds with backend-illegal characters", () => {
+    const invalidPayload = {
+      schemaVersion: 2,
+      surveyId: "survey-1",
+      surveyType: "rating",
+      submittedAt: "2026-01-21T12:00:00.000Z",
+      deduplicationKey: "retryable-submit:survey-1",
+      definition: {
+        surveyType: "rating",
+        fields: [
+          {
+            fieldId: "rating.field",
+            fieldType: "RATING",
+            ratingVariant: "emoji",
+            ratingScale: 5,
+          },
+        ],
+      },
+      answers: [
+        {
+          fieldId: "rating.field",
+          fieldType: "RATING",
+          question: { label: "How was it?" },
+          value: {
+            type: "rating",
+            rating: 4,
+            ratingVariant: "emoji",
+            ratingScale: 5,
+          },
+        },
+      ],
+    };
+
+    expect(() => FeedbackSubmissionV2Schema.parse(invalidPayload)).toThrow(
+      /fieldId must contain only letters, digits, hyphen, or underscore/,
+    );
+  });
 });

--- a/docs/kom-i-gang/konfigurer-survey.md
+++ b/docs/kom-i-gang/konfigurer-survey.md
@@ -54,7 +54,7 @@ Tre ting å merke seg:
 - **Vær konkret** — still spørsmål om en spesifikk opplevelse, ikke generell tilfredshet.
 - **Bruk progresjon** — vis oppfølgingsspørsmål med `visibleIf` i stedet for å vise alt på én gang.
 - **Segmentér med tags** — bruk `context.tags` for å skille mellom brukergrupper eller flater. Se [Context og tags](/guider/context-og-tags).
-- **Velg en stabil `surveyId`** — denne identifiserer surveyen på tvers av deploy og brukes til analyse i dashboardet.
+- **Velg en stabil `surveyId`** — denne identifiserer surveyen på tvers av deploy og brukes til analyse i dashboardet. Bruk ny `surveyId` når du fjerner, endrer navn på eller endrer type/options for spørsmål, for eksempel `min-flate-feedback-v2`.
 
 ## Snarvei: Bruk en preset
 

--- a/docs/kom-i-gang/konfigurer-survey.md
+++ b/docs/kom-i-gang/konfigurer-survey.md
@@ -54,7 +54,7 @@ Tre ting å merke seg:
 - **Vær konkret** — still spørsmål om en spesifikk opplevelse, ikke generell tilfredshet.
 - **Bruk progresjon** — vis oppfølgingsspørsmål med `visibleIf` i stedet for å vise alt på én gang.
 - **Segmentér med tags** — bruk `context.tags` for å skille mellom brukergrupper eller flater. Se [Context og tags](/guider/context-og-tags).
-- **Velg en stabil `surveyId`** — denne identifiserer surveyen på tvers av deploy og brukes til analyse i dashboardet. Bruk ny `surveyId` når du fjerner, endrer navn på eller endrer type/options for spørsmål, for eksempel `min-flate-feedback-v2`.
+- **Velg en stabil `surveyId`** — denne identifiserer surveyen på tvers av deploy og brukes til analyse i dashboardet. Bruk ny `surveyId` når du legger til, fjerner, endrer navn på eller endrer type/options for spørsmål, for eksempel `min-flate-feedback-v2`.
 
 ## Snarvei: Bruk en preset
 

--- a/docs/referanse/datakontrakt.md
+++ b/docs/referanse/datakontrakt.md
@@ -12,7 +12,7 @@ Widgeten samler inn svar og sender en strukturert JSON-payload til backend. Payl
 
 | Felt | Påkrevd | Beskrivelse |
 | :--- | :--- | :--- |
-| `schemaVersion` | ✅ | Alltid `2` (gjeldende versjon) |
+| `schemaVersion` | ✅ | Nåværende widget sender alltid `2`. Backend godtar også `1` i en overgangsperiode mens eldre widget-versjoner fases ut |
 | `submittedAt` | ✅ | ISO 8601 tidsstempel for innsending |
 | `surveyId` | ✅ | Unik survey-identifikator |
 | `surveyType` | ✅ | En av: `"rating"`, `"topTasks"`, `"discovery"`, `"taskPriority"`, `"custom"` |

--- a/docs/referanse/datakontrakt.md
+++ b/docs/referanse/datakontrakt.md
@@ -16,13 +16,17 @@ Widgeten samler inn svar og sender en strukturert JSON-payload til backend. Payl
 | `submittedAt` | ✅ | ISO 8601 tidsstempel for innsending |
 | `surveyId` | ✅ | Unik survey-identifikator |
 | `surveyType` | ✅ | En av: `"rating"`, `"topTasks"`, `"discovery"`, `"taskPriority"`, `"custom"` |
-| `deduplicationKey` | ✅ | Stabil nøkkel som gjør retry trygt |
+| `deduplicationKey` | ✅ | Genereres av widgeten og gjør nytt forsøk etter transportfeil trygt |
 | `definition` | ✅ | Alle spørsmålene i surveyen, også de som ikke er besvart |
 | `answers` | ✅ | Strukturert array med svar (se under) |
 | `context` | Anbefalt | Nettleser-/brukerkontekst for segmentering |
 
 ::: tip Når skal du endre `surveyId`?
 Bruk ny `surveyId` når du legger til, fjerner, endrer navn på eller endrer type/options for spørsmål. Da unngår du å blande ulike datastrukturer i samme analyse og 409-feil fra backend.
+:::
+
+::: info Deduplication
+Du trenger ikke sette `deduplicationKey` selv når du bruker widgeten. Den samme nøkkelen brukes når en innsending feiler og brukeren prøver på nytt. Etter vellykket innsending, reset eller ny sidevisning får neste innsending en ny nøkkel.
 :::
 
 ## Answers-arrayet

--- a/docs/referanse/datakontrakt.md
+++ b/docs/referanse/datakontrakt.md
@@ -22,7 +22,7 @@ Widgeten samler inn svar og sender en strukturert JSON-payload til backend. Payl
 | `context` | Anbefalt | Nettleser-/brukerkontekst for segmentering |
 
 ::: tip Når skal du endre `surveyId`?
-Behold samme `surveyId` når du legger til spørsmål. Bruk ny `surveyId` når du fjerner, endrer navn på eller endrer type/options for spørsmål. Da unngår du å blande ulike datastrukturer i samme analyse.
+Bruk ny `surveyId` når du legger til, fjerner, endrer navn på eller endrer type/options for spørsmål. Da unngår du å blande ulike datastrukturer i samme analyse og 409-feil fra backend.
 :::
 
 ## Answers-arrayet
@@ -51,7 +51,7 @@ interface TransportAnswer {
 { type: "text", text: "Veldig bra!" }
 
 // Rating (tallverdi)
-{ type: "rating", rating: 5 }
+{ type: "rating", rating: 5, ratingVariant: "emoji", ratingScale: 5 }
 
 // Enkeltvalg
 { type: "singleChoice", selectedOptionId: "opt_1" }
@@ -144,7 +144,12 @@ Backend mapper `surveyType`-strenger til enums:
       "fieldId": "rating",
       "fieldType": "RATING",
       "question": { "label": "Hvordan var opplevelsen din?" },
-      "value": { "type": "rating", "rating": 4 }
+      "value": {
+        "type": "rating",
+        "rating": 4,
+        "ratingVariant": "emoji",
+        "ratingScale": 5
+      }
     },
     {
       "fieldId": "feedback",

--- a/docs/referanse/datakontrakt.md
+++ b/docs/referanse/datakontrakt.md
@@ -8,16 +8,22 @@ Datakontrakten definerer strukturen på payloaden som sendes fra Lumi Survey-wid
 
 ## Transport payload
 
-Widgeten samler inn svar og sender en strukturert JSON-payload til backend. Payloaden har fire hoveddeler:
+Widgeten samler inn svar og sender en strukturert JSON-payload til backend. Payloaden har disse hoveddelene:
 
 | Felt | Påkrevd | Beskrivelse |
 | :--- | :--- | :--- |
-| `schemaVersion` | ✅ | Alltid `1` (gjeldende versjon) |
+| `schemaVersion` | ✅ | Alltid `2` (gjeldende versjon) |
 | `submittedAt` | ✅ | ISO 8601 tidsstempel for innsending |
 | `surveyId` | ✅ | Unik survey-identifikator |
 | `surveyType` | ✅ | En av: `"rating"`, `"topTasks"`, `"discovery"`, `"taskPriority"`, `"custom"` |
+| `deduplicationKey` | ✅ | Stabil nøkkel som gjør retry trygt |
+| `definition` | ✅ | Alle spørsmålene i surveyen, også de som ikke er besvart |
 | `answers` | ✅ | Strukturert array med svar (se under) |
 | `context` | Anbefalt | Nettleser-/brukerkontekst for segmentering |
+
+::: tip Når skal du endre `surveyId`?
+Behold samme `surveyId` når du legger til spørsmål. Bruk ny `surveyId` når du fjerner, endrer navn på eller endrer type/options for spørsmål. Da unngår du å blande ulike datastrukturer i samme analyse.
+:::
 
 ## Answers-arrayet
 
@@ -104,10 +110,26 @@ Backend mapper `surveyType`-strenger til enums:
 
 ```json
 {
-  "schemaVersion": 1,
+  "schemaVersion": 2,
   "submittedAt": "2024-12-03T14:22:00.000Z",
   "surveyId": "sykepenger-rating",
   "surveyType": "rating",
+  "deduplicationKey": "retryable-submit:sykepenger-rating:abc123",
+  "definition": {
+    "surveyType": "rating",
+    "fields": [
+      {
+        "fieldId": "rating",
+        "fieldType": "RATING",
+        "ratingVariant": "emoji",
+        "ratingScale": 5
+      },
+      {
+        "fieldId": "feedback",
+        "fieldType": "TEXT"
+      }
+    ]
+  },
   "context": {
     "url": "https://nav.no/sykepenger",
     "pathname": "/sykepenger",

--- a/packages/lumi-survey/README.md
+++ b/packages/lumi-survey/README.md
@@ -212,7 +212,7 @@ Anbefaling: Start med `rating` eller `discovery`, og gå videre til `topTasks`/`
 - Bruk progresjon: vis fritekst først etter at rating er valgt (`visibleIf`).
 - Bruk `context.tags` for segmentering (lav kardinalitet), og `context.debug` kun for feilsøking (høy kardinalitet).
 - Unngå identifikatorer i `context` (og ikke auto-collect `pathname` på dynamiske ruter).
-- Velg en stabil `surveyId` per flate/bruksmønster (ikke per deploy). Bruk ny `surveyId` når du fjerner, endrer navn på eller endrer type/options for spørsmål, for eksempel `min-flate-feedback-v2`.
+- Velg en stabil `surveyId` per flate/bruksmønster (ikke per deploy). Bruk ny `surveyId` når du legger til, fjerner, endrer navn på eller endrer type/options for spørsmål, for eksempel `min-flate-feedback-v2`.
 
 **Go-live sjekkliste**
 
@@ -249,7 +249,7 @@ versjonert (`schemaVersion: 2`). Den inkluderer:
 - `answers`: Normalisert struktur per spørsmål
 - `context`: tags/debug/auto-collectet miljøinfo
 
-`surveyId` er en del av datakontrakten. Behold samme `surveyId` når du legger til spørsmål, men bruk ny `surveyId` når du fjerner, endrer navn på eller endrer type/options for spørsmål. Da unngår du å blande ulike datastrukturer i samme analyse.
+`surveyId` er en del av datakontrakten. Bruk ny `surveyId` når du legger til, fjerner, endrer navn på eller endrer type/options for spørsmål. Da unngår du å blande ulike datastrukturer i samme analyse og 409-feil fra backend.
 
 Backend-oppsett (token exchange, NAIS-tilgang) er beskrevet i [Koble til backend](https://navikt.github.io/lumi/kom-i-gang/koble-til-backend).
 

--- a/packages/lumi-survey/README.md
+++ b/packages/lumi-survey/README.md
@@ -212,7 +212,7 @@ Anbefaling: Start med `rating` eller `discovery`, og gå videre til `topTasks`/`
 - Bruk progresjon: vis fritekst først etter at rating er valgt (`visibleIf`).
 - Bruk `context.tags` for segmentering (lav kardinalitet), og `context.debug` kun for feilsøking (høy kardinalitet).
 - Unngå identifikatorer i `context` (og ikke auto-collect `pathname` på dynamiske ruter).
-- Velg en stabil `surveyId` per flate/bruksmønster (ikke per deploy).
+- Velg en stabil `surveyId` per flate/bruksmønster (ikke per deploy). Bruk ny `surveyId` når du fjerner, endrer navn på eller endrer type/options for spørsmål, for eksempel `min-flate-feedback-v2`.
 
 **Go-live sjekkliste**
 
@@ -241,11 +241,15 @@ Anbefaling: Start med `rating` eller `discovery`, og gå videre til `topTasks`/`
 ## Transport og payload
 
 Widgeten sender `submission.transportPayload` til din backend. Payloaden er stabil og
-versjonert (`schemaVersion: 1`). Den inkluderer:
+versjonert (`schemaVersion: 2`). Den inkluderer:
 
 - `surveyId`, `surveyType`, `submittedAt`, `startedAt`
+- `deduplicationKey`: stabil nøkkel som gjør retry trygt
+- `definition`: alle spørsmålene i surveyen, også de som ikke er besvart
 - `answers`: Normalisert struktur per spørsmål
 - `context`: tags/debug/auto-collectet miljøinfo
+
+`surveyId` er en del av datakontrakten. Behold samme `surveyId` når du legger til spørsmål, men bruk ny `surveyId` når du fjerner, endrer navn på eller endrer type/options for spørsmål. Da unngår du å blande ulike datastrukturer i samme analyse.
 
 Backend-oppsett (token exchange, NAIS-tilgang) er beskrevet i [Koble til backend](https://navikt.github.io/lumi/kom-i-gang/koble-til-backend).
 

--- a/packages/lumi-survey/README.md
+++ b/packages/lumi-survey/README.md
@@ -244,12 +244,14 @@ Widgeten sender `submission.transportPayload` til din backend. Payloaden er stab
 versjonert (`schemaVersion: 2`). Den inkluderer:
 
 - `surveyId`, `surveyType`, `submittedAt`, `startedAt`
-- `deduplicationKey`: stabil nøkkel som gjør retry trygt
+- `deduplicationKey`: genereres av widgeten og gjør nytt forsøk etter transportfeil trygt
 - `definition`: alle spørsmålene i surveyen, også de som ikke er besvart
 - `answers`: Normalisert struktur per spørsmål
 - `context`: tags/debug/auto-collectet miljøinfo
 
 `surveyId` er en del av datakontrakten. Bruk ny `surveyId` når du legger til, fjerner, endrer navn på eller endrer type/options for spørsmål. Da unngår du å blande ulike datastrukturer i samme analyse og 409-feil fra backend.
+
+Du trenger ikke sette `deduplicationKey` selv. Widgeten bruker samme nøkkel når en innsending feiler og brukeren prøver på nytt. Etter en vellykket innsending eller reset lages en ny nøkkel, slik at en ny innsending lagres som en ny tilbakemelding.
 
 Backend-oppsett (token exchange, NAIS-tilgang) er beskrevet i [Koble til backend](https://navikt.github.io/lumi/kom-i-gang/koble-til-backend).
 

--- a/packages/lumi-survey/src/contracts/lumiApi.ts
+++ b/packages/lumi-survey/src/contracts/lumiApi.ts
@@ -129,6 +129,66 @@ export interface FeedbackSubmissionV1 {
   answers: Answer[];
 }
 
+// ============================================
+// V2 Submission Types
+// Matches lumi-types FeedbackSubmissionV2
+// ============================================
+
+export interface SubmissionFieldDefinitionBase {
+  fieldId: string;
+  fieldType: FieldType;
+}
+
+export interface RatingSubmissionFieldDefinition
+  extends SubmissionFieldDefinitionBase {
+  fieldType: "RATING";
+  ratingVariant: "emoji" | "thumbs" | "stars" | "nps";
+  ratingScale: number;
+}
+
+export interface TextSubmissionFieldDefinition
+  extends SubmissionFieldDefinitionBase {
+  fieldType: "TEXT";
+}
+
+export interface SingleChoiceSubmissionFieldDefinition
+  extends SubmissionFieldDefinitionBase {
+  fieldType: "SINGLE_CHOICE";
+  optionIds: string[];
+}
+
+export interface MultiChoiceSubmissionFieldDefinition
+  extends SubmissionFieldDefinitionBase {
+  fieldType: "MULTI_CHOICE";
+  optionIds: string[];
+}
+
+export type SubmissionFieldDefinition =
+  | RatingSubmissionFieldDefinition
+  | TextSubmissionFieldDefinition
+  | SingleChoiceSubmissionFieldDefinition
+  | MultiChoiceSubmissionFieldDefinition;
+
+export interface SubmissionDefinition {
+  surveyType: SurveyType;
+  fields: SubmissionFieldDefinition[];
+}
+
+export interface FeedbackSubmissionV2 {
+  schemaVersion: 2;
+  surveyId: string;
+  surveyType: SurveyType;
+  submittedAt: string;
+  startedAt?: string | null;
+  timeToCompleteMs?: number | null;
+  deduplicationKey: string;
+  definition: SubmissionDefinition;
+  context?: SubmissionContextV1 | null;
+  answers: Answer[];
+}
+
+export type FeedbackSubmission = FeedbackSubmissionV1 | FeedbackSubmissionV2;
+
 export interface SubmissionCreatedResponse {
   id: string;
 }

--- a/packages/lumi-survey/src/contracts/lumiApi.ts
+++ b/packages/lumi-survey/src/contracts/lumiApi.ts
@@ -164,11 +164,17 @@ export interface MultiChoiceSubmissionFieldDefinition
   optionIds: string[];
 }
 
+export interface DateSubmissionFieldDefinition
+  extends SubmissionFieldDefinitionBase {
+  fieldType: "DATE";
+}
+
 export type SubmissionFieldDefinition =
   | RatingSubmissionFieldDefinition
   | TextSubmissionFieldDefinition
   | SingleChoiceSubmissionFieldDefinition
-  | MultiChoiceSubmissionFieldDefinition;
+  | MultiChoiceSubmissionFieldDefinition
+  | DateSubmissionFieldDefinition;
 
 export interface SubmissionDefinition {
   surveyType: SurveyType;

--- a/packages/lumi-survey/src/contracts/lumiApi.ts
+++ b/packages/lumi-survey/src/contracts/lumiApi.ts
@@ -125,6 +125,7 @@ export interface FeedbackSubmissionV1 {
   submittedAt: string;
   startedAt?: string | null;
   timeToCompleteMs?: number | null;
+  deduplicationKey?: string | null;
   context?: SubmissionContextV1 | null;
   answers: Answer[];
 }

--- a/packages/lumi-survey/src/core/__tests__/deduplicationKey.test.ts
+++ b/packages/lumi-survey/src/core/__tests__/deduplicationKey.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, it } from "vitest";
+import { generateDeduplicationKey } from "../deduplicationKey.js";
+
+describe("generateDeduplicationKey", () => {
+  it("generates a key matching backend rules: 16-128 chars, [A-Za-z0-9._:-]", () => {
+    const key = generateDeduplicationKey();
+    expect(key.length).toBeGreaterThanOrEqual(16);
+    expect(key.length).toBeLessThanOrEqual(128);
+    expect(key).toMatch(/^[A-Za-z0-9._:-]+$/);
+  });
+
+  it("generates unique keys on each call", () => {
+    const keys = new Set(
+      Array.from({ length: 100 }, () => generateDeduplicationKey()),
+    );
+    expect(keys.size).toBe(100);
+  });
+});

--- a/packages/lumi-survey/src/core/__tests__/definitionBlock.test.ts
+++ b/packages/lumi-survey/src/core/__tests__/definitionBlock.test.ts
@@ -1,0 +1,87 @@
+import { describe, expect, it } from "vitest";
+import { buildDefinitionBlock } from "../definitionBlock.js";
+import type { LumiSurveyQuestion } from "../types.js";
+
+describe("buildDefinitionBlock", () => {
+  it("builds definition with all questions regardless of answers", () => {
+    const questions: LumiSurveyQuestion[] = [
+      { id: "rating", type: "rating", prompt: "Rate us", variant: "emoji" },
+      { id: "comment", type: "text", prompt: "Comment?", maxLength: 500 },
+      {
+        id: "category",
+        type: "singleChoice",
+        prompt: "Category?",
+        options: [
+          { value: "bug", label: "Bug" },
+          { value: "feature", label: "Feature" },
+        ],
+      },
+      {
+        id: "tags",
+        type: "multiChoice",
+        prompt: "Tags?",
+        options: [
+          { value: "ui", label: "UI" },
+          { value: "perf", label: "Performance" },
+        ],
+      },
+    ];
+
+    const definition = buildDefinitionBlock(questions, "rating");
+
+    expect(definition.surveyType).toBe("rating");
+    expect(definition.fields).toHaveLength(4);
+
+    expect(definition.fields[0]).toEqual({
+      fieldId: "rating",
+      fieldType: "RATING",
+      ratingVariant: "emoji",
+      ratingScale: 5,
+    });
+
+    expect(definition.fields[1]).toEqual({
+      fieldId: "comment",
+      fieldType: "TEXT",
+    });
+
+    expect(definition.fields[2]).toEqual({
+      fieldId: "category",
+      fieldType: "SINGLE_CHOICE",
+      optionIds: ["bug", "feature"],
+    });
+
+    expect(definition.fields[3]).toEqual({
+      fieldId: "tags",
+      fieldType: "MULTI_CHOICE",
+      optionIds: ["ui", "perf"],
+    });
+  });
+
+  it("defaults rating variant to emoji when not specified", () => {
+    const questions: LumiSurveyQuestion[] = [
+      { id: "r", type: "rating", prompt: "Rate?" },
+    ];
+
+    const definition = buildDefinitionBlock(questions, "custom");
+    expect(definition.fields[0]).toEqual({
+      fieldId: "r",
+      fieldType: "RATING",
+      ratingVariant: "emoji",
+      ratingScale: 5,
+    });
+  });
+
+  it("handles nps variant correctly", () => {
+    const questions: LumiSurveyQuestion[] = [
+      { id: "nps", type: "rating", prompt: "NPS?", variant: "nps" },
+    ];
+
+    const definition = buildDefinitionBlock(questions, "custom");
+    expect(definition.fields[0]).toEqual({
+      fieldId: "nps",
+      fieldType: "RATING",
+      ratingVariant: "nps",
+      ratingScale: 11,
+    });
+  });
+});

--- a/packages/lumi-survey/src/core/__tests__/fixtures/submissionPayloads.ts
+++ b/packages/lumi-survey/src/core/__tests__/fixtures/submissionPayloads.ts
@@ -1,0 +1,177 @@
+/**
+ * Test fixtures for v1 and v2 submission payloads.
+ * Used for contract regression tests ensuring widget payloads
+ * conform to the lumi-types contract.
+ */
+import type {
+  FeedbackSubmissionV1,
+  FeedbackSubmissionV2,
+} from "../../../contracts/lumiApi";
+
+// ============================================
+// V1 Payload Fixture
+// ============================================
+
+export const v1RatingPayload: FeedbackSubmissionV1 = {
+  schemaVersion: 1,
+  surveyId: "test-rating-survey",
+  surveyType: "rating",
+  submittedAt: "2024-06-01T10:02:00.000Z",
+  startedAt: "2024-06-01T10:00:00.000Z",
+  timeToCompleteMs: 120000,
+  context: {
+    url: "https://www.nav.no/dagpenger",
+    pathname: "/dagpenger",
+    deviceType: "desktop",
+    viewport: { width: 1920, height: 1080 },
+    screenResolution: { width: 1920, height: 1080 },
+    userAgent: "Mozilla/5.0",
+    tags: { abTest: "variant-a" },
+  },
+  answers: [
+    {
+      fieldId: "rating",
+      fieldType: "RATING",
+      question: { label: "Hvor fornøyd er du?" },
+      value: {
+        type: "rating",
+        rating: 4,
+        ratingVariant: "stars",
+        ratingScale: 5,
+      },
+    },
+    {
+      fieldId: "comment",
+      fieldType: "TEXT",
+      question: { label: "Har du en kommentar?" },
+      value: { type: "text", text: "Bra tjeneste!" },
+    },
+  ],
+};
+
+// ============================================
+// V2 Payload Fixture — complete answers
+// ============================================
+
+export const v2CompletePayload: FeedbackSubmissionV2 = {
+  schemaVersion: 2,
+  surveyId: "test-rating-survey",
+  surveyType: "rating",
+  submittedAt: "2024-06-01T10:02:00.000Z",
+  startedAt: "2024-06-01T10:00:00.000Z",
+  timeToCompleteMs: 120000,
+  deduplicationKey: "dedup-key-01234567890123456",
+  definition: {
+    surveyType: "rating",
+    fields: [
+      {
+        fieldId: "rating",
+        fieldType: "RATING",
+        ratingVariant: "stars",
+        ratingScale: 5,
+      },
+      { fieldId: "comment", fieldType: "TEXT" },
+      {
+        fieldId: "category",
+        fieldType: "SINGLE_CHOICE",
+        optionIds: ["bug", "feature"],
+      },
+    ],
+  },
+  context: {
+    url: "https://www.nav.no/dagpenger",
+    pathname: "/dagpenger",
+    deviceType: "desktop",
+    viewport: { width: 1920, height: 1080 },
+    screenResolution: { width: 1920, height: 1080 },
+    userAgent: "Mozilla/5.0",
+    tags: { abTest: "variant-a" },
+  },
+  answers: [
+    {
+      fieldId: "rating",
+      fieldType: "RATING",
+      question: { label: "Hvor fornøyd er du?" },
+      value: {
+        type: "rating",
+        rating: 4,
+        ratingVariant: "stars",
+        ratingScale: 5,
+      },
+    },
+    {
+      fieldId: "comment",
+      fieldType: "TEXT",
+      question: { label: "Har du en kommentar?" },
+      value: { type: "text", text: "Bra tjeneste!" },
+    },
+    {
+      fieldId: "category",
+      fieldType: "SINGLE_CHOICE",
+      question: {
+        label: "Kategori?",
+        options: [
+          { id: "bug", label: "Bug" },
+          { id: "feature", label: "Feature" },
+        ],
+      },
+      value: { type: "singleChoice", selectedOptionId: "feature" },
+    },
+  ],
+};
+
+// ============================================
+// V2 Payload Fixture — partial answers, complete definition
+// ============================================
+
+export const v2PartialAnswersPayload: FeedbackSubmissionV2 = {
+  schemaVersion: 2,
+  surveyId: "test-rating-survey",
+  surveyType: "rating",
+  submittedAt: "2024-06-01T10:02:00.000Z",
+  startedAt: "2024-06-01T10:00:00.000Z",
+  timeToCompleteMs: 120000,
+  deduplicationKey: "dedup-partial-0123456789012345",
+  definition: {
+    surveyType: "rating",
+    fields: [
+      {
+        fieldId: "rating",
+        fieldType: "RATING",
+        ratingVariant: "stars",
+        ratingScale: 5,
+      },
+      { fieldId: "comment", fieldType: "TEXT" },
+      {
+        fieldId: "category",
+        fieldType: "SINGLE_CHOICE",
+        optionIds: ["bug", "feature"],
+      },
+    ],
+  },
+  context: null,
+  answers: [
+    {
+      fieldId: "rating",
+      fieldType: "RATING",
+      question: { label: "Hvor fornøyd er du?" },
+      value: {
+        type: "rating",
+        rating: 3,
+        ratingVariant: "stars",
+        ratingScale: 5,
+      },
+    },
+    // comment and category not answered — only rating submitted
+  ],
+};
+
+// ============================================
+// V2 Retry Fixture — same deduplicationKey
+// ============================================
+
+export const v2RetryPayload: FeedbackSubmissionV2 = {
+  ...v2CompletePayload,
+  // Retry uses the same deduplicationKey but a later submittedAt
+  submittedAt: "2024-06-01T10:03:00.000Z",
+};

--- a/packages/lumi-survey/src/core/__tests__/submissionContract.test.ts
+++ b/packages/lumi-survey/src/core/__tests__/submissionContract.test.ts
@@ -22,10 +22,24 @@ describe("submission contract regression", () => {
       expect(payload.answers.length).toBeGreaterThan(0);
     });
 
-    it("does NOT have definition or deduplicationKey", () => {
+    it("does NOT have definition and may omit deduplicationKey at runtime", () => {
       const payload = v1RatingPayload as unknown as Record<string, unknown>;
       expect(payload).not.toHaveProperty("definition");
       expect(payload).not.toHaveProperty("deduplicationKey");
+    });
+
+    it("allows optional deduplicationKey in the v1 type contract", () => {
+      const withNull: FeedbackSubmissionV1 = {
+        ...v1RatingPayload,
+        deduplicationKey: null,
+      };
+      const withString: FeedbackSubmissionV1 = {
+        ...v1RatingPayload,
+        deduplicationKey: "dedup-key-01234567890123456",
+      };
+
+      expect(withNull.deduplicationKey).toBeNull();
+      expect(withString.deduplicationKey).toBe("dedup-key-01234567890123456");
     });
 
     it("is assignable to FeedbackSubmission union", () => {
@@ -102,13 +116,13 @@ describe("submission contract regression", () => {
   });
 
   describe("v1/v2 structural differences", () => {
-    it("v1 lacks v2-only fields", () => {
+    it("v1 fixture still omits definition and optional deduplicationKey at runtime", () => {
       const v1 = v1RatingPayload as unknown as Record<string, unknown>;
       expect(v1).not.toHaveProperty("definition");
       expect(v1).not.toHaveProperty("deduplicationKey");
     });
 
-    it("v2 has all v1 required fields plus definition and deduplicationKey", () => {
+    it("v2 has all v1 required fields plus required definition and deduplicationKey", () => {
       const v2 = v2CompletePayload;
       // Shared fields
       expect(v2.surveyId).toBeDefined();

--- a/packages/lumi-survey/src/core/__tests__/submissionContract.test.ts
+++ b/packages/lumi-survey/src/core/__tests__/submissionContract.test.ts
@@ -1,0 +1,132 @@
+import { describe, expect, it } from "vitest";
+import type {
+  FeedbackSubmission,
+  FeedbackSubmissionV1,
+  FeedbackSubmissionV2,
+} from "../../contracts/lumiApi";
+import {
+  v1RatingPayload,
+  v2CompletePayload,
+  v2PartialAnswersPayload,
+  v2RetryPayload,
+} from "./fixtures/submissionPayloads";
+
+describe("submission contract regression", () => {
+  describe("v1 payload", () => {
+    it("has schemaVersion 1 and required fields", () => {
+      const payload: FeedbackSubmissionV1 = v1RatingPayload;
+      expect(payload.schemaVersion).toBe(1);
+      expect(payload.surveyId).toBeDefined();
+      expect(payload.surveyType).toBeDefined();
+      expect(payload.submittedAt).toBeDefined();
+      expect(payload.answers.length).toBeGreaterThan(0);
+    });
+
+    it("does NOT have definition or deduplicationKey", () => {
+      const payload = v1RatingPayload as unknown as Record<string, unknown>;
+      expect(payload).not.toHaveProperty("definition");
+      expect(payload).not.toHaveProperty("deduplicationKey");
+    });
+
+    it("is assignable to FeedbackSubmission union", () => {
+      // Type-level check: v1 is part of the discriminated union
+      const _submission: FeedbackSubmission = v1RatingPayload;
+      expect(_submission.schemaVersion).toBe(1);
+    });
+  });
+
+  describe("v2 payload — complete", () => {
+    it("has schemaVersion 2 with definition and deduplicationKey", () => {
+      const payload: FeedbackSubmissionV2 = v2CompletePayload;
+      expect(payload.schemaVersion).toBe(2);
+      expect(payload.deduplicationKey).toBeDefined();
+      expect(payload.definition).toBeDefined();
+      expect(payload.definition.surveyType).toBe(payload.surveyType);
+    });
+
+    it("deduplicationKey matches format constraints", () => {
+      expect(v2CompletePayload.deduplicationKey.length).toBeGreaterThanOrEqual(
+        16,
+      );
+      expect(v2CompletePayload.deduplicationKey.length).toBeLessThanOrEqual(
+        128,
+      );
+      expect(v2CompletePayload.deduplicationKey).toMatch(/^[A-Za-z0-9._:-]+$/);
+    });
+
+    it("definition.fields covers all survey questions", () => {
+      expect(v2CompletePayload.definition.fields).toHaveLength(3);
+      expect(v2CompletePayload.definition.fields[0].fieldType).toBe("RATING");
+      expect(v2CompletePayload.definition.fields[1].fieldType).toBe("TEXT");
+      expect(v2CompletePayload.definition.fields[2].fieldType).toBe(
+        "SINGLE_CHOICE",
+      );
+    });
+
+    it("is assignable to FeedbackSubmission union", () => {
+      const _submission: FeedbackSubmission = v2CompletePayload;
+      expect(_submission.schemaVersion).toBe(2);
+    });
+  });
+
+  describe("v2 payload — partial answers with complete definition", () => {
+    it("has fewer answers than definition fields", () => {
+      const payload = v2PartialAnswersPayload;
+      expect(payload.definition.fields.length).toBeGreaterThan(
+        payload.answers.length,
+      );
+    });
+
+    it("definition still describes all possible fields", () => {
+      expect(v2PartialAnswersPayload.definition.fields).toHaveLength(3);
+    });
+
+    it("answers only contains actually answered fields", () => {
+      expect(v2PartialAnswersPayload.answers).toHaveLength(1);
+      expect(v2PartialAnswersPayload.answers[0].fieldId).toBe("rating");
+    });
+  });
+
+  describe("v2 retry — same deduplicationKey", () => {
+    it("retry has same deduplicationKey as original", () => {
+      expect(v2RetryPayload.deduplicationKey).toBe(
+        v2CompletePayload.deduplicationKey,
+      );
+    });
+
+    it("retry has a different submittedAt", () => {
+      expect(v2RetryPayload.submittedAt).not.toBe(
+        v2CompletePayload.submittedAt,
+      );
+    });
+  });
+
+  describe("v1/v2 structural differences", () => {
+    it("v1 lacks v2-only fields", () => {
+      const v1 = v1RatingPayload as unknown as Record<string, unknown>;
+      expect(v1).not.toHaveProperty("definition");
+      expect(v1).not.toHaveProperty("deduplicationKey");
+    });
+
+    it("v2 has all v1 required fields plus definition and deduplicationKey", () => {
+      const v2 = v2CompletePayload;
+      // Shared fields
+      expect(v2.surveyId).toBeDefined();
+      expect(v2.surveyType).toBeDefined();
+      expect(v2.submittedAt).toBeDefined();
+      expect(v2.answers).toBeDefined();
+      // V2-specific
+      expect(v2.definition).toBeDefined();
+      expect(v2.deduplicationKey).toBeDefined();
+    });
+
+    it("surveyType at top level matches definition.surveyType in v2", () => {
+      expect(v2CompletePayload.surveyType).toBe(
+        v2CompletePayload.definition.surveyType,
+      );
+      expect(v2PartialAnswersPayload.surveyType).toBe(
+        v2PartialAnswersPayload.definition.surveyType,
+      );
+    });
+  });
+});

--- a/packages/lumi-survey/src/core/__tests__/transportPayloadV2.test.ts
+++ b/packages/lumi-survey/src/core/__tests__/transportPayloadV2.test.ts
@@ -1,0 +1,329 @@
+import { act, renderHook } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type {
+  LumiSurveyQuestion,
+  LumiSurveySubmission,
+  LumiSurveyTransport,
+} from "../types.js";
+import { useLumiSurvey } from "../useLumiSurvey.js";
+
+const SURVEY_ID = "v2-test-survey";
+
+const mixedQuestions: LumiSurveyQuestion[] = [
+  {
+    id: "rating",
+    type: "rating",
+    prompt: "How satisfied?",
+    required: true,
+    variant: "stars",
+  },
+  {
+    id: "comment",
+    type: "text",
+    prompt: "Any comments?",
+    required: false,
+    maxLength: 500,
+  },
+  {
+    id: "category",
+    type: "singleChoice",
+    prompt: "Category?",
+    required: false,
+    options: [
+      { value: "bug", label: "Bug" },
+      { value: "feature", label: "Feature" },
+    ],
+  },
+];
+
+describe("v2 transport payload", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2024-06-01T10:00:00.000Z"));
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("produces schemaVersion 2 with definition and deduplicationKey", async () => {
+    const submitMock = vi.fn(async (_: LumiSurveySubmission) => {});
+    const transport: LumiSurveyTransport = { submit: submitMock };
+
+    const { result } = renderHook(() =>
+      useLumiSurvey({
+        surveyId: SURVEY_ID,
+        questions: mixedQuestions,
+        transport,
+      }),
+    );
+
+    await act(() => {
+      result.current.setAnswer("rating", 4);
+    });
+
+    vi.setSystemTime(new Date("2024-06-01T10:02:00.000Z"));
+
+    await act(async () => {
+      await result.current.submit();
+    });
+
+    const payload = submitMock.mock.calls[0][0].transportPayload;
+    expect(payload.schemaVersion).toBe(2);
+    expect(payload.deduplicationKey).toMatch(/^[A-Za-z0-9._:-]+$/);
+    expect(payload.deduplicationKey.length).toBeGreaterThanOrEqual(16);
+    expect(payload.deduplicationKey.length).toBeLessThanOrEqual(128);
+    expect(payload.definition).toBeDefined();
+    expect(payload.definition.surveyType).toBe("rating");
+  });
+
+  it("definition.fields includes ALL questions, answers only includes answered ones", async () => {
+    const submitMock = vi.fn(async (_: LumiSurveySubmission) => {});
+    const transport: LumiSurveyTransport = { submit: submitMock };
+
+    const { result } = renderHook(() =>
+      useLumiSurvey({
+        surveyId: SURVEY_ID,
+        questions: mixedQuestions,
+        transport,
+      }),
+    );
+
+    // Only answer the rating question — leave comment and category unanswered
+    await act(() => {
+      result.current.setAnswer("rating", 3);
+    });
+
+    vi.setSystemTime(new Date("2024-06-01T10:02:00.000Z"));
+
+    await act(async () => {
+      await result.current.submit();
+    });
+
+    const payload = submitMock.mock.calls[0][0].transportPayload;
+
+    // Definition has ALL 3 fields
+    expect(payload.definition.fields).toHaveLength(3);
+    expect(
+      payload.definition.fields.map((f: { fieldId: string }) => f.fieldId),
+    ).toEqual(["rating", "comment", "category"]);
+
+    // Answers only has the 1 answered question
+    expect(payload.answers).toHaveLength(1);
+    expect(payload.answers[0].fieldId).toBe("rating");
+  });
+
+  it("deduplication key is stable on retry after transport error", async () => {
+    const transportError = new Error("Network failure");
+    let callCount = 0;
+    const submitMock = vi.fn(async (_: LumiSurveySubmission) => {
+      callCount++;
+      if (callCount === 1) throw transportError;
+    });
+    const transport: LumiSurveyTransport = { submit: submitMock };
+
+    const { result } = renderHook(() =>
+      useLumiSurvey({
+        surveyId: SURVEY_ID,
+        questions: mixedQuestions,
+        transport,
+      }),
+    );
+
+    await act(() => {
+      result.current.setAnswer("rating", 5);
+    });
+
+    vi.setSystemTime(new Date("2024-06-01T10:02:00.000Z"));
+
+    // First submit — fails
+    await act(async () => {
+      await result.current.submit();
+    });
+    expect(result.current.status).toBe("error");
+
+    // Second submit — succeeds, should use SAME key
+    vi.setSystemTime(new Date("2024-06-01T10:03:00.000Z"));
+    await act(async () => {
+      await result.current.submit();
+    });
+    expect(result.current.status).toBe("success");
+
+    const key1 = submitMock.mock.calls[0][0].transportPayload.deduplicationKey;
+    const key2 = submitMock.mock.calls[1][0].transportPayload.deduplicationKey;
+    expect(key1).toBe(key2);
+  });
+
+  it("deduplication key rotates after successful submit", async () => {
+    const submitMock = vi.fn(async (_: LumiSurveySubmission) => {});
+    const transport: LumiSurveyTransport = { submit: submitMock };
+
+    const { result } = renderHook(() =>
+      useLumiSurvey({
+        surveyId: SURVEY_ID,
+        questions: [{ id: "r", type: "rating", prompt: "Rate?" }],
+        transport,
+      }),
+    );
+
+    await act(() => {
+      result.current.setAnswer("r", 5);
+    });
+
+    vi.setSystemTime(new Date("2024-06-01T10:02:00.000Z"));
+    await act(async () => {
+      await result.current.submit();
+    });
+
+    // Reset and submit again to get a new key
+    await act(() => {
+      result.current.reset();
+    });
+
+    await act(() => {
+      result.current.setAnswer("r", 3);
+    });
+
+    vi.setSystemTime(new Date("2024-06-01T10:04:00.000Z"));
+    await act(async () => {
+      await result.current.submit();
+    });
+
+    const key1 = submitMock.mock.calls[0][0].transportPayload.deduplicationKey;
+    const key2 = submitMock.mock.calls[1][0].transportPayload.deduplicationKey;
+    expect(key1).not.toBe(key2);
+  });
+
+  it("deduplication key rotates on reset", async () => {
+    const submitMock = vi.fn(async (_: LumiSurveySubmission) => {});
+    const transport: LumiSurveyTransport = { submit: submitMock };
+
+    const { result } = renderHook(() =>
+      useLumiSurvey({
+        surveyId: SURVEY_ID,
+        questions: [{ id: "r", type: "rating", prompt: "Rate?" }],
+        transport,
+      }),
+    );
+
+    // Submit once
+    await act(() => {
+      result.current.setAnswer("r", 4);
+    });
+    vi.setSystemTime(new Date("2024-06-01T10:02:00.000Z"));
+    await act(async () => {
+      await result.current.submit();
+    });
+    const key1 = submitMock.mock.calls[0][0].transportPayload.deduplicationKey;
+
+    // Reset
+    await act(() => {
+      result.current.reset();
+    });
+
+    // Submit again
+    await act(() => {
+      result.current.setAnswer("r", 2);
+    });
+    vi.setSystemTime(new Date("2024-06-01T10:05:00.000Z"));
+    await act(async () => {
+      await result.current.submit();
+    });
+    const key2 = submitMock.mock.calls[1][0].transportPayload.deduplicationKey;
+
+    expect(key1).not.toBe(key2);
+  });
+
+  it("does not expose deduplicationKey in the public hook API", () => {
+    const transport: LumiSurveyTransport = { submit: vi.fn() };
+
+    const { result } = renderHook(() =>
+      useLumiSurvey({
+        surveyId: SURVEY_ID,
+        questions: mixedQuestions,
+        transport,
+      }),
+    );
+
+    // Public API should only expose these keys
+    const publicKeys = Object.keys(result.current);
+    expect(publicKeys).toEqual([
+      "answers",
+      "status",
+      "error",
+      "setAnswer",
+      "submit",
+      "validate",
+      "reset",
+    ]);
+  });
+
+  it("includes top-level surveyType matching definition.surveyType", async () => {
+    const submitMock = vi.fn(async (_: LumiSurveySubmission) => {});
+    const transport: LumiSurveyTransport = { submit: submitMock };
+
+    const { result } = renderHook(() =>
+      useLumiSurvey({
+        surveyId: SURVEY_ID,
+        questions: mixedQuestions,
+        transport,
+      }),
+    );
+
+    await act(() => {
+      result.current.setAnswer("rating", 4);
+    });
+
+    vi.setSystemTime(new Date("2024-06-01T10:02:00.000Z"));
+
+    await act(async () => {
+      await result.current.submit();
+    });
+
+    const payload = submitMock.mock.calls[0][0].transportPayload;
+    expect(payload.surveyType).toBe("rating");
+    expect(payload.surveyType).toBe(payload.definition.surveyType);
+  });
+
+  it("definition includes correct field metadata for rating and choice types", async () => {
+    const submitMock = vi.fn(async (_: LumiSurveySubmission) => {});
+    const transport: LumiSurveyTransport = { submit: submitMock };
+
+    const { result } = renderHook(() =>
+      useLumiSurvey({
+        surveyId: SURVEY_ID,
+        questions: mixedQuestions,
+        transport,
+      }),
+    );
+
+    await act(() => {
+      result.current.setAnswer("rating", 5);
+    });
+
+    vi.setSystemTime(new Date("2024-06-01T10:02:00.000Z"));
+    await act(async () => {
+      await result.current.submit();
+    });
+
+    const definition = submitMock.mock.calls[0][0].transportPayload.definition;
+
+    expect(definition.fields[0]).toEqual({
+      fieldId: "rating",
+      fieldType: "RATING",
+      ratingVariant: "stars",
+      ratingScale: 5,
+    });
+
+    expect(definition.fields[1]).toEqual({
+      fieldId: "comment",
+      fieldType: "TEXT",
+    });
+
+    expect(definition.fields[2]).toEqual({
+      fieldId: "category",
+      fieldType: "SINGLE_CHOICE",
+      optionIds: ["bug", "feature"],
+    });
+  });
+});

--- a/packages/lumi-survey/src/core/__tests__/useLumiSurvey.test.ts
+++ b/packages/lumi-survey/src/core/__tests__/useLumiSurvey.test.ts
@@ -158,10 +158,15 @@ describe("useLumiSurvey", () => {
     expect(payload.answers).toEqual({ rating: 5 });
     expect(payload.surveyId).toBe(SURVEY_ID);
     expect(payload.transportPayload).toMatchObject({
-      schemaVersion: 1,
+      schemaVersion: 2,
       surveyId: SURVEY_ID,
-      surveyType: "rating",
+      definition: {
+        surveyType: "rating",
+      },
     });
+    expect(payload.transportPayload.deduplicationKey).toMatch(
+      /^[A-Za-z0-9._:-]+$/,
+    );
     expect(payload.transportPayload).not.toHaveProperty("rating");
     expect(payload.transportPayload).not.toHaveProperty("feedback");
     expect(payload.transportPayload.answers).toHaveLength(1);
@@ -210,7 +215,7 @@ describe("useLumiSurvey", () => {
     });
 
     const payload = submitMock.mock.calls[0][0];
-    expect(payload.transportPayload.surveyType).toBe("topTasks");
+    expect(payload.transportPayload.definition.surveyType).toBe("topTasks");
   });
 
   it("submits answers when validation passes", async () => {
@@ -252,13 +257,16 @@ describe("useLumiSurvey", () => {
       "free-text": "Alt fungerer fint",
     });
     expect(payload.transportPayload).toMatchObject({
-      schemaVersion: 1,
+      schemaVersion: 2,
       surveyId: SURVEY_ID,
     });
+    expect(payload.transportPayload.deduplicationKey).toMatch(
+      /^[A-Za-z0-9._:-]+$/,
+    );
     expect(payload.transportPayload).not.toHaveProperty("rating");
     expect(payload.transportPayload).not.toHaveProperty("feedback");
     expect(payload.transportPayload).not.toHaveProperty("free-text");
-    expect(payload.transportPayload.surveyType).toBe("rating");
+    expect(payload.transportPayload.definition.surveyType).toBe("rating");
     expect(payload.transportPayload.answers).toHaveLength(3);
     expect(payload.transportPayload.answers[0]).toMatchObject({
       fieldId: "rating",

--- a/packages/lumi-survey/src/core/deduplicationKey.ts
+++ b/packages/lumi-survey/src/core/deduplicationKey.ts
@@ -1,0 +1,10 @@
+/**
+ * Generates a deduplication key for submission idempotency.
+ * Must match backend rules: 16-128 characters, pattern ^[A-Za-z0-9._:-]+$
+ *
+ * Uses crypto.randomUUID() which produces a v4 UUID (36 chars with hyphens).
+ * Hyphens are allowed by the backend pattern, so UUID is used directly.
+ */
+export function generateDeduplicationKey(): string {
+  return crypto.randomUUID();
+}

--- a/packages/lumi-survey/src/core/definitionBlock.ts
+++ b/packages/lumi-survey/src/core/definitionBlock.ts
@@ -1,30 +1,11 @@
 import type {
   LumiSurveyQuestion,
   RatingQuestion,
-  RatingVariant,
   SurveyType,
+  TransportDefinition,
+  TransportFieldDefinition,
 } from "./types";
 import { RATING_SCALES } from "./types";
-
-/**
- * A field definition for the v2 transport payload.
- * Mirrors SubmissionFieldDefinition from lumi-types.
- */
-export type FieldDefinition =
-  | {
-      fieldId: string;
-      fieldType: "RATING";
-      ratingVariant: RatingVariant;
-      ratingScale: number;
-    }
-  | { fieldId: string; fieldType: "TEXT" }
-  | { fieldId: string; fieldType: "SINGLE_CHOICE"; optionIds: string[] }
-  | { fieldId: string; fieldType: "MULTI_CHOICE"; optionIds: string[] };
-
-export interface DefinitionBlock {
-  surveyType: SurveyType;
-  fields: FieldDefinition[];
-}
 
 /**
  * Builds the `definition` block for v2 transport payload.
@@ -33,12 +14,12 @@ export interface DefinitionBlock {
 export function buildDefinitionBlock(
   questions: LumiSurveyQuestion[],
   surveyType: SurveyType,
-): DefinitionBlock {
-  const fields: FieldDefinition[] = questions.map((question) => {
+): TransportDefinition {
+  const fields: TransportFieldDefinition[] = questions.map((question) => {
     switch (question.type) {
       case "rating": {
         const ratingQ = question as RatingQuestion;
-        const variant: RatingVariant = ratingQ.variant ?? "emoji";
+        const variant = ratingQ.variant ?? "emoji";
         return {
           fieldId: question.id,
           fieldType: "RATING" as const,

--- a/packages/lumi-survey/src/core/definitionBlock.ts
+++ b/packages/lumi-survey/src/core/definitionBlock.ts
@@ -1,0 +1,70 @@
+import type {
+  LumiSurveyQuestion,
+  RatingQuestion,
+  RatingVariant,
+  SurveyType,
+} from "./types";
+import { RATING_SCALES } from "./types";
+
+/**
+ * A field definition for the v2 transport payload.
+ * Mirrors SubmissionFieldDefinition from lumi-types.
+ */
+export type FieldDefinition =
+  | {
+      fieldId: string;
+      fieldType: "RATING";
+      ratingVariant: RatingVariant;
+      ratingScale: number;
+    }
+  | { fieldId: string; fieldType: "TEXT" }
+  | { fieldId: string; fieldType: "SINGLE_CHOICE"; optionIds: string[] }
+  | { fieldId: string; fieldType: "MULTI_CHOICE"; optionIds: string[] };
+
+export interface DefinitionBlock {
+  surveyType: SurveyType;
+  fields: FieldDefinition[];
+}
+
+/**
+ * Builds the `definition` block for v2 transport payload.
+ * Includes ALL survey questions, not just answered ones.
+ */
+export function buildDefinitionBlock(
+  questions: LumiSurveyQuestion[],
+  surveyType: SurveyType,
+): DefinitionBlock {
+  const fields: FieldDefinition[] = questions.map((question) => {
+    switch (question.type) {
+      case "rating": {
+        const ratingQ = question as RatingQuestion;
+        const variant: RatingVariant = ratingQ.variant ?? "emoji";
+        return {
+          fieldId: question.id,
+          fieldType: "RATING" as const,
+          ratingVariant: variant,
+          ratingScale: RATING_SCALES[variant],
+        };
+      }
+      case "singleChoice":
+        return {
+          fieldId: question.id,
+          fieldType: "SINGLE_CHOICE" as const,
+          optionIds: question.options.map((o) => o.value),
+        };
+      case "multiChoice":
+        return {
+          fieldId: question.id,
+          fieldType: "MULTI_CHOICE" as const,
+          optionIds: question.options.map((o) => o.value),
+        };
+      default:
+        return {
+          fieldId: question.id,
+          fieldType: "TEXT" as const,
+        };
+    }
+  });
+
+  return { surveyType, fields };
+}

--- a/packages/lumi-survey/src/core/index.ts
+++ b/packages/lumi-survey/src/core/index.ts
@@ -1,8 +1,12 @@
 export type {
   Answer as LumiApiAnswer,
   ApiError as LumiApiError,
+  FeedbackSubmission as LumiApiFeedbackSubmission,
   FeedbackSubmissionV1 as LumiApiFeedbackSubmissionV1,
+  FeedbackSubmissionV2 as LumiApiFeedbackSubmissionV2,
   SubmissionCreatedResponse as LumiApiSubmissionCreatedResponse,
+  SubmissionDefinition as LumiApiSubmissionDefinition,
+  SubmissionFieldDefinition as LumiApiSubmissionFieldDefinition,
 } from "../contracts/lumiApi";
 export { ErrorType as LumiApiErrorType } from "../contracts/lumiApi";
 

--- a/packages/lumi-survey/src/core/transportPayload.ts
+++ b/packages/lumi-survey/src/core/transportPayload.ts
@@ -1,3 +1,4 @@
+import { buildDefinitionBlock } from "./definitionBlock.js";
 import type {
   ChoiceOption,
   LumiSurveyAnswerValue,
@@ -49,6 +50,7 @@ export function buildTransportPayload(
   surveyId: string,
   answers: Record<string, LumiSurveyAnswerValue>,
   questions: LumiSurveyQuestion[],
+  deduplicationKey: string,
   surveyType?: SurveyType,
   context?: LumiSurveyContext,
   startedAt?: string,
@@ -60,12 +62,17 @@ export function buildTransportPayload(
 
   // Add survey type - use provided or infer from questions
   const resolvedSurveyType = surveyType ?? inferSurveyType(questions);
+
+  const definition = buildDefinitionBlock(questions, resolvedSurveyType);
+
   const payload: LumiSurveyTransportPayload = {
-    schemaVersion: 1,
+    schemaVersion: 2,
     surveyId,
     surveyType: resolvedSurveyType,
     submittedAt,
     startedAt,
+    deduplicationKey,
+    definition,
     context,
     answers: [],
   };
@@ -83,6 +90,7 @@ export function buildTransportPayload(
   }
 
   // Add structured answers array (rich metadata for analytics)
+  // Only includes actually answered questions
   const answersList: TransportAnswer[] = [];
 
   for (const question of questions) {

--- a/packages/lumi-survey/src/core/types.ts
+++ b/packages/lumi-survey/src/core/types.ts
@@ -289,16 +289,40 @@ export interface TransportAnswer {
 }
 
 /**
- * Canonical submission payload (schemaVersion=1).
- * This is the ONLY payload shape that should be sent to analytics backends.
+ * V2 field definition for the transport payload definition block.
+ */
+export type TransportFieldDefinition =
+  | {
+      fieldId: string;
+      fieldType: "RATING";
+      ratingVariant: RatingVariant;
+      ratingScale: number;
+    }
+  | { fieldId: string; fieldType: "TEXT" }
+  | { fieldId: string; fieldType: "SINGLE_CHOICE"; optionIds: string[] }
+  | { fieldId: string; fieldType: "MULTI_CHOICE"; optionIds: string[] };
+
+/**
+ * V2 submission definition block containing survey structure.
+ */
+export interface TransportDefinition {
+  surveyType: SurveyType;
+  fields: TransportFieldDefinition[];
+}
+
+/**
+ * Canonical submission payload (schemaVersion=2).
+ * Includes full definition of all fields and deduplication key.
  */
 export interface LumiSurveyTransportPayload {
-  schemaVersion: 1;
+  schemaVersion: 2;
   surveyId: string;
   surveyType: SurveyType;
   submittedAt: string;
   startedAt?: string;
   timeToCompleteMs?: number;
+  deduplicationKey: string;
+  definition: TransportDefinition;
   context?: LumiSurveyContext;
   answers: TransportAnswer[];
 }

--- a/packages/lumi-survey/src/core/useLumiSurvey.ts
+++ b/packages/lumi-survey/src/core/useLumiSurvey.ts
@@ -1,5 +1,6 @@
-import { useCallback, useState } from "react";
+import { useCallback, useRef, useState } from "react";
 import { cloneAnswers, useAnswerState } from "./answers.js";
+import { generateDeduplicationKey } from "./deduplicationKey.js";
 import { buildTransportPayload } from "./transportPayload.js";
 import type {
   LumiSurveyAnswerValue,
@@ -61,6 +62,7 @@ export function useLumiSurvey(
   });
   const [status, setStatus] = useState<LumiSurveyStatus>("idle");
   const [error, setError] = useState<LumiSurveyError | null>(null);
+  const deduplicationKeyRef = useRef<string>(generateDeduplicationKey());
 
   const validate = useCallback(
     (questionsToValidate?: LumiSurveyQuestion[]): string[] => {
@@ -101,6 +103,7 @@ export function useLumiSurvey(
           surveyId,
           answerSnapshot,
           questions,
+          deduplicationKeyRef.current,
           surveyType,
           context,
           startedAtRef.current,
@@ -114,6 +117,8 @@ export function useLumiSurvey(
         await transport.submit(submission);
         setStatus("success");
         setError(null);
+        // Rotate deduplication key after successful submit
+        deduplicationKeyRef.current = generateDeduplicationKey();
         events?.onSubmitSuccess?.(submission);
         return { ok: true, submission };
       } catch (cause) {
@@ -141,6 +146,8 @@ export function useLumiSurvey(
     resetAnswers();
     setStatus("idle");
     setError(null);
+    // Rotate deduplication key on reset
+    deduplicationKeyRef.current = generateDeduplicationKey();
     events?.onReset?.();
   }, [events, resetAnswers]);
 

--- a/packages/lumi-survey/src/core/useLumiSurvey.ts
+++ b/packages/lumi-survey/src/core/useLumiSurvey.ts
@@ -62,7 +62,14 @@ export function useLumiSurvey(
   });
   const [status, setStatus] = useState<LumiSurveyStatus>("idle");
   const [error, setError] = useState<LumiSurveyError | null>(null);
-  const deduplicationKeyRef = useRef<string>(generateDeduplicationKey());
+  const deduplicationKeyRef = useRef<string | null>(null);
+
+  const getDeduplicationKey = useCallback(() => {
+    if (deduplicationKeyRef.current === null) {
+      deduplicationKeyRef.current = generateDeduplicationKey();
+    }
+    return deduplicationKeyRef.current;
+  }, []);
 
   const validate = useCallback(
     (questionsToValidate?: LumiSurveyQuestion[]): string[] => {
@@ -93,6 +100,7 @@ export function useLumiSurvey(
 
       const answerSnapshot = cloneAnswers(answers);
       const submittedAtTimestamp = new Date().toISOString();
+      const deduplicationKey = getDeduplicationKey();
       const submission: LumiSurveySubmission = {
         surveyId,
         answers: answerSnapshot,
@@ -103,7 +111,7 @@ export function useLumiSurvey(
           surveyId,
           answerSnapshot,
           questions,
-          deduplicationKeyRef.current,
+          deduplicationKey,
           surveyType,
           context,
           startedAtRef.current,
@@ -133,6 +141,7 @@ export function useLumiSurvey(
       answers,
       context,
       events,
+      getDeduplicationKey,
       questions,
       startedAtRef,
       surveyId,

--- a/packages/lumi-types/src/api.ts
+++ b/packages/lumi-types/src/api.ts
@@ -35,9 +35,71 @@ export interface FeedbackSubmissionV1 {
   submittedAt: string;
   startedAt?: string | null;
   timeToCompleteMs?: number | null;
+  deduplicationKey?: string | null;
   context?: SubmissionContextV1 | null;
   answers: Answer[];
 }
+
+export interface SubmissionFieldDefinitionBase {
+  fieldId: string;
+  fieldType: FieldType;
+}
+
+export interface RatingSubmissionFieldDefinition
+  extends SubmissionFieldDefinitionBase {
+  fieldType: "RATING";
+  ratingVariant: "emoji" | "thumbs" | "stars" | "nps";
+  ratingScale: number;
+}
+
+export interface TextSubmissionFieldDefinition
+  extends SubmissionFieldDefinitionBase {
+  fieldType: "TEXT";
+}
+
+export interface SingleChoiceSubmissionFieldDefinition
+  extends SubmissionFieldDefinitionBase {
+  fieldType: "SINGLE_CHOICE";
+  optionIds: string[];
+}
+
+export interface MultiChoiceSubmissionFieldDefinition
+  extends SubmissionFieldDefinitionBase {
+  fieldType: "MULTI_CHOICE";
+  optionIds: string[];
+}
+
+export interface DateSubmissionFieldDefinition
+  extends SubmissionFieldDefinitionBase {
+  fieldType: "DATE";
+}
+
+export type SubmissionFieldDefinition =
+  | RatingSubmissionFieldDefinition
+  | TextSubmissionFieldDefinition
+  | SingleChoiceSubmissionFieldDefinition
+  | MultiChoiceSubmissionFieldDefinition
+  | DateSubmissionFieldDefinition;
+
+export interface SubmissionDefinition {
+  surveyType: SurveyType;
+  fields: SubmissionFieldDefinition[];
+}
+
+export interface FeedbackSubmissionV2 {
+  schemaVersion: 2;
+  surveyId: string;
+  surveyType: SurveyType;
+  submittedAt: string;
+  startedAt?: string | null;
+  timeToCompleteMs?: number | null;
+  deduplicationKey: string;
+  definition: SubmissionDefinition;
+  context?: SubmissionContextV1 | null;
+  answers: Answer[];
+}
+
+export type FeedbackSubmission = FeedbackSubmissionV1 | FeedbackSubmissionV2;
 
 export interface SubmissionCreatedResponse {
   id: string;

--- a/packages/lumi-types/src/schemas.ts
+++ b/packages/lumi-types/src/schemas.ts
@@ -556,6 +556,142 @@ const SubmissionAnswerSchema = z.discriminatedUnion("fieldType", [
   SubmissionDateAnswerSchema,
 ]);
 
+const SubmissionFieldIdSchema = z.string().min(1);
+
+const SubmissionOptionIdsSchema = z
+  .array(z.string().min(1))
+  .min(1)
+  .superRefine((optionIds, ctx) => {
+    const seen = new Set<string>();
+    for (let i = 0; i < optionIds.length; i += 1) {
+      const optionId = optionIds[i];
+      if (!optionId) continue;
+      if (seen.has(optionId)) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          message: `optionIds must be unique (duplicate: ${optionId})`,
+          path: [i],
+        });
+      }
+      seen.add(optionId);
+    }
+  });
+
+const SubmissionFieldDefinitionBaseSchema = z.object({
+  fieldId: SubmissionFieldIdSchema,
+});
+
+const SubmissionRatingFieldDefinitionSchema =
+  SubmissionFieldDefinitionBaseSchema.extend({
+    fieldType: z.literal("RATING"),
+    ratingVariant: RatingVariantSchema,
+    ratingScale: z.number().int(),
+  });
+
+const SubmissionTextFieldDefinitionSchema =
+  SubmissionFieldDefinitionBaseSchema.extend({
+    fieldType: z.literal("TEXT"),
+  });
+
+const SubmissionSingleChoiceFieldDefinitionSchema =
+  SubmissionFieldDefinitionBaseSchema.extend({
+    fieldType: z.literal("SINGLE_CHOICE"),
+    optionIds: SubmissionOptionIdsSchema,
+  });
+
+const SubmissionMultiChoiceFieldDefinitionSchema =
+  SubmissionFieldDefinitionBaseSchema.extend({
+    fieldType: z.literal("MULTI_CHOICE"),
+    optionIds: SubmissionOptionIdsSchema,
+  });
+
+const SubmissionDateFieldDefinitionSchema =
+  SubmissionFieldDefinitionBaseSchema.extend({
+    fieldType: z.literal("DATE"),
+  });
+
+export const SubmissionFieldDefinitionSchema = z.discriminatedUnion(
+  "fieldType",
+  [
+    SubmissionRatingFieldDefinitionSchema,
+    SubmissionTextFieldDefinitionSchema,
+    SubmissionSingleChoiceFieldDefinitionSchema,
+    SubmissionMultiChoiceFieldDefinitionSchema,
+    SubmissionDateFieldDefinitionSchema,
+  ],
+);
+
+export const SubmissionDefinitionSchema = z
+  .object({
+    surveyType: SurveyTypeSchema,
+    fields: z.array(SubmissionFieldDefinitionSchema).min(1),
+  })
+  .superRefine((definition, ctx) => {
+    const expectedScaleByVariant: Record<
+      z.infer<typeof RatingVariantSchema>,
+      number
+    > = {
+      emoji: 5,
+      thumbs: 2,
+      stars: 5,
+      nps: 11,
+    };
+
+    const seen = new Set<string>();
+    for (let i = 0; i < definition.fields.length; i += 1) {
+      const field = definition.fields[i];
+      const fieldId = field?.fieldId;
+      if (!fieldId) continue;
+      if (seen.has(fieldId)) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          message: `definition.fields.fieldId must be unique (duplicate: ${fieldId})`,
+          path: ["fields", i, "fieldId"],
+        });
+      }
+      seen.add(fieldId);
+
+      if (field.fieldType === "RATING") {
+        const expectedScale = expectedScaleByVariant[field.ratingVariant];
+        if (field.ratingScale !== expectedScale) {
+          ctx.addIssue({
+            code: z.ZodIssueCode.custom,
+            message: `ratingScale=${field.ratingScale} does not match ratingVariant=${field.ratingVariant} (expected ${expectedScale})`,
+            path: ["fields", i, "ratingScale"],
+          });
+        }
+      }
+    }
+  });
+
+const DeduplicationKeySchema = z
+  .string()
+  .min(16)
+  .max(128)
+  .regex(
+    /^[A-Za-z0-9._:-]+$/,
+    "deduplicationKey must contain only letters, digits, '.', '_', ':', or '-'",
+  );
+
+function validateUniqueAnswerFieldIds(
+  submission: { answers: Array<{ fieldId: string }> },
+  ctx: z.RefinementCtx,
+) {
+  const seen = new Set<string>();
+  for (let i = 0; i < submission.answers.length; i += 1) {
+    const fieldId = submission.answers[i]?.fieldId;
+    if (!fieldId) continue;
+    if (seen.has(fieldId)) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: `answers.fieldId must be unique (duplicate: ${fieldId})`,
+        path: ["answers", i, "fieldId"],
+      });
+    }
+    seen.add(fieldId);
+  }
+}
+
 export const FeedbackSubmissionV1Schema = z
   .object({
     schemaVersion: z.literal(1),
@@ -564,24 +700,42 @@ export const FeedbackSubmissionV1Schema = z
     submittedAt: IsoInstantSchema,
     startedAt: IsoInstantSchema.nullable().optional(),
     timeToCompleteMs: z.number().int().nonnegative().nullable().optional(),
+    deduplicationKey: DeduplicationKeySchema.nullable().optional(),
     context: SubmissionContextV1Schema.nullable().optional(),
     answers: z.array(SubmissionAnswerSchema).min(1),
   })
   .superRefine((submission, ctx) => {
-    const seen = new Set<string>();
-    for (let i = 0; i < submission.answers.length; i += 1) {
-      const fieldId = submission.answers[i]?.fieldId;
-      if (!fieldId) continue;
-      if (seen.has(fieldId)) {
-        ctx.addIssue({
-          code: z.ZodIssueCode.custom,
-          message: `answers.fieldId must be unique (duplicate: ${fieldId})`,
-          path: ["answers", i, "fieldId"],
-        });
-      }
-      seen.add(fieldId);
+    validateUniqueAnswerFieldIds(submission, ctx);
+  });
+
+export const FeedbackSubmissionV2Schema = z
+  .object({
+    schemaVersion: z.literal(2),
+    surveyId: z.string().min(1),
+    surveyType: SurveyTypeSchema,
+    submittedAt: IsoInstantSchema,
+    startedAt: IsoInstantSchema.nullable().optional(),
+    timeToCompleteMs: z.number().int().nonnegative().nullable().optional(),
+    deduplicationKey: DeduplicationKeySchema,
+    definition: SubmissionDefinitionSchema,
+    context: SubmissionContextV1Schema.nullable().optional(),
+    answers: z.array(SubmissionAnswerSchema).min(1),
+  })
+  .superRefine((submission, ctx) => {
+    validateUniqueAnswerFieldIds(submission, ctx);
+    if (submission.surveyType !== submission.definition.surveyType) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: "surveyType must match definition.surveyType",
+        path: ["surveyType"],
+      });
     }
   });
+
+export const FeedbackSubmissionSchema = z.union([
+  FeedbackSubmissionV1Schema,
+  FeedbackSubmissionV2Schema,
+]);
 
 export const SubmissionCreatedResponseSchema = z.object({
   id: z.string(),

--- a/packages/lumi-types/src/schemas.ts
+++ b/packages/lumi-types/src/schemas.ts
@@ -559,13 +559,46 @@ const SubmissionAnswerSchema = z.discriminatedUnion("fieldType", [
 const SubmissionFieldIdSchema = z
   .string()
   .min(1)
+  .max(200, "fieldId must not exceed 200 characters")
   .regex(
-    /^[A-Za-z0-9_-]+$/,
+    /^[\p{L}\p{Nd}_-]+$/u,
     "fieldId must contain only letters, digits, hyphen, or underscore",
   );
 
+/**
+ * Mirrors backend isSafeChoiceValue: forbids JSONPath special characters
+ * (", \, $, @, ?, (, ), ,) and control characters (code < 32).
+ * Max length matches backend MAX_IDENTIFIER_LENGTH = 200.
+ */
+const OPTION_ID_FORBIDDEN_CHARS = new Set([
+  '"',
+  "\\",
+  "$",
+  "@",
+  "?",
+  "(",
+  ")",
+  ",",
+]);
+
+const SubmissionOptionIdSchema = z
+  .string()
+  .min(1)
+  .max(200, "optionId must not exceed 200 characters")
+  .refine(
+    (s) => s.trim().length > 0,
+    "optionId must not be blank or whitespace-only",
+  )
+  .refine(
+    (s) =>
+      [...s].every(
+        (c) => !OPTION_ID_FORBIDDEN_CHARS.has(c) && c.charCodeAt(0) >= 32,
+      ),
+    "optionId contains illegal characters (JSONPath special or control characters are not allowed)",
+  );
+
 const SubmissionOptionIdsSchema = z
-  .array(z.string().min(1))
+  .array(SubmissionOptionIdSchema)
   .min(1)
   .superRefine((optionIds, ctx) => {
     const seen = new Set<string>();

--- a/packages/lumi-types/src/schemas.ts
+++ b/packages/lumi-types/src/schemas.ts
@@ -625,29 +625,29 @@ const SubmissionRatingFieldDefinitionSchema =
     fieldType: z.literal("RATING"),
     ratingVariant: RatingVariantSchema,
     ratingScale: z.number().int(),
-  });
+  }).strict();
 
 const SubmissionTextFieldDefinitionSchema =
   SubmissionFieldDefinitionBaseSchema.extend({
     fieldType: z.literal("TEXT"),
-  });
+  }).strict();
 
 const SubmissionSingleChoiceFieldDefinitionSchema =
   SubmissionFieldDefinitionBaseSchema.extend({
     fieldType: z.literal("SINGLE_CHOICE"),
     optionIds: SubmissionOptionIdsSchema,
-  });
+  }).strict();
 
 const SubmissionMultiChoiceFieldDefinitionSchema =
   SubmissionFieldDefinitionBaseSchema.extend({
     fieldType: z.literal("MULTI_CHOICE"),
     optionIds: SubmissionOptionIdsSchema,
-  });
+  }).strict();
 
 const SubmissionDateFieldDefinitionSchema =
   SubmissionFieldDefinitionBaseSchema.extend({
     fieldType: z.literal("DATE"),
-  });
+  }).strict();
 
 export const SubmissionFieldDefinitionSchema = z.discriminatedUnion(
   "fieldType",
@@ -734,6 +734,108 @@ function validateUniqueAnswerFieldIds(
   }
 }
 
+function validateChoiceQuestionOptions(
+  answer:
+    | z.infer<typeof SubmissionSingleChoiceAnswerSchema>
+    | z.infer<typeof SubmissionMultiChoiceAnswerSchema>,
+  field:
+    | z.infer<typeof SubmissionSingleChoiceFieldDefinitionSchema>
+    | z.infer<typeof SubmissionMultiChoiceFieldDefinitionSchema>,
+  answerIndex: number,
+  ctx: z.RefinementCtx,
+) {
+  const answerOptionIds = answer.question.options?.map((option) => option.id);
+  if (!answerOptionIds) {
+    ctx.addIssue({
+      code: z.ZodIssueCode.custom,
+      message: `choice answer fieldId=${answer.fieldId} must include question.options to match definition.optionIds`,
+      path: ["answers", answerIndex, "question", "options"],
+    });
+    return;
+  }
+
+  if (
+    answerOptionIds.length !== field.optionIds.length ||
+    answerOptionIds.some((optionId, i) => optionId !== field.optionIds[i])
+  ) {
+    ctx.addIssue({
+      code: z.ZodIssueCode.custom,
+      message: `choice answer fieldId=${answer.fieldId} question.options must match definition.optionIds`,
+      path: ["answers", answerIndex, "question", "options"],
+    });
+  }
+}
+
+function validateAnswerValueAgainstDefinition(
+  answer: z.infer<typeof SubmissionAnswerSchema>,
+  field: z.infer<typeof SubmissionFieldDefinitionSchema>,
+  answerIndex: number,
+  ctx: z.RefinementCtx,
+) {
+  if (answer.fieldType === "RATING" && field.fieldType === "RATING") {
+    if (
+      field.ratingVariant !== answer.value.ratingVariant ||
+      field.ratingScale !== answer.value.ratingScale
+    ) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: `rating config for fieldId=${answer.fieldId} must match definition`,
+        path: ["answers", answerIndex, "value"],
+      });
+    }
+    return;
+  }
+
+  if (
+    answer.fieldType === "SINGLE_CHOICE" &&
+    field.fieldType === "SINGLE_CHOICE"
+  ) {
+    validateChoiceQuestionOptions(answer, field, answerIndex, ctx);
+    if (!field.optionIds.includes(answer.value.selectedOptionId)) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: `selectedOptionId=${answer.value.selectedOptionId} is not valid for fieldId=${answer.fieldId}`,
+        path: ["answers", answerIndex, "value", "selectedOptionId"],
+      });
+    }
+    return;
+  }
+
+  if (
+    answer.fieldType === "MULTI_CHOICE" &&
+    field.fieldType === "MULTI_CHOICE"
+  ) {
+    validateChoiceQuestionOptions(answer, field, answerIndex, ctx);
+    const seen = new Set<string>();
+    const duplicateSelections = new Set<string>();
+    for (const selectedOptionId of answer.value.selectedOptionIds) {
+      if (seen.has(selectedOptionId)) {
+        duplicateSelections.add(selectedOptionId);
+      }
+      seen.add(selectedOptionId);
+    }
+
+    if (duplicateSelections.size > 0) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: `duplicate selectedOptionIds=${[...duplicateSelections].join(",")} for fieldId=${answer.fieldId}`,
+        path: ["answers", answerIndex, "value", "selectedOptionIds"],
+      });
+    }
+
+    const invalidIds = answer.value.selectedOptionIds.filter(
+      (selectedOptionId) => !field.optionIds.includes(selectedOptionId),
+    );
+    if (invalidIds.length > 0) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: `selectedOptionIds=${invalidIds.join(",")} are not valid for fieldId=${answer.fieldId}`,
+        path: ["answers", answerIndex, "value", "selectedOptionIds"],
+      });
+    }
+  }
+}
+
 export const FeedbackSubmissionV1Schema = z
   .object({
     schemaVersion: z.literal(1),
@@ -795,7 +897,10 @@ export const FeedbackSubmissionV2Schema = z
           message: `answers.fieldType must match definition fieldType for fieldId=${answer.fieldId}`,
           path: ["answers", i, "fieldType"],
         });
+        continue;
       }
+
+      validateAnswerValueAgainstDefinition(answer, field, i, ctx);
     }
   });
 

--- a/packages/lumi-types/src/schemas.ts
+++ b/packages/lumi-types/src/schemas.ts
@@ -556,7 +556,13 @@ const SubmissionAnswerSchema = z.discriminatedUnion("fieldType", [
   SubmissionDateAnswerSchema,
 ]);
 
-const SubmissionFieldIdSchema = z.string().min(1);
+const SubmissionFieldIdSchema = z
+  .string()
+  .min(1)
+  .regex(
+    /^[A-Za-z0-9_-]+$/,
+    "fieldId must contain only letters, digits, hyphen, or underscore",
+  );
 
 const SubmissionOptionIdsSchema = z
   .array(z.string().min(1))
@@ -729,6 +735,31 @@ export const FeedbackSubmissionV2Schema = z
         message: "surveyType must match definition.surveyType",
         path: ["surveyType"],
       });
+    }
+
+    const fieldsById = new Map(
+      submission.definition.fields.map((field) => [field.fieldId, field]),
+    );
+    for (let i = 0; i < submission.answers.length; i += 1) {
+      const answer = submission.answers[i];
+      if (!answer) continue;
+      const field = fieldsById.get(answer.fieldId);
+      if (!field) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          message: `answers.fieldId must exist in definition.fields (unknown: ${answer.fieldId})`,
+          path: ["answers", i, "fieldId"],
+        });
+        continue;
+      }
+
+      if (field.fieldType !== answer.fieldType) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          message: `answers.fieldType must match definition fieldType for fieldId=${answer.fieldId}`,
+          path: ["answers", i, "fieldType"],
+        });
+      }
     }
   });
 

--- a/packages/lumi-types/src/schemas.ts
+++ b/packages/lumi-types/src/schemas.ts
@@ -663,7 +663,10 @@ export const SubmissionFieldDefinitionSchema = z.discriminatedUnion(
 export const SubmissionDefinitionSchema = z
   .object({
     surveyType: SurveyTypeSchema,
-    fields: z.array(SubmissionFieldDefinitionSchema).min(1),
+    fields: z
+      .array(SubmissionFieldDefinitionSchema)
+      .min(1)
+      .max(50, "definition.fields must not exceed 50 fields"),
   })
   .superRefine((definition, ctx) => {
     const expectedScaleByVariant: Record<


### PR DESCRIPTION
## Beskrivelse

Legger til `schemaVersion: 2` for Lumi feedback-submissions med eksplisitt survey-`definition` og `deduplicationKey`, samtidig som eksisterende v1-payloads fortsatt aksepteres på samme submission-endepunkt.

Backend bruker v2-definition som komplett immutable surveystruktur, validerer answers mot definition og stripper `definition`/rå `deduplicationKey` før `feedback_json` persisteres. Widgeten sender v2-payload med komplett definition og stabil deduplicationKey for retry av samme innsending.

## Endringer

- `packages/lumi-types`: v2 submission-typer og Zod-schemas, inkludert v1/v2-union og v1 `deduplicationKey`-kontrakt
- `packages/lumi-survey`: bygger v2 transport-payload med komplett definition og intern deduplicationKey-livssyklus
- `apps/lumi-api`: dispatcher v1/v2 på eksisterende submission-rute, validerer v2-definition, bruker strict immutable definition-sjekk og dedupliserer med hash
- Tester: kontrakttester, widget payload-tester og målrettede API-tester for v2-ruter/definition/persist-stripping

## Issue

Closes #275

Del av epic: #270

## Verifisering

- [x] `pnpm run lint`
- [x] `pnpm run typecheck`
- [x] `pnpm run test`
- [x] `cd apps/lumi-api && ./gradlew test --tests 'no.nav.lumi.routes.SubmissionV2RoutesTest' --tests 'no.nav.lumi.service.SurveyDefinitionServiceTest' --tests 'no.nav.lumi.domain.RatingVariantTest'`
- [ ] `pnpm run api:test` — lokalt blokkert av manglende Docker/Testcontainers-miljø; må kjøres i CI

## Merknader

- API bør deployes før widget-release siden eldre backend vil avvise v2-payload.
- Smoke-test anbefales for eksisterende v1-registrerte `surveyId`, fordi første v2-definition er komplett og kan gi 409 dersom lagret v1-definition er partiell.

## Sjekkliste

- [x] Koden kompilerer og linter uten feil
- [x] Endringene er testet (manuelt eller automatisk)
- [x] Ingen sensitiv data eksponert (tokens, credentials, PII)
