### PR TITLE
ci(dashboard): fix Playwright install in deploy checks

### DIFF
--- a/.github/workflows/deploy-dashboard.yaml
+++ b/.github/workflows/deploy-dashboard.yaml
@@ -46,8 +46,19 @@ jobs:
       - run: pnpm run lint
       - run: pnpm run typecheck
       - run: pnpm test
+      - name: Set up Node 22 for Playwright install
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e
+        with:
+          node-version: 22
       - name: Install Playwright
-        run: pnpm --filter lumi-dashboard exec playwright install chromium --with-deps
+        timeout-minutes: 10
+        run: pnpm --filter lumi-dashboard exec playwright install chromium --with-deps --only-shell
+        env:
+          DEBUG: pw:install
+      - name: Restore Node from package.json
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e
+        with:
+          node-version-file: package.json
       - name: Run E2E tests
         run: pnpm run e2e
         env:


### PR DESCRIPTION
## Beskrivelse

Fikser `Deploy dashboard` sin dupliserte `Run checks`-jobb, som fortsatt hang i Playwright browser-install etter Node 24-bumpen. CI-workflowen var allerede justert, men deploy-workflowen hadde fortsatt gammel kommando.

## Endringer

- `.github/workflows/deploy-dashboard.yaml`: bruker Node 22 kun for Playwright browser-install, med `--only-shell`, 10 minutters timeout og `DEBUG=pw:install`
- `.github/workflows/deploy-dashboard.yaml`: gjenoppretter Node fra `package.json` før E2E-testene kjører, slik at E2E fortsatt kjører på Node 24

## Issue

Ingen issue. Hotfix for hengende main deploy-run etter #314.

## Review

Kryssmodell-review: OK, ingen blockere eller warnings.

## Sjekkliste

- [x] Koden kompilerer og linter uten feil
- [x] Endringene er testet (manuelt eller automatisk)
- [x] Ingen sensitiv data eksponert (tokens, credentials, PII)