### PR TITLE
feat(api): autentiser mot Nais Console API med workload-identity-token

### DIFF
--- a/apps/lumi-api/build.gradle.kts
+++ b/apps/lumi-api/build.gradle.kts
@@ -102,6 +102,9 @@ dependencies {
     testImplementation("org.testcontainers:testcontainers:$testcontainersVersion")
     testImplementation("org.testcontainers:postgresql:$testcontainersVersion")
     testImplementation("no.nav.security:mock-oauth2-server:4.0.0")
+    // JUnit Jupiter API is pulled in transitively by Kotest, but the Jupiter *engine* is not.
+    // Without it, plain @Test classes (e.g. NaisGraphQlClientTest) compile but are never run.
+    testRuntimeOnly("org.junit.jupiter:junit-jupiter-engine")
 }
 
 java {

--- a/apps/lumi-api/nais/app/dev.yaml
+++ b/apps/lumi-api/nais/app/dev.yaml
@@ -71,7 +71,6 @@ spec:
     - instance: lumi-cache
       access: readwrite
   envFrom:
-    - secret: nais-api-key
     - secret: lumi
   env:
     - name: NAIS_CLUSTER_NAME

--- a/apps/lumi-api/nais/app/prod.yaml
+++ b/apps/lumi-api/nais/app/prod.yaml
@@ -75,8 +75,6 @@ spec:
   valkey:
     - instance: lumi-cache
       access: readwrite
-  envFrom:
-    - secret: nais-api-key
   env:
     - name: NAIS_CLUSTER_NAME
       value: prod-gcp

--- a/apps/lumi-api/src/main/kotlin/no/nav/lumi/config/auth/TeamAuthorizationPlugin.kt
+++ b/apps/lumi-api/src/main/kotlin/no/nav/lumi/config/auth/TeamAuthorizationPlugin.kt
@@ -84,7 +84,7 @@ val TeamAuthorizationPlugin = createRouteScopedPlugin("TeamAuthorization", ::Tea
         val requestedTeam = call.request.queryParameters["team"]
 
         val configuredNaisLookup = naisLookup ?: run {
-            log.error("TeamAuthorization: NAIS team lookup is not configured (missing NAIS_SERVICE_ACCOUNT_TOKEN_PATH/NAIS_API_KEY/TEAMS_TOKEN and/or NAIS_API_GRAPHQL_URL/NAIS_API_ENDPOINT)")
+            log.error("TeamAuthorization: NAIS team lookup is not configured (missing NAIS_SERVICE_ACCOUNT_TOKEN_PATH/NAIS_API_KEY and/or NAIS_API_GRAPHQL_URL/NAIS_API_ENDPOINT)")
             throw ApiErrorException.ServiceUnavailableException(
                 errorMessage = "Team lookup via NAIS is not configured",
                 details = "Missing NAIS configuration for team lookup.",

--- a/apps/lumi-api/src/main/kotlin/no/nav/lumi/config/auth/TeamAuthorizationPlugin.kt
+++ b/apps/lumi-api/src/main/kotlin/no/nav/lumi/config/auth/TeamAuthorizationPlugin.kt
@@ -84,7 +84,7 @@ val TeamAuthorizationPlugin = createRouteScopedPlugin("TeamAuthorization", ::Tea
         val requestedTeam = call.request.queryParameters["team"]
 
         val configuredNaisLookup = naisLookup ?: run {
-            log.error("TeamAuthorization: NAIS team lookup is not configured (missing NAIS_API_KEY/TEAMS_TOKEN and/or NAIS_API_GRAPHQL_URL/NAIS_API_ENDPOINT)")
+            log.error("TeamAuthorization: NAIS team lookup is not configured (missing NAIS_SERVICE_ACCOUNT_TOKEN_PATH/NAIS_API_KEY/TEAMS_TOKEN and/or NAIS_API_GRAPHQL_URL/NAIS_API_ENDPOINT)")
             throw ApiErrorException.ServiceUnavailableException(
                 errorMessage = "Team lookup via NAIS is not configured",
                 details = "Missing NAIS configuration for team lookup.",

--- a/apps/lumi-api/src/main/kotlin/no/nav/lumi/integrations/nais/NaisGraphQlClient.kt
+++ b/apps/lumi-api/src/main/kotlin/no/nav/lumi/integrations/nais/NaisGraphQlClient.kt
@@ -24,6 +24,8 @@ import no.nav.lumi.config.appMicrometerRegistry
 import no.nav.lumi.integrations.valkey.TeamCache
 import no.nav.lumi.integrations.valkey.ValkeyTeamCache
 import org.slf4j.LoggerFactory
+import java.nio.file.Files
+import java.nio.file.Path
 import java.time.Clock
 import java.time.Duration
 import java.time.Instant
@@ -82,7 +84,7 @@ object CacheTtl {
  */
 class NaisGraphQlClient private constructor(
     private val graphqlUrl: String,
-    private val apiKey: String,
+    private val tokenProvider: () -> String,
     private val teamCache: TeamCache,
     private val clock: Clock = Clock.systemUTC(),
     private val client: HttpClient = defaultHttpClient()
@@ -161,7 +163,7 @@ class NaisGraphQlClient private constructor(
             client.post(graphqlUrl) {
                 contentType(ContentType.Application.Json)
                 header(HttpHeaders.UserAgent, userAgent)
-                header(HttpHeaders.Authorization, "Bearer $apiKey")
+                header(HttpHeaders.Authorization, "Bearer ${tokenProvider()}")
                 setBody(
                     GraphQlRequest(
                         query = USER_TEAMS_QUERY,
@@ -265,7 +267,7 @@ class NaisGraphQlClient private constructor(
             client.post(graphqlUrl) {
                 contentType(ContentType.Application.Json)
                 header(HttpHeaders.UserAgent, userAgent)
-                header(HttpHeaders.Authorization, "Bearer $apiKey")
+                header(HttpHeaders.Authorization, "Bearer ${tokenProvider()}")
                 setBody(GraphQlRequest(query = VIEWER_TEAMS_QUERY, variables = EmptyVariables()))
             }
         } catch (e: Exception) {
@@ -472,13 +474,19 @@ class NaisGraphQlClient private constructor(
             val urlFromFallback = System.getenv("NAIS_API_ENDPOINT")?.trim()?.takeIf { it.isNotBlank() }
             val url = urlFromPrimary ?: urlFromFallback
 
+            // Preferred: a workload-bound service account token, mounted as a file that NAIS
+            // rotates in-place. It must be re-read on every call. Falls back to the legacy static
+            // API key (env var) for local development and during the migration window.
+            val tokenPath = System.getenv("NAIS_SERVICE_ACCOUNT_TOKEN_PATH")?.trim()?.takeIf { it.isNotBlank() }
             val keyFromPrimary = System.getenv("NAIS_API_KEY")?.trim()?.takeIf { it.isNotBlank() }
             val keyFromFallback = System.getenv("TEAMS_TOKEN")?.trim()?.takeIf { it.isNotBlank() }
-            val key = keyFromPrimary ?: keyFromFallback
+            val staticKey = keyFromPrimary ?: keyFromFallback
 
-            if (url == null && key == null) {
+            val tokenProvider = resolveTokenProvider(tokenPath, staticKey)
+
+            if (url == null && tokenProvider == null) {
                 log.debug(
-                    "NAIS API integration not configured (NAIS_API_GRAPHQL_URL/NAIS_API_ENDPOINT and NAIS_API_KEY/TEAMS_TOKEN not set)"
+                    "NAIS API integration not configured (no NAIS_API_GRAPHQL_URL/NAIS_API_ENDPOINT and no NAIS_SERVICE_ACCOUNT_TOKEN_PATH/NAIS_API_KEY/TEAMS_TOKEN)"
                 )
                 return null
             }
@@ -486,19 +494,55 @@ class NaisGraphQlClient private constructor(
             require(!url.isNullOrBlank()) {
                 "NAIS_API_GRAPHQL_URL must be set when NAIS API integration is enabled"
             }
-            require(!key.isNullOrBlank()) {
-                "NAIS_API_KEY must be set when NAIS API integration is enabled"
+            requireNotNull(tokenProvider) {
+                "NAIS auth must be configured: set NAIS_SERVICE_ACCOUNT_TOKEN_PATH (workload binding, preferred) or NAIS_API_KEY/TEAMS_TOKEN"
             }
 
             // Create cache (Valkey if configured, otherwise in-memory)
             val teamCache = ValkeyTeamCache.fromEnvOrFallback()
-            
+
             val urlSource = if (urlFromPrimary != null) "NAIS_API_GRAPHQL_URL" else "NAIS_API_ENDPOINT"
-            val keySource = if (keyFromPrimary != null) "NAIS_API_KEY" else "TEAMS_TOKEN"
+            val authSource = when {
+                tokenPath != null -> "NAIS_SERVICE_ACCOUNT_TOKEN_PATH(file)"
+                keyFromPrimary != null -> "NAIS_API_KEY"
+                else -> "TEAMS_TOKEN"
+            }
+            // Best-effort: read the token once so we can log its format. A workload-bound token
+            // file may not be present yet at startup; that's fine — the per-call provider retries.
+            val tokenInfo = try {
+                val token = tokenProvider()
+                "keyLength=${token.length}, keyFormat=${tokenFormat(token)}"
+            } catch (e: Exception) {
+                "token not readable at startup (${e.javaClass.simpleName}); will retry per call"
+            }
             log.info(
-                "NAIS API integration enabled (endpoint: ${url.take(50)}..., urlSource=$urlSource, keySource=$keySource, keyLength=${key.length}, keyFormat=${tokenFormat(key)}, cache=${teamCache::class.simpleName})"
+                "NAIS API integration enabled (endpoint: ${url.take(50)}..., urlSource=$urlSource, authSource=$authSource, $tokenInfo, cache=${teamCache::class.simpleName})"
             )
-            return NaisGraphQlClient(graphqlUrl = url, apiKey = key, teamCache = teamCache)
+            return NaisGraphQlClient(graphqlUrl = url, tokenProvider = tokenProvider, teamCache = teamCache)
+        }
+
+        /**
+         * Resolve the bearer-token source.
+         *
+         * Prefers a workload-identity token file (path from NAIS_SERVICE_ACCOUNT_TOKEN_PATH),
+         * which NAIS rotates in-place — so the returned provider re-reads the file on every
+         * invocation. Falls back to a static key (legacy API key / TEAMS_TOKEN). Returns null
+         * when neither is configured. `readFile` is injectable for testing.
+         */
+        internal fun resolveTokenProvider(
+            tokenPath: String?,
+            staticKey: String?,
+            readFile: (String) -> String = { path -> Files.readString(Path.of(path)).trim() }
+        ): (() -> String)? {
+            val path = tokenPath?.trim()?.takeIf { it.isNotBlank() }
+            if (path != null) {
+                return { readFile(path) }
+            }
+            val key = staticKey?.trim()?.takeIf { it.isNotBlank() }
+            if (key != null) {
+                return { key }
+            }
+            return null
         }
         
         /**
@@ -510,10 +554,24 @@ class NaisGraphQlClient private constructor(
             teamCache: TeamCache,
             clock: Clock = Clock.systemUTC(),
             client: HttpClient = defaultHttpClient()
+        ): NaisGraphQlClient = forTesting(
+            graphqlUrl = graphqlUrl,
+            tokenProvider = { apiKey },
+            teamCache = teamCache,
+            clock = clock,
+            client = client
+        )
+
+        fun forTesting(
+            graphqlUrl: String,
+            tokenProvider: () -> String,
+            teamCache: TeamCache,
+            clock: Clock = Clock.systemUTC(),
+            client: HttpClient = defaultHttpClient()
         ): NaisGraphQlClient {
             return NaisGraphQlClient(
                 graphqlUrl = graphqlUrl,
-                apiKey = apiKey,
+                tokenProvider = tokenProvider,
                 teamCache = teamCache,
                 clock = clock,
                 client = client

--- a/apps/lumi-api/src/main/kotlin/no/nav/lumi/integrations/nais/NaisGraphQlClient.kt
+++ b/apps/lumi-api/src/main/kotlin/no/nav/lumi/integrations/nais/NaisGraphQlClient.kt
@@ -325,7 +325,7 @@ class NaisGraphQlClient private constructor(
             viewerUserTypeCounter.increment()
             if (hasLoggedViewerUserType.compareAndSet(false, true)) {
                 log.warn(
-                    "NAIS viewer query resolved as User. Verify NAIS_API_KEY/TEAMS_TOKEN is a service account token in NAIS."
+                    "NAIS viewer query resolved as User. Verify the configured token is a service account token in NAIS."
                 )
             }
             me.teams?.nodes
@@ -461,7 +461,9 @@ class NaisGraphQlClient private constructor(
          * 
          * Required env vars:
          * - NAIS_API_GRAPHQL_URL: The GraphQL endpoint (e.g., https://console.nav.cloud.nais.io/graphql)
-         * - NAIS_API_KEY: API key for authentication
+         * - Auth, in order of preference:
+         *   - NAIS_SERVICE_ACCOUNT_TOKEN_PATH: file with a workload-bound, auto-rotated token (prod/dev)
+         *   - NAIS_API_KEY: static key for local development (e.g. via `nais api proxy`)
          * 
          * Optional env vars (for Valkey cache):
          * - VALKEY_URI_LUMI_CACHE: Valkey connection URI
@@ -475,18 +477,17 @@ class NaisGraphQlClient private constructor(
             val url = urlFromPrimary ?: urlFromFallback
 
             // Preferred: a workload-bound service account token, mounted as a file that NAIS
-            // rotates in-place. It must be re-read on every call. Falls back to the legacy static
-            // API key (env var) for local development and during the migration window.
+            // rotates in-place. It must be re-read on every call. Falls back to a static API key
+            // (NAIS_API_KEY) for local development, where there is no workload binding
+            // (e.g. via `nais api proxy`).
             val tokenPath = System.getenv("NAIS_SERVICE_ACCOUNT_TOKEN_PATH")?.trim()?.takeIf { it.isNotBlank() }
-            val keyFromPrimary = System.getenv("NAIS_API_KEY")?.trim()?.takeIf { it.isNotBlank() }
-            val keyFromFallback = System.getenv("TEAMS_TOKEN")?.trim()?.takeIf { it.isNotBlank() }
-            val staticKey = keyFromPrimary ?: keyFromFallback
+            val staticKey = System.getenv("NAIS_API_KEY")?.trim()?.takeIf { it.isNotBlank() }
 
             val tokenProvider = resolveTokenProvider(tokenPath, staticKey)
 
             if (url == null && tokenProvider == null) {
                 log.debug(
-                    "NAIS API integration not configured (no NAIS_API_GRAPHQL_URL/NAIS_API_ENDPOINT and no NAIS_SERVICE_ACCOUNT_TOKEN_PATH/NAIS_API_KEY/TEAMS_TOKEN)"
+                    "NAIS API integration not configured (no NAIS_API_GRAPHQL_URL/NAIS_API_ENDPOINT and no NAIS_SERVICE_ACCOUNT_TOKEN_PATH/NAIS_API_KEY)"
                 )
                 return null
             }
@@ -495,18 +496,14 @@ class NaisGraphQlClient private constructor(
                 "NAIS_API_GRAPHQL_URL must be set when NAIS API integration is enabled"
             }
             requireNotNull(tokenProvider) {
-                "NAIS auth must be configured: set NAIS_SERVICE_ACCOUNT_TOKEN_PATH (workload binding, preferred) or NAIS_API_KEY/TEAMS_TOKEN"
+                "NAIS auth must be configured: set NAIS_SERVICE_ACCOUNT_TOKEN_PATH (workload binding, preferred) or NAIS_API_KEY (local dev)"
             }
 
             // Create cache (Valkey if configured, otherwise in-memory)
             val teamCache = ValkeyTeamCache.fromEnvOrFallback()
 
             val urlSource = if (urlFromPrimary != null) "NAIS_API_GRAPHQL_URL" else "NAIS_API_ENDPOINT"
-            val authSource = when {
-                tokenPath != null -> "NAIS_SERVICE_ACCOUNT_TOKEN_PATH(file)"
-                keyFromPrimary != null -> "NAIS_API_KEY"
-                else -> "TEAMS_TOKEN"
-            }
+            val authSource = if (tokenPath != null) "NAIS_SERVICE_ACCOUNT_TOKEN_PATH(file)" else "NAIS_API_KEY"
             // Best-effort: read the token once so we can log its format. A workload-bound token
             // file may not be present yet at startup; that's fine — the per-call provider retries.
             val tokenInfo = try {
@@ -526,7 +523,7 @@ class NaisGraphQlClient private constructor(
          *
          * Prefers a workload-identity token file (path from NAIS_SERVICE_ACCOUNT_TOKEN_PATH),
          * which NAIS rotates in-place — so the returned provider re-reads the file on every
-         * invocation. Falls back to a static key (legacy API key / TEAMS_TOKEN). Returns null
+         * invocation. Falls back to a static key (NAIS_API_KEY, for local dev). Returns null
          * when neither is configured. `readFile` is injectable for testing.
          */
         internal fun resolveTokenProvider(

--- a/apps/lumi-api/src/test/kotlin/no/nav/lumi/integrations/nais/NaisGraphQlClientTest.kt
+++ b/apps/lumi-api/src/test/kotlin/no/nav/lumi/integrations/nais/NaisGraphQlClientTest.kt
@@ -561,10 +561,90 @@ class NaisGraphQlClientTest {
         // First call - caches with long TTL (because user HAS teams)
         client.getTeamSlugsForUser("test@nav.no")
         assertEquals(1, callCount)
-        
+
         // Even after 30 minutes, cache should still be valid
         // (In real usage, TTL is enforced by Valkey, but InMemoryTeamCache respects the TTL)
         client.getTeamSlugsForUser("test@nav.no")
         assertEquals(1, callCount)
+    }
+
+    @Test
+    fun `resolveTokenProvider reads the token file fresh on each call (rotation)`() {
+        val rotated = ArrayDeque(listOf("token-1", "token-2", "token-3"))
+        val readPaths = mutableListOf<String>()
+        val provider = NaisGraphQlClient.resolveTokenProvider(
+            tokenPath = "/var/run/secrets/nais.io/serviceaccount/token",
+            staticKey = null,
+            readFile = { path -> readPaths.add(path); rotated.removeFirst() }
+        )
+
+        assertNotNull(provider)
+        assertEquals("token-1", provider!!())
+        assertEquals("token-2", provider())
+        assertEquals("token-3", provider())
+        assertEquals(3, readPaths.size, "file must be re-read on every call to pick up rotation")
+        assertTrue(readPaths.all { it == "/var/run/secrets/nais.io/serviceaccount/token" })
+    }
+
+    @Test
+    fun `resolveTokenProvider prefers the token file over the static key`() {
+        val provider = NaisGraphQlClient.resolveTokenProvider(
+            tokenPath = "/path/token",
+            staticKey = "static-key",
+            readFile = { "file-token" }
+        )
+
+        assertEquals("file-token", provider!!())
+    }
+
+    @Test
+    fun `resolveTokenProvider falls back to the static key when no token path`() {
+        val provider = NaisGraphQlClient.resolveTokenProvider(tokenPath = null, staticKey = "static-key")
+
+        assertEquals("static-key", provider!!())
+    }
+
+    @Test
+    fun `resolveTokenProvider ignores a blank token path and falls back to the static key`() {
+        val provider = NaisGraphQlClient.resolveTokenProvider(tokenPath = "   ", staticKey = "static-key")
+
+        assertEquals("static-key", provider!!())
+    }
+
+    @Test
+    fun `resolveTokenProvider returns null when neither token path nor static key is set`() {
+        assertNull(NaisGraphQlClient.resolveTokenProvider(tokenPath = null, staticKey = null))
+    }
+
+    @Test
+    fun `client sends a freshly read token on each request`() = runBlocking {
+        val rotated = ArrayDeque(listOf("rotated-1", "rotated-2"))
+        val observedAuth = mutableListOf<String?>()
+        val mockEngine = MockEngine { request ->
+            observedAuth.add(request.headers[HttpHeaders.Authorization])
+            respond(
+                content = """{"data":{"user":{"teams":{"nodes":[]}}}}""",
+                status = HttpStatusCode.OK,
+                headers = headersOf(HttpHeaders.ContentType, "application/json")
+            )
+        }
+        val mockClient = HttpClient(mockEngine) {
+            install(ContentNegotiation) {
+                json(Json { ignoreUnknownKeys = true; isLenient = true })
+            }
+        }
+
+        val client = NaisGraphQlClient.forTesting(
+            graphqlUrl = testUrl,
+            tokenProvider = { rotated.removeFirst() },
+            teamCache = teamCache,
+            clock = fixedClock,
+            client = mockClient
+        )
+
+        client.getTeamSlugsForUser("a@nav.no")
+        client.getTeamSlugsForUser("b@nav.no") // different email avoids the cache
+
+        assertEquals(listOf("Bearer rotated-1", "Bearer rotated-2"), observedAuth)
     }
 }


### PR DESCRIPTION
## Hvorfor

Plattform-teamet ba oss slutte å bruke den statiske Nais Console-API-nøkkelen (`nais-esyfo-flexjar-api`) og gå over til en self-service team-service-account. `lumi-api` er den eneste workloaden som kaller Nais Console GraphQL-API-et (for team-autorisasjon i dashboardet), så vi binder en self-service service account (`lumi-api-console`) til den og bruker workload-identity-tokenet i stedet.

Vi verifiserte empirisk at **default**-rollen på service-accounten klarer å slå opp vilkårlige brukeres team-medlemskap på tvers av tenanten (`user(email:){ teams }`), så ingen forhøyet rolle trengs — dette er et rent bytte av credential.

## Hva er endret

- **`NaisGraphQlClient`** — erstatt `apiKey`-feltet (lest én gang ved oppstart) med en `tokenProvider` som leser `NAIS_SERVICE_ACCOUNT_TOKEN_PATH` **for hvert kall**, slik at NAIS sin in-place token-rotasjon fanges opp. Oppstartsloggen rapporterer nå `authSource` og token-format.
- **Manifester** — fjernet `envFrom: - secret: nais-api-key` fra **dev + prod**. In-cluster autentiserer lumi-api nå utelukkende med det workload-bundne SA-tokenet.
- **Fjernet `TEAMS_TOKEN`-aliaset** (dødt, aldri satt i lumi). `NAIS_API_KEY` beholdes **kun for lokal utvikling** (f.eks. via `nais api proxy`), der det ikke finnes workload-binding.
- **`TeamAuthorizationPlugin`** — diagnostikk-logglinje oppdatert.
- **Tester** — 6 nye: fil leses per kall (rotasjon), fil foran env (presedens), env-fallback, blank sti, ukonfigurert → null, og end-to-end at hvert request sender et ferskt lest bearer-token.

## Test-infra-fiks (merk)

`NaisGraphQlClientTest` **hadde aldri kjørt**. Repoet bruker Kotest, og JUnit Jupiter-*engine* manglet på test-runtime — så de tre `@Test`-baserte klassene (`NaisGraphQlClientTest`, `TeamAuthorizationPluginTest`, `StatsServiceTest`) kompilerte, men ble stille hoppet over. Å legge til `junit-jupiter-engine` gjenoppliver alle tre (41 tester, alle grønne). Tatt med her fordi det er en forutsetning for faktisk å teste denne endringen; kan splittes ut hvis ønskelig.

## Verifisering

Hele modul-suiten: **613 tester, 0 failures** (1 forhåndseksisterende skip).

## Utrulling

SA-en er allerede bundet til `lumi-api` i **dev og prod**. Siden secret-mounten også fjernes her, har dev/prod **ingen fallback** — fil-tokenet er eneste vei (fail-closed). Derfor:

1. **Test branchen i dev først** via `workflow_dispatch` (kun dev — ikke merge, siden push til `main` deployer dev **og** prod):
   ```
   gh workflow run deploy-api.yaml --ref chore/nais-api-workload-token -f target=dev
   ```
   Verifiser oppstartslogg: `authSource=NAIS_SERVICE_ACCOUNT_TOKEN_PATH(file)`, `keyFormat=jwt`, `nais_api_*`-metrics friske, et ekte team-oppslag funker.
2. Ser dev bra ut → **merge** → dev + prod får ren tilstand.
3. Verifiser **prod**.
4. Opprydding: slett k8s-secreten `nais-api-key` i team-esyfo, og gi plattform-teamet klarsignal til å slette `nais-esyfo-flexjar-api`.