### PR TITLE
refactor(api): injiser NAIS-API-config via ServerEnv i stedet for System.getenv

### DIFF
--- a/apps/lumi-api/src/main/kotlin/no/nav/lumi/config/ServerEnv.kt
+++ b/apps/lumi-api/src/main/kotlin/no/nav/lumi/config/ServerEnv.kt
@@ -14,7 +14,8 @@ data class ServerEnv(
     val database: DatabaseEnv,
     val nais: NaisEnv,
     val auth: AuthEnv,
-    val valkey: ValkeyEnv
+    val valkey: ValkeyEnv,
+    val naisApi: NaisApiEnv
 ) {
     /**
      * Database connection configuration.
@@ -129,7 +130,42 @@ data class ServerEnv(
             )
         }
     }
-    
+
+    /**
+     * NAIS Console API integration (team-authorization lookups).
+     *
+     * Env reading lives here so [no.nav.lumi.integrations.nais.NaisGraphQlClient] receives its
+     * configuration injected instead of calling `System.getenv` itself. Note: the workload-bound
+     * token is referenced by *path* (re-read on every call by the client to honor NAIS's in-place
+     * rotation), never as the resolved token string — reading it once here would break rotation.
+     */
+    data class NaisApiEnv(
+        /** GraphQL endpoint, e.g. https://console.nav.cloud.nais.io/graphql */
+        val graphqlUrl: String?,
+        /** Path to the workload-bound, auto-rotated token file (NAIS, preferred). */
+        val tokenPath: String?,
+        /** Static API key — only honored outside NAIS for local development (e.g. `nais api proxy`). */
+        val staticKey: String?,
+    ) {
+        companion object {
+            fun fromEnvironment() = NaisApiEnv(
+                // Support both our naming and the convention used by e.g. appsec-notifiers.
+                graphqlUrl = envOrNull("NAIS_API_GRAPHQL_URL") ?: envOrNull("NAIS_API_ENDPOINT"),
+                tokenPath = envOrNull("NAIS_SERVICE_ACCOUNT_TOKEN_PATH"),
+                staticKey = envOrNull("NAIS_API_KEY"),
+            )
+
+            /**
+             * Local development reads the same env vars (e.g. `nais api proxy` sets NAIS_API_KEY);
+             * there is no localhost default for the Console API.
+             */
+            fun forLocal() = fromEnvironment()
+
+            private fun envOrNull(name: String): String? =
+                System.getenv(name)?.trim()?.takeIf { it.isNotBlank() }
+        }
+    }
+
     companion object {
         private val log = LoggerFactory.getLogger("ServerEnv")
 
@@ -182,7 +218,8 @@ data class ServerEnv(
                 database = DatabaseEnv.fromNais(),
                 nais = nais,
                 auth = AuthEnv.fromEnvironment(nais.clusterName),
-                valkey = ValkeyEnv.fromEnvironment()
+                valkey = ValkeyEnv.fromEnvironment(),
+                naisApi = NaisApiEnv.fromEnvironment()
             )
         }
         
@@ -196,7 +233,8 @@ data class ServerEnv(
                 database = DatabaseEnv.forLocal(),
                 nais = NaisEnv.forLocal(),
                 auth = AuthEnv.forLocal(),
-                valkey = ValkeyEnv.forLocal()
+                valkey = ValkeyEnv.forLocal(),
+                naisApi = NaisApiEnv.forLocal()
             )
         }
         
@@ -219,7 +257,8 @@ data class ServerEnv(
                 ),
                 nais = NaisEnv.forLocal(),
                 auth = AuthEnv.forLocal(),
-                valkey = ValkeyEnv.forLocal()
+                valkey = ValkeyEnv.forLocal(),
+                naisApi = NaisApiEnv(graphqlUrl = null, tokenPath = null, staticKey = null)
             )
         }
     }

--- a/apps/lumi-api/src/main/kotlin/no/nav/lumi/config/auth/TeamAuthorizationPlugin.kt
+++ b/apps/lumi-api/src/main/kotlin/no/nav/lumi/config/auth/TeamAuthorizationPlugin.kt
@@ -49,7 +49,13 @@ class TeamAuthorizationConfig {
      * Defaults to env-based NAIS GraphQL client when configured.
      */
     var naisTeamLookupProvider: () -> NaisTeamLookup? = {
-        NaisGraphQlClient.fromEnvOrNull()?.let { NaisGraphQlTeamLookup(it) }
+        val env = ServerEnv.current
+        NaisGraphQlClient.fromConfig(
+            graphqlUrl = env.naisApi.graphqlUrl,
+            tokenPath = env.naisApi.tokenPath,
+            staticKey = env.naisApi.staticKey,
+            isNaisEnvironment = env.nais.isNais,
+        )?.let { NaisGraphQlTeamLookup(it) }
     }
 }
 

--- a/apps/lumi-api/src/main/kotlin/no/nav/lumi/integrations/nais/NaisGraphQlClient.kt
+++ b/apps/lumi-api/src/main/kotlin/no/nav/lumi/integrations/nais/NaisGraphQlClient.kt
@@ -457,34 +457,27 @@ class NaisGraphQlClient private constructor(
         """.trimIndent()
 
         /**
-         * Create a client from environment variables, or null if not configured.
-         * 
-         * Required env vars:
-         * - NAIS_API_GRAPHQL_URL: The GraphQL endpoint (e.g., https://console.nav.cloud.nais.io/graphql)
-         * - Auth, in order of preference:
-         *   - NAIS_SERVICE_ACCOUNT_TOKEN_PATH: file with a workload-bound, auto-rotated token (prod/dev)
-         *   - NAIS_API_KEY: static key for local development outside NAIS (e.g. via `nais api proxy`)
-         * 
-         * Optional env vars (for Valkey cache):
-         * - VALKEY_URI_LUMI_CACHE: Valkey connection URI
-         * - VALKEY_USERNAME_LUMI_CACHE: Valkey username
-         * - VALKEY_PASSWORD_LUMI_CACHE: Valkey password
+         * Create a client from already-resolved configuration, or null when the integration is
+         * not configured.
+         *
+         * Env reading lives in [no.nav.lumi.config.ServerEnv.NaisApiEnv]; this factory stays free
+         * of `System.getenv` so the client can be wired and tested with injected config.
+         *
+         * @param graphqlUrl resolved endpoint (from NAIS_API_GRAPHQL_URL / NAIS_API_ENDPOINT)
+         * @param tokenPath path to the workload-bound, auto-rotated token file (re-read per call)
+         * @param staticKey static API key — only honored outside NAIS for local development
+         * @param isNaisEnvironment true in a NAIS cluster; rejects the static-key fallback there
+         * @param teamCache cache to use; defaults to Valkey-if-configured (created only when the
+         *   integration is actually enabled, never on the not-configured path)
          */
-        fun fromEnvOrNull(): NaisGraphQlClient? {
-            // Support both our naming and the convention used by e.g. appsec-notifiers.
-            val urlFromPrimary = System.getenv("NAIS_API_GRAPHQL_URL")?.trim()?.takeIf { it.isNotBlank() }
-            val urlFromFallback = System.getenv("NAIS_API_ENDPOINT")?.trim()?.takeIf { it.isNotBlank() }
-            val url = urlFromPrimary ?: urlFromFallback
-            val isNaisEnvironment = isNaisEnvironment(
-                System.getenv("NAIS_CLUSTER_NAME")?.trim()?.takeIf { it.isNotBlank() }
-            )
-
-            // Preferred: a workload-bound service account token, mounted as a file that NAIS
-            // rotates in-place. It must be re-read on every call. Falls back to a static API key
-            // (NAIS_API_KEY) only outside NAIS for local development, where there is no workload
-            // binding (e.g. via `nais api proxy`).
-            val tokenPath = System.getenv("NAIS_SERVICE_ACCOUNT_TOKEN_PATH")?.trim()?.takeIf { it.isNotBlank() }
-            val staticKey = System.getenv("NAIS_API_KEY")?.trim()?.takeIf { it.isNotBlank() }
+        fun fromConfig(
+            graphqlUrl: String?,
+            tokenPath: String?,
+            staticKey: String?,
+            isNaisEnvironment: Boolean,
+            teamCache: TeamCache? = null,
+        ): NaisGraphQlClient? {
+            val url = graphqlUrl?.trim()?.takeIf { it.isNotBlank() }
 
             requireSupportedAuthConfiguration(
                 url = url,
@@ -492,6 +485,9 @@ class NaisGraphQlClient private constructor(
                 isNaisEnvironment = isNaisEnvironment
             )
 
+            // Preferred: a workload-bound service account token, mounted as a file that NAIS
+            // rotates in-place — re-read on every call. Falls back to a static API key only
+            // outside NAIS for local development (e.g. via `nais api proxy`).
             val tokenProvider = resolveTokenProvider(
                 tokenPath = tokenPath,
                 staticKey = staticKey,
@@ -505,7 +501,7 @@ class NaisGraphQlClient private constructor(
                 return null
             }
 
-            require(!url.isNullOrBlank()) {
+            requireNotNull(url) {
                 "NAIS_API_GRAPHQL_URL must be set when NAIS API integration is enabled"
             }
             requireNotNull(tokenProvider) {
@@ -518,10 +514,10 @@ class NaisGraphQlClient private constructor(
                 }
             }
 
-            // Create cache (Valkey if configured, otherwise in-memory)
-            val teamCache = ValkeyTeamCache.fromEnvOrFallback()
+            // Create cache only now that we know the integration is enabled (Valkey if configured,
+            // otherwise in-memory).
+            val cache = teamCache ?: ValkeyTeamCache.fromEnvOrFallback()
 
-            val urlSource = if (urlFromPrimary != null) "NAIS_API_GRAPHQL_URL" else "NAIS_API_ENDPOINT"
             val authSource = if (tokenPath != null) "NAIS_SERVICE_ACCOUNT_TOKEN_PATH(file)" else "NAIS_API_KEY"
             // Best-effort: read the token once so we can log its format. A workload-bound token
             // file may not be present yet at startup; that's fine — the per-call provider retries.
@@ -532,12 +528,10 @@ class NaisGraphQlClient private constructor(
                 "token not readable at startup (${e.javaClass.simpleName}); will retry per call"
             }
             log.info(
-                "NAIS API integration enabled (endpoint: ${url.take(50)}..., urlSource=$urlSource, authSource=$authSource, $tokenInfo, cache=${teamCache::class.simpleName})"
+                "NAIS API integration enabled (endpoint: ${url.take(50)}..., authSource=$authSource, $tokenInfo, cache=${cache::class.simpleName})"
             )
-            return NaisGraphQlClient(graphqlUrl = url, tokenProvider = tokenProvider, teamCache = teamCache)
+            return NaisGraphQlClient(graphqlUrl = url, tokenProvider = tokenProvider, teamCache = cache)
         }
-
-        private fun isNaisEnvironment(clusterName: String?): Boolean = !clusterName.isNullOrBlank()
 
         internal fun requireSupportedAuthConfiguration(
             url: String?,

--- a/apps/lumi-api/src/test/kotlin/no/nav/lumi/integrations/nais/NaisGraphQlClientTest.kt
+++ b/apps/lumi-api/src/test/kotlin/no/nav/lumi/integrations/nais/NaisGraphQlClientTest.kt
@@ -687,4 +687,58 @@ class NaisGraphQlClientTest {
 
         assertEquals(listOf("Bearer rotated-1", "Bearer rotated-2"), observedAuth)
     }
+
+    @Test
+    fun `fromConfig returns null when nothing is configured`() {
+        val client = NaisGraphQlClient.fromConfig(
+            graphqlUrl = null,
+            tokenPath = null,
+            staticKey = null,
+            isNaisEnvironment = false,
+            teamCache = teamCache
+        )
+
+        assertNull(client)
+    }
+
+    @Test
+    fun `fromConfig builds a client from an injected token path`() {
+        val client = NaisGraphQlClient.fromConfig(
+            graphqlUrl = testUrl,
+            tokenPath = "/var/run/secrets/nais.io/console/token",
+            staticKey = null,
+            isNaisEnvironment = true,
+            teamCache = teamCache
+        )
+
+        assertNotNull(client)
+    }
+
+    @Test
+    fun `fromConfig rejects the static key fallback in NAIS`() {
+        val exception = assertThrows(IllegalStateException::class.java) {
+            NaisGraphQlClient.fromConfig(
+                graphqlUrl = testUrl,
+                tokenPath = null,
+                staticKey = "static-key",
+                isNaisEnvironment = true,
+                teamCache = teamCache
+            )
+        }
+
+        assertTrue(exception.message!!.contains("NAIS_SERVICE_ACCOUNT_TOKEN_PATH"))
+    }
+
+    @Test
+    fun `fromConfig allows the static key outside NAIS`() {
+        val client = NaisGraphQlClient.fromConfig(
+            graphqlUrl = testUrl,
+            tokenPath = null,
+            staticKey = "static-key",
+            isNaisEnvironment = false,
+            teamCache = teamCache
+        )
+
+        assertNotNull(client)
+    }
 }


### PR DESCRIPTION
Lukker #345.

## Hva

Flytter env-lesingen for Nais Console API inn i en typet `ServerEnv.NaisApiEnv` (graphqlUrl, tokenPath, staticKey), slik at `NaisGraphQlClient` ikke lenger kaller `System.getenv` selv. Klienten eksponerer nå `fromConfig(...)` som tar ferdig resolved config, og `TeamAuthorizationPlugin` wirer den fra `ServerEnv.current`.

Adresserer review-tilbakemeldingen fra @bjorn-faaberg på #344 om å lese env tidlig og injecte den.

## Hvorfor

`ServerEnv` har allerede dette mønsteret (typet, nested config lest én gang); `NaisGraphQlClient.fromEnvOrNull()` var det eneste stedet som brøt det. Samme sentrale `Environment` + injection-mønster brukes ellers i NAV (f.eks. `esyfo-narmesteleder`, `syfo-dokumentporten`).

## ⚠️ Rotasjon bevart

Workload-tokenet refereres fortsatt via **sti** og leses på **hvert kall** — kun stien/configen leses én gang ved oppstart, aldri selve token-strengen. Å lese tokenet én gang ville knekt rotasjonen. Testen `client sends a freshly read token on each request` dekker dette.

## Endringer

- `ServerEnv.NaisApiEnv` (`fromEnvironment()` / `forLocal()`) — én lese-plass for `NAIS_API_GRAPHQL_URL`/`NAIS_API_ENDPOINT`, `NAIS_SERVICE_ACCOUNT_TOKEN_PATH`, `NAIS_API_KEY`.
- `NaisGraphQlClient.fromConfig(graphqlUrl, tokenPath, staticKey, isNaisEnvironment, teamCache?)` erstatter `fromEnvOrNull()`; ingen `System.getenv` igjen i klienten. Fail-closed-logikken (`requireSupportedAuthConfiguration`, `allowStaticKeyFallback`) fra #346 består.
- `TeamAuthorizationPlugin` bygger klienten fra `ServerEnv.current.naisApi` + `ServerEnv.current.nais.isNais`.
- 4 nye tester for `fromConfig`.

## Test

- `NaisGraphQlClientTest`, `*TeamAuthorization*`, `*ServerEnv*` grønne lokalt.
- DB-baserte specs krever Docker (kjøres i CI).

## Merk

Bygget oppå #346 (fail-closed-hardeningen) siden begge rører samme kode. Basen retargetes til `main` automatisk når #346 merges; jeg rebaser da så diffen er ren.

HOCON-diskusjonen (den andre review-kommentaren) er bevisst utenfor scope — egen prat med Gregersen.
