### PR TITLE
chore(local): docker-compose stack + end-to-end submission smoke test

### DIFF
--- a/apps/lumi-api/Dockerfile.local
+++ b/apps/lumi-api/Dockerfile.local
@@ -12,7 +12,7 @@ FROM eclipse-temurin:21-jdk AS build
 WORKDIR /src
 COPY gradlew gradlew.bat settings.gradle.kts build.gradle.kts gradle.properties ./
 COPY gradle ./gradle
-RUN ./gradlew --no-daemon dependencies >/dev/null 2>&1 || true
+RUN ./gradlew --no-daemon dependencies --configuration runtimeClasspath -q
 COPY . .
 RUN ./gradlew --no-daemon clean shadowJar
 

--- a/apps/lumi-api/Dockerfile.local
+++ b/apps/lumi-api/Dockerfile.local
@@ -1,0 +1,18 @@
+# Local-only image used by docker-compose to run the whole stack with one command.
+#
+# The PRODUCTION image is apps/lumi-api/Dockerfile (expects a prebuilt
+# build/libs/app.jar from CI). This one is self-contained: it builds the fat jar
+# inside Docker via the gradle wrapper, then runs it. Not used by any deploy.
+
+FROM eclipse-temurin:21-jdk AS build
+WORKDIR /src
+COPY . .
+RUN ./gradlew --no-daemon clean shadowJar
+
+FROM eclipse-temurin:21-jre
+WORKDIR /app
+COPY --from=build /src/build/libs/app.jar app.jar
+ENV TZ="Europe/Oslo"
+EXPOSE 8080
+# No NAIS_CLUSTER_NAME -> lumi-api runs in local mode (auth disabled, DB_* from env).
+ENTRYPOINT ["java", "-jar", "app.jar"]

--- a/apps/lumi-api/Dockerfile.local
+++ b/apps/lumi-api/Dockerfile.local
@@ -4,12 +4,24 @@
 # build/libs/app.jar from CI). This one is self-contained: it builds the fat jar
 # inside Docker via the gradle wrapper, then runs it. Not used by any deploy.
 
+# Build stage: Temurin JDK + the project's own Gradle wrapper. Build images are
+# discarded, so a Docker Hub base here is fine (NAV's docker guide does the same).
+# Copy dependency descriptors first so `docker compose build` can reuse the Gradle
+# cache layer when only source changes.
 FROM eclipse-temurin:21-jdk AS build
 WORKDIR /src
+COPY gradlew gradlew.bat settings.gradle.kts build.gradle.kts gradle.properties ./
+COPY gradle ./gradle
+RUN ./gradlew --no-daemon dependencies >/dev/null 2>&1 || true
 COPY . .
 RUN ./gradlew --no-daemon clean shadowJar
 
-FROM eclipse-temurin:21-jre
+# Runtime stage: the SAME Chainguard JRE as production (apps/lumi-api/Dockerfile),
+# so the local image matches prod and follows NAV's Chainguard standard
+# (.github/instructions/docker.instructions.md). Runs as non-root automatically.
+# NOTE: pulling cgr-nav needs `gcloud auth configure-docker
+# europe-north1-docker.pkg.dev` + cgr-nav access first (see scripts/README.md).
+FROM europe-north1-docker.pkg.dev/cgr-nav/pull-through/nav.no/jre:openjdk-21
 WORKDIR /app
 COPY --from=build /src/build/libs/app.jar app.jar
 ENV TZ="Europe/Oslo"

--- a/apps/lumi-api/Dockerfile.local.dockerignore
+++ b/apps/lumi-api/Dockerfile.local.dockerignore
@@ -1,0 +1,6 @@
+# Ignore file scoped to Dockerfile.local (BuildKit per-Dockerfile ignore).
+# Keeps the build context small and forces a clean in-container build.
+# Does NOT affect the production Dockerfile.
+build
+.gradle
+*.log

--- a/apps/lumi-api/Dockerfile.local.dockerignore
+++ b/apps/lumi-api/Dockerfile.local.dockerignore
@@ -4,3 +4,4 @@
 build
 .gradle
 *.log
+.env*

--- a/apps/lumi-api/src/main/kotlin/no/nav/lumi/config/ServerEnv.kt
+++ b/apps/lumi-api/src/main/kotlin/no/nav/lumi/config/ServerEnv.kt
@@ -62,7 +62,10 @@ data class ServerEnv(
              */
             fun forLocal(
                 host: String = System.getenv("DB_HOST") ?: "localhost",
-                port: Int = System.getenv("DB_PORT")?.toIntOrNull() ?: 5432,
+                port: Int = System.getenv("DB_PORT")?.let {
+                    it.toIntOrNull()
+                        ?: throw IllegalStateException("DB_PORT is set but not a valid integer: '$it'")
+                } ?: 5432,
                 database: String = System.getenv("DB_DATABASE") ?: "lumi",
                 username: String = System.getenv("DB_USERNAME") ?: "lumi",
                 password: String = System.getenv("DB_PASSWORD") ?: "lumi"

--- a/apps/lumi-api/src/main/kotlin/no/nav/lumi/config/ServerEnv.kt
+++ b/apps/lumi-api/src/main/kotlin/no/nav/lumi/config/ServerEnv.kt
@@ -55,13 +55,17 @@ data class ServerEnv(
             
             /**
              * Configuration for local development with Docker Compose or local Postgres.
+             *
+             * Reads standard DB_* env vars (same names as NAIS) so the API can run
+             * inside docker-compose pointing at the `postgres` service, while plain
+             * `./gradlew run` on the host falls back to localhost defaults.
              */
             fun forLocal(
-                host: String = "localhost",
-                port: Int = 5432,
-                database: String = "lumi",
-                username: String = "lumi",
-                password: String = "lumi"
+                host: String = System.getenv("DB_HOST") ?: "localhost",
+                port: Int = System.getenv("DB_PORT")?.toIntOrNull() ?: 5432,
+                database: String = System.getenv("DB_DATABASE") ?: "lumi",
+                username: String = System.getenv("DB_USERNAME") ?: "lumi",
+                password: String = System.getenv("DB_PASSWORD") ?: "lumi"
             ) = DatabaseEnv(
                 jdbcUrl = null,
                 host = host,

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,54 @@
+# Local development stack for Lumi.
+#
+# Two ways to run, both give lumi-api "local mode" (NAIS_CLUSTER_NAME absent ->
+# auth disabled, any bearer token accepted as a mock identity):
+#
+#   A) Whole stack in containers (one command):
+#        docker compose up -d --build          # postgres + api
+#        ./scripts/lumi-local-smoke.sh
+#
+#   B) Just the database, API on the host (faster iteration):
+#        docker compose up -d postgres
+#        cd apps/lumi-api && ./gradlew run
+#        ./scripts/lumi-local-smoke.sh
+#
+# Flyway migrates on API boot, so a fresh volume gets the full schema. Valkey is
+# omitted: without VALKEY_URI_* the cache factories return Noop implementations.
+
+services:
+  postgres:
+    image: postgres:17-alpine
+    container_name: lumi-postgres
+    environment:
+      POSTGRES_DB: lumi
+      POSTGRES_USER: lumi
+      POSTGRES_PASSWORD: lumi
+    ports:
+      - "5432:5432"
+    volumes:
+      - lumi-postgres-data:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U lumi -d lumi"]
+      interval: 3s
+      timeout: 3s
+      retries: 20
+
+  api:
+    build:
+      context: ./apps/lumi-api
+      dockerfile: Dockerfile.local
+    container_name: lumi-api
+    depends_on:
+      postgres:
+        condition: service_healthy
+    environment:
+      DB_HOST: postgres
+      DB_PORT: "5432"
+      DB_DATABASE: lumi
+      DB_USERNAME: lumi
+      DB_PASSWORD: lumi
+    ports:
+      - "8080:8080"
+
+volumes:
+  lumi-postgres-data:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,6 +6,9 @@
 #   A) Whole stack in containers (one command):
 #        docker compose up -d --build          # postgres + api
 #        ./scripts/lumi-local-smoke.sh
+#      The api image runs on the same Chainguard JRE as prod, pulled from NAV's
+#      registry -> run `gcloud auth configure-docker europe-north1-docker.pkg.dev`
+#      once first (needs cgr-nav access). Option B builds nothing and skips this.
 #
 #   B) Just the database, API on the host (faster iteration):
 #        docker compose up -d postgres

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -1,0 +1,67 @@
+# Local development scripts
+
+## Local end-to-end submission flow
+
+Test the **whole** Lumi submission chain locally — widget-shaped payload → API
+parsing → v1/v2 dispatch → immutable definition + deduplication → Postgres
+persistence — without any real TokenX/Azure token.
+
+This works because lumi-api runs in **local mode** when `NAIS_CLUSTER_NAME` is
+absent: authentication is disabled and any non-empty `Authorization: Bearer <x>`
+is mapped to a mock identity (`team=local-dev`). See
+`apps/lumi-api/src/main/kotlin/no/nav/lumi/config/Auth.kt` and
+`config/auth/SubmissionAuthPlugin.kt`. **This bypass is fail-safe**: deployed
+environments always have `NAIS_CLUSTER_NAME`, so real Texas auth is always used
+there.
+
+### Steps
+
+**Option A — whole stack in containers (one command):**
+
+```bash
+docker compose up -d --build          # postgres + api (first build takes a few min)
+./scripts/lumi-local-smoke.sh         # waits for the API, then runs the flow
+```
+
+**Option B — database in a container, API on the host (faster iteration):**
+
+```bash
+docker compose up -d postgres
+cd apps/lumi-api && ./gradlew run     # Flyway migrates on boot
+./scripts/lumi-local-smoke.sh         # in another terminal
+```
+
+Both give "local mode" (auth disabled). The API reads `DB_*` env vars, so the
+container points at the `postgres` service while the host falls back to
+`localhost:5432`.
+
+The smoke test walks the full rollout lifecycle on a single `surveyId` and
+prints the resulting DB rows:
+
+| Scenario | Expected |
+| --- | --- |
+| Legacy `schemaVersion: 1` submission | `201 Created` — existing widgets still work; registers an `auto` definition |
+| `schemaVersion: 2` compatible takeover | `201 Created` — definition promoted `auto` → `api` |
+| Same `deduplicationKey` again | `200 OK` (deduplicated, no new row) |
+| Structural change, same `surveyId` | `409 Conflict` (immutable definition guard) |
+
+> Requires port `5432` to be free. If you already run a local Postgres, stop it
+> or change the published port in `docker-compose.yml`.
+
+### Manual curl
+
+`fixtures/v2-feedback.example.json` is a ready-to-send v2 payload:
+
+```bash
+curl -X POST http://localhost:8080/api/tokenx/v1/feedback \
+  -H 'Authorization: Bearer local-dev' \
+  -H 'Content-Type: application/json' \
+  --data-binary @scripts/fixtures/v2-feedback.example.json
+```
+
+### Teardown
+
+```bash
+docker compose down          # stop Postgres, keep data volume
+docker compose down -v       # also drop the data volume (fresh schema next time)
+```

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -7,12 +7,12 @@ parsing → v1/v2 dispatch → immutable definition + deduplication → Postgres
 persistence — without any real TokenX/Azure token.
 
 This works because lumi-api runs in **local mode** when `NAIS_CLUSTER_NAME` is
-absent: authentication is disabled and any non-empty `Authorization: Bearer <x>`
-is mapped to a mock identity (`team=local-dev`). See
-`apps/lumi-api/src/main/kotlin/no/nav/lumi/config/Auth.kt` and
-`config/auth/SubmissionAuthPlugin.kt`. **This bypass is fail-safe**: deployed
-environments always have `NAIS_CLUSTER_NAME`, so real Texas auth is always used
-there.
+absent: submission auth is disabled entirely — the plugin assigns a mock identity
+(`team=local-dev`) *without inspecting the `Authorization` header at all*. The
+smoke test still sends `Bearer local-dev`, but no token is actually required. See
+`apps/lumi-api/src/main/kotlin/no/nav/lumi/config/auth/SubmissionAuthPlugin.kt`.
+The bypass relies on the NAIS platform guarantee that deployed environments always
+set `NAIS_CLUSTER_NAME`, so it never activates outside local dev.
 
 ### Steps
 

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -18,6 +18,11 @@ there.
 
 **Option A — whole stack in containers (one command):**
 
+> **Prerequisite:** the api image runs on the same Chainguard JRE as production,
+> pulled from NAV's registry. Authenticate once with
+> `gcloud auth configure-docker europe-north1-docker.pkg.dev` (needs cgr-nav
+> access). Option B builds no image and skips this.
+
 ```bash
 docker compose up -d --build          # postgres + api (first build takes a few min)
 ./scripts/lumi-local-smoke.sh         # waits for the API, then runs the flow

--- a/scripts/fixtures/v2-feedback.example.json
+++ b/scripts/fixtures/v2-feedback.example.json
@@ -1,0 +1,43 @@
+{
+  "schemaVersion": 2,
+  "surveyId": "local-example",
+  "surveyType": "rating",
+  "submittedAt": "2026-06-20T12:00:00.000Z",
+  "deduplicationKey": "manual-example-key",
+  "definition": {
+    "surveyType": "rating",
+    "fields": [
+      {
+        "fieldId": "rating",
+        "fieldType": "RATING",
+        "ratingVariant": "emoji",
+        "ratingScale": 5
+      },
+      { "fieldId": "feedback", "fieldType": "TEXT" }
+    ]
+  },
+  "context": {
+    "url": "http://localhost",
+    "deviceType": "desktop",
+    "tags": { "abTest": "A" }
+  },
+  "answers": [
+    {
+      "fieldId": "rating",
+      "fieldType": "RATING",
+      "question": { "label": "Hvordan var opplevelsen?" },
+      "value": {
+        "type": "rating",
+        "rating": 4,
+        "ratingVariant": "emoji",
+        "ratingScale": 5
+      }
+    },
+    {
+      "fieldId": "feedback",
+      "fieldType": "TEXT",
+      "question": { "label": "Begrunnelse" },
+      "value": { "type": "text", "text": "Manuelt eksempel" }
+    }
+  ]
+}

--- a/scripts/lumi-local-smoke.sh
+++ b/scripts/lumi-local-smoke.sh
@@ -1,0 +1,160 @@
+#!/usr/bin/env bash
+#
+# Local end-to-end smoke test for the Lumi submission flow.
+#
+# Exercises REAL widget-shaped payloads against a locally-running lumi-api (auth
+# disabled in local mode) and a Postgres from docker-compose, then prints the
+# resulting database rows. No real TokenX/Azure token is required.
+#
+# Walks the full rollout lifecycle on a single surveyId:
+#   1. v1 submission                  -> 201  (legacy widget still works; AUTO definition)
+#   2. v2 compatible takeover         -> 201  (AUTO -> API promotion)
+#   3. v2 same deduplicationKey again -> 200  (deduplicated, no new row)
+#   4. v2 structural change           -> 409  (immutable definition guard)
+#
+# Prerequisites (the script checks these for you):
+#   - docker compose available
+#   - lumi-api running on the host:  (cd apps/lumi-api && ./gradlew run)
+#
+# Usage:  scripts/lumi-local-smoke.sh
+set -euo pipefail
+
+API="${LUMI_API_URL:-http://localhost:8080}"
+ENDPOINT="$API/api/tokenx/v1/feedback"
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+COMPOSE="docker compose -f $ROOT/docker-compose.yml"
+SURVEY_ID="local-smoke-$(date +%Y%m%d-%H%M%S)-${RANDOM}"   # unique per run
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+
+note()  { printf '\n\033[1;36m== %s ==\033[0m\n' "$1"; }
+ok()    { printf '\033[1;32m  ✓ %s\033[0m\n' "$1"; }
+bad()   { printf '\033[1;31m  ✗ %s\033[0m\n' "$1"; }
+die()   { printf '\n\033[1;31m✗ %s\033[0m\n' "$1" >&2; exit 1; }
+
+FAILED=0
+
+psql_q()    { $COMPOSE exec -T postgres psql -U lumi -d lumi -At -c "$1"; }
+def_source(){ psql_q "SELECT source FROM survey_definitions WHERE survey_id = '$SURVEY_ID';"; }
+
+post() { # $1 = json file -> echoes HTTP status, body in $TMP/body
+  curl -s -o "$TMP/body" -w '%{http_code}' \
+    -X POST "$ENDPOINT" \
+    -H 'Authorization: Bearer local-dev' \
+    -H 'Content-Type: application/json' \
+    --data-binary "@$1"
+}
+
+expect() { # $1 = actual, $2 = expected, $3 = label
+  if [ "$1" = "$2" ]; then ok "$3 -> HTTP $1"; else
+    bad "$3 -> HTTP $1 (forventet $2)"; printf '    body: %s\n' "$(cat "$TMP/body")"; FAILED=1
+  fi
+}
+
+check() { # $1 = actual, $2 = expected, $3 = label
+  if [ "$1" = "$2" ]; then ok "$3 = $1"; else bad "$3 = $1 (forventet $2)"; FAILED=1; fi
+}
+
+# --- payload builders ---------------------------------------------------------
+payload_v1() { # legacy widget: no definition block, no deduplicationKey
+  cat <<JSON
+{
+  "schemaVersion": 1,
+  "surveyId": "$SURVEY_ID",
+  "surveyType": "rating",
+  "submittedAt": "2026-06-20T12:00:00.000Z",
+  "answers": [
+    { "fieldId": "rating", "fieldType": "RATING", "question": { "label": "Hvordan var opplevelsen?" },
+      "value": { "type": "rating", "rating": 4, "ratingVariant": "stars", "ratingScale": 5 } },
+    { "fieldId": "feedback", "fieldType": "TEXT", "question": { "label": "Begrunnelse" },
+      "value": { "type": "text", "text": "v1 smoke" } }
+  ]
+}
+JSON
+}
+
+payload_v2() { # $1 = deduplicationKey, $2 = ratingVariant
+  cat <<JSON
+{
+  "schemaVersion": 2,
+  "surveyId": "$SURVEY_ID",
+  "surveyType": "rating",
+  "submittedAt": "2026-06-20T12:00:00.000Z",
+  "deduplicationKey": "$1",
+  "definition": {
+    "surveyType": "rating",
+    "fields": [
+      { "fieldId": "rating", "fieldType": "RATING", "ratingVariant": "$2", "ratingScale": 5 },
+      { "fieldId": "feedback", "fieldType": "TEXT" }
+    ]
+  },
+  "answers": [
+    { "fieldId": "rating", "fieldType": "RATING", "question": { "label": "Hvordan var opplevelsen?" },
+      "value": { "type": "rating", "rating": 4, "ratingVariant": "$2", "ratingScale": 5 } },
+    { "fieldId": "feedback", "fieldType": "TEXT", "question": { "label": "Begrunnelse" },
+      "value": { "type": "text", "text": "v2 smoke" } }
+  ]
+}
+JSON
+}
+
+# --- 1. Postgres --------------------------------------------------------------
+note "1/8  Postgres (docker-compose)"
+$COMPOSE up -d postgres >/dev/null
+for i in $(seq 1 20); do
+  if $COMPOSE exec -T postgres pg_isready -U lumi -d lumi >/dev/null 2>&1; then ok "Postgres oppe"; break; fi
+  [ "$i" = "20" ] && die "Postgres ble ikke klar i tide"
+  sleep 2
+done
+
+# --- 2. API health ------------------------------------------------------------
+note "2/8  lumi-api ($API)"
+curl -fsS -o /dev/null "$API/internal/isAlive" 2>/dev/null \
+  || die "lumi-api svarer ikke på /internal/isAlive.\n  Start den i et eget terminalvindu:\n    cd apps/lumi-api && ./gradlew run"
+ok "lumi-api oppe (/internal/isAlive)"
+printf '  surveyId for denne kjøringen: \033[1m%s\033[0m\n' "$SURVEY_ID"
+
+# --- 3. v1 submission -> 201 (backward-compat) --------------------------------
+note "3/8  Legacy v1-innsending (eksisterende widget)"
+payload_v1 > "$TMP/v1.json"
+expect "$(post "$TMP/v1.json")" "201" "v1-innsending"
+
+# --- 4. AUTO definition registered --------------------------------------------
+note "4/8  v1 registrerte en AUTO-definisjon"
+check "$(def_source)" "auto" "survey_definitions.source"
+
+# --- 5. v2 compatible takeover -> 201 (AUTO -> API) ---------------------------
+note "5/8  v2 tar over kompatibelt (AUTO -> API)"
+payload_v2 "local-smoke-key-aaaaaaaa" "stars" > "$TMP/v2ok.json"
+expect "$(post "$TMP/v2ok.json")" "201" "v2-overtakelse"
+check "$(def_source)" "api" "survey_definitions.source"
+
+# --- 6. duplicate -> 200 ------------------------------------------------------
+note "6/8  Samme deduplicationKey igjen (dedup)"
+expect "$(post "$TMP/v2ok.json")" "200" "v2-duplikat"
+
+# --- 7. structural change -> 409 ----------------------------------------------
+note "7/8  Endret definisjon, samme surveyId (immutability)"
+payload_v2 "local-smoke-key-bbbbbbbb" "emoji" > "$TMP/v2bad.json"  # stars -> emoji
+expect "$(post "$TMP/v2bad.json")" "409" "Strukturendring"
+printf '    melding: %s\n' "$(cat "$TMP/body")"
+
+# --- 8. database rows ---------------------------------------------------------
+note "8/8  Rader i databasen for $SURVEY_ID"
+echo "  feedback:"
+psql_q "SELECT id, team, app, survey_id, definition_hash, deduplication_key_hash
+        FROM feedback WHERE survey_id = '$SURVEY_ID' ORDER BY opprettet;" | sed 's/^/    /'
+echo "  survey_definitions:"
+psql_q "SELECT survey_id, team, source, definition_hash
+        FROM survey_definitions WHERE survey_id = '$SURVEY_ID';" | sed 's/^/    /'
+
+FB_COUNT="$(psql_q "SELECT count(*) FROM feedback WHERE survey_id = '$SURVEY_ID';")"
+note "Oppsummering"
+# v1 (1) + v2 takeover (1) persist; dedup (0) and 409 (0) do not -> 2 rows
+check "$FB_COUNT" "2" "feedback-rader"
+
+if [ "$FAILED" = "0" ]; then
+  printf '\n\033[1;32m✓ Lokal ende-til-ende-flyt OK (v1 + v2 + promotering + dedup + immutability)\033[0m\n'
+else
+  die "Én eller flere sjekker feilet (se over)"
+fi

--- a/scripts/lumi-local-smoke.sh
+++ b/scripts/lumi-local-smoke.sh
@@ -34,8 +34,10 @@ die()   { printf '\n\033[1;31m✗ %s\033[0m\n' "$1" >&2; exit 1; }
 
 FAILED=0
 
-psql_q()    { $COMPOSE exec -T postgres psql -U lumi -d lumi -At -c "$1"; }
-def_source(){ psql_q "SELECT source FROM survey_definitions WHERE survey_id = '$SURVEY_ID';"; }
+# survey_id is passed as a psql variable (:'survey_id'), never interpolated into
+# the SQL string — keeps the repo's "no SQL string-interpolation" rule intact.
+psql_q()    { $COMPOSE exec -T postgres psql -U lumi -d lumi -v survey_id="$SURVEY_ID" -At -c "$1"; }
+def_source(){ psql_q "SELECT source FROM survey_definitions WHERE survey_id = :'survey_id';"; }
 
 post() { # $1 = json file -> echoes HTTP status, body in $TMP/body
   curl -s -o "$TMP/body" -w '%{http_code}' \
@@ -109,8 +111,13 @@ done
 
 # --- 2. API health ------------------------------------------------------------
 note "2/8  lumi-api ($API)"
-curl -fsS -o /dev/null "$API/internal/isAlive" 2>/dev/null \
-  || die "lumi-api svarer ikke på /internal/isAlive.\n  Start den i et eget terminalvindu:\n    cd apps/lumi-api && ./gradlew run"
+# Poll, don't assume: with `docker compose up -d` the api container may still be
+# booting (Ktor + Flyway) when this runs. Retry for ~60s before giving up.
+for i in $(seq 1 30); do
+  curl -fsS --max-time 3 -o /dev/null "$API/internal/isAlive" 2>/dev/null && break
+  [ "$i" = "30" ] && die "lumi-api svarer ikke på /internal/isAlive etter ~60s.\n  Start den i et eget terminalvindu:\n    cd apps/lumi-api && ./gradlew run"
+  sleep 2
+done
 ok "lumi-api oppe (/internal/isAlive)"
 printf '  surveyId for denne kjøringen: \033[1m%s\033[0m\n' "$SURVEY_ID"
 
@@ -143,12 +150,12 @@ printf '    melding: %s\n' "$(cat "$TMP/body")"
 note "8/8  Rader i databasen for $SURVEY_ID"
 echo "  feedback:"
 psql_q "SELECT id, team, app, survey_id, definition_hash, deduplication_key_hash
-        FROM feedback WHERE survey_id = '$SURVEY_ID' ORDER BY opprettet;" | sed 's/^/    /'
+        FROM feedback WHERE survey_id = :'survey_id' ORDER BY opprettet;" | sed 's/^/    /'
 echo "  survey_definitions:"
 psql_q "SELECT survey_id, team, source, definition_hash
-        FROM survey_definitions WHERE survey_id = '$SURVEY_ID';" | sed 's/^/    /'
+        FROM survey_definitions WHERE survey_id = :'survey_id';" | sed 's/^/    /'
 
-FB_COUNT="$(psql_q "SELECT count(*) FROM feedback WHERE survey_id = '$SURVEY_ID';")"
+FB_COUNT="$(psql_q "SELECT count(*) FROM feedback WHERE survey_id = :'survey_id';")"
 note "Oppsummering"
 # v1 (1) + v2 takeover (1) persist; dedup (0) and 409 (0) do not -> 2 rows
 check "$FB_COUNT" "2" "feedback-rader"


### PR DESCRIPTION
## What

One-command local rig for testing the full Lumi submission flow without real TokenX/Azure tokens.

lumi-api runs in **local mode** when `NAIS_CLUSTER_NAME` is absent: auth disabled, any bearer token mapped to a mock identity (`team=local-dev`), and `DB_*` read from env. This bypass is fail-safe — deployed environments always have `NAIS_CLUSTER_NAME`, so real Texas auth is always used there.

## Two ways to run

```bash
# A) whole stack in containers
docker compose up -d --build
./scripts/lumi-local-smoke.sh

# B) db only, API on host (faster iteration)
docker compose up -d postgres
cd apps/lumi-api && ./gradlew run
./scripts/lumi-local-smoke.sh
```

## What the smoke test proves

Walks the full rollout lifecycle on one `surveyId` and prints the resulting `feedback` + `survey_definitions` rows:

| Scenario | Expected |
| --- | --- |
| Legacy `schemaVersion: 1` submission | `201` — existing widgets still work; `auto` definition |
| `schemaVersion: 2` compatible takeover | `201` — definition promoted `auto` → `api` |
| Same `deduplicationKey` again | `200` (deduplicated, no new row) |
| Structural change, same `surveyId` | `409` (immutable definition guard) |

## Changes

- `docker-compose.yml`: Postgres + optional `api` service
- `apps/lumi-api/Dockerfile.local` (+ `Dockerfile.local.dockerignore`): self-contained local image that builds the fat jar in Docker. **Production `Dockerfile` untouched** (BuildKit per-Dockerfile ignore).
- `ServerEnv.forLocal()`: read `DB_*` env vars (defaults to `localhost`) so the API can run in compose pointing at the `postgres` service — only affects local mode
- `scripts/lumi-local-smoke.sh`, `scripts/fixtures/`, `scripts/README.md`

## Testing

- Verified end-to-end against **both** the containerized stack and a host-run API
- Full `lumi-api` test suite green (Testcontainers)
- `shellcheck` clean

Refs #209
