### PR TITLE
chore(api): use Chainguard JRE image

### DIFF
--- a/apps/lumi-api/Dockerfile
+++ b/apps/lumi-api/Dockerfile
@@ -1,4 +1,4 @@
-FROM gcr.io/distroless/java21-debian12:nonroot
+FROM  europe-north1-docker.pkg.dev/cgr-nav/pull-through/nav.no/jre:openjdk-21
 
 WORKDIR /app
 
@@ -9,4 +9,4 @@ ENV JAVA_OPTS="-XX:+UseG1GC -XX:MaxRAMPercentage=75.0"
 
 EXPOSE 8080
 
-CMD ["app.jar"]
+ENTRYPOINT ["java", "-jar", "app.jar"]

--- a/apps/lumi-api/Dockerfile
+++ b/apps/lumi-api/Dockerfile
@@ -5,7 +5,7 @@ WORKDIR /app
 COPY build/libs/app.jar app.jar
 
 ENV TZ="Europe/Oslo"
-ENV JAVA_OPTS="-XX:+UseG1GC -XX:MaxRAMPercentage=75.0"
+ENV JDK_JAVA_OPTIONS="-XX:+UseG1GC -XX:MaxRAMPercentage=75.0"
 
 EXPOSE 8080
 

--- a/apps/lumi-submission-proxy/Dockerfile
+++ b/apps/lumi-submission-proxy/Dockerfile
@@ -5,8 +5,8 @@ WORKDIR /app
 COPY build/libs/app.jar app.jar
 
 ENV TZ="Europe/Oslo"
-ENV JAVA_TOOL_OPTIONS="-XX:+UseG1GC -XX:MaxRAMPercentage=75.0"
+ENV JDK_JAVA_OPTIONS="-XX:+UseG1GC -XX:MaxRAMPercentage=75.0"
 
 EXPOSE 8080
 
-CMD ["-jar", "app.jar"]
+ENTRYPOINT ["java", "-jar", "app.jar"]


### PR DESCRIPTION
## Beskrivelse

Bytter Lumi API Docker-image fra Distroless Java 21 til Navs Chainguard-baserte JRE-image og starter applikasjonen eksplisitt med `java -jar`.

## Endringer

- `apps/lumi-api/Dockerfile`: Bruker `europe-north1-docker.pkg.dev/cgr-nav/pull-through/nav.no/jre:openjdk-21` som baseimage.
- `apps/lumi-api/Dockerfile`: Erstatter `CMD ["app.jar"]` med `ENTRYPOINT ["java", "-jar", "app.jar"]`.

## Issue

Ingen issue koblet.

## Sjekkliste

- [x] Koden kompilerer og linter uten feil
- [x] Endringene er testet (manuelt eller automatisk)
- [x] Ingen sensitiv data eksponert (tokens, credentials, PII)