### PR TITLE
fix(api): fail-closed local-mode auth bypass + DB-backed readiness probe

### DIFF
--- a/apps/lumi-api/Dockerfile.local
+++ b/apps/lumi-api/Dockerfile.local
@@ -26,5 +26,6 @@ WORKDIR /app
 COPY --from=build /src/build/libs/app.jar app.jar
 ENV TZ="Europe/Oslo"
 EXPOSE 8080
-# No NAIS_CLUSTER_NAME -> lumi-api runs in local mode (auth disabled, DB_* from env).
+# No NAIS_CLUSTER_NAME -> local mode (auth disabled, DB_* from env). Local mode is
+# fail-closed: docker-compose must set LUMI_LOCAL_AUTH_BYPASS=true or the app refuses to start.
 ENTRYPOINT ["java", "-jar", "app.jar"]

--- a/apps/lumi-api/build.gradle.kts
+++ b/apps/lumi-api/build.gradle.kts
@@ -116,8 +116,17 @@ kotlin {
     }
 }
 
+tasks.named<JavaExec>("run") {
+    // `./gradlew run` is local dev outside NAIS — opt in to the (fail-closed)
+    // local-mode auth bypass so the app starts.
+    environment("LUMI_LOCAL_AUTH_BYPASS", "true")
+}
+
 tasks.withType<Test>().configureEach {
     useJUnitPlatform()
+    // Tests run outside NAIS (no NAIS_CLUSTER_NAME), so explicitly opt in to the
+    // local-mode auth bypass — ServerEnv.requireValidLocalAuthPolicy is fail-closed.
+    environment("LUMI_LOCAL_AUTH_BYPASS", "true")
     System.getProperties()
         .filterKeys { it.toString().startsWith("lumi.perf.") }
         .forEach { (key, value) -> systemProperty(key.toString(), value) }

--- a/apps/lumi-api/src/main/kotlin/no/nav/lumi/config/Database.kt
+++ b/apps/lumi-api/src/main/kotlin/no/nav/lumi/config/Database.kt
@@ -122,6 +122,20 @@ fun createDataSource(config: ServerEnv.DatabaseEnv): HikariDataSource {
 }
 
 /**
+ * Readiness probe helper: true if a valid connection can be obtained from the pool.
+ * Backs GET /internal/isReady so NAIS pulls the pod from the load balancer when the
+ * database is unreachable. Flyway has already run by the time the server serves
+ * requests, so a live connection is a sufficient readiness signal.
+ */
+fun isDatabaseReady(dataSource: DataSource): Boolean =
+    try {
+        dataSource.connection.use { it.isValid(2) }
+    } catch (e: Exception) {
+        log.warn("Readiness check failed: database not reachable", e)
+        false
+    }
+
+/**
  * Run Flyway database migrations.
  */
 fun runMigrations(dataSource: DataSource) {

--- a/apps/lumi-api/src/main/kotlin/no/nav/lumi/config/ServerEnv.kt
+++ b/apps/lumi-api/src/main/kotlin/no/nav/lumi/config/ServerEnv.kt
@@ -132,9 +132,25 @@ data class ServerEnv(
     
     companion object {
         private val log = LoggerFactory.getLogger("ServerEnv")
-        
+
         // Singleton instance (lazy-loaded)
         val current: ServerEnv by lazy { fromEnvironment() }
+
+        /**
+         * Fail-closed guard for the submission-auth bypass. Running outside NAIS
+         * (no NAIS_CLUSTER_NAME) disables submission auth entirely, so it must be
+         * an explicit opt-in via LUMI_LOCAL_AUTH_BYPASS rather than a silent default.
+         */
+        internal fun requireValidLocalAuthPolicy(clusterName: String?, localAuthBypass: Boolean) {
+            if (clusterName == null && !localAuthBypass) {
+                throw IllegalStateException(
+                    "Refusing to start: NAIS_CLUSTER_NAME is absent and LUMI_LOCAL_AUTH_BYPASS " +
+                        "is not 'true'. In this mode submission auth is fully disabled and any " +
+                        "request is accepted. Set LUMI_LOCAL_AUTH_BYPASS=true for local " +
+                        "development, or run on NAIS where NAIS_CLUSTER_NAME is always set."
+                )
+            }
+        }
         
         /**
          * Load environment configuration.
@@ -142,12 +158,17 @@ data class ServerEnv(
          */
         fun fromEnvironment(): ServerEnv {
             val nais = NaisEnv.fromEnvironment()
-            
+            val localAuthBypass = System.getenv("LUMI_LOCAL_AUTH_BYPASS").toBoolean()
+            requireValidLocalAuthPolicy(nais.clusterName, localAuthBypass)
+
             return if (nais.isNais) {
                 log.info("Running in NAIS cluster: ${nais.clusterName}")
                 forProduction(nais)
             } else {
-                log.info("Running in local development mode")
+                log.warn(
+                    "Running in LOCAL mode via LUMI_LOCAL_AUTH_BYPASS — submission auth is " +
+                        "DISABLED and any request is accepted. Never expose this outside local dev."
+                )
                 forLocal()
             }
         }

--- a/apps/lumi-api/src/main/kotlin/no/nav/lumi/routes/InternalRoutes.kt
+++ b/apps/lumi-api/src/main/kotlin/no/nav/lumi/routes/InternalRoutes.kt
@@ -3,15 +3,25 @@ package no.nav.lumi.routes
 import io.ktor.http.*
 import io.ktor.server.response.*
 import io.ktor.server.routing.*
+import no.nav.lumi.config.DatabaseHolder
+import no.nav.lumi.config.isDatabaseReady
 
 fun Route.internalRoutes() {
     route("/internal") {
         get("/isAlive") {
             call.respondText("OK", ContentType.Text.Plain)
         }
-        
+
         get("/isReady") {
-            call.respondText("OK", ContentType.Text.Plain)
+            if (isDatabaseReady(DatabaseHolder.dataSource)) {
+                call.respondText("OK", ContentType.Text.Plain)
+            } else {
+                call.respondText(
+                    "Database not ready",
+                    ContentType.Text.Plain,
+                    HttpStatusCode.ServiceUnavailable
+                )
+            }
         }
         
         get("/prometheus") {

--- a/apps/lumi-api/src/test/kotlin/no/nav/lumi/config/DatabaseReadinessTest.kt
+++ b/apps/lumi-api/src/test/kotlin/no/nav/lumi/config/DatabaseReadinessTest.kt
@@ -1,0 +1,41 @@
+package no.nav.lumi.config
+
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import no.nav.lumi.TestDatabase
+import java.io.PrintWriter
+import java.sql.Connection
+import java.sql.SQLException
+import java.util.logging.Logger
+import javax.sql.DataSource
+
+/**
+ * /internal/isReady must reflect real database reachability so NAIS pulls the pod
+ * from the load balancer when the DB is down — not return a hardcoded "OK".
+ */
+class DatabaseReadinessTest : FunSpec({
+
+    beforeSpec { TestDatabase.initialize() }
+
+    test("isDatabaseReady should return true when the database is reachable") {
+        isDatabaseReady(TestDatabase.dataSource) shouldBe true
+    }
+
+    test("isDatabaseReady should return false when the database is unreachable") {
+        isDatabaseReady(UnreachableDataSource) shouldBe false
+    }
+})
+
+/** A DataSource that always fails to connect, standing in for a down database. */
+private object UnreachableDataSource : DataSource {
+    override fun getConnection(): Connection = throw SQLException("database unreachable")
+    override fun getConnection(username: String?, password: String?): Connection =
+        throw SQLException("database unreachable")
+    override fun getLogWriter(): PrintWriter? = null
+    override fun setLogWriter(out: PrintWriter?) {}
+    override fun setLoginTimeout(seconds: Int) {}
+    override fun getLoginTimeout(): Int = 0
+    override fun getParentLogger(): Logger = Logger.getGlobal()
+    override fun <T : Any?> unwrap(iface: Class<T>?): T = throw SQLException("not a wrapper")
+    override fun isWrapperFor(iface: Class<*>?): Boolean = false
+}

--- a/apps/lumi-api/src/test/kotlin/no/nav/lumi/config/ServerEnvAuthPolicyTest.kt
+++ b/apps/lumi-api/src/test/kotlin/no/nav/lumi/config/ServerEnvAuthPolicyTest.kt
@@ -1,0 +1,34 @@
+package no.nav.lumi.config
+
+import io.kotest.assertions.throwables.shouldNotThrowAny
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.string.shouldContain
+
+/**
+ * The submission-auth bypass must be fail-closed: running outside NAIS (no
+ * NAIS_CLUSTER_NAME) disables auth entirely, so it must require an explicit
+ * LUMI_LOCAL_AUTH_BYPASS opt-in rather than activating silently.
+ */
+class ServerEnvAuthPolicyTest : FunSpec({
+
+    test("should refuse to start in local mode when the bypass is not explicitly enabled") {
+        val ex = shouldThrow<IllegalStateException> {
+            ServerEnv.requireValidLocalAuthPolicy(clusterName = null, localAuthBypass = false)
+        }
+        ex.message shouldContain "LUMI_LOCAL_AUTH_BYPASS"
+    }
+
+    test("should allow local mode when the auth bypass is explicitly enabled") {
+        shouldNotThrowAny {
+            ServerEnv.requireValidLocalAuthPolicy(clusterName = null, localAuthBypass = true)
+        }
+    }
+
+    test("should allow NAIS mode regardless of the bypass flag") {
+        shouldNotThrowAny {
+            ServerEnv.requireValidLocalAuthPolicy(clusterName = "prod-gcp", localAuthBypass = false)
+            ServerEnv.requireValidLocalAuthPolicy(clusterName = "dev-gcp", localAuthBypass = false)
+        }
+    }
+})

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -50,6 +50,8 @@ services:
       DB_DATABASE: lumi
       DB_USERNAME: lumi
       DB_PASSWORD: lumi
+      # Local mode disables submission auth — it is fail-closed, so opt in explicitly.
+      LUMI_LOCAL_AUTH_BYPASS: "true"
     ports:
       - "8080:8080"
 

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -7,12 +7,15 @@ parsing → v1/v2 dispatch → immutable definition + deduplication → Postgres
 persistence — without any real TokenX/Azure token.
 
 This works because lumi-api runs in **local mode** when `NAIS_CLUSTER_NAME` is
-absent: submission auth is disabled entirely — the plugin assigns a mock identity
-(`team=local-dev`) *without inspecting the `Authorization` header at all*. The
-smoke test still sends `Bearer local-dev`, but no token is actually required. See
-`apps/lumi-api/src/main/kotlin/no/nav/lumi/config/auth/SubmissionAuthPlugin.kt`.
-The bypass relies on the NAIS platform guarantee that deployed environments always
-set `NAIS_CLUSTER_NAME`, so it never activates outside local dev.
+absent **and** `LUMI_LOCAL_AUTH_BYPASS=true` is set: submission auth is disabled
+entirely — the plugin assigns a mock identity (`team=local-dev`) *without inspecting
+the `Authorization` header at all*. The smoke test still sends `Bearer local-dev`,
+but no token is actually required. Both `docker compose` and `./gradlew run` set the
+flag for you; the bypass is **fail-closed**, so if the flag is missing in local mode
+the app refuses to start. Deployed environments always have `NAIS_CLUSTER_NAME`, so
+the bypass never activates there. See
+`apps/lumi-api/src/main/kotlin/no/nav/lumi/config/auth/SubmissionAuthPlugin.kt` and
+`config/ServerEnv.kt`.
 
 ### Steps
 


### PR DESCRIPTION
Closes #341. Built test-first (Kotest); see the two new test files.

## What

Two code-level gaps surfaced while reviewing the local rig (#340) — both relied on a platform assumption rather than being enforced in code.

### 1. Fail-closed local-mode auth bypass
Submission auth is disabled in local mode (no `NAIS_CLUSTER_NAME`), and the plugin assigned a mock identity *without reading the `Authorization` header at all*. It now requires an explicit `LUMI_LOCAL_AUTH_BYPASS=true` opt-in — `ServerEnv` **refuses to start** otherwise:

- `ServerEnv.requireValidLocalAuthPolicy(clusterName, localAuthBypass)` throws when `clusterName == null && !bypass`, called from `fromEnvironment()` at startup.
- NAIS is unaffected (`NAIS_CLUSTER_NAME` is always set there → the guard never trips).
- `docker compose`, `./gradlew run` and the Gradle `test` task all set the flag, so local dev and CI are unchanged.

### 2. DB-backed readiness probe
`/internal/isReady` returned a hardcoded `OK`. It now reflects real database reachability via `isDatabaseReady(dataSource)` (valid pooled connection) and returns **503** when the DB is unreachable, so NAIS pulls the pod from the load balancer on a DB outage. `/internal/isAlive` stays a pure liveness check.

## Testing

- `ServerEnvAuthPolicyTest` — refuses local mode without opt-in; allows with opt-in; allows NAIS regardless.
- `DatabaseReadinessTest` — true for a live datasource, false for an unreachable one.
- Full `./gradlew test` green; `docker compose config` valid.
