### PR TITLE
fix(dashboard): deploy demo on main merge

### DIFF
--- a/.github/workflows/deploy-dashboard.yaml
+++ b/.github/workflows/deploy-dashboard.yaml
@@ -69,6 +69,7 @@ jobs:
     needs: checks
     runs-on: ubuntu-latest
     if: |
+      (github.event_name == 'push' && github.ref_name == 'main') ||
       startsWith(github.ref_name, 'demo-') ||
       (github.event_name == 'workflow_dispatch' && inputs.target == 'demo')
     outputs:
@@ -180,6 +181,7 @@ jobs:
     needs: build-demo
     runs-on: ubuntu-latest
     if: |
+      (github.event_name == 'push' && github.ref_name == 'main') ||
       startsWith(github.ref_name, 'demo-') ||
       (github.event_name == 'workflow_dispatch' && inputs.target == 'demo')
     environment:

--- a/.github/workflows/deploy-dashboard.yaml
+++ b/.github/workflows/deploy-dashboard.yaml
@@ -126,7 +126,7 @@ jobs:
     needs: checks
     runs-on: ubuntu-latest
     if: |
-      github.ref_name == 'main' ||
+      (github.event_name == 'push' && github.ref_name == 'main') ||
       (github.event_name == 'workflow_dispatch' && (inputs.target == 'dev' || inputs.target == 'prod'))
     outputs:
       image: ${{ steps.docker-build-push.outputs.image }}
@@ -200,7 +200,7 @@ jobs:
     needs: build-production
     runs-on: ubuntu-latest
     if: |
-      github.ref_name == 'main' ||
+      (github.event_name == 'push' && github.ref_name == 'main') ||
       (github.event_name == 'workflow_dispatch' && inputs.target == 'dev')
     environment:
       name: dev
@@ -218,7 +218,7 @@ jobs:
     needs: [build-production, deploy-dev]
     runs-on: ubuntu-latest
     if: |
-      github.ref_name == 'main' ||
+      (github.event_name == 'push' && github.ref_name == 'main') ||
       (github.event_name == 'workflow_dispatch' && inputs.target == 'prod')
     environment:
       name: prod


### PR DESCRIPTION
## Beskrivelse

Deploy demo-dashboardet automatisk ved push/merge til `main`, slik at `lumi-demo`-imaget ikke blir stående på en gammel versjon med sårbarheter.

## Endringer

- `.github/workflows/deploy-dashboard.yaml`: lar `build-demo` og `deploy-demo` kjøre på `push` til `main`, i tillegg til eksisterende `demo-*` og manuell `target=demo`.
- Begrenser `main`-regelen til `github.event_name == 'push'` slik at manuell dispatch med `target=dev` eller `target=prod` ikke utilsiktet deployer demo.\n\n## Issue\n\nIngen issue.\n\n## Sjekkliste\n\n- [x] Koden kompilerer og linter uten feil\n- [x] Endringene er testet (manuelt eller automatisk)\n- [x] Ingen sensitiv data eksponert (tokens, credentials, PII)