### PR TITLE
fix(deps): pin patched netty bom

### DIFF
--- a/apps/lumi-api/build.gradle.kts
+++ b/apps/lumi-api/build.gradle.kts
@@ -38,8 +38,11 @@ val tokenSupportVersion = "5.0.13"
 val exposedVersion = "1.3.0"
 val micrometerVersion = "1.16.5"
 val log4jVersion = "2.26.0"
+val nettyVersion = "4.2.13.Final"
 
 dependencies {
+    implementation(platform("io.netty:netty-bom:$nettyVersion"))
+
     // Ktor Server
     implementation("io.ktor:ktor-server-core:$ktorVersion")
     implementation("io.ktor:ktor-server-netty:$ktorVersion")

--- a/apps/lumi-submission-proxy/build.gradle.kts
+++ b/apps/lumi-submission-proxy/build.gradle.kts
@@ -21,8 +21,11 @@ repositories {
 val ktorVersion = "3.4.0"
 val logbackVersion = "1.5.32"
 val logstashVersion = "9.0"
+val nettyVersion = "4.2.13.Final"
 
 dependencies {
+    implementation(platform("io.netty:netty-bom:$nettyVersion"))
+
     // Ktor Server (minimal)
     implementation("io.ktor:ktor-server-core:$ktorVersion")
     implementation("io.ktor:ktor-server-netty:$ktorVersion")


### PR DESCRIPTION
## Beskrivelse

Fikser Netty-CVE-funn ved å pinne en patched Netty BOM for Ktor-appene, uten å oppgradere Ktor.

## Endringer

- `apps/lumi-api`: legger til `io.netty:netty-bom:4.2.13.Final`
- `apps/lumi-submission-proxy`: legger til `io.netty:netty-bom:4.2.13.Final`
- Ingen Ktor-versjoner eller Ktor Gradle plugin-versjoner er endret

## Issue

Ingen issue. Motivasjon: sikkerhetsremediering av Netty-CVE-er rapportert for `netty-codec-http` og `netty-codec-compression`.

## Sjekkliste

- [x] Koden kompilerer og linter uten feil
- [x] Endringene er testet (manuelt eller automatisk)
- [x] Ingen sensitiv data eksponert (tokens, credentials, PII)

## Verifisering

- `pnpm run lint`
- `pnpm run typecheck`
- `cd apps/lumi-api && ./gradlew --no-daemon dependencies --configuration runtimeClasspath`
- `cd apps/lumi-api && ./gradlew --no-daemon dependencyInsight --configuration runtimeClasspath --dependency io.netty:netty-codec-http`
- `cd apps/lumi-submission-proxy && ./gradlew --no-daemon dependencies --configuration runtimeClasspath`
- `cd apps/lumi-submission-proxy && ./gradlew --no-daemon dependencyInsight --configuration runtimeClasspath --dependency io.netty:netty-codec-http`
- `cd apps/lumi-submission-proxy && ./gradlew --no-daemon shadowJar`

Merknad: `cd apps/lumi-api && ./gradlew --no-daemon test` feiler lokalt fordi Testcontainers ikke finner et gyldig Docker-miljø (`Could not find a valid Docker environment`).