### PR TITLE
fix(api): krev workload-token i NAIS, avvis statisk NAIS_API_KEY-fallback

### DIFF
--- a/apps/lumi-api/src/main/kotlin/no/nav/lumi/integrations/nais/NaisGraphQlClient.kt
+++ b/apps/lumi-api/src/main/kotlin/no/nav/lumi/integrations/nais/NaisGraphQlClient.kt
@@ -463,7 +463,7 @@ class NaisGraphQlClient private constructor(
          * - NAIS_API_GRAPHQL_URL: The GraphQL endpoint (e.g., https://console.nav.cloud.nais.io/graphql)
          * - Auth, in order of preference:
          *   - NAIS_SERVICE_ACCOUNT_TOKEN_PATH: file with a workload-bound, auto-rotated token (prod/dev)
-         *   - NAIS_API_KEY: static key for local development (e.g. via `nais api proxy`)
+         *   - NAIS_API_KEY: static key for local development outside NAIS (e.g. via `nais api proxy`)
          * 
          * Optional env vars (for Valkey cache):
          * - VALKEY_URI_LUMI_CACHE: Valkey connection URI
@@ -475,15 +475,28 @@ class NaisGraphQlClient private constructor(
             val urlFromPrimary = System.getenv("NAIS_API_GRAPHQL_URL")?.trim()?.takeIf { it.isNotBlank() }
             val urlFromFallback = System.getenv("NAIS_API_ENDPOINT")?.trim()?.takeIf { it.isNotBlank() }
             val url = urlFromPrimary ?: urlFromFallback
+            val isNaisEnvironment = isNaisEnvironment(
+                System.getenv("NAIS_CLUSTER_NAME")?.trim()?.takeIf { it.isNotBlank() }
+            )
 
             // Preferred: a workload-bound service account token, mounted as a file that NAIS
             // rotates in-place. It must be re-read on every call. Falls back to a static API key
-            // (NAIS_API_KEY) for local development, where there is no workload binding
-            // (e.g. via `nais api proxy`).
+            // (NAIS_API_KEY) only outside NAIS for local development, where there is no workload
+            // binding (e.g. via `nais api proxy`).
             val tokenPath = System.getenv("NAIS_SERVICE_ACCOUNT_TOKEN_PATH")?.trim()?.takeIf { it.isNotBlank() }
             val staticKey = System.getenv("NAIS_API_KEY")?.trim()?.takeIf { it.isNotBlank() }
 
-            val tokenProvider = resolveTokenProvider(tokenPath, staticKey)
+            requireSupportedAuthConfiguration(
+                url = url,
+                tokenPath = tokenPath,
+                isNaisEnvironment = isNaisEnvironment
+            )
+
+            val tokenProvider = resolveTokenProvider(
+                tokenPath = tokenPath,
+                staticKey = staticKey,
+                allowStaticKeyFallback = !isNaisEnvironment
+            )
 
             if (url == null && tokenProvider == null) {
                 log.debug(
@@ -496,7 +509,13 @@ class NaisGraphQlClient private constructor(
                 "NAIS_API_GRAPHQL_URL must be set when NAIS API integration is enabled"
             }
             requireNotNull(tokenProvider) {
-                "NAIS auth must be configured: set NAIS_SERVICE_ACCOUNT_TOKEN_PATH (workload binding, preferred) or NAIS_API_KEY (local dev)"
+                if (isNaisEnvironment) {
+                    "NAIS auth must be configured: set NAIS_SERVICE_ACCOUNT_TOKEN_PATH " +
+                        "(workload binding is required in NAIS when the integration is enabled)"
+                } else {
+                    "NAIS auth must be configured: set NAIS_SERVICE_ACCOUNT_TOKEN_PATH " +
+                        "(workload binding, preferred) or NAIS_API_KEY (local dev)"
+                }
             }
 
             // Create cache (Valkey if configured, otherwise in-memory)
@@ -518,17 +537,36 @@ class NaisGraphQlClient private constructor(
             return NaisGraphQlClient(graphqlUrl = url, tokenProvider = tokenProvider, teamCache = teamCache)
         }
 
+        private fun isNaisEnvironment(clusterName: String?): Boolean = !clusterName.isNullOrBlank()
+
+        internal fun requireSupportedAuthConfiguration(
+            url: String?,
+            tokenPath: String?,
+            isNaisEnvironment: Boolean
+        ) {
+            if (isNaisEnvironment && !url.isNullOrBlank() && tokenPath.isNullOrBlank()) {
+                throw IllegalStateException(
+                    "NAIS API integration is enabled in NAIS, but NAIS_SERVICE_ACCOUNT_TOKEN_PATH " +
+                        "is missing. When NAIS_API_GRAPHQL_URL/NAIS_API_ENDPOINT is set in NAIS, " +
+                        "workload binding is required and NAIS_API_KEY is only supported outside " +
+                        "NAIS for local development."
+                )
+            }
+        }
+
         /**
          * Resolve the bearer-token source.
          *
          * Prefers a workload-identity token file (path from NAIS_SERVICE_ACCOUNT_TOKEN_PATH),
          * which NAIS rotates in-place — so the returned provider re-reads the file on every
-         * invocation. Falls back to a static key (NAIS_API_KEY, for local dev). Returns null
-         * when neither is configured. `readFile` is injectable for testing.
+         * invocation. Falls back to a static key (NAIS_API_KEY, for local dev) only when
+         * [allowStaticKeyFallback] is true. Returns null when no supported auth source is
+         * configured. `readFile` is injectable for testing.
          */
         internal fun resolveTokenProvider(
             tokenPath: String?,
             staticKey: String?,
+            allowStaticKeyFallback: Boolean = true,
             readFile: (String) -> String = { path -> Files.readString(Path.of(path)).trim() }
         ): (() -> String)? {
             val path = tokenPath?.trim()?.takeIf { it.isNotBlank() }
@@ -536,7 +574,7 @@ class NaisGraphQlClient private constructor(
                 return { readFile(path) }
             }
             val key = staticKey?.trim()?.takeIf { it.isNotBlank() }
-            if (key != null) {
+            if (key != null && allowStaticKeyFallback) {
                 return { key }
             }
             return null

--- a/apps/lumi-api/src/test/kotlin/no/nav/lumi/integrations/nais/NaisGraphQlClientTest.kt
+++ b/apps/lumi-api/src/test/kotlin/no/nav/lumi/integrations/nais/NaisGraphQlClientTest.kt
@@ -598,8 +598,12 @@ class NaisGraphQlClientTest {
     }
 
     @Test
-    fun `resolveTokenProvider falls back to the static key when no token path`() {
-        val provider = NaisGraphQlClient.resolveTokenProvider(tokenPath = null, staticKey = "static-key")
+    fun `resolveTokenProvider falls back to the static key outside NAIS when no token path`() {
+        val provider = NaisGraphQlClient.resolveTokenProvider(
+            tokenPath = null,
+            staticKey = "static-key",
+            allowStaticKeyFallback = true
+        )
 
         assertEquals("static-key", provider!!())
     }
@@ -609,6 +613,42 @@ class NaisGraphQlClientTest {
         val provider = NaisGraphQlClient.resolveTokenProvider(tokenPath = "   ", staticKey = "static-key")
 
         assertEquals("static-key", provider!!())
+    }
+
+    @Test
+    fun `resolveTokenProvider does not fall back to the static key in NAIS`() {
+        val provider = NaisGraphQlClient.resolveTokenProvider(
+            tokenPath = null,
+            staticKey = "static-key",
+            allowStaticKeyFallback = false
+        )
+
+        assertNull(provider)
+    }
+
+    @Test
+    fun `requireSupportedAuthConfiguration fails in NAIS when url is set without token path`() {
+        val exception = assertThrows(IllegalStateException::class.java) {
+            NaisGraphQlClient.requireSupportedAuthConfiguration(
+                url = testUrl,
+                tokenPath = null,
+                isNaisEnvironment = true
+            )
+        }
+
+        assertTrue(exception.message!!.contains("NAIS_SERVICE_ACCOUNT_TOKEN_PATH"))
+        assertTrue(exception.message!!.contains("NAIS_API_KEY is only supported outside NAIS"))
+    }
+
+    @Test
+    fun `requireSupportedAuthConfiguration allows local static key fallback outside NAIS`() {
+        assertDoesNotThrow {
+            NaisGraphQlClient.requireSupportedAuthConfiguration(
+                url = testUrl,
+                tokenPath = null,
+                isNaisEnvironment = false
+            )
+        }
     }
 
     @Test


### PR DESCRIPTION
## Hva

Fail-closed-herding av `NaisGraphQlClient`: i en NAIS-cluster skal klienten **kun** bruke det workload-bundne tokenet (`NAIS_SERVICE_ACCOUNT_TOKEN_PATH`) og **aldri** falle tilbake til en statisk `NAIS_API_KEY`.

Denne endringen skulle egentlig vært med i #344, men ble glemt å pushe — derfor en liten frittstående PR.

## Hvorfor

Etter #344 mountes ikke `nais-api-key`-secreten lenger in-cluster, så fallbacken er allerede borte *ved fravær*. Denne PR-en gjør det fail-closed *ved policy*: selv om `NAIS_API_KEY` skulle dukke opp i et NAIS-miljø (feilkonfig, arv, copy-paste), nektes den. Den statiske nøkkelen er kun ment for lokal utvikling utenfor NAIS (f.eks. `nais api proxy`).

## Endringer

- `requireSupportedAuthConfiguration(...)`: feiler raskt ved oppstart hvis integrasjonen er aktivert i NAIS (`NAIS_API_GRAPHQL_URL` satt) uten `NAIS_SERVICE_ACCOUNT_TOKEN_PATH`, med tydelig feilmelding.
- `resolveTokenProvider(...)` får `allowStaticKeyFallback` (false i NAIS) — statisk nøkkel gir `null` i stedet for å bli brukt in-cluster.
- `NAIS_API_KEY` støttes fortsatt utenfor NAIS for lokal utvikling.

## Test

- 3 nye tester: nekter statisk nøkkel i NAIS, `requireSupportedAuthConfiguration` kaster i NAIS uten token-path, og tillater lokal fallback utenfor NAIS.
- `./gradlew test --tests "*NaisGraphQlClientTest"` grønn.

Oppfølging av #344.
