### PR TITLE
feat(survey): any/all condition groups in visibleIf (#333)

### DIFF
--- a/docs/adr/0001-flytmodell-visibility-vs-logic.md
+++ b/docs/adr/0001-flytmodell-visibility-vs-logic.md
@@ -51,7 +51,7 @@ Konklusjon: vi kan ikke rive ut `logic`. Men vi kan slutte å behandle den som e
 
 ## Beslutning
 
-1. **Ett betingelseslag.** `LogicCondition` (med `questionId`, og fremtidig AND/OR fra #333) er det *eneste* betingelsesspråket. Begge evaluatorene resolver svar identisk. #332-fiksen tok første steg: `evaluateBranching` tar nå `answers` og speiler `evaluateVisibility`. #333 implementeres **én gang** på denne delte typen.
+1. **Ett betingelseslag.** Leaf-betingelsen (`questionId`, operatorer, `METADATA`) er det *eneste* betingelsesspråket, og begge evaluatorene resolver leaf-svar identisk via det delte laget (`isLeafCondition` / `getLeafConditions`). #332-fiksen tok første steg: `evaluateBranching` tar nå `answers` og speiler `evaluateVisibility`. **Levert i #333:** any/all-grupper ble lagt på `visibleIf` via en egen vid type (`VisibleIfCondition`), mens `LogicCondition` forble leaf-only og `logic` avviser grupper. Full evaluator-unifisering er bevisst utsatt (se Oppfølging).
 
 2. **`visibleIf` er den kanoniske flytmodellen.** Den mentale modellen vi dokumenterer, anbefaler og bygger Survey Builder (#338) rundt er: *ordnet liste → filtrer på synlighet → gå gjennom de synlige i rekkefølge → send inn når ingen flere er synlige.* Builder-UI-en eksponerer dette som standard.
 
@@ -68,7 +68,7 @@ Konklusjon: vi kan ikke rive ut `logic`. Men vi kan slutte å behandle den som e
 
 **Positivt**
 - Én mental modell for forfattere og for builder-UI-en (#338).
-- AND/OR (#333) implementeres én gang på det delte betingelseslaget.
+- AND/OR (#333) bygger på det delte leaf-laget; gruppene ble lagt på `visibleIf` (via `VisibleIfCondition`), ikke på `logic`.
 - Ingen brudd: `logic` fortsetter å virke for eksisterende konsumenter og `createTopTasksSurvey`.
 - Divergens-bugen (#332-klassen) forhindres ved at de to evaluatorene nå deler resolusjonslogikk.
 

--- a/docs/adr/0001-flytmodell-visibility-vs-logic.md
+++ b/docs/adr/0001-flytmodell-visibility-vs-logic.md
@@ -85,7 +85,9 @@ Konklusjon: vi kan ikke rive ut `logic`. Men vi kan slutte å behandle den som e
 
 ## Oppfølging
 
-- [ ] #333: implementer AND/OR på delt `LogicCondition`.
+- [x] #333: implementer AND/OR på delt `LogicCondition` (levert: `any`/`all`-grupper i
+  `visibleIf`; `logic` snevret til leaf. Evaluator-unifisering bevisst utsatt —
+  operator-divergensen lever videre, men kun i den utfasede `logic`-mekanismen.)
 - [ ] Oppdater `docs/guider/branching.md` (avansert-posisjonering + linje 64-klargjøring).
 - [ ] #338: bygg builder rundt synlighetsmodellen; `logic` bak «avansert»-luke.
 - [ ] Etter #333: migrer `createTopTasksSurvey` `SKIP`/`SUBMIT` → `visibleIf`.

--- a/docs/adr/0001-flytmodell-visibility-vs-logic.md
+++ b/docs/adr/0001-flytmodell-visibility-vs-logic.md
@@ -85,7 +85,7 @@ Konklusjon: vi kan ikke rive ut `logic`. Men vi kan slutte å behandle den som e
 
 ## Oppfølging
 
-- [x] #333: implementer AND/OR på delt `LogicCondition` (levert: `any`/`all`-grupper i
+- [x] #333: implementer AND/OR i `visibleIf` (levert: `any`/`all`-grupper i
   `visibleIf`; `logic` snevret til leaf. Evaluator-unifisering bevisst utsatt —
   operator-divergensen lever videre, men kun i den utfasede `logic`-mekanismen.)
 - [ ] Oppdater `docs/guider/branching.md` (avansert-posisjonering + linje 64-klargjøring).

--- a/docs/guider/betinget-synlighet.md
+++ b/docs/guider/betinget-synlighet.md
@@ -125,23 +125,39 @@ ikke nestes (ett nivå), og en tom gruppe avvises ved validering.
 
 ## Condition-struktur
 
-Alle `visibleIf`-betingelser følger samme form:
+En `visibleIf` er enten **én leaf-betingelse**, eller en **`any`/`all`-gruppe** av
+leaf-betingelser (se [Flere betingelser (AND/OR)](#flere-betingelser-andor)). En
+leaf-betingelse har formen:
 
 ```ts
-interface LogicCondition {
-  /** Hva sammenlignes — "ANSWER" eller "METADATA" */
-  field?: "ANSWER" | "METADATA";
+type LogicLeafCondition =
+  | {
+      /** Sammenlign mot et svar (standard) */
+      field?: "ANSWER";
+      /** Hvilket spørsmål svaret hentes fra (kryssreferanse) */
+      questionId?: string;
+      /** Sammenligningsoperator */
+      operator: "EXISTS" | "EQ" | "NEQ" | "GT" | "LT" | "CONTAINS";
+      /** Verdi å sammenligne med (ikke nødvendig for EXISTS) */
+      value?: string | number | boolean;
+    }
+  | {
+      /** Sammenlign mot en metadata-verdi */
+      field: "METADATA";
+      /** Nøkkel i metadata (påkrevd for METADATA) */
+      key: string;
+      operator: "EXISTS" | "EQ" | "NEQ" | "GT" | "LT" | "CONTAINS";
+      value?: string | number | boolean;
+    };
 
-  /** Hvilket spørsmål svaret hentes fra (påkrevd for ANSWER med kryssreferanse) */
-  questionId?: string;
-
-  /** Sammenligningsoperator */
-  operator: "EXISTS" | "EQ" | "NEQ" | "GT" | "LT" | "CONTAINS";
-
-  /** Verdi å sammenligne med (ikke nødvendig for EXISTS) */
-  value?: string | number | boolean;
-}
+// visibleIf aksepterer en leaf ELLER en gruppe (typen heter VisibleIfCondition):
+type VisibleIfCondition =
+  | LogicLeafCondition
+  | { any: LogicLeafCondition[] } // OR
+  | { all: LogicLeafCondition[] }; // AND
 ```
+
+Grupper er **ett nivå** (kan ikke nestes), og en tom `any`/`all` avvises ved validering.
 
 ::: tip Bruk `questionId` for kryss-referanser
 `questionId` refererer til `id`-en til spørsmålet du vil sjekke svaret på. Uten `questionId` evalueres betingelsen mot det *gjeldende* spørsmålets svar.

--- a/docs/guider/betinget-synlighet.md
+++ b/docs/guider/betinget-synlighet.md
@@ -147,7 +147,8 @@ type LogicLeafCondition =
       /** Nøkkel i metadata (påkrevd for METADATA) */
       key: string;
       operator: "EXISTS" | "EQ" | "NEQ" | "GT" | "LT" | "CONTAINS";
-      value?: string | number | boolean;
+      /** Påkrevd for METADATA */
+      value: string | number | boolean;
     };
 
 // visibleIf aksepterer en leaf ELLER en gruppe (typen heter VisibleIfCondition):

--- a/docs/guider/betinget-synlighet.md
+++ b/docs/guider/betinget-synlighet.md
@@ -49,6 +49,30 @@ Her vises tekstfeltet først etter at brukeren har valgt en emoji. Ingen ekstra 
 | `LT` | Mindre enn | Vis oppfølging for rating < 3 |
 | `CONTAINS` | Inneholder verdi (for multi-choice) | Vis når «Annet» er blant valgene |
 
+## Flere betingelser (AND/OR)
+
+Du kan kombinere flere betingelser med `all` (AND — alle må være sanne) eller
+`any` (OR — minst én må være sann). Hvert element er en vanlig betingelse, og kan
+referere ulike spørsmål.
+
+```tsx
+{
+  id: "oppfolging",
+  type: "text",
+  prompt: "Hva manglet?",
+  // Vises hvis ETT av de to svarene er "nei":
+  visibleIf: {
+    any: [
+      { questionId: "spm1", operator: "EQ", value: "nei" },
+      { questionId: "spm2", operator: "EQ", value: "nei" },
+    ],
+  },
+}
+```
+
+Bytt `any` med `all` for å kreve at *begge* betingelsene er oppfylt. Grupper kan
+ikke nestes (ett nivå), og en tom gruppe avvises ved validering.
+
 ## Eksempler
 
 ### Vis kun for lav score

--- a/docs/guider/branching.md
+++ b/docs/guider/branching.md
@@ -63,6 +63,9 @@ type LogicCondition =
 
 For `logic` evalueres betingelsen vanligvis mot *det gjeldende spørsmålets* svar — `questionId` er valgfri her (i motsetning til `visibleIf` der du alltid refererer til et annet spørsmål).
 
+> **Merk:** `logic`-betingelser støtter ikke `any`/`all`-grupper — kun enkeltbetingelser.
+> Trenger du AND/OR, bruk [`visibleIf`](./betinget-synlighet.md#flere-betingelser-andor).
+
 ## Eksempler
 
 ### Avslutt tidlig for høy score

--- a/docs/guider/sporsmalstyper.md
+++ b/docs/guider/sporsmalstyper.md
@@ -200,7 +200,7 @@ Alle spørsmålstyper deler disse:
 | `description` | `string` | Valgfri hjelpetekst under spørsmålet |
 | `required` | `boolean` | Krever svar for å sende inn |
 | `analyticsId` | `string` | Valgfri ID for analytics (bruker `id` om ikke satt) |
-| `visibleIf` | `LogicCondition` | Betinget visning — se [Betinget synlighet](/guider/betinget-synlighet) |
+| `visibleIf` | `VisibleIfCondition` | Betinget visning — se [Betinget synlighet](/guider/betinget-synlighet) |
 | `logic` | `LogicRule[]` | Branching-regler — se [Avansert](/guider/branching) |
 
 ## Komplett eksempel

--- a/packages/lumi-survey/CHANGELOG.md
+++ b/packages/lumi-survey/CHANGELOG.md
@@ -6,6 +6,10 @@ This project follows SemVer.
 
 ## [Unreleased]
 
+### Added
+
+- `visibleIf` støtter nå `any` (OR) og `all` (AND) for å kombinere flere betingelser (#333).
+
 ### Fixed
 
 - `logic` conditions that reference another question via `condition.questionId` are now evaluated against that question's answer instead of the current question's. Cross-question branching (e.g. routing on an earlier answer) now works the same way `visibleIf` already did. (#332)

--- a/packages/lumi-survey/CHANGELOG.md
+++ b/packages/lumi-survey/CHANGELOG.md
@@ -8,7 +8,7 @@ This project follows SemVer.
 
 ### Added
 
-- `visibleIf` støtter nå `any` (OR) og `all` (AND) for å kombinere flere betingelser (#333).
+- `visibleIf` now supports `any` (OR) and `all` (AND) to combine multiple conditions (#333).
 
 ### Fixed
 

--- a/packages/lumi-survey/CHANGELOG.md
+++ b/packages/lumi-survey/CHANGELOG.md
@@ -8,7 +8,7 @@ This project follows SemVer.
 
 ### Added
 
-- `visibleIf` now supports `any` (OR) and `all` (AND) to combine multiple conditions (#333).
+- `visibleIf` now supports `any` (OR) and `all` (AND) to combine multiple conditions. The wider condition type is exported as `VisibleIfCondition` (with `isConditionGroup`/`getLeafConditions` helpers); `LogicCondition` stays leaf-only so existing type consumers are unaffected. (#333)
 
 ### Fixed
 

--- a/packages/lumi-survey/CHANGELOG.md
+++ b/packages/lumi-survey/CHANGELOG.md
@@ -8,7 +8,7 @@ This project follows SemVer.
 
 ### Added
 
-- `visibleIf` now supports `any` (OR) and `all` (AND) to combine multiple conditions. The wider condition type is exported as `VisibleIfCondition` (with `isConditionGroup`/`getLeafConditions` helpers); `LogicCondition` stays leaf-only so existing type consumers are unaffected. (#333)
+- `visibleIf` now supports `any` (OR) and `all` (AND) to combine multiple conditions. The wider condition type is exported as `VisibleIfCondition` (with `isConditionGroup`/`getLeafConditions`/`isLeafCondition` helpers); `LogicCondition` stays leaf-only so `LogicRule` consumers are unaffected. Note: `question.visibleIf` is now typed `VisibleIfCondition` (leaf | group), so code reading `visibleIf.operator` directly must first narrow with `isConditionGroup`/`isLeafCondition`. (#333)
 
 ### Fixed
 

--- a/packages/lumi-survey/src/components/LumiSurveyDock/hooks/__tests__/stepNavigationUtils.test.ts
+++ b/packages/lumi-survey/src/components/LumiSurveyDock/hooks/__tests__/stepNavigationUtils.test.ts
@@ -396,6 +396,34 @@ describe("hasReachableQuestionsAfter", () => {
     );
     expect(result).toBe(true);
   });
+
+  it("returns true when a later question's any-group references the current question (#333)", () => {
+    const questions: LumiSurveyQuestion[] = [
+      { id: "q1", type: "rating", prompt: "Rate", required: true },
+      {
+        id: "later",
+        type: "text",
+        prompt: "Why?",
+        visibleIf: {
+          any: [
+            {
+              field: "ANSWER",
+              questionId: "other",
+              operator: "EQ",
+              value: "x",
+            },
+            { field: "ANSWER", questionId: "q1", operator: "EQ", value: "nei" },
+          ],
+        },
+      },
+    ] as unknown as LumiSurveyQuestion[];
+    // current question is q1 at index 0; the group references q1 as its 2nd leaf
+    // the group does NOT currently evaluate visible (no answers match), but because
+    // a leaf references the current question the navigation bar must stay visible
+    expect(hasReachableQuestionsAfter(questions, 0, "q1", {}, undefined)).toBe(
+      true,
+    );
+  });
 });
 
 describe("findRedirectTarget", () => {

--- a/packages/lumi-survey/src/components/LumiSurveyDock/hooks/__tests__/stepNavigationUtils.test.ts
+++ b/packages/lumi-survey/src/components/LumiSurveyDock/hooks/__tests__/stepNavigationUtils.test.ts
@@ -424,6 +424,21 @@ describe("hasReachableQuestionsAfter", () => {
       true,
     );
   });
+
+  it("does not crash on a malformed group member (#333)", () => {
+    const questions = [
+      { id: "q1", type: "rating", prompt: "Rate", required: true },
+      {
+        id: "q2",
+        type: "text",
+        prompt: "Why?",
+        visibleIf: { any: [null] },
+      },
+    ] as unknown as LumiSurveyQuestion[];
+    expect(() =>
+      hasReachableQuestionsAfter(questions, 0, "q1", {}, undefined),
+    ).not.toThrow();
+  });
 });
 
 describe("findRedirectTarget", () => {

--- a/packages/lumi-survey/src/components/LumiSurveyDock/hooks/stepNavigationUtils.ts
+++ b/packages/lumi-survey/src/components/LumiSurveyDock/hooks/stepNavigationUtils.ts
@@ -1,3 +1,4 @@
+import { getLeafConditions } from "../../../core/conditionUtils.js";
 import { evaluateVisibility } from "../../../core/evaluateVisibility.js";
 import type {
   LumiSurveyAnswerValue,
@@ -33,8 +34,10 @@ export function hasReachableQuestionsAfter(
     if (index <= currentIndex) return false;
     if (!question.visibleIf) return true;
     if (
-      question.visibleIf.field !== "METADATA" &&
-      question.visibleIf.questionId === currentQuestionId
+      getLeafConditions(question.visibleIf).some(
+        (leaf) =>
+          leaf.field !== "METADATA" && leaf.questionId === currentQuestionId,
+      )
     ) {
       return true;
     }

--- a/packages/lumi-survey/src/components/LumiSurveyDock/hooks/stepNavigationUtils.ts
+++ b/packages/lumi-survey/src/components/LumiSurveyDock/hooks/stepNavigationUtils.ts
@@ -1,4 +1,7 @@
-import { getLeafConditions } from "../../../core/conditionUtils.js";
+import {
+  getLeafConditions,
+  isLeafCondition,
+} from "../../../core/conditionUtils.js";
 import { evaluateVisibility } from "../../../core/evaluateVisibility.js";
 import type {
   LumiSurveyAnswerValue,
@@ -32,16 +35,19 @@ export function hasReachableQuestionsAfter(
 ): boolean {
   return questions.some((question, index) => {
     if (index <= currentIndex) return false;
-    if (!question.visibleIf) return true;
+    const visibleIf = question.visibleIf;
+    if (visibleIf === undefined || visibleIf === null) return true;
     if (
-      getLeafConditions(question.visibleIf).some(
+      getLeafConditions(visibleIf).some(
         (leaf) =>
-          leaf.field !== "METADATA" && leaf.questionId === currentQuestionId,
+          isLeafCondition(leaf) &&
+          leaf.field !== "METADATA" &&
+          leaf.questionId === currentQuestionId,
       )
     ) {
       return true;
     }
-    return evaluateVisibility(question.visibleIf, answers, metadata);
+    return evaluateVisibility(visibleIf, answers, metadata);
   });
 }
 

--- a/packages/lumi-survey/src/components/shared/__tests__/canonicalSurvey.test.ts
+++ b/packages/lumi-survey/src/components/shared/__tests__/canonicalSurvey.test.ts
@@ -159,4 +159,43 @@ describe("buildCanonicalSurvey", () => {
       }),
     ).toThrowError(/logic.*group|group.*logic/i);
   });
+
+  it("throws if a visibleIf group is nested", () => {
+    expect(() =>
+      buildCanonicalSurvey({
+        type: "custom",
+        questions: [
+          { id: "q1", type: "rating", prompt: "Rating", required: true },
+          {
+            id: "q2",
+            type: "text",
+            prompt: "Text",
+            visibleIf: {
+              all: [{ any: [{ operator: "EXISTS", questionId: "q1" }] }],
+            },
+          },
+        ] as unknown as LumiSurveyConfig["questions"],
+      }),
+    ).toThrowError(/nested visibleIf group/i);
+  });
+
+  it("throws if a visibleIf group has both any and all", () => {
+    expect(() =>
+      buildCanonicalSurvey({
+        type: "custom",
+        questions: [
+          { id: "q1", type: "rating", prompt: "Rating", required: true },
+          {
+            id: "q2",
+            type: "text",
+            prompt: "Text",
+            visibleIf: {
+              any: [{ operator: "EXISTS", questionId: "q1" }],
+              all: [],
+            },
+          },
+        ] as unknown as LumiSurveyConfig["questions"],
+      }),
+    ).toThrowError(/both "any" and "all"/i);
+  });
 });

--- a/packages/lumi-survey/src/components/shared/__tests__/canonicalSurvey.test.ts
+++ b/packages/lumi-survey/src/components/shared/__tests__/canonicalSurvey.test.ts
@@ -215,4 +215,27 @@ describe("buildCanonicalSurvey", () => {
       }),
     ).toThrowError(/not a list/i);
   });
+
+  it("throws a clean error (no crash) for null/invalid group members", () => {
+    const make = (member: unknown) =>
+      buildCanonicalSurvey({
+        type: "custom",
+        questions: [
+          { id: "q1", type: "rating", prompt: "Rating", required: true },
+          {
+            id: "q2",
+            type: "text",
+            prompt: "Text",
+            visibleIf: { any: [member] },
+          },
+        ] as unknown as LumiSurveyConfig["questions"],
+      });
+    // Old code read `.field` off the member and threw a raw TypeError on null.
+    expect(() => make(null)).toThrowError(/invalid visibleIf condition/i);
+    expect(() => make({})).toThrowError(/invalid visibleIf condition/i);
+    expect(() => make(1)).toThrowError(/invalid visibleIf condition/i);
+    expect(() => make({ operator: "BOGUS", questionId: "q1" })).toThrowError(
+      /invalid visibleIf condition/i,
+    );
+  });
 });

--- a/packages/lumi-survey/src/components/shared/__tests__/canonicalSurvey.test.ts
+++ b/packages/lumi-survey/src/components/shared/__tests__/canonicalSurvey.test.ts
@@ -134,7 +134,7 @@ describe("buildCanonicalSurvey", () => {
           { id: "q2", type: "text", prompt: "Text", visibleIf: { any: [] } },
         ] as unknown as LumiSurveyConfig["questions"],
       }),
-    ).toThrowError(/empty/i);
+    ).toThrowError(/empty visibleIf .*group/i);
   });
 
   it("throws if a logic condition is an any/all group", () => {

--- a/packages/lumi-survey/src/components/shared/__tests__/canonicalSurvey.test.ts
+++ b/packages/lumi-survey/src/components/shared/__tests__/canonicalSurvey.test.ts
@@ -105,4 +105,58 @@ describe("buildCanonicalSurvey", () => {
     expect(canonical.type).toBe("rating");
     expect(canonical.questions[0]?.required).toBe(true);
   });
+
+  it("throws if a visibleIf group references an unknown questionId", () => {
+    expect(() =>
+      buildCanonicalSurvey({
+        type: "custom",
+        questions: [
+          { id: "q1", type: "rating", prompt: "Rating", required: true },
+          {
+            id: "q2",
+            type: "text",
+            prompt: "Text",
+            visibleIf: {
+              any: [{ operator: "EQ", questionId: "ghost", value: "nei" }],
+            },
+          },
+        ] as unknown as LumiSurveyConfig["questions"],
+      }),
+    ).toThrowError(/visibleIf\.questionId/i);
+  });
+
+  it("throws if a visibleIf group is empty", () => {
+    expect(() =>
+      buildCanonicalSurvey({
+        type: "custom",
+        questions: [
+          { id: "q1", type: "rating", prompt: "Rating", required: true },
+          { id: "q2", type: "text", prompt: "Text", visibleIf: { any: [] } },
+        ] as unknown as LumiSurveyConfig["questions"],
+      }),
+    ).toThrowError(/empty/i);
+  });
+
+  it("throws if a logic condition is an any/all group", () => {
+    expect(() =>
+      buildCanonicalSurvey({
+        type: "custom",
+        questions: [
+          {
+            id: "q1",
+            type: "singleChoice",
+            prompt: "Choice",
+            required: true,
+            options: [{ value: "yes", label: "Ja" }],
+            logic: [
+              {
+                condition: { any: [{ operator: "EXISTS" }] },
+                action: { type: "SUBMIT" },
+              },
+            ],
+          },
+        ] as unknown as LumiSurveyConfig["questions"],
+      }),
+    ).toThrowError(/logic.*group|group.*logic/i);
+  });
 });

--- a/packages/lumi-survey/src/components/shared/__tests__/canonicalSurvey.test.ts
+++ b/packages/lumi-survey/src/components/shared/__tests__/canonicalSurvey.test.ts
@@ -238,6 +238,20 @@ describe("buildCanonicalSurvey", () => {
     ).toThrowError(/not a list/i);
   });
 
+  it("throws if visibleIf is a non-object value (false/0/empty string)", () => {
+    for (const bad of [false, 0, ""]) {
+      expect(() =>
+        buildCanonicalSurvey({
+          type: "custom",
+          questions: [
+            { id: "q1", type: "rating", prompt: "Rating", required: true },
+            { id: "q2", type: "text", prompt: "Text", visibleIf: bad },
+          ] as unknown as LumiSurveyConfig["questions"],
+        }),
+      ).toThrowError(/not a condition object/i);
+    }
+  });
+
   it("throws a clean error (no crash) for null/invalid group members", () => {
     const make = (member: unknown) =>
       buildCanonicalSurvey({

--- a/packages/lumi-survey/src/components/shared/__tests__/canonicalSurvey.test.ts
+++ b/packages/lumi-survey/src/components/shared/__tests__/canonicalSurvey.test.ts
@@ -198,4 +198,21 @@ describe("buildCanonicalSurvey", () => {
       }),
     ).toThrowError(/both "any" and "all"/i);
   });
+
+  it("throws a clean error for a non-array visibleIf group body", () => {
+    expect(() =>
+      buildCanonicalSurvey({
+        type: "custom",
+        questions: [
+          { id: "q1", type: "rating", prompt: "Rating", required: true },
+          {
+            id: "q2",
+            type: "text",
+            prompt: "Text",
+            visibleIf: { any: "nope" },
+          },
+        ] as unknown as LumiSurveyConfig["questions"],
+      }),
+    ).toThrowError(/not a list/i);
+  });
 });

--- a/packages/lumi-survey/src/components/shared/__tests__/canonicalSurvey.test.ts
+++ b/packages/lumi-survey/src/components/shared/__tests__/canonicalSurvey.test.ts
@@ -160,6 +160,28 @@ describe("buildCanonicalSurvey", () => {
     ).toThrowError(/logic.*group|group.*logic/i);
   });
 
+  it("throws a clean error (no crash) for a null/invalid logic.condition", () => {
+    const make = (condition: unknown) =>
+      buildCanonicalSurvey({
+        type: "custom",
+        questions: [
+          {
+            id: "q1",
+            type: "singleChoice",
+            prompt: "Choice",
+            required: true,
+            options: [{ value: "yes", label: "Ja" }],
+            logic: [{ condition, action: { type: "SUBMIT" } }],
+          },
+        ] as unknown as LumiSurveyConfig["questions"],
+      });
+    expect(() => make(null)).toThrowError(/invalid logic\.condition/i);
+    expect(() => make({})).toThrowError(/invalid logic\.condition/i);
+    expect(() => make({ operator: "BOGUS" })).toThrowError(
+      /invalid logic\.condition/i,
+    );
+  });
+
   it("throws if a visibleIf group is nested", () => {
     expect(() =>
       buildCanonicalSurvey({

--- a/packages/lumi-survey/src/components/shared/canonicalSurvey.ts
+++ b/packages/lumi-survey/src/components/shared/canonicalSurvey.ts
@@ -1,5 +1,8 @@
-import { getLeafConditions } from "../../core/conditionUtils.js";
-import type { LumiSurveyQuestion } from "../../core/types.js";
+import {
+  getLeafConditions,
+  isConditionGroup,
+} from "../../core/conditionUtils.js";
+import type { LogicCondition, LumiSurveyQuestion } from "../../core/types.js";
 import type { LumiSurveyConfig, SurveyType } from "../surveyTypes.js";
 
 export const RATING_ANSWER_KEY = "svar";
@@ -54,6 +57,14 @@ export function buildCanonicalSurvey(
   for (const question of questions) {
     const visibleIf = question.visibleIf;
     if (visibleIf) {
+      if (
+        isConditionGroup(visibleIf) &&
+        getLeafConditions(visibleIf).length === 0
+      ) {
+        throw new Error(
+          `Lumi: Question "${question.id}" has an empty visibleIf "any"/"all" group`,
+        );
+      }
       for (const leaf of getLeafConditions(visibleIf)) {
         if (
           leaf.field !== "METADATA" &&
@@ -70,6 +81,11 @@ export function buildCanonicalSurvey(
     if (!question.logic) continue;
     for (const rule of question.logic) {
       const condition = rule.condition;
+      if (isConditionGroup(condition as LogicCondition)) {
+        throw new Error(
+          `Lumi: Question "${question.id}" uses an any/all group in logic.condition, but logic does not support groups (use visibleIf)`,
+        );
+      }
       if (condition.field !== "METADATA") {
         const referencedId = condition.questionId;
         if (referencedId && !ids.has(referencedId)) {

--- a/packages/lumi-survey/src/components/shared/canonicalSurvey.ts
+++ b/packages/lumi-survey/src/components/shared/canonicalSurvey.ts
@@ -57,22 +57,25 @@ export function buildCanonicalSurvey(
   for (const question of questions) {
     const visibleIf = question.visibleIf;
     if (visibleIf) {
-      if (
-        isConditionGroup(visibleIf) &&
-        "any" in visibleIf &&
-        "all" in visibleIf
-      ) {
-        throw new Error(
-          `Lumi: Question "${question.id}" has a visibleIf group with both "any" and "all" — use exactly one`,
-        );
+      if (isConditionGroup(visibleIf)) {
+        if ("any" in visibleIf && "all" in visibleIf) {
+          throw new Error(
+            `Lumi: Question "${question.id}" has a visibleIf group with both "any" and "all" — use exactly one`,
+          );
+        }
+        const body = "any" in visibleIf ? visibleIf.any : visibleIf.all;
+        if (!Array.isArray(body)) {
+          throw new Error(
+            `Lumi: Question "${question.id}" has a visibleIf "any"/"all" that is not a list of conditions`,
+          );
+        }
+        if (body.length === 0) {
+          throw new Error(
+            `Lumi: Question "${question.id}" has an empty visibleIf "any"/"all" group`,
+          );
+        }
       }
-      const leaves = getLeafConditions(visibleIf);
-      if (isConditionGroup(visibleIf) && leaves.length === 0) {
-        throw new Error(
-          `Lumi: Question "${question.id}" has an empty visibleIf "any"/"all" group`,
-        );
-      }
-      for (const leaf of leaves) {
+      for (const leaf of getLeafConditions(visibleIf)) {
         if (isConditionGroup(leaf)) {
           throw new Error(
             `Lumi: Question "${question.id}" has a nested visibleIf group — "any"/"all" groups may only contain leaf conditions (one level)`,

--- a/packages/lumi-survey/src/components/shared/canonicalSurvey.ts
+++ b/packages/lumi-survey/src/components/shared/canonicalSurvey.ts
@@ -1,3 +1,4 @@
+import { getLeafConditions } from "../../core/conditionUtils.js";
 import type { LumiSurveyQuestion } from "../../core/types.js";
 import type { LumiSurveyConfig, SurveyType } from "../surveyTypes.js";
 
@@ -52,12 +53,17 @@ export function buildCanonicalSurvey(
   // Validate cross-references in visibility and branching logic
   for (const question of questions) {
     const visibleIf = question.visibleIf;
-    if (visibleIf && visibleIf.field !== "METADATA") {
-      const referencedId = visibleIf.questionId;
-      if (referencedId && !ids.has(referencedId)) {
-        throw new Error(
-          `Lumi: Question "${question.id}" has visibleIf.questionId "${referencedId}", but no such question exists`,
-        );
+    if (visibleIf) {
+      for (const leaf of getLeafConditions(visibleIf)) {
+        if (
+          leaf.field !== "METADATA" &&
+          leaf.questionId &&
+          !ids.has(leaf.questionId)
+        ) {
+          throw new Error(
+            `Lumi: Question "${question.id}" has visibleIf.questionId "${leaf.questionId}", but no such question exists`,
+          );
+        }
       }
     }
 

--- a/packages/lumi-survey/src/components/shared/canonicalSurvey.ts
+++ b/packages/lumi-survey/src/components/shared/canonicalSurvey.ts
@@ -57,6 +57,11 @@ export function buildCanonicalSurvey(
   for (const question of questions) {
     const visibleIf = question.visibleIf;
     if (visibleIf) {
+      if (typeof visibleIf !== "object" || Array.isArray(visibleIf)) {
+        throw new Error(
+          `Lumi: Question "${question.id}" has a visibleIf that is not a condition object`,
+        );
+      }
       if (isConditionGroup(visibleIf)) {
         if ("any" in visibleIf && "all" in visibleIf) {
           throw new Error(

--- a/packages/lumi-survey/src/components/shared/canonicalSurvey.ts
+++ b/packages/lumi-survey/src/components/shared/canonicalSurvey.ts
@@ -57,15 +57,13 @@ export function buildCanonicalSurvey(
   for (const question of questions) {
     const visibleIf = question.visibleIf;
     if (visibleIf) {
-      if (
-        isConditionGroup(visibleIf) &&
-        getLeafConditions(visibleIf).length === 0
-      ) {
+      const leaves = getLeafConditions(visibleIf);
+      if (isConditionGroup(visibleIf) && leaves.length === 0) {
         throw new Error(
           `Lumi: Question "${question.id}" has an empty visibleIf "any"/"all" group`,
         );
       }
-      for (const leaf of getLeafConditions(visibleIf)) {
+      for (const leaf of leaves) {
         if (
           leaf.field !== "METADATA" &&
           leaf.questionId &&

--- a/packages/lumi-survey/src/components/shared/canonicalSurvey.ts
+++ b/packages/lumi-survey/src/components/shared/canonicalSurvey.ts
@@ -1,6 +1,7 @@
 import {
   getLeafConditions,
   isConditionGroup,
+  isLeafCondition,
 } from "../../core/conditionUtils.js";
 import type { LumiSurveyQuestion } from "../../core/types.js";
 import type { LumiSurveyConfig, SurveyType } from "../surveyTypes.js";
@@ -84,6 +85,11 @@ export function buildCanonicalSurvey(
         if (isConditionGroup(leaf)) {
           throw new Error(
             `Lumi: Question "${question.id}" has a nested visibleIf group — "any"/"all" groups may only contain leaf conditions (one level)`,
+          );
+        }
+        if (!isLeafCondition(leaf)) {
+          throw new Error(
+            `Lumi: Question "${question.id}" has an invalid visibleIf condition — each leaf needs an operator (EQ/NEQ/GT/LT/CONTAINS/EXISTS)`,
           );
         }
         if (

--- a/packages/lumi-survey/src/components/shared/canonicalSurvey.ts
+++ b/packages/lumi-survey/src/components/shared/canonicalSurvey.ts
@@ -112,6 +112,11 @@ export function buildCanonicalSurvey(
           `Lumi: Question "${question.id}" uses an any/all group in logic.condition, but logic does not support groups (use visibleIf)`,
         );
       }
+      if (!isLeafCondition(condition)) {
+        throw new Error(
+          `Lumi: Question "${question.id}" has an invalid logic.condition — it must be a leaf with an operator (EQ/NEQ/GT/LT/CONTAINS/EXISTS)`,
+        );
+      }
       if (condition.field !== "METADATA") {
         const referencedId = condition.questionId;
         if (referencedId && !ids.has(referencedId)) {

--- a/packages/lumi-survey/src/components/shared/canonicalSurvey.ts
+++ b/packages/lumi-survey/src/components/shared/canonicalSurvey.ts
@@ -2,7 +2,7 @@ import {
   getLeafConditions,
   isConditionGroup,
 } from "../../core/conditionUtils.js";
-import type { LogicCondition, LumiSurveyQuestion } from "../../core/types.js";
+import type { LumiSurveyQuestion } from "../../core/types.js";
 import type { LumiSurveyConfig, SurveyType } from "../surveyTypes.js";
 
 export const RATING_ANSWER_KEY = "svar";
@@ -57,6 +57,15 @@ export function buildCanonicalSurvey(
   for (const question of questions) {
     const visibleIf = question.visibleIf;
     if (visibleIf) {
+      if (
+        isConditionGroup(visibleIf) &&
+        "any" in visibleIf &&
+        "all" in visibleIf
+      ) {
+        throw new Error(
+          `Lumi: Question "${question.id}" has a visibleIf group with both "any" and "all" — use exactly one`,
+        );
+      }
       const leaves = getLeafConditions(visibleIf);
       if (isConditionGroup(visibleIf) && leaves.length === 0) {
         throw new Error(
@@ -64,6 +73,11 @@ export function buildCanonicalSurvey(
         );
       }
       for (const leaf of leaves) {
+        if (isConditionGroup(leaf)) {
+          throw new Error(
+            `Lumi: Question "${question.id}" has a nested visibleIf group — "any"/"all" groups may only contain leaf conditions (one level)`,
+          );
+        }
         if (
           leaf.field !== "METADATA" &&
           leaf.questionId &&
@@ -79,7 +93,7 @@ export function buildCanonicalSurvey(
     if (!question.logic) continue;
     for (const rule of question.logic) {
       const condition = rule.condition;
-      if (isConditionGroup(condition as LogicCondition)) {
+      if (isConditionGroup(condition)) {
         throw new Error(
           `Lumi: Question "${question.id}" uses an any/all group in logic.condition, but logic does not support groups (use visibleIf)`,
         );

--- a/packages/lumi-survey/src/components/shared/canonicalSurvey.ts
+++ b/packages/lumi-survey/src/components/shared/canonicalSurvey.ts
@@ -57,7 +57,7 @@ export function buildCanonicalSurvey(
   // Validate cross-references in visibility and branching logic
   for (const question of questions) {
     const visibleIf = question.visibleIf;
-    if (visibleIf) {
+    if (visibleIf !== undefined && visibleIf !== null) {
       if (typeof visibleIf !== "object" || Array.isArray(visibleIf)) {
         throw new Error(
           `Lumi: Question "${question.id}" has a visibleIf that is not a condition object`,

--- a/packages/lumi-survey/src/core/__tests__/branchingEngine.test.ts
+++ b/packages/lumi-survey/src/core/__tests__/branchingEngine.test.ts
@@ -739,7 +739,9 @@ describe("logic group guard (#333)", () => {
       q1: "yes",
     });
 
-    // The group rule must NOT trigger SUBMIT — it is ignored, not mis-evaluated.
+    // Outcome (default next) coincides with the old accidental no-match — a group
+    // has no operator so it never matched anyway. The console.warn below is the
+    // real behavioral discriminator the guard adds.
     expect(result.triggeredByRule).toBe(false);
     expect(result.nextIndex).toBe(1);
     expect(warn).toHaveBeenCalledWith(

--- a/packages/lumi-survey/src/core/__tests__/branchingEngine.test.ts
+++ b/packages/lumi-survey/src/core/__tests__/branchingEngine.test.ts
@@ -745,8 +745,26 @@ describe("logic group guard (#333)", () => {
     expect(result.triggeredByRule).toBe(false);
     expect(result.nextIndex).toBe(1);
     expect(warn).toHaveBeenCalledWith(
-      expect.stringContaining("group in logic.condition"),
+      expect.stringContaining("logic.condition"),
     );
+    warn.mockRestore();
+  });
+
+  it("ignores (and warns about) a malformed (non-leaf) logic.condition without crashing", () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const logic = [
+      { condition: null, action: { type: "SUBMIT" } },
+    ] as unknown as LogicRule[];
+    const q1 = createQuestion("q1", logic);
+    const questions = [q1, createQuestion("q2")];
+
+    const result = evaluateBranching(q1, "yes", undefined, questions, 0, {
+      q1: "yes",
+    });
+
+    expect(result.triggeredByRule).toBe(false);
+    expect(result.nextIndex).toBe(1);
+    expect(warn).toHaveBeenCalled();
     warn.mockRestore();
   });
 });

--- a/packages/lumi-survey/src/core/__tests__/branchingEngine.test.ts
+++ b/packages/lumi-survey/src/core/__tests__/branchingEngine.test.ts
@@ -722,3 +722,29 @@ describe("validateBranchingTargets", () => {
     expect(validateBranchingTargets(questions)).toEqual([]);
   });
 });
+
+describe("logic group guard (#333)", () => {
+  it("ignores (and warns about) an any/all group smuggled into logic.condition", () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const logic = [
+      {
+        condition: { any: [{ operator: "EXISTS" }] },
+        action: { type: "SUBMIT" },
+      },
+    ] as unknown as LogicRule[];
+    const q1 = createQuestion("q1", logic);
+    const questions = [q1, createQuestion("q2")];
+
+    const result = evaluateBranching(q1, "yes", undefined, questions, 0, {
+      q1: "yes",
+    });
+
+    // The group rule must NOT trigger SUBMIT — it is ignored, not mis-evaluated.
+    expect(result.triggeredByRule).toBe(false);
+    expect(result.nextIndex).toBe(1);
+    expect(warn).toHaveBeenCalledWith(
+      expect.stringContaining("group in logic.condition"),
+    );
+    warn.mockRestore();
+  });
+});

--- a/packages/lumi-survey/src/core/__tests__/computeReachableSteps.test.ts
+++ b/packages/lumi-survey/src/core/__tests__/computeReachableSteps.test.ts
@@ -165,6 +165,24 @@ describe("computeReachableSteps", () => {
     expect(computeReachableSteps([], {})).toBe(0);
   });
 
+  it("counts a group-gated question as reachable (overestimate)", () => {
+    const questions: LumiSurveyQuestion[] = [
+      { id: "q1", type: "rating", prompt: "Rate", required: true },
+      {
+        id: "q2",
+        type: "text",
+        prompt: "Why?",
+        visibleIf: {
+          any: [
+            { field: "ANSWER", questionId: "q1", operator: "EQ", value: 1 },
+          ],
+        },
+      },
+    ];
+    // No answers yet: a group-gated question is treated as reachable.
+    expect(computeReachableSteps(questions, {})).toBe(2);
+  });
+
   it("returns a realistic estimate for a real-world survey", () => {
     const questions: LumiSurveyQuestion[] = [
       {

--- a/packages/lumi-survey/src/core/__tests__/computeReachableSteps.test.ts
+++ b/packages/lumi-survey/src/core/__tests__/computeReachableSteps.test.ts
@@ -343,6 +343,52 @@ describe("computeReachableSteps", () => {
     ] as unknown as LumiSurveyQuestion[];
     expect(getVisibleQuestions(bothKeys, { a: 1 }).length).toBe(1);
     expect(computeReachableSteps(bothKeys, { a: 1 })).toBe(1);
+
+    // Invalid (non-LogicOperator) string operators are hidden by visibility too.
+    for (const bad of [
+      { operator: "" },
+      { operator: "BOGUS", questionId: "q1" },
+    ]) {
+      const qs = [
+        { id: "q1", type: "text", prompt: "Q1" },
+        { id: "q2", type: "text", prompt: "Q2", visibleIf: bad },
+      ] as unknown as LumiSurveyQuestion[];
+      expect(computeReachableSteps(qs, {})).toBe(
+        getVisibleQuestions(qs, {}).length,
+      );
+    }
+  });
+
+  it("does not undercount a question reachable through a cyclic group dependency (#333)", () => {
+    const questions: LumiSurveyQuestion[] = [
+      { id: "q1", type: "text", prompt: "Q1" },
+      {
+        id: "q2",
+        type: "text",
+        prompt: "Q2",
+        visibleIf: {
+          any: [
+            { field: "ANSWER", questionId: "q3", operator: "EXISTS" },
+            { field: "ANSWER", questionId: "q1", operator: "EXISTS" },
+          ],
+        },
+      },
+      {
+        id: "q3",
+        type: "text",
+        prompt: "Q3",
+        visibleIf: { field: "ANSWER", questionId: "q2", operator: "EXISTS" },
+      },
+    ];
+    const answers = { q1: "x", q2: "y" };
+    // q2 is reachable via the q1 branch; q3 then becomes reachable via q2.
+    // The old cycle guard cached q3=false while proving q2, undercounting to 2.
+    expect(getVisibleQuestions(questions, answers).map((q) => q.id)).toEqual([
+      "q1",
+      "q2",
+      "q3",
+    ]);
+    expect(computeReachableSteps(questions, answers)).toBe(3);
   });
 
   it("returns a realistic estimate for a real-world survey", () => {

--- a/packages/lumi-survey/src/core/__tests__/computeReachableSteps.test.ts
+++ b/packages/lumi-survey/src/core/__tests__/computeReachableSteps.test.ts
@@ -344,10 +344,14 @@ describe("computeReachableSteps", () => {
     expect(getVisibleQuestions(bothKeys, { a: 1 }).length).toBe(1);
     expect(computeReachableSteps(bothKeys, { a: 1 })).toBe(1);
 
-    // Invalid (non-LogicOperator) string operators are hidden by visibility too.
+    // Invalid string operators AND falsy-but-not-null values are hidden by
+    // visibility, so reachability must match (no crash, no overcount).
     for (const bad of [
       { operator: "" },
       { operator: "BOGUS", questionId: "q1" },
+      false,
+      0,
+      "",
     ]) {
       const qs = [
         { id: "q1", type: "text", prompt: "Q1" },

--- a/packages/lumi-survey/src/core/__tests__/computeReachableSteps.test.ts
+++ b/packages/lumi-survey/src/core/__tests__/computeReachableSteps.test.ts
@@ -183,6 +183,38 @@ describe("computeReachableSteps", () => {
     expect(computeReachableSteps(questions, {})).toBe(2);
   });
 
+  it("excludes a group-gated question once answers falsify its group (#333)", () => {
+    const questions: LumiSurveyQuestion[] = [
+      { id: "q1", type: "rating", prompt: "Rate", required: true },
+      {
+        id: "q2",
+        type: "text",
+        prompt: "low",
+        visibleIf: {
+          any: [
+            { field: "ANSWER", questionId: "q1", operator: "EQ", value: 1 },
+          ],
+        },
+      },
+      {
+        id: "q3",
+        type: "text",
+        prompt: "high",
+        visibleIf: {
+          any: [
+            { field: "ANSWER", questionId: "q1", operator: "EQ", value: 5 },
+          ],
+        },
+      },
+    ];
+    // q1=1 → q2's group is true, q3's group is false. The old unconditional
+    // overestimate counted both (3); resolved groups are now evaluated.
+    expect(computeReachableSteps(questions, { q1: 1 })).toBe(2);
+    expect(computeReachableSteps(questions, { q1: 5 })).toBe(2);
+    // Still unresolved (no answer): both overestimated as reachable.
+    expect(computeReachableSteps(questions, {})).toBe(3);
+  });
+
   it("returns a realistic estimate for a real-world survey", () => {
     const questions: LumiSurveyQuestion[] = [
       {

--- a/packages/lumi-survey/src/core/__tests__/computeReachableSteps.test.ts
+++ b/packages/lumi-survey/src/core/__tests__/computeReachableSteps.test.ts
@@ -215,6 +215,46 @@ describe("computeReachableSteps", () => {
     expect(computeReachableSteps(questions, {})).toBe(3);
   });
 
+  it("handles METADATA and all-group edge cases (#333)", () => {
+    // A METADATA leaf keeps the group overestimated even when the answer leaf is
+    // falsified, because metadata may arrive/change later.
+    const withMeta: LumiSurveyQuestion[] = [
+      { id: "q1", type: "rating", prompt: "Rate", required: true },
+      {
+        id: "q2",
+        type: "text",
+        prompt: "m",
+        visibleIf: {
+          any: [
+            { field: "METADATA", key: "role", operator: "EQ", value: "admin" },
+            { field: "ANSWER", questionId: "q1", operator: "EQ", value: 1 },
+          ],
+        },
+      },
+    ];
+    expect(computeReachableSteps(withMeta, { q1: 2 }, { role: "user" })).toBe(
+      2,
+    );
+
+    // all-group is evaluated once the referenced answer is present.
+    const allGroup: LumiSurveyQuestion[] = [
+      { id: "q1", type: "rating", prompt: "Rate", required: true },
+      {
+        id: "q2",
+        type: "text",
+        prompt: "a",
+        visibleIf: {
+          all: [
+            { field: "ANSWER", questionId: "q1", operator: "GT", value: 2 },
+            { field: "ANSWER", questionId: "q1", operator: "LT", value: 4 },
+          ],
+        },
+      },
+    ];
+    expect(computeReachableSteps(allGroup, { q1: 3 })).toBe(2); // 2 < 3 < 4
+    expect(computeReachableSteps(allGroup, { q1: 5 })).toBe(1); // 5 not < 4
+  });
+
   it("returns a realistic estimate for a real-world survey", () => {
     const questions: LumiSurveyQuestion[] = [
       {

--- a/packages/lumi-survey/src/core/__tests__/computeReachableSteps.test.ts
+++ b/packages/lumi-survey/src/core/__tests__/computeReachableSteps.test.ts
@@ -255,6 +255,50 @@ describe("computeReachableSteps", () => {
     expect(computeReachableSteps(allGroup, { q1: 5 })).toBe(1); // 5 not < 4
   });
 
+  it("does not count a group whose referenced parent is unreachable (#333)", () => {
+    const questions: LumiSurveyQuestion[] = [
+      {
+        id: "gate",
+        type: "singleChoice",
+        prompt: "Gate",
+        options: [{ value: "show", label: "s" }],
+      },
+      {
+        id: "parent",
+        type: "singleChoice",
+        prompt: "Parent",
+        options: [{ value: "yes", label: "y" }],
+        visibleIf: {
+          field: "ANSWER",
+          questionId: "gate",
+          operator: "EQ",
+          value: "show",
+        },
+      },
+      {
+        id: "child",
+        type: "text",
+        prompt: "Child",
+        visibleIf: {
+          any: [
+            {
+              field: "ANSWER",
+              questionId: "parent",
+              operator: "EQ",
+              value: "yes",
+            },
+          ],
+        },
+      },
+    ];
+    // gate=hide → parent unreachable → child's group can never be true. The old
+    // overestimate counted child (2); now only `gate` counts.
+    expect(computeReachableSteps(questions, { gate: "hide" })).toBe(1);
+    // gate=show → parent reachable (still unanswered) → child stays a reachable
+    // overestimate.
+    expect(computeReachableSteps(questions, { gate: "show" })).toBe(3);
+  });
+
   it("returns a realistic estimate for a real-world survey", () => {
     const questions: LumiSurveyQuestion[] = [
       {

--- a/packages/lumi-survey/src/core/__tests__/computeReachableSteps.test.ts
+++ b/packages/lumi-survey/src/core/__tests__/computeReachableSteps.test.ts
@@ -327,6 +327,22 @@ describe("computeReachableSteps", () => {
       expect(getVisibleQuestions(qs, {}).length).toBe(1);
       expect(computeReachableSteps(qs, {})).toBe(1);
     }
+
+    // Both-keys group (raw input): hidden by visibility → not reachable either.
+    const bothKeys = [
+      { id: "a", type: "text", prompt: "A" },
+      {
+        id: "b",
+        type: "text",
+        prompt: "B",
+        visibleIf: {
+          any: [{ questionId: "a", operator: "EXISTS" }],
+          all: [{ questionId: "a", operator: "EQ", value: 9 }],
+        },
+      },
+    ] as unknown as LumiSurveyQuestion[];
+    expect(getVisibleQuestions(bothKeys, { a: 1 }).length).toBe(1);
+    expect(computeReachableSteps(bothKeys, { a: 1 })).toBe(1);
   });
 
   it("returns a realistic estimate for a real-world survey", () => {

--- a/packages/lumi-survey/src/core/__tests__/computeReachableSteps.test.ts
+++ b/packages/lumi-survey/src/core/__tests__/computeReachableSteps.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 import { computeReachableSteps } from "../computeReachableSteps";
+import { getVisibleQuestions } from "../evaluateVisibility";
 import type { LumiSurveyQuestion } from "../types";
 
 describe("computeReachableSteps", () => {
@@ -297,6 +298,24 @@ describe("computeReachableSteps", () => {
     // gate=show → parent reachable (still unanswered) → child stays a reachable
     // overestimate.
     expect(computeReachableSteps(questions, { gate: "show" })).toBe(3);
+  });
+
+  it("handles null/malformed visibleIf without crashing, consistent with visibility (#333)", () => {
+    // null = no condition: visible AND reachable; must not crash isAnswerCondition.
+    const nullQs = [
+      { id: "q1", type: "text", prompt: "Q1" },
+      { id: "q2", type: "text", prompt: "Q2", visibleIf: null },
+    ] as unknown as LumiSurveyQuestion[];
+    expect(computeReachableSteps(nullQs, {})).toBe(2);
+    expect(getVisibleQuestions(nullQs, {}).length).toBe(2);
+
+    // Malformed truthy condition: hidden by visibility → excluded from reachable.
+    const badQs = [
+      { id: "q1", type: "text", prompt: "Q1" },
+      { id: "q2", type: "text", prompt: "Q2", visibleIf: 1 },
+    ] as unknown as LumiSurveyQuestion[];
+    expect(getVisibleQuestions(badQs, {}).length).toBe(1);
+    expect(computeReachableSteps(badQs, {})).toBe(1);
   });
 
   it("returns a realistic estimate for a real-world survey", () => {

--- a/packages/lumi-survey/src/core/__tests__/computeReachableSteps.test.ts
+++ b/packages/lumi-survey/src/core/__tests__/computeReachableSteps.test.ts
@@ -316,6 +316,17 @@ describe("computeReachableSteps", () => {
     ] as unknown as LumiSurveyQuestion[];
     expect(getVisibleQuestions(badQs, {}).length).toBe(1);
     expect(computeReachableSteps(badQs, {})).toBe(1);
+
+    // Object that is not a valid leaf (missing operator) is hidden by visibility,
+    // so it must not be counted reachable either.
+    for (const bad of [{}, { questionId: "q1" }]) {
+      const qs = [
+        { id: "q1", type: "text", prompt: "Q1" },
+        { id: "q2", type: "text", prompt: "Q2", visibleIf: bad },
+      ] as unknown as LumiSurveyQuestion[];
+      expect(getVisibleQuestions(qs, {}).length).toBe(1);
+      expect(computeReachableSteps(qs, {})).toBe(1);
+    }
   });
 
   it("returns a realistic estimate for a real-world survey", () => {

--- a/packages/lumi-survey/src/core/__tests__/evaluateVisibility.test.ts
+++ b/packages/lumi-survey/src/core/__tests__/evaluateVisibility.test.ts
@@ -4,7 +4,7 @@ import {
   getVisibleQuestions,
   shouldShowSubmitButton,
 } from "../evaluateVisibility";
-import type { LumiSurveyQuestion } from "../types";
+import type { LumiSurveyQuestion, VisibleIfCondition } from "../types";
 
 describe("evaluateVisibility", () => {
   describe("with no condition", () => {
@@ -378,5 +378,16 @@ describe("evaluateVisibility with any/all groups", () => {
     expect(
       evaluateVisibility(condition, { q1: "ja" }, { userType: "employer" }),
     ).toBe(false);
+  });
+});
+
+describe("evaluateVisibility fail-closed guards (#333)", () => {
+  it("fails closed when a group member is itself a group (nested, malformed input)", () => {
+    const nested = {
+      all: [{ any: [{ questionId: "a", operator: "EQ", value: "x" }] }],
+    } as unknown as VisibleIfCondition;
+    // Old behavior returned the inner group as a value-less leaf => always visible.
+    expect(evaluateVisibility(nested, { a: "x" })).toBe(false);
+    expect(evaluateVisibility(nested, { a: "WRONG" })).toBe(false);
   });
 });

--- a/packages/lumi-survey/src/core/__tests__/evaluateVisibility.test.ts
+++ b/packages/lumi-survey/src/core/__tests__/evaluateVisibility.test.ts
@@ -390,4 +390,21 @@ describe("evaluateVisibility fail-closed guards (#333)", () => {
     expect(evaluateVisibility(nested, { a: "x" })).toBe(false);
     expect(evaluateVisibility(nested, { a: "WRONG" })).toBe(false);
   });
+
+  it("fails closed (no throw) on malformed group bodies", () => {
+    // Non-array body: old code called `.some`/`.every` on a string and threw.
+    expect(
+      evaluateVisibility({ any: "nope" } as unknown as VisibleIfCondition, {}),
+    ).toBe(false);
+    // Both keys at once is ambiguous → hide rather than silently pick one branch.
+    expect(
+      evaluateVisibility(
+        {
+          any: [{ questionId: "a", operator: "EXISTS" }],
+          all: [{ questionId: "a", operator: "EQ", value: 9 }],
+        } as unknown as VisibleIfCondition,
+        { a: 1 },
+      ),
+    ).toBe(false);
+  });
 });

--- a/packages/lumi-survey/src/core/__tests__/evaluateVisibility.test.ts
+++ b/packages/lumi-survey/src/core/__tests__/evaluateVisibility.test.ts
@@ -418,5 +418,8 @@ describe("evaluateVisibility fail-closed guards (#333)", () => {
     // Malformed leaf members: old code threw on null, returned true for {}.
     expect(ev({ any: [null] })).toBe(false);
     expect(ev({ any: [{}] })).toBe(false);
+    // Invalid (non-LogicOperator) string operators must not be accepted.
+    expect(ev({ operator: "" })).toBe(false);
+    expect(ev({ operator: "BOGUS", questionId: "q1" })).toBe(false);
   });
 });

--- a/packages/lumi-survey/src/core/__tests__/evaluateVisibility.test.ts
+++ b/packages/lumi-survey/src/core/__tests__/evaluateVisibility.test.ts
@@ -407,4 +407,16 @@ describe("evaluateVisibility fail-closed guards (#333)", () => {
       ),
     ).toBe(false);
   });
+
+  it("fails closed (no throw) on non-object conditions and malformed leaves", () => {
+    const ev = (c: unknown) =>
+      evaluateVisibility(c as unknown as VisibleIfCondition, {});
+    // Old code did `"any" in condition` on a primitive → TypeError.
+    expect(ev(1)).toBe(false);
+    expect(ev("x")).toBe(false);
+    expect(ev([])).toBe(false);
+    // Malformed leaf members: old code threw on null, returned true for {}.
+    expect(ev({ any: [null] })).toBe(false);
+    expect(ev({ any: [{}] })).toBe(false);
+  });
 });

--- a/packages/lumi-survey/src/core/__tests__/evaluateVisibility.test.ts
+++ b/packages/lumi-survey/src/core/__tests__/evaluateVisibility.test.ts
@@ -421,5 +421,15 @@ describe("evaluateVisibility fail-closed guards (#333)", () => {
     // Invalid (non-LogicOperator) string operators must not be accepted.
     expect(ev({ operator: "" })).toBe(false);
     expect(ev({ operator: "BOGUS", questionId: "q1" })).toBe(false);
+    // Falsy-but-not-null values are malformed, NOT "no condition" → fail closed.
+    expect(ev(false)).toBe(false);
+    expect(ev(0)).toBe(false);
+    expect(ev("")).toBe(false);
+    expect(ev(Number.NaN)).toBe(false);
+    // Only null/undefined mean "no condition" → visible.
+    expect(evaluateVisibility(null as unknown as VisibleIfCondition, {})).toBe(
+      true,
+    );
+    expect(evaluateVisibility(undefined, {})).toBe(true);
   });
 });

--- a/packages/lumi-survey/src/core/__tests__/evaluateVisibility.test.ts
+++ b/packages/lumi-survey/src/core/__tests__/evaluateVisibility.test.ts
@@ -270,3 +270,113 @@ describe("shouldShowSubmitButton", () => {
     ).toBe(true);
   });
 });
+
+describe("evaluateVisibility with any/all groups", () => {
+  it("any: visible when at least one leaf matches", () => {
+    const condition = {
+      any: [
+        {
+          field: "ANSWER" as const,
+          questionId: "q1",
+          operator: "EQ" as const,
+          value: "nei",
+        },
+        {
+          field: "ANSWER" as const,
+          questionId: "q2",
+          operator: "EQ" as const,
+          value: "nei",
+        },
+      ],
+    };
+    expect(evaluateVisibility(condition, { q1: "ja", q2: "nei" })).toBe(true);
+  });
+
+  it("any: hidden when no leaf matches", () => {
+    const condition = {
+      any: [
+        {
+          field: "ANSWER" as const,
+          questionId: "q1",
+          operator: "EQ" as const,
+          value: "nei",
+        },
+        {
+          field: "ANSWER" as const,
+          questionId: "q2",
+          operator: "EQ" as const,
+          value: "nei",
+        },
+      ],
+    };
+    expect(evaluateVisibility(condition, { q1: "ja", q2: "ja" })).toBe(false);
+  });
+
+  it("all: visible only when every leaf matches", () => {
+    const condition = {
+      all: [
+        {
+          field: "ANSWER" as const,
+          questionId: "q1",
+          operator: "EQ" as const,
+          value: "nei",
+        },
+        {
+          field: "ANSWER" as const,
+          questionId: "q2",
+          operator: "EQ" as const,
+          value: "nei",
+        },
+      ],
+    };
+    expect(evaluateVisibility(condition, { q1: "nei", q2: "nei" })).toBe(true);
+    expect(evaluateVisibility(condition, { q1: "nei", q2: "ja" })).toBe(false);
+  });
+
+  it("mixes EXISTS and EQ leaves in one group", () => {
+    const condition = {
+      all: [
+        {
+          field: "ANSWER" as const,
+          questionId: "rating",
+          operator: "EXISTS" as const,
+        },
+        {
+          field: "ANSWER" as const,
+          questionId: "success",
+          operator: "EQ" as const,
+          value: "no",
+        },
+      ],
+    };
+    expect(evaluateVisibility(condition, { rating: 2, success: "no" })).toBe(
+      true,
+    );
+    expect(evaluateVisibility(condition, { success: "no" })).toBe(false);
+  });
+
+  it("evaluates a METADATA leaf inside a group", () => {
+    const condition = {
+      any: [
+        {
+          field: "METADATA" as const,
+          key: "userType",
+          operator: "EQ" as const,
+          value: "employee",
+        },
+        {
+          field: "ANSWER" as const,
+          questionId: "q1",
+          operator: "EQ" as const,
+          value: "nei",
+        },
+      ],
+    };
+    expect(
+      evaluateVisibility(condition, { q1: "ja" }, { userType: "employee" }),
+    ).toBe(true);
+    expect(
+      evaluateVisibility(condition, { q1: "ja" }, { userType: "employer" }),
+    ).toBe(false);
+  });
+});

--- a/packages/lumi-survey/src/core/branchingEngine.ts
+++ b/packages/lumi-survey/src/core/branchingEngine.ts
@@ -1,3 +1,4 @@
+import { isConditionGroup } from "./conditionUtils.js";
 import type {
   LogicLeafCondition,
   LogicOperator,
@@ -172,6 +173,15 @@ export function evaluateBranching(
 
   // Evaluate rules in order - first match wins
   for (const rule of rules) {
+    // logic is leaf-only; defensively ignore an any/all group smuggled in via
+    // raw (untyped) input rather than mis-evaluating it as a value-less leaf.
+    if (isConditionGroup(rule.condition)) {
+      console.warn(
+        "Lumi: ignored an any/all group in logic.condition — logic does not support groups (use visibleIf)",
+      );
+      continue;
+    }
+
     const matches = evaluateCondition(
       rule.condition,
       currentAnswer,

--- a/packages/lumi-survey/src/core/branchingEngine.ts
+++ b/packages/lumi-survey/src/core/branchingEngine.ts
@@ -1,5 +1,5 @@
 import type {
-  LogicCondition,
+  LogicLeafCondition,
   LogicOperator,
   LogicRule,
   LumiSurveyAnswerValue,
@@ -22,7 +22,7 @@ export interface BranchingResult {
  * Evaluates a single condition against an answer or metadata value.
  */
 function evaluateCondition(
-  condition: LogicCondition,
+  condition: LogicLeafCondition,
   currentAnswer: LumiSurveyAnswerValue | undefined,
   metadata: Record<string, unknown> | undefined,
   answers: Record<string, LumiSurveyAnswerValue> | undefined,

--- a/packages/lumi-survey/src/core/branchingEngine.ts
+++ b/packages/lumi-survey/src/core/branchingEngine.ts
@@ -1,4 +1,4 @@
-import { isConditionGroup } from "./conditionUtils.js";
+import { isLeafCondition } from "./conditionUtils.js";
 import type {
   LogicLeafCondition,
   LogicOperator,
@@ -173,11 +173,12 @@ export function evaluateBranching(
 
   // Evaluate rules in order - first match wins
   for (const rule of rules) {
-    // logic is leaf-only; defensively ignore an any/all group smuggled in via
-    // raw (untyped) input rather than mis-evaluating it as a value-less leaf.
-    if (isConditionGroup(rule.condition)) {
+    // logic is leaf-only; defensively ignore an any/all group or any malformed
+    // condition smuggled in via raw (untyped) input rather than crashing or
+    // mis-evaluating it as a value-less leaf.
+    if (!isLeafCondition(rule.condition)) {
       console.warn(
-        "Lumi: ignored an any/all group in logic.condition — logic does not support groups (use visibleIf)",
+        "Lumi: ignored an invalid or group condition in logic.condition — logic supports only leaf conditions (use visibleIf for any/all)",
       );
       continue;
     }

--- a/packages/lumi-survey/src/core/computeReachableSteps.ts
+++ b/packages/lumi-survey/src/core/computeReachableSteps.ts
@@ -1,14 +1,20 @@
+import { isConditionGroup } from "./conditionUtils.js";
 import { evaluateVisibility } from "./evaluateVisibility.js";
 import type {
   LogicCondition,
+  LogicLeafCondition,
   LumiSurveyAnswerValue,
   LumiSurveyQuestion,
 } from "./types.js";
 
 function isAnswerCondition(
   condition: LogicCondition | undefined,
-): condition is Extract<LogicCondition, { field?: "ANSWER" }> {
-  return condition !== undefined && condition.field !== "METADATA";
+): condition is Extract<LogicLeafCondition, { field?: "ANSWER" }> {
+  return (
+    condition !== undefined &&
+    !isConditionGroup(condition) &&
+    condition.field !== "METADATA"
+  );
 }
 
 /**
@@ -76,6 +82,12 @@ export function computeReachableSteps(
       return true;
     }
 
+    if (isConditionGroup(condition)) {
+      // Group-gated: overestimate as reachable (same policy as METADATA).
+      deterministicReachableCache.set(questionId, true);
+      return true;
+    }
+
     if (condition.field === "METADATA") {
       deterministicReachableCache.set(questionId, true);
       return true;
@@ -119,7 +131,12 @@ export function computeReachableSteps(
     }
 
     const condition = question.visibleIf;
-    if (condition && condition.field !== "METADATA" && condition.questionId) {
+    if (
+      condition &&
+      !isConditionGroup(condition) &&
+      condition.field !== "METADATA" &&
+      condition.questionId
+    ) {
       if (condition.operator !== "EXISTS") {
         const parentId = condition.questionId;
         if (answers[parentId] !== undefined) {

--- a/packages/lumi-survey/src/core/computeReachableSteps.ts
+++ b/packages/lumi-survey/src/core/computeReachableSteps.ts
@@ -1,4 +1,4 @@
-import { isConditionGroup } from "./conditionUtils.js";
+import { getLeafConditions, isConditionGroup } from "./conditionUtils.js";
 import { evaluateVisibility } from "./evaluateVisibility.js";
 import type {
   LogicLeafCondition,
@@ -26,6 +26,9 @@ function isAnswerCondition(
  * the real number of visible questions.
  * METADATA-gated conditions are always treated as reachable to prefer
  * overestimation over underestimation when metadata may arrive or change later.
+ * `any`/`all` group conditions are evaluated once every referenced answer is
+ * present (so an answered-but-falsified group is excluded); while still
+ * unresolved they are overestimated as reachable, like METADATA.
  */
 export function computeReachableSteps(
   questions: LumiSurveyQuestion[],
@@ -83,7 +86,27 @@ export function computeReachableSteps(
     }
 
     if (isConditionGroup(condition)) {
-      // Group-gated: overestimate as reachable (same policy as METADATA).
+      // When every answer the group references is already present (and no
+      // METADATA leaf, whose value may still arrive/change), the group is fully
+      // resolvable — evaluate it so an answered-but-falsified group is excluded.
+      // Otherwise overestimate as reachable (same policy as METADATA leaves).
+      const leaves = getLeafConditions(condition);
+      const hasMetadataLeaf = leaves.some((leaf) => leaf.field === "METADATA");
+      const answerLeaves = leaves.filter((leaf) => leaf.field !== "METADATA");
+      const allReferencedAnswered = answerLeaves.every(
+        (leaf) => !leaf.questionId || answers[leaf.questionId] !== undefined,
+      );
+
+      if (
+        !hasMetadataLeaf &&
+        answerLeaves.length > 0 &&
+        allReferencedAnswered
+      ) {
+        const result = evaluateVisibility(condition, answers, metadata);
+        deterministicReachableCache.set(questionId, result);
+        return result;
+      }
+
       deterministicReachableCache.set(questionId, true);
       return true;
     }

--- a/packages/lumi-survey/src/core/computeReachableSteps.ts
+++ b/packages/lumi-survey/src/core/computeReachableSteps.ts
@@ -83,7 +83,9 @@ export function computeReachableSteps(
 
     const condition = question.visibleIf;
 
-    if (!condition) {
+    // Only null/undefined mean "no condition"; other falsy values are malformed
+    // and fall through to the fail-closed guard below.
+    if (condition === null || condition === undefined) {
       deterministicReachableCache.set(questionId, true);
       return true;
     }

--- a/packages/lumi-survey/src/core/computeReachableSteps.ts
+++ b/packages/lumi-survey/src/core/computeReachableSteps.ts
@@ -67,7 +67,10 @@ export function computeReachableSteps(
     }
 
     if (visited.has(questionId)) {
-      return false;
+      // Cyclic visibleIf dependency — genuinely indeterminate. Overestimate as
+      // reachable (this function's documented policy) so a cycle never
+      // UNDER-counts and hides a step that is actually reachable.
+      return true;
     }
 
     visited.add(questionId);

--- a/packages/lumi-survey/src/core/computeReachableSteps.ts
+++ b/packages/lumi-survey/src/core/computeReachableSteps.ts
@@ -86,29 +86,31 @@ export function computeReachableSteps(
     }
 
     if (isConditionGroup(condition)) {
-      // When every answer the group references is already present (and no
-      // METADATA leaf, whose value may still arrive/change), the group is fully
-      // resolvable — evaluate it so an answered-but-falsified group is excluded.
-      // Otherwise overestimate as reachable (same policy as METADATA leaves).
+      // Reachability of a group, per leaf:
+      //  - METADATA / no-questionId leaves stay open (value may arrive).
+      //  - an answered leaf contributes its actual truth (so an answered-but-
+      //    falsified group is excluded).
+      //  - an unanswered leaf stays open ONLY if its referenced parent is itself
+      //    deterministically reachable — a leaf whose parent can never be shown
+      //    can never become true, so it must not keep the group alive.
+      // Combine with any (some) / all (every).
       const leaves = getLeafConditions(condition);
-      const hasMetadataLeaf = leaves.some((leaf) => leaf.field === "METADATA");
-      const answerLeaves = leaves.filter((leaf) => leaf.field !== "METADATA");
-      const allReferencedAnswered = answerLeaves.every(
-        (leaf) => !leaf.questionId || answers[leaf.questionId] !== undefined,
-      );
+      const leafCanBeTrue = (leaf: LogicLeafCondition): boolean => {
+        if (leaf.field === "METADATA") return true;
+        if (!leaf.questionId) return true;
+        if (answers[leaf.questionId] !== undefined) {
+          return evaluateVisibility(leaf, answers, metadata);
+        }
+        return isDeterministicallyReachable(leaf.questionId, new Set(visited));
+      };
 
-      if (
-        !hasMetadataLeaf &&
-        answerLeaves.length > 0 &&
-        allReferencedAnswered
-      ) {
-        const result = evaluateVisibility(condition, answers, metadata);
-        deterministicReachableCache.set(questionId, result);
-        return result;
-      }
+      const reachable =
+        "any" in condition
+          ? leaves.some(leafCanBeTrue)
+          : leaves.length > 0 && leaves.every(leafCanBeTrue);
 
-      deterministicReachableCache.set(questionId, true);
-      return true;
+      deterministicReachableCache.set(questionId, reachable);
+      return reachable;
     }
 
     if (condition.field === "METADATA") {

--- a/packages/lumi-survey/src/core/computeReachableSteps.ts
+++ b/packages/lumi-survey/src/core/computeReachableSteps.ts
@@ -1,14 +1,14 @@
 import { isConditionGroup } from "./conditionUtils.js";
 import { evaluateVisibility } from "./evaluateVisibility.js";
 import type {
-  LogicCondition,
   LogicLeafCondition,
   LumiSurveyAnswerValue,
   LumiSurveyQuestion,
+  VisibleIfCondition,
 } from "./types.js";
 
 function isAnswerCondition(
-  condition: LogicCondition | undefined,
+  condition: VisibleIfCondition | undefined,
 ): condition is Extract<LogicLeafCondition, { field?: "ANSWER" }> {
   return (
     condition !== undefined &&

--- a/packages/lumi-survey/src/core/computeReachableSteps.ts
+++ b/packages/lumi-survey/src/core/computeReachableSteps.ts
@@ -14,12 +14,7 @@ import type {
 function isAnswerCondition(
   condition: VisibleIfCondition | undefined,
 ): condition is Extract<LogicLeafCondition, { field?: "ANSWER" }> {
-  return (
-    typeof condition === "object" &&
-    condition !== null &&
-    !isConditionGroup(condition) &&
-    condition.field !== "METADATA"
-  );
+  return isLeafCondition(condition) && condition.field !== "METADATA";
 }
 
 /**
@@ -124,6 +119,13 @@ export function computeReachableSteps(
 
       deterministicReachableCache.set(questionId, reachable);
       return reachable;
+    }
+
+    // A non-group condition that isn't a valid leaf (e.g. missing operator) is
+    // hidden by evaluateVisibility → not reachable. Keeps the two consistent.
+    if (!isLeafCondition(condition)) {
+      deterministicReachableCache.set(questionId, false);
+      return false;
     }
 
     if (condition.field === "METADATA") {

--- a/packages/lumi-survey/src/core/computeReachableSteps.ts
+++ b/packages/lumi-survey/src/core/computeReachableSteps.ts
@@ -1,4 +1,8 @@
-import { getLeafConditions, isConditionGroup } from "./conditionUtils.js";
+import {
+  getLeafConditions,
+  isConditionGroup,
+  isLeafCondition,
+} from "./conditionUtils.js";
 import { evaluateVisibility } from "./evaluateVisibility.js";
 import type {
   LogicLeafCondition,
@@ -11,7 +15,8 @@ function isAnswerCondition(
   condition: VisibleIfCondition | undefined,
 ): condition is Extract<LogicLeafCondition, { field?: "ANSWER" }> {
   return (
-    condition !== undefined &&
+    typeof condition === "object" &&
+    condition !== null &&
     !isConditionGroup(condition) &&
     condition.field !== "METADATA"
   );
@@ -85,6 +90,13 @@ export function computeReachableSteps(
       return true;
     }
 
+    // Malformed condition (not a plain object): evaluateVisibility hides it, so
+    // reachability mirrors visibility and excludes it (rather than crashing).
+    if (typeof condition !== "object" || Array.isArray(condition)) {
+      deterministicReachableCache.set(questionId, false);
+      return false;
+    }
+
     if (isConditionGroup(condition)) {
       // Reachability of a group, per leaf:
       //  - METADATA / no-questionId leaves stay open (value may arrive).
@@ -96,6 +108,7 @@ export function computeReachableSteps(
       // Combine with any (some) / all (every).
       const leaves = getLeafConditions(condition);
       const leafCanBeTrue = (leaf: LogicLeafCondition): boolean => {
+        if (!isLeafCondition(leaf)) return false;
         if (leaf.field === "METADATA") return true;
         if (!leaf.questionId) return true;
         if (answers[leaf.questionId] !== undefined) {

--- a/packages/lumi-survey/src/core/computeReachableSteps.ts
+++ b/packages/lumi-survey/src/core/computeReachableSteps.ts
@@ -93,6 +93,13 @@ export function computeReachableSteps(
     }
 
     if (isConditionGroup(condition)) {
+      // Both keys at once is ambiguous — mirror evaluateVisibility and fail
+      // closed so reachability matches visibility for raw both-keys input.
+      if ("any" in condition && "all" in condition) {
+        deterministicReachableCache.set(questionId, false);
+        return false;
+      }
+
       // Reachability of a group, per leaf:
       //  - METADATA / no-questionId leaves stay open (value may arrive).
       //  - an answered leaf contributes its actual truth (so an answered-but-

--- a/packages/lumi-survey/src/core/conditionUtils.ts
+++ b/packages/lumi-survey/src/core/conditionUtils.ts
@@ -1,19 +1,19 @@
 import type {
-  LogicCondition,
   LogicConditionGroup,
   LogicLeafCondition,
+  VisibleIfCondition,
 } from "./types.js";
 
 /** True when the condition is an `any`/`all` group rather than a leaf. */
 export function isConditionGroup(
-  condition: LogicCondition,
+  condition: VisibleIfCondition,
 ): condition is LogicConditionGroup {
   return "any" in condition || "all" in condition;
 }
 
 /** Flattens a condition to its leaf conditions (a leaf yields itself). */
 export function getLeafConditions(
-  condition: LogicCondition,
+  condition: VisibleIfCondition,
 ): LogicLeafCondition[] {
   if ("any" in condition) return condition.any;
   if ("all" in condition) return condition.all;

--- a/packages/lumi-survey/src/core/conditionUtils.ts
+++ b/packages/lumi-survey/src/core/conditionUtils.ts
@@ -1,0 +1,21 @@
+import type {
+  LogicCondition,
+  LogicConditionGroup,
+  LogicLeafCondition,
+} from "./types.js";
+
+/** True when the condition is an `any`/`all` group rather than a leaf. */
+export function isConditionGroup(
+  condition: LogicCondition,
+): condition is LogicConditionGroup {
+  return "any" in condition || "all" in condition;
+}
+
+/** Flattens a condition to its leaf conditions (a leaf yields itself). */
+export function getLeafConditions(
+  condition: LogicCondition,
+): LogicLeafCondition[] {
+  if ("any" in condition) return condition.any;
+  if ("all" in condition) return condition.all;
+  return [condition];
+}

--- a/packages/lumi-survey/src/core/conditionUtils.ts
+++ b/packages/lumi-survey/src/core/conditionUtils.ts
@@ -11,11 +11,17 @@ export function isConditionGroup(
   return "any" in condition || "all" in condition;
 }
 
-/** Flattens a condition to its leaf conditions (a leaf yields itself). */
+/**
+ * Flattens a condition to its leaf conditions (a leaf yields itself).
+ * A group whose body is not an array (malformed raw input) yields no leaves
+ * rather than throwing, so callers can fail closed instead of crashing.
+ */
 export function getLeafConditions(
   condition: VisibleIfCondition,
 ): LogicLeafCondition[] {
-  if ("any" in condition) return condition.any;
-  if ("all" in condition) return condition.all;
+  if ("any" in condition)
+    return Array.isArray(condition.any) ? condition.any : [];
+  if ("all" in condition)
+    return Array.isArray(condition.all) ? condition.all : [];
   return [condition];
 }

--- a/packages/lumi-survey/src/core/conditionUtils.ts
+++ b/packages/lumi-survey/src/core/conditionUtils.ts
@@ -8,7 +8,11 @@ import type {
 export function isConditionGroup(
   condition: VisibleIfCondition,
 ): condition is LogicConditionGroup {
-  return "any" in condition || "all" in condition;
+  return (
+    typeof condition === "object" &&
+    condition !== null &&
+    ("any" in condition || "all" in condition)
+  );
 }
 
 /**
@@ -19,6 +23,7 @@ export function isConditionGroup(
 export function getLeafConditions(
   condition: VisibleIfCondition,
 ): LogicLeafCondition[] {
+  if (typeof condition !== "object" || condition === null) return [];
   if ("any" in condition)
     return Array.isArray(condition.any) ? condition.any : [];
   if ("all" in condition)

--- a/packages/lumi-survey/src/core/conditionUtils.ts
+++ b/packages/lumi-survey/src/core/conditionUtils.ts
@@ -30,3 +30,21 @@ export function getLeafConditions(
     return Array.isArray(condition.all) ? condition.all : [];
   return [condition];
 }
+
+/**
+ * True for a structurally valid leaf condition: a plain object with a string
+ * `operator` that is not an `any`/`all` group. Use to fail closed on malformed
+ * raw input rather than crash or treat it as visible.
+ */
+export function isLeafCondition(
+  condition: unknown,
+): condition is LogicLeafCondition {
+  return (
+    typeof condition === "object" &&
+    condition !== null &&
+    !Array.isArray(condition) &&
+    !("any" in condition) &&
+    !("all" in condition) &&
+    typeof (condition as { operator?: unknown }).operator === "string"
+  );
+}

--- a/packages/lumi-survey/src/core/conditionUtils.ts
+++ b/packages/lumi-survey/src/core/conditionUtils.ts
@@ -4,6 +4,16 @@ import type {
   VisibleIfCondition,
 } from "./types.js";
 
+/** Valid `LogicOperator` values — keep in sync with the type in `types.ts`. */
+const LOGIC_OPERATORS = new Set<string>([
+  "EQ",
+  "NEQ",
+  "GT",
+  "LT",
+  "CONTAINS",
+  "EXISTS",
+]);
+
 /** True when the condition is an `any`/`all` group rather than a leaf. */
 export function isConditionGroup(
   condition: VisibleIfCondition,
@@ -45,6 +55,7 @@ export function isLeafCondition(
     !Array.isArray(condition) &&
     !("any" in condition) &&
     !("all" in condition) &&
-    typeof (condition as { operator?: unknown }).operator === "string"
+    typeof (condition as { operator?: unknown }).operator === "string" &&
+    LOGIC_OPERATORS.has((condition as { operator: string }).operator)
   );
 }

--- a/packages/lumi-survey/src/core/evaluateVisibility.ts
+++ b/packages/lumi-survey/src/core/evaluateVisibility.ts
@@ -28,8 +28,9 @@ export function evaluateVisibility(
   answers: Record<string, LumiSurveyAnswerValue>,
   metadata?: Record<string, unknown>,
 ): boolean {
-  // No condition = always visible
-  if (!condition) return true;
+  // No condition = always visible. Only null/undefined mean "no condition";
+  // other falsy values (false, 0, "", NaN, 0n) are malformed → fail closed below.
+  if (condition === null || condition === undefined) return true;
 
   // Defensive: a condition must be a plain (non-array) object — fail closed
   // otherwise (e.g. a primitive or array slipping in via untyped/raw input).

--- a/packages/lumi-survey/src/core/evaluateVisibility.ts
+++ b/packages/lumi-survey/src/core/evaluateVisibility.ts
@@ -1,8 +1,8 @@
 import type {
-  LogicCondition,
   LogicLeafCondition,
   LumiSurveyAnswerValue,
   LumiSurveyQuestion,
+  VisibleIfCondition,
 } from "./types";
 
 /**
@@ -23,7 +23,7 @@ import type {
  * ```
  */
 export function evaluateVisibility(
-  condition: LogicCondition | undefined,
+  condition: VisibleIfCondition | undefined,
   answers: Record<string, LumiSurveyAnswerValue>,
   metadata?: Record<string, unknown>,
 ): boolean {

--- a/packages/lumi-survey/src/core/evaluateVisibility.ts
+++ b/packages/lumi-survey/src/core/evaluateVisibility.ts
@@ -1,4 +1,4 @@
-import { isConditionGroup } from "./conditionUtils.js";
+import { isLeafCondition } from "./conditionUtils.js";
 import type {
   LogicLeafCondition,
   LumiSurveyAnswerValue,
@@ -62,17 +62,10 @@ function evaluateLeaf(
   answers: Record<string, LumiSurveyAnswerValue>,
   metadata?: Record<string, unknown>,
 ): boolean {
-  // Defensive: a leaf must be a plain object with a string operator. Anything
-  // else (nested group, null, primitive, array, missing operator) is malformed
-  // raw input; fail closed (hide) rather than crash or fail open.
-  if (
-    typeof condition !== "object" ||
-    condition === null ||
-    isConditionGroup(condition) ||
-    typeof (condition as { operator?: unknown }).operator !== "string"
-  ) {
-    return false;
-  }
+  // A leaf must be a structurally valid leaf object; anything else (nested
+  // group, null, primitive, array, missing operator) is malformed raw input —
+  // fail closed (hide) rather than crash or fail open.
+  if (!isLeafCondition(condition)) return false;
 
   if (condition.field === "METADATA") {
     const metaValue = metadata?.[condition.key];

--- a/packages/lumi-survey/src/core/evaluateVisibility.ts
+++ b/packages/lumi-survey/src/core/evaluateVisibility.ts
@@ -1,5 +1,6 @@
 import type {
   LogicCondition,
+  LogicLeafCondition,
   LumiSurveyAnswerValue,
   LumiSurveyQuestion,
 } from "./types";
@@ -29,6 +30,24 @@ export function evaluateVisibility(
   // No condition = always visible
   if (!condition) return true;
 
+  if ("all" in condition) {
+    return condition.all.every((leaf) => evaluateLeaf(leaf, answers, metadata));
+  }
+  if ("any" in condition) {
+    return condition.any.some((leaf) => evaluateLeaf(leaf, answers, metadata));
+  }
+
+  return evaluateLeaf(condition, answers, metadata);
+}
+
+/**
+ * Evaluates a single leaf condition (no groups).
+ */
+function evaluateLeaf(
+  condition: LogicLeafCondition,
+  answers: Record<string, LumiSurveyAnswerValue>,
+  metadata?: Record<string, unknown>,
+): boolean {
   if (condition.field === "METADATA") {
     const metaValue = metadata?.[condition.key];
     return evaluateOperator(metaValue, condition.operator, condition.value);

--- a/packages/lumi-survey/src/core/evaluateVisibility.ts
+++ b/packages/lumi-survey/src/core/evaluateVisibility.ts
@@ -1,3 +1,4 @@
+import { isConditionGroup } from "./conditionUtils.js";
 import type {
   LogicLeafCondition,
   LumiSurveyAnswerValue,
@@ -48,6 +49,10 @@ function evaluateLeaf(
   answers: Record<string, LumiSurveyAnswerValue>,
   metadata?: Record<string, unknown>,
 ): boolean {
+  // Defensive: group members must be leaves. A nested group reaching here is
+  // malformed (untyped/raw input); fail closed (hide) rather than fail open.
+  if (isConditionGroup(condition)) return false;
+
   if (condition.field === "METADATA") {
     const metaValue = metadata?.[condition.key];
     return evaluateOperator(metaValue, condition.operator, condition.value);

--- a/packages/lumi-survey/src/core/evaluateVisibility.ts
+++ b/packages/lumi-survey/src/core/evaluateVisibility.ts
@@ -31,6 +31,10 @@ export function evaluateVisibility(
   // No condition = always visible
   if (!condition) return true;
 
+  // Defensive: a condition must be a plain (non-array) object — fail closed
+  // otherwise (e.g. a primitive or array slipping in via untyped/raw input).
+  if (typeof condition !== "object" || Array.isArray(condition)) return false;
+
   // Malformed group input (raw/untyped): both keys at once is ambiguous, and a
   // non-array body cannot be iterated — fail closed (hide) rather than open/crash.
   if ("all" in condition && "any" in condition) return false;
@@ -58,9 +62,17 @@ function evaluateLeaf(
   answers: Record<string, LumiSurveyAnswerValue>,
   metadata?: Record<string, unknown>,
 ): boolean {
-  // Defensive: group members must be leaves. A nested group reaching here is
-  // malformed (untyped/raw input); fail closed (hide) rather than fail open.
-  if (isConditionGroup(condition)) return false;
+  // Defensive: a leaf must be a plain object with a string operator. Anything
+  // else (nested group, null, primitive, array, missing operator) is malformed
+  // raw input; fail closed (hide) rather than crash or fail open.
+  if (
+    typeof condition !== "object" ||
+    condition === null ||
+    isConditionGroup(condition) ||
+    typeof (condition as { operator?: unknown }).operator !== "string"
+  ) {
+    return false;
+  }
 
   if (condition.field === "METADATA") {
     const metaValue = metadata?.[condition.key];

--- a/packages/lumi-survey/src/core/evaluateVisibility.ts
+++ b/packages/lumi-survey/src/core/evaluateVisibility.ts
@@ -31,11 +31,20 @@ export function evaluateVisibility(
   // No condition = always visible
   if (!condition) return true;
 
+  // Malformed group input (raw/untyped): both keys at once is ambiguous, and a
+  // non-array body cannot be iterated — fail closed (hide) rather than open/crash.
+  if ("all" in condition && "any" in condition) return false;
   if ("all" in condition) {
-    return condition.all.every((leaf) => evaluateLeaf(leaf, answers, metadata));
+    return (
+      Array.isArray(condition.all) &&
+      condition.all.every((leaf) => evaluateLeaf(leaf, answers, metadata))
+    );
   }
   if ("any" in condition) {
-    return condition.any.some((leaf) => evaluateLeaf(leaf, answers, metadata));
+    return (
+      Array.isArray(condition.any) &&
+      condition.any.some((leaf) => evaluateLeaf(leaf, answers, metadata))
+    );
   }
 
   return evaluateLeaf(condition, answers, metadata);

--- a/packages/lumi-survey/src/core/index.ts
+++ b/packages/lumi-survey/src/core/index.ts
@@ -12,7 +12,11 @@ export { ErrorType as LumiApiErrorType } from "../contracts/lumiApi";
 
 export * from "./branchingEngine";
 export { computeReachableSteps } from "./computeReachableSteps.js";
-export { getLeafConditions, isConditionGroup } from "./conditionUtils.js";
+export {
+  getLeafConditions,
+  isConditionGroup,
+  isLeafCondition,
+} from "./conditionUtils.js";
 export * from "./evaluateVisibility";
 export * from "./ratingLabels";
 export * from "./types";

--- a/packages/lumi-survey/src/core/index.ts
+++ b/packages/lumi-survey/src/core/index.ts
@@ -12,6 +12,7 @@ export { ErrorType as LumiApiErrorType } from "../contracts/lumiApi";
 
 export * from "./branchingEngine";
 export { computeReachableSteps } from "./computeReachableSteps.js";
+export { getLeafConditions, isConditionGroup } from "./conditionUtils.js";
 export * from "./evaluateVisibility";
 export * from "./ratingLabels";
 export * from "./types";

--- a/packages/lumi-survey/src/core/types.ts
+++ b/packages/lumi-survey/src/core/types.ts
@@ -21,20 +21,7 @@ export type LogicField = "ANSWER" | "METADATA";
  */
 export type LogicOperator = "EQ" | "NEQ" | "GT" | "LT" | "CONTAINS" | "EXISTS";
 
-/**
- * A condition that determines whether a logic rule should trigger.
- * Uses discriminated unions for type safety.
- *
- * @example Cross-question visibility
- * ```typescript
- * visibleIf: {
- *   field: "ANSWER",
- *   questionId: "rating",
- *   operator: "EXISTS"
- * }
- * ```
- */
-export type LogicCondition =
+export type LogicLeafCondition =
   | {
       /** Compare against a question's answer */
       field?: "ANSWER";
@@ -55,6 +42,18 @@ export type LogicCondition =
       /** Value to compare against */
       value: string | number | boolean;
     };
+
+/**
+ * A group of leaf conditions combined with AND (`all`) or OR (`any`).
+ * One level only — group members are leaves, not nested groups (kept
+ * forward-compatible: widening to `LogicCondition[]` later is non-breaking).
+ * Only `visibleIf` supports groups; `logic` is leaf-only.
+ */
+export type LogicConditionGroup =
+  | { any: LogicLeafCondition[] }
+  | { all: LogicLeafCondition[] };
+
+export type LogicCondition = LogicLeafCondition | LogicConditionGroup;
 
 /**
  * Action type for logic rules.
@@ -89,8 +88,8 @@ export type LogicAction =
  * Rules are evaluated in order; first matching rule wins.
  */
 export interface LogicRule {
-  /** Condition to evaluate */
-  condition: LogicCondition;
+  /** Condition to evaluate (leaf only — `logic` does not support any/all groups) */
+  condition: LogicLeafCondition;
   /** Action to perform if condition is met */
   action: LogicAction;
 }

--- a/packages/lumi-survey/src/core/types.ts
+++ b/packages/lumi-survey/src/core/types.ts
@@ -53,7 +53,18 @@ export type LogicConditionGroup =
   | { any: LogicLeafCondition[] }
   | { all: LogicLeafCondition[] };
 
-export type LogicCondition = LogicLeafCondition | LogicConditionGroup;
+/**
+ * Leaf-only condition language. Kept as the historical public name so existing
+ * `LogicRule` / `visibleIf` authorings stay source-compatible after `any`/`all`
+ * groups were added — groups live in the wider `VisibleIfCondition`.
+ */
+export type LogicCondition = LogicLeafCondition;
+
+/**
+ * Condition language for `visibleIf`: a single leaf, or a one-level `any`/`all`
+ * group of leaves. Wider than `LogicCondition`; only `visibleIf` accepts groups.
+ */
+export type VisibleIfCondition = LogicLeafCondition | LogicConditionGroup;
 
 /**
  * Action type for logic rules.
@@ -89,7 +100,7 @@ export type LogicAction =
  */
 export interface LogicRule {
   /** Condition to evaluate (leaf only — `logic` does not support any/all groups) */
-  condition: LogicLeafCondition;
+  condition: LogicCondition;
   /** Action to perform if condition is met */
   action: LogicAction;
 }
@@ -129,7 +140,7 @@ export interface LumiSurveyQuestionBase<TType extends LumiSurveyQuestionType> {
    * }
    * ```
    */
-  visibleIf?: LogicCondition;
+  visibleIf?: VisibleIfCondition;
 }
 
 // ============================================


### PR DESCRIPTION
## Hva

Legger til **`any` (OR) / `all` (AND)** betingelsesgrupper i `visibleIf`, så et spørsmål kan vises basert på flere betingelser samtidig.

Det motiverende behovet (også konteksten bak #332): «vis det siste spørsmålet hvis **ett av** de foregående svarene er "Nei"» — nå et rent `visibleIf`-uttrykk, uten `logic`:

```ts
{
  id: "siste",
  type: "text",
  prompt: "Hva manglet?",
  visibleIf: {
    any: [
      { questionId: "q1", operator: "EQ", value: "nei" },
      { questionId: "q2", operator: "EQ", value: "nei" },
    ],
  },
}
```

## Designbeslutninger

Følger **ADR 0001** (`visibleIf` kanonisk flytmodell, `logic` som escape hatch):

- **Ett nivå `any`/`all`, ingen nesting (YAGNI).** Typen er forward-kompatibel, så nesting kan legges til senere uten brudd (`LogicLeafCondition[]` → `LogicCondition[]`).
- **AND/OR kun for `visibleIf`.** `logic` snevres til leaf på **type-nivå** (`LogicRule.condition: LogicLeafCondition`) og avvises i validering for rå JSON. ADR-beslutningen blir dermed en kompilerings-garanti, ikke bare en konvensjon.
- **Strukturert objekt, ikke streng-DSL** — bevarer TS-autocomplete, statisk `questionId`-validering, og lar Survey Builder (#338) round-trippe uten parser/generator.
- **Ingen operator-unifisering** mellom de to evaluatorene (bevisst utsatt; den pre-eksisterende divergensen berører kun den utfasede `logic`).

## Endringer

- Nye typer: `LogicLeafCondition` / `LogicConditionGroup` / `LogicCondition` (supersett — det offentlige `LogicCondition`-navnet er bevart, så endringen er ikke-brytende).
- `evaluateVisibility` evaluerer `any`/`all`; intern `conditionUtils` (`isConditionGroup`, `getLeafConditions`).
- Tilpasset alle steder som snevrer `LogicCondition`: `canonicalSurvey`, `computeReachableSteps`, `branchingEngine`, `stepNavigationUtils`. Gruppe-gatede spørsmål overestimeres som «alltid reachable» i progress-estimatet (samme policy som METADATA).
- Validering avviser tomme grupper og grupper smuglet inn i `logic.condition`.
- Docs (`betinget-synlighet.md`, `branching.md`), ADR 0001-oppfølging krysset av, CHANGELOG.
- Design-spec + implementasjonsplan under `docs/superpowers/` for sporbarhet.

## Test

- **285/285** tester grønne, `tsc` rent.
- Bakoverkompatibelt: eksisterende leaf-`visibleIf` og all `logic` er funksjonelt uendret (`evaluateLeaf`-kroppen er identisk med tidligere kode; `branchingEngine`-evaluering urørt).

## Utenfor scope (egne oppgaver)

- Nesting (ett nivå nå).
- Migrering av `createTopTasksSurvey` `SKIP`/`SUBMIT` → `visibleIf` (ADR 0001 punkt 4).
- Operator-unifisering mellom evaluatorene.

Closes #333
