### PR TITLE
fix(api): håndter Ktor rate-limit-endring

### DIFF
--- a/apps/lumi-api/build.gradle.kts
+++ b/apps/lumi-api/build.gradle.kts
@@ -5,7 +5,7 @@ plugins {
     // Keep this at 2.3.0 for now; current CodeQL (linked tools v2.24.1) does not support 2.3.10 yet.
     kotlin("jvm")
     kotlin("plugin.serialization")
-    id("io.ktor.plugin") version "3.5.0"
+    id("io.ktor.plugin") version "3.5.1"
     id("com.gradleup.shadow") version "9.4.2"
     id("com.github.ben-manes.versions") version "0.54.0"
     application
@@ -25,7 +25,7 @@ repositories {
     }
 }
 
-val ktorVersion = "3.5.0"
+val ktorVersion = "3.5.1"
 val logbackVersion = "1.5.35"
 val logstashVersion = "9.0"
 val postgresVersion = "42.7.11"

--- a/apps/lumi-api/src/main/kotlin/no/nav/lumi/config/RateLimiting.kt
+++ b/apps/lumi-api/src/main/kotlin/no/nav/lumi/config/RateLimiting.kt
@@ -8,9 +8,28 @@ import kotlin.time.Duration.Companion.minutes
 
 /**
  * Rate limiting to prevent abuse.
- * 
- * Uses validated caller identity when available.
- * Falls back to clientId from validated principal, then to IP address.
+ *
+ * Keying semantics differ per route family because of *when* identity becomes
+ * available relative to the RateLimit plugin.
+ *
+ * On Ktor 3.5.1 the RateLimit `requestKey` is evaluated before a Ktor
+ * `BrukerPrincipal` from the standard `authenticate` flow is available. In this
+ * version rejected nested `authenticate` calls also count toward the limit
+ * (KTOR-9621) instead of bypassing it.
+ *
+ * - Submission routes: a route-scoped auth plugin
+ *   (Token/Azure SubmissionAuthPlugin) sets [CallerIdentityKey] and
+ *   [UserRateLimitHashKey] in its `onCall`, which runs before the RateLimit
+ *   `requestKey`. These routes are therefore keyed per caller-app and, when a
+ *   user hash is present, per hashed user.
+ * - Analytics/export routes: authentication happens in the standard Ktor
+ *   `authenticate` flow, so no principal is available when `requestKey` runs.
+ *   These routes fall back to the caller's source IP (X-Forwarded-For on NAIS,
+ *   otherwise the remote address). They are NOT keyed per validated user.
+ *
+ * The `getBrukerPrincipal()` branch in [rateLimitKey] is a defensive fallback
+ * that only fires if a principal is already present when `requestKey` runs; it
+ * does not fire for the normal Ktor `authenticate` flow.
  */
 
 val SubmissionRateLimit = RateLimitName("submission")
@@ -53,12 +72,15 @@ fun Application.configureRateLimiting() {
 }
 
 private fun io.ktor.server.application.ApplicationCall.rateLimitKey(): String {
-    // Submission routes set CallerIdentityKey after successful token introspection.
+    // Submission routes set CallerIdentityKey in their route-scoped auth plugin's
+    // onCall, which runs before this requestKey is evaluated.
     attributes.getOrNull(CallerIdentityKey)?.let { identity ->
         return "${identity.team}:${identity.app}"
     }
 
-    // Analytics routes authenticate with BrukerPrincipal from Texas introspection.
+    // Defensive fallback: only fires if a BrukerPrincipal is already present when
+    // this requestKey runs. For the normal Ktor authenticate flow the principal is
+    // not yet set here, so analytics/export fall through to IP below.
     getBrukerPrincipal()?.let { principal ->
         extractCallerIdentityFromPrincipal(principal)?.let { identity ->
             return "${identity.team}:${identity.app}"

--- a/apps/lumi-api/src/test/kotlin/no/nav/lumi/config/RateLimitingKeyingTest.kt
+++ b/apps/lumi-api/src/test/kotlin/no/nav/lumi/config/RateLimitingKeyingTest.kt
@@ -14,6 +14,7 @@ import no.nav.lumi.config.auth.BrukerPrincipal
 import no.nav.lumi.config.auth.CallerIdentity
 import no.nav.lumi.config.auth.CallerIdentityKey
 import no.nav.lumi.config.auth.UserRateLimitHashKey
+import no.nav.lumi.config.exception.ApiErrorException
 
 private val HeaderCallerIdentityPlugin = createRouteScopedPlugin("HeaderCallerIdentityPlugin") {
     onCall { call ->
@@ -34,6 +35,18 @@ private val HeaderCallerIdentityPlugin = createRouteScopedPlugin("HeaderCallerId
         if (userHash != null) {
             call.attributes.put(UserRateLimitHashKey, userHash)
         }
+    }
+}
+
+/**
+ * Mirrors the production submission auth plugins (Token/Azure SubmissionAuthPlugin):
+ * a route-scoped plugin that rejects unauthenticated callers in `onCall`, i.e.
+ * *before* the nested `rateLimit` block. Used to document that this rejection path
+ * is NOT covered by the KTOR-9621 fix (which only affects nested Ktor `authenticate`).
+ */
+private val RejectingSubmissionAuthPlugin = createRouteScopedPlugin("RejectingSubmissionAuthPlugin") {
+    onCall {
+        throw ApiErrorException.UnauthorizedException("Authorization header required")
     }
 }
 
@@ -73,7 +86,10 @@ class RateLimitingKeyingTest : FunSpec({
         }
     }
 
-    test("export rate limit uses validated principal clientId as key") {
+    test("export rate limit falls back to source IP when principal is unavailable in the RateLimit phase") {
+        // Ktor 3.5.1 runs the RateLimit plugin in the Plugins phase, before the
+        // Authentication phase, so getBrukerPrincipal() is null at requestKey time.
+        // Analytics/export therefore bucket on source IP, NOT per validated client.
         testApplication {
             application {
                 configureRateLimiting()
@@ -119,10 +135,89 @@ class RateLimitingKeyingTest : FunSpec({
             }
             blockedResponse.status shouldBe HttpStatusCode.TooManyRequests
 
+            // A different validated client shares the same source-IP bucket, so it is
+            // also blocked. This documents that export is per-IP, not per-client, in 3.5.1.
             val otherClientResponse = client.get("/export-test") {
                 header(HttpHeaders.Authorization, "Bearer client-b")
             }
-            otherClientResponse.status shouldBe HttpStatusCode.OK
+            otherClientResponse.status shouldBe HttpStatusCode.TooManyRequests
+        }
+    }
+
+    test("KTOR-9621: rejected auth in nested authenticate still counts toward export rate limit") {
+        // Regression guard for KTOR-9621: before Ktor 3.5.1, a nested authenticate
+        // block that rejected the request bypassed the RateLimit plugin, so an
+        // attacker could spam invalid tokens without ever hitting 429. In 3.5.1 the
+        // rejected calls are counted, so the limit is enforced.
+        testApplication {
+            application {
+                configureRateLimiting()
+                install(Authentication) {
+                    bearer(AZURE_REALM) {
+                        authenticate {
+                            // Every token is rejected in this test.
+                            null
+                        }
+                    }
+                }
+
+                routing {
+                    authenticate(AZURE_REALM) {
+                        rateLimit(ExportRateLimit) {
+                            get("/export-reject-test") {
+                                call.respond(HttpStatusCode.OK)
+                            }
+                        }
+                    }
+                }
+            }
+
+            // First 30 rejected calls pass the (not-yet-exhausted) rate limit but fail
+            // auth -> 401. Each still consumes a rate-limit token.
+            repeat(30) {
+                val response = client.get("/export-reject-test") {
+                    header(HttpHeaders.Authorization, "Bearer invalid-$it")
+                }
+                response.status shouldBe HttpStatusCode.Unauthorized
+            }
+
+            // 31st rejected call is blocked by the rate limit instead of bypassing it.
+            val blockedResponse = client.get("/export-reject-test") {
+                header(HttpHeaders.Authorization, "Bearer invalid-final")
+            }
+            blockedResponse.status shouldBe HttpStatusCode.TooManyRequests
+        }
+    }
+
+    test("submission auth plugin that rejects before nested rateLimit is not covered by KTOR-9621") {
+        // The submission auth plugins reject in a route-scoped `onCall` that runs
+        // before the nested `rateLimit`. KTOR-9621 only fixes nested Ktor
+        // `authenticate`, so these rejections are NOT rate-limited: the auth error
+        // is returned and no rate-limit token is consumed. This test documents that
+        // actual behavior; the DoS surface for unauthenticated submission spam is
+        // instead bounded by the global rate limit.
+        testApplication {
+            application {
+                configureSerialization()
+                configureStatusPages()
+                configureRateLimiting()
+                routing {
+                    route("/submission-reject-test") {
+                        install(RejectingSubmissionAuthPlugin)
+                        rateLimit(SubmissionRateLimit) {
+                            get {
+                                call.respond(HttpStatusCode.OK)
+                            }
+                        }
+                    }
+                }
+            }
+
+            // The route-scoped auth plugin throws before the nested rateLimit ever runs,
+            // so far more than the submission limit (100/min) can be rejected without a
+            // single 429: these rejections are NOT counted by SubmissionRateLimit.
+            val statuses = (1..150).map { client.get("/submission-reject-test").status }
+            statuses.all { it == HttpStatusCode.Unauthorized } shouldBe true
         }
     }
 

--- a/docs/dashboard/eksport.md
+++ b/docs/dashboard/eksport.md
@@ -36,5 +36,5 @@ GET /api/v1/intern/export?format=csv|json|excel
 Alle aktive query-parametre (team, app, datoer, etc.) sendes med, slik at eksporten gjenspeiler det du ser i dashboardet. Se [API-referansen](/referanse/api-endepunkter) for full parameteroversikt.
 
 ::: warning Rate limiting
-Eksport er rate-begrenset til **30 forespørsler per minutt** for å beskytte backend-ytelsen. Grensen deles på kilde-IP for dashboard-trafikken, ikke per innlogget bruker.
+Eksport er rate-begrenset til **30 forespørsler per minutt** for å beskytte backend-ytelsen. Grensen deles på kilde-IP for dashboard-trafikken, ikke per innlogget bruker. På NAIS brukes første IP i `X-Forwarded-For`-headeren.
 :::

--- a/docs/dashboard/eksport.md
+++ b/docs/dashboard/eksport.md
@@ -36,5 +36,5 @@ GET /api/v1/intern/export?format=csv|json|excel
 Alle aktive query-parametre (team, app, datoer, etc.) sendes med, slik at eksporten gjenspeiler det du ser i dashboardet. Se [API-referansen](/referanse/api-endepunkter) for full parameteroversikt.
 
 ::: warning Rate limiting
-Eksport er rate-begrenset til **30 forespørsler per minutt** per bruker for å beskytte backend-ytelsen.
+Eksport er rate-begrenset til **30 forespørsler per minutt** for å beskytte backend-ytelsen. Grensen deles på kilde-IP for dashboard-trafikken, ikke per innlogget bruker.
 :::

--- a/docs/referanse/sikkerhet.md
+++ b/docs/referanse/sikkerhet.md
@@ -31,9 +31,14 @@ API-et håndhever rate limiting på flere nivåer for å beskytte mot misbruk:
 | Kategori | Grense | Beskrivelse |
 | :--- | :--- | :--- |
 | Innsending | 100 req/min | Per kaller-app |
-| Analyse | 300 req/min | Per bruker |
-| Eksport | 30 req/min | Per bruker |
+| Innsending (per bruker) | 15 req/min | Per hashet sluttbruker innenfor samme kaller-app |
+| Analyse | 300 req/min | Per kilde-IP for dashboard-trafikken |
+| Eksport | 30 req/min | Per kilde-IP for dashboard-trafikken |
 | Global | 1000 req/min | Alle kall samlet |
+
+::: info Nøkling av analyse og eksport
+Analyse- og eksport-endepunktene autentiseres i Ktors auth-fase, som kjører *etter* rate limit-pluginen. Den validerte klient-identiteten er derfor ikke tilgjengelig når rate limit-nøkkelen beregnes, så disse endepunktene nøkles på kilde-IP (`X-Forwarded-For` på NAIS). Innsending nøkles derimot per kaller-app, og per hashet sluttbruker, fordi identiteten settes i en route-scoped plugin før rate limit-pluginen.
+:::
 
 ## Inndatavalidering
 

--- a/docs/referanse/sikkerhet.md
+++ b/docs/referanse/sikkerhet.md
@@ -37,7 +37,7 @@ API-et håndhever rate limiting på flere nivåer for å beskytte mot misbruk:
 | Global | 1000 req/min | Alle kall samlet |
 
 ::: info Nøkling av analyse og eksport
-Analyse- og eksport-endepunktene autentiseres i Ktors auth-fase, som kjører *etter* rate limit-pluginen. Den validerte klient-identiteten er derfor ikke tilgjengelig når rate limit-nøkkelen beregnes, så disse endepunktene nøkles på kilde-IP (`X-Forwarded-For` på NAIS). Innsending nøkles derimot per kaller-app, og per hashet sluttbruker, fordi identiteten settes i en route-scoped plugin før rate limit-pluginen.
+Analyse- og eksport-endepunktene autentiseres i Ktors auth-fase, som kjører *etter* rate limit-pluginen. Den validerte klient-identiteten er derfor ikke tilgjengelig når rate limit-nøkkelen beregnes, så disse endepunktene nøkles på kilde-IP. På NAIS brukes første IP i `X-Forwarded-For`-headeren. Innsending nøkles derimot per kaller-app, og per hashet sluttbruker, fordi identiteten settes i en route-scoped plugin før rate limit-pluginen.
 :::
 
 ## Inndatavalidering


### PR DESCRIPTION
## Beskrivelse

Oppgraderer Ktor i `lumi-api` fra 3.5.0 til 3.5.1 for å ta inn KTOR-9621-fiksen, der nested `authenticate`-avvisninger ikke lenger bypasser Ktor RateLimit.

Dette er den godkjente minimale løsningen: ingen ny auth-mekanisme og ingen custom post-auth limiter. Analyse/eksport dokumenteres og testes nå som kilde-IP-baserte når principal ikke er tilgjengelig i RateLimit-fasen. Submission-vernet beholdes med per kaller-app og per hashet sluttbruker.

## Endringer

- `apps/lumi-api/build.gradle.kts`: bump Ktor plugin og `ktorVersion` til 3.5.1
- `RateLimiting.kt`: oppdaterer KDoc/kommentarer til faktisk 3.5.1-semantikk
- `RateLimitingKeyingTest.kt`: legger til regresjonstest for KTOR-9621 og dokumenterer IP-fallback/submission-avvisninger
- `docs/referanse/sikkerhet.md` og `docs/dashboard/eksport.md`: retter feilaktig «per bruker» for analyse/eksport til kilde-IP-basert nøkling

## Issue

Ingen GitHub-issue. Bakgrunn: KTOR-9621 og intern diskusjon om rate limiting ved Ktor 3.5.1-bump.

## Verifisering

- [x] `./gradlew test --tests no.nav.lumi.config.RateLimitingKeyingTest --quiet`
- [x] `pnpm run lint`
- [x] `pnpm run typecheck`
- [ ] `pnpm run api:test` full suite lokalt

Full `pnpm run api:test` ble kjørt, men 43 Testcontainers/Postgres-tester feilet fordi Docker ikke er tilgjengelig i lokalt miljø (`Previous attempts to find a Docker environment failed`). Rate-limit-testene er grønne, og feilene var ikke assertion-feil fra denne endringen.

## Risiko

Kjent tradeoff: analyse/eksport deler bøtte per kilde-IP. Det betyr at flere legitime dashboard-brukere bak samme IP kan påvirke hverandre, og at rate-limit-effekten forutsetter at NAIS/ingress håndterer `X-Forwarded-For` pålitelig. Hvis vi vil ha ekte per-bruker eller post-auth per-client rate limiting for dashboard/export, bør det tas som egen oppfølgingsendring.

## Sjekkliste

- [x] Koden kompilerer og linter uten feil
- [x] Endringene er testet automatisk der miljøet støtter det
- [x] Ingen sensitiv data eksponert (tokens, credentials, PII)
