### PR TITLE
fix(survey): evaluate logic conditions against the referenced question (#332)

### DIFF
--- a/packages/lumi-survey/CHANGELOG.md
+++ b/packages/lumi-survey/CHANGELOG.md
@@ -6,6 +6,10 @@ This project follows SemVer.
 
 ## [Unreleased]
 
+### Fixed
+
+- `logic` conditions that reference another question via `condition.questionId` are now evaluated against that question's answer instead of the current question's. Cross-question branching (e.g. routing on an earlier answer) now works the same way `visibleIf` already did. (#332)
+
 ## [1.0.0] - 2026-06-24
 
 This release switches the widget to the **v2 submission schema**. The widget now always emits `schemaVersion: 2`; the v1 wire format is no longer sent. Requires a backend that accepts schema v2 (`@navikt/lumi-api` with schema v2 support, shipped in #297).

--- a/packages/lumi-survey/src/components/LumiSurveyDock/hooks/__tests__/useStepNavigation.test.ts
+++ b/packages/lumi-survey/src/components/LumiSurveyDock/hooks/__tests__/useStepNavigation.test.ts
@@ -104,6 +104,67 @@ const BRANCHING_QUESTIONS: LumiSurveyQuestion[] = [
   },
 ];
 
+// Repro of #332: logic on the 2nd question references the 1st question's
+// answer via condition.questionId ("show innspill if EITHER question is nei").
+const CROSS_QUESTION_BRANCHING_QUESTIONS: LumiSurveyQuestion[] = [
+  {
+    id: "identifisering",
+    type: "singleChoice",
+    prompt: "Identifisering?",
+    required: true,
+    options: [
+      { value: "ja", label: "Ja" },
+      { value: "nei", label: "Nei" },
+    ],
+  },
+  {
+    id: "prioritering",
+    type: "singleChoice",
+    prompt: "Prioritering?",
+    required: true,
+    options: [
+      { value: "ja", label: "Ja" },
+      { value: "nei", label: "Nei" },
+    ],
+    logic: [
+      {
+        condition: {
+          field: "ANSWER",
+          questionId: "identifisering",
+          operator: "EQ",
+          value: "nei",
+        },
+        action: { type: "JUMP_TO", targetId: "innspill" },
+      },
+      {
+        condition: {
+          field: "ANSWER",
+          questionId: "prioritering",
+          operator: "EQ",
+          value: "nei",
+        },
+        action: { type: "JUMP_TO", targetId: "innspill" },
+      },
+      {
+        condition: {
+          field: "ANSWER",
+          questionId: "identifisering",
+          operator: "EQ",
+          value: "ja",
+        },
+        action: { type: "SUBMIT" },
+      },
+    ],
+  },
+  {
+    id: "innspill",
+    type: "text",
+    prompt: "Innspill?",
+    required: false,
+    maxLength: 1000,
+  },
+];
+
 const VISIBLE_IF_QUESTIONS: LumiSurveyQuestion[] = [
   {
     id: "q1",
@@ -376,6 +437,27 @@ describe("useStepNavigation", () => {
       );
 
       expect(result.current.currentStep).toBe(0);
+      expect(result.current.isLastStep).toBe(false);
+    });
+
+    it("returns false when a cross-question rule jumps forward (#332)", () => {
+      // identifisering = "nei", prioritering = "ja". On the prioritering step,
+      // rule 1 (identifisering === "nei") must win → JUMP_TO innspill, so this
+      // is NOT the last step. Before the fix, questionId was ignored and the
+      // SUBMIT rule matched → isLastStep true → "Send" instead of "Neste".
+      const { result } = renderHook(() =>
+        useStepNavigation({
+          questions: CROSS_QUESTION_BRANCHING_QUESTIONS,
+          answers: { identifisering: "nei", prioritering: "ja" },
+        }),
+      );
+
+      // Advance from identifisering (step 0) to prioritering (step 1).
+      act(() => {
+        result.current.goToNext();
+      });
+
+      expect(result.current.currentStep).toBe(1);
       expect(result.current.isLastStep).toBe(false);
     });
   });

--- a/packages/lumi-survey/src/components/LumiSurveyDock/hooks/useStepNavigation.ts
+++ b/packages/lumi-survey/src/components/LumiSurveyDock/hooks/useStepNavigation.ts
@@ -117,6 +117,7 @@ export function useStepNavigation(
       metadata,
       questions,
       currentStep,
+      answers,
     );
   }, [
     currentQuestion,
@@ -125,6 +126,7 @@ export function useStepNavigation(
     questions,
     currentStep,
     hasAnsweredCurrent,
+    answers,
   ]);
 
   // Determines whether the current step is the last one in the survey path.
@@ -231,6 +233,7 @@ export function useStepNavigation(
         metadata,
         questions,
         currentStep,
+        answers,
       );
 
     if (result.nextIndex === -1) {

--- a/packages/lumi-survey/src/core/__tests__/branchingEngine.test.ts
+++ b/packages/lumi-survey/src/core/__tests__/branchingEngine.test.ts
@@ -489,6 +489,90 @@ describe("evaluateBranching", () => {
       }
     });
   });
+
+  describe("cross-question conditions (questionId)", () => {
+    // Regression for #332: a logic rule on the current question references a
+    // DIFFERENT question's answer via condition.questionId. The engine must
+    // evaluate against that referenced answer, not the current question's.
+    const logic: LogicRule[] = [
+      {
+        condition: {
+          field: "ANSWER",
+          questionId: "identifisering",
+          operator: "EQ",
+          value: "nei",
+        },
+        action: { type: "JUMP_TO", targetId: "innspill" },
+      },
+      {
+        condition: {
+          field: "ANSWER",
+          questionId: "prioritering",
+          operator: "EQ",
+          value: "nei",
+        },
+        action: { type: "JUMP_TO", targetId: "innspill" },
+      },
+      {
+        condition: {
+          field: "ANSWER",
+          questionId: "identifisering",
+          operator: "EQ",
+          value: "ja",
+        },
+        action: { type: "SUBMIT" },
+      },
+    ];
+
+    function buildSurvey(): LumiSurveyQuestion[] {
+      return [
+        createChoiceQuestion("identifisering", ["ja", "nei"]),
+        createChoiceQuestion("prioritering", ["ja", "nei"], logic),
+        createQuestion("innspill"),
+      ];
+    }
+
+    it("matches the first rule against the referenced question's answer, not the current one", () => {
+      const questions = buildSurvey();
+      // identifisering = "nei" (first question), prioritering = "ja" (current)
+      const answers = { identifisering: "nei", prioritering: "ja" };
+
+      const result = evaluateBranching(
+        questions[1],
+        answers.prioritering,
+        undefined,
+        questions,
+        1,
+        answers,
+      );
+
+      // Rule 1 (identifisering === "nei") must win → JUMP_TO innspill (index 2).
+      // Before the fix, questionId was ignored and rule 3 (current answer "ja")
+      // matched → SUBMIT (-1), surfacing as a "Send" button instead of "Neste".
+      expect(result.nextIndex).toBe(2);
+      expect(result.matchedRule?.action).toEqual({
+        type: "JUMP_TO",
+        targetId: "innspill",
+      });
+    });
+
+    it("submits only when neither referenced question is 'nei'", () => {
+      const questions = buildSurvey();
+      const answers = { identifisering: "ja", prioritering: "ja" };
+
+      const result = evaluateBranching(
+        questions[1],
+        answers.prioritering,
+        undefined,
+        questions,
+        1,
+        answers,
+      );
+
+      // Rules 1 & 2 (nei) don't match; rule 3 (identifisering === "ja") → SUBMIT.
+      expect(result.nextIndex).toBe(-1);
+    });
+  });
 });
 
 describe("surveyHasBranchingLogic", () => {

--- a/packages/lumi-survey/src/core/__tests__/branchingEngine.test.ts
+++ b/packages/lumi-survey/src/core/__tests__/branchingEngine.test.ts
@@ -556,20 +556,103 @@ describe("evaluateBranching", () => {
       });
     });
 
-    it("submits only when neither referenced question is 'nei'", () => {
-      const questions = buildSurvey();
-      const answers = { identifisering: "ja", prioritering: "ja" };
+    it("evaluates a cross-question SUBMIT rule against the referenced answer", () => {
+      const logic: LogicRule[] = [
+        {
+          condition: {
+            field: "ANSWER",
+            questionId: "q1",
+            operator: "EQ",
+            value: "ja",
+          },
+          action: { type: "SUBMIT" },
+        },
+      ];
+      const questions = [
+        createChoiceQuestion("q1", ["ja", "nei"]),
+        createChoiceQuestion("q2", ["ja", "nei"], logic),
+        createQuestion("q3"),
+      ];
+      // q1 (referenced) = "ja" drives SUBMIT, but the CURRENT answer (q2) =
+      // "nei" differs. The pre-fix code compared the current answer, so it
+      // would NOT submit — it would fall through to the next question.
+      // nextIndex === -1 is only reachable if questionId is honoured.
+      const answers = { q1: "ja", q2: "nei" };
 
       const result = evaluateBranching(
         questions[1],
-        answers.prioritering,
+        answers.q2,
         undefined,
         questions,
         1,
         answers,
       );
 
-      // Rules 1 & 2 (nei) don't match; rule 3 (identifisering === "ja") → SUBMIT.
+      expect(result.nextIndex).toBe(-1);
+    });
+
+    it("supports cross-question NEQ with a non-adjacent JUMP_TO", () => {
+      const logic: LogicRule[] = [
+        {
+          condition: {
+            field: "ANSWER",
+            questionId: "q1",
+            operator: "NEQ",
+            value: "ja",
+          },
+          action: { type: "JUMP_TO", targetId: "q4" },
+        },
+      ];
+      const questions = [
+        createChoiceQuestion("q1", ["ja", "nei"]),
+        createChoiceQuestion("q2", ["ja", "nei"], logic),
+        createQuestion("q3"),
+        createQuestion("q4"),
+      ];
+      // q1 = "nei" → NEQ "ja" is true → JUMP to q4 (index 3). The current
+      // answer (q2) = "ja" would make the pre-fix code read NEQ "ja" as false
+      // → fall through to the adjacent next (index 2), so the target (3 vs 2)
+      // distinguishes the fix from the bug.
+      const answers = { q1: "nei", q2: "ja" };
+
+      const result = evaluateBranching(
+        questions[1],
+        answers.q2,
+        undefined,
+        questions,
+        1,
+        answers,
+      );
+
+      expect(result.nextIndex).toBe(3);
+    });
+
+    it("still evaluates METADATA conditions after the answers-map change", () => {
+      const logic: LogicRule[] = [
+        {
+          condition: {
+            field: "METADATA",
+            key: "channel",
+            operator: "EQ",
+            value: "app",
+          },
+          action: { type: "SUBMIT" },
+        },
+      ];
+      const questions = [
+        createChoiceQuestion("q1", ["ja", "nei"], logic),
+        createQuestion("q2"),
+      ];
+
+      const result = evaluateBranching(
+        questions[0],
+        "ja",
+        { channel: "app" },
+        questions,
+        0,
+        { q1: "ja" },
+      );
+
       expect(result.nextIndex).toBe(-1);
     });
   });

--- a/packages/lumi-survey/src/core/branchingEngine.ts
+++ b/packages/lumi-survey/src/core/branchingEngine.ts
@@ -25,6 +25,7 @@ function evaluateCondition(
   condition: LogicCondition,
   currentAnswer: LumiSurveyAnswerValue | undefined,
   metadata: Record<string, unknown> | undefined,
+  answers: Record<string, LumiSurveyAnswerValue> | undefined,
 ): boolean {
   // Determine the actual value to compare
   let actualValue: unknown;
@@ -32,8 +33,13 @@ function evaluateCondition(
   if (condition.field === "METADATA") {
     actualValue = metadata?.[condition.key];
   } else {
-    // Default: condition.field is "ANSWER" (or omitted)
-    actualValue = currentAnswer;
+    // Default: condition.field is "ANSWER" (or omitted). A questionId
+    // references another question's answer (cross-question); without one, the
+    // condition applies to the current question's own answer. Mirrors
+    // evaluateVisibility() so logic and visibleIf resolve answers the same way.
+    actualValue = condition.questionId
+      ? answers?.[condition.questionId]
+      : currentAnswer;
   }
 
   // Handle EXISTS operator separately
@@ -139,6 +145,8 @@ function findQuestionIndex(
  * @param metadata - Optional survey metadata for METADATA conditions
  * @param questions - All questions in the survey
  * @param currentIndex - The index of the current question
+ * @param answers - All answers so far, keyed by question id. Used to resolve
+ *   conditions that reference another question via `condition.questionId`.
  * @returns BranchingResult indicating the next question index
  */
 export function evaluateBranching(
@@ -147,6 +155,7 @@ export function evaluateBranching(
   metadata: Record<string, unknown> | undefined,
   questions: LumiSurveyQuestion[],
   currentIndex: number,
+  answers?: Record<string, LumiSurveyAnswerValue>,
 ): BranchingResult {
   const rules = currentQuestion.logic;
 
@@ -160,7 +169,12 @@ export function evaluateBranching(
 
   // Evaluate rules in order - first match wins
   for (const rule of rules) {
-    const matches = evaluateCondition(rule.condition, currentAnswer, metadata);
+    const matches = evaluateCondition(
+      rule.condition,
+      currentAnswer,
+      metadata,
+      answers,
+    );
 
     if (matches) {
       switch (rule.action.type) {

--- a/packages/lumi-survey/src/core/branchingEngine.ts
+++ b/packages/lumi-survey/src/core/branchingEngine.ts
@@ -147,6 +147,9 @@ function findQuestionIndex(
  * @param currentIndex - The index of the current question
  * @param answers - All answers so far, keyed by question id. Used to resolve
  *   conditions that reference another question via `condition.questionId`.
+ *   Optional for backward compatibility, but cross-question (`questionId`)
+ *   conditions silently fall back to the current answer when it is omitted —
+ *   callers with branching logic should always pass the full answers map.
  * @returns BranchingResult indicating the next question index
  */
 export function evaluateBranching(


### PR DESCRIPTION
Closes #332.

## Symptom

I en `questionLayout: "steps"`-survey hvor et spørsmåls `logic` refererer et **annet** spørsmåls svar (via `condition.questionId`), ble ruting avgjort feil: knappen viste **"Send"** der den skulle vist **"Neste"**. Utvikleren som meldte det observerte at «"Nei" på første spørsmålet hadde ingen innvirkning, bare det andre».

## Rotårsak

`evaluateCondition` i `branchingEngine.ts` brukte **alltid** `currentAnswer` (svaret på spørsmålet som *eier* logikken) for `ANSWER`-betingelser, og ignorerte `condition.questionId` fullstendig. Hver regel testet altså egentlig bare det gjeldende spørsmålets svar mot den litterale verdien — kryss-spørsmål-referanser var stille ødelagt.

Søsken-funksjonen `evaluateVisibility` (som `visibleIf` bruker) gjør dette riktig: den tar et `answers`-map og slår opp `answers[condition.questionId]`. Branching-motoren var bare tvillingen som aldri fikk svar-mappet.

## Fiks

Tre `answers`-mappet inn i `evaluateBranching` → `evaluateCondition`, og resolve `condition.questionId` mot det (fall tilbake til `currentAnswer` når `questionId` mangler) — speiler `evaluateVisibility` så `logic` og `visibleIf` resolver svar likt. `answers` var allerede tilgjengelig ved begge kallstedene i `useStepNavigation`.

## Tester

- **Engine** (`branchingEngine.test.ts`): kryss-spørsmål matcher mot referert svar; submitter kun når ingen referert betingelse treffer.
- **Brukervendt** (`useStepNavigation.test.ts`): `isLastStep` blir `false` (→ "Neste") for repro-caset. Verifisert at testen feiler uten motor-fiksen, så den fanger regresjonen gjennom hele wiringen.
- Full widget-suite: **273/273** grønn, typecheck + lint rent.

## Merknad (oppfølging, ikke i denne PR-en)

Denne fiksen er en **stop-gap** for et live NAV-team. Den dypere spørsmålet — om `logic` og `visibleIf` bør konvergere til én modell før Survey Builder UI (#338) og AND/OR (#333) — kommer som en egen ADR.