### PR TITLE
fix(survey): omit answers hidden by visibleIf at submit time (#357)

### DIFF
--- a/docs/referanse/datakontrakt.md
+++ b/docs/referanse/datakontrakt.md
@@ -18,7 +18,7 @@ Widgeten samler inn svar og sender en strukturert JSON-payload til backend. Payl
 | `surveyType` | ✅ | En av: `"rating"`, `"topTasks"`, `"discovery"`, `"taskPriority"`, `"custom"` |
 | `deduplicationKey` | ✅ | Genereres av widgeten og gjør nytt forsøk etter transportfeil trygt |
 | `definition` | ✅ | Alle spørsmålene i surveyen, også de som ikke er besvart |
-| `answers` | ✅ | Strukturert array med svar (se under) |
+| `answers` | ✅ | Strukturert array med svar på spørsmål som er synlige ved innsending (se under) |
 | `context` | Anbefalt | Nettleser-/brukerkontekst for segmentering |
 
 ::: tip Når skal du endre `surveyId`?
@@ -31,7 +31,9 @@ Du trenger ikke sette `deduplicationKey` selv når du bruker widgeten. Den samme
 
 ## Answers-arrayet
 
-Hvert element i `answers` følger dette skjemaet:
+Hvert element i `answers` følger dette skjemaet. Dersom et besvart spørsmål blir
+skjult av `visibleIf` før innsending, utelates svaret. `definition` inneholder
+fortsatt alle spørsmålene, slik at surveydefinisjonen er stabil.
 
 ```typescript
 interface TransportAnswer {

--- a/packages/lumi-survey/CHANGELOG.md
+++ b/packages/lumi-survey/CHANGELOG.md
@@ -13,6 +13,7 @@ This project follows SemVer.
 ### Fixed
 
 - `logic` conditions that reference another question via `condition.questionId` are now evaluated against that question's answer instead of the current question's. Cross-question branching (e.g. routing on an earlier answer) now works the same way `visibleIf` already did. (#332)
+- Submissions now omit answers from questions hidden by `visibleIf` at submit time while retaining the complete survey definition. Hidden answers remain in local state so they are restored if the user reopens the branch. (#357)
 
 ## [1.0.0] - 2026-06-24
 

--- a/packages/lumi-survey/src/components/LumiSurveyDock/LumiSurveyDock.tsx
+++ b/packages/lumi-survey/src/components/LumiSurveyDock/LumiSurveyDock.tsx
@@ -238,11 +238,11 @@ export const LumiSurveyDock = ({
     [questions, answers, enrichedContext?.tags],
   );
 
-  // Progressive submit: hide the button until there is at least one meaningful answer
-  // and all required questions are currently valid.
+  // Progressive submit: hide the button until a currently visible question has
+  // at least one meaningful answer. Required-answer validation happens on submit.
   const isSubmitBlocked = useMemo(
-    () => !shouldShowSubmitButton(questions, answers),
-    [questions, answers],
+    () => !shouldShowSubmitButton(questions, answers, enrichedContext?.tags),
+    [questions, answers, enrichedContext?.tags],
   );
 
   // In step mode with branching, only validate questions the user actually visited

--- a/packages/lumi-survey/src/core/__tests__/evaluateVisibility.test.ts
+++ b/packages/lumi-survey/src/core/__tests__/evaluateVisibility.test.ts
@@ -269,6 +269,75 @@ describe("shouldShowSubmitButton", () => {
       shouldShowSubmitButton(requiredQuestions, { rating: 4, why: "Because" }),
     ).toBe(true);
   });
+
+  it("ignores meaningful answers from questions that are currently hidden", () => {
+    const conditionalQuestions: LumiSurveyQuestion[] = [
+      {
+        id: "gate",
+        type: "singleChoice",
+        prompt: "Show follow-up?",
+        options: [
+          { value: "show", label: "Show" },
+          { value: "hide", label: "Hide" },
+        ],
+      },
+      {
+        id: "details",
+        type: "text",
+        prompt: "Details",
+        maxLength: 500,
+        visibleIf: {
+          questionId: "gate",
+          operator: "EQ",
+          value: "show",
+        },
+      },
+    ];
+
+    expect(
+      shouldShowSubmitButton(conditionalQuestions, {
+        details: "stale hidden answer",
+      }),
+    ).toBe(false);
+    expect(
+      shouldShowSubmitButton(conditionalQuestions, {
+        gate: "show",
+        details: "visible answer",
+      }),
+    ).toBe(true);
+  });
+
+  it("uses metadata when deciding whether an answered question is visible", () => {
+    const metadataQuestions: LumiSurveyQuestion[] = [
+      {
+        id: "details",
+        type: "text",
+        prompt: "Internal details",
+        maxLength: 500,
+        visibleIf: {
+          field: "METADATA",
+          key: "audience",
+          operator: "EQ",
+          value: "internal",
+        },
+      },
+    ];
+
+    expect(
+      shouldShowSubmitButton(
+        metadataQuestions,
+        { details: "stale hidden answer" },
+        { audience: "external" },
+      ),
+    ).toBe(false);
+    expect(
+      shouldShowSubmitButton(
+        metadataQuestions,
+        { details: "visible answer" },
+        { audience: "internal" },
+      ),
+    ).toBe(true);
+  });
 });
 
 describe("evaluateVisibility with any/all groups", () => {

--- a/packages/lumi-survey/src/core/__tests__/useLumiSurvey.test.ts
+++ b/packages/lumi-survey/src/core/__tests__/useLumiSurvey.test.ts
@@ -308,6 +308,84 @@ describe("useLumiSurvey", () => {
     expect(result.current.error).toBeNull();
   });
 
+  it("omits answers hidden at submission time while retaining the full definition", async () => {
+    const conditionalQuestions: LumiSurveyQuestion[] = [
+      {
+        id: "gate",
+        type: "singleChoice",
+        prompt: "Show follow-up?",
+        required: true,
+        options: [
+          { value: "yes", label: "Yes" },
+          { value: "no", label: "No" },
+        ],
+      },
+      {
+        id: "details",
+        type: "text",
+        prompt: "Sensitive details",
+        required: false,
+        maxLength: 500,
+        visibleIf: {
+          any: [
+            {
+              questionId: "gate",
+              operator: "EQ",
+              value: "yes",
+            },
+            {
+              field: "METADATA",
+              key: "audience",
+              operator: "EQ",
+              value: "internal",
+            },
+          ],
+        },
+      },
+    ];
+    const submitMock = vi.fn(async (_: LumiSurveySubmission) => {});
+    const transport: LumiSurveyTransport = { submit: submitMock };
+
+    const { result } = renderHook(() =>
+      useLumiSurvey({
+        surveyId: SURVEY_ID,
+        questions: conditionalQuestions,
+        transport,
+        context: { tags: { audience: "external" } },
+      }),
+    );
+
+    await act(() => {
+      result.current.setAnswer("gate", "yes");
+      result.current.setAnswer("details", "should not leave the browser");
+    });
+
+    await act(() => {
+      result.current.setAnswer("gate", "no");
+    });
+
+    await act(async () => {
+      await result.current.submit();
+    });
+
+    const submission = submitMock.mock.calls[0][0];
+    expect(submission.answers).toEqual({ gate: "no" });
+    expect(
+      submission.transportPayload.answers.map((answer) => answer.fieldId),
+    ).toEqual(["gate"]);
+    expect(
+      submission.transportPayload.definition.fields.map(
+        (field) => field.fieldId,
+      ),
+    ).toEqual(["gate", "details"]);
+
+    // Preserve local state so reopening the branch restores the user's input.
+    expect(result.current.answers).toEqual({
+      gate: "no",
+      details: "should not leave the browser",
+    });
+  });
+
   it("surfaces transport failures and triggers error callbacks", async () => {
     const transportError = new Error("Transport failed");
     const transport: LumiSurveyTransport = {

--- a/packages/lumi-survey/src/core/evaluateVisibility.ts
+++ b/packages/lumi-survey/src/core/evaluateVisibility.ts
@@ -145,18 +145,48 @@ export function getVisibleQuestions<T extends LumiSurveyQuestion>(
 }
 
 /**
- * Checks if the submit button should be shown.
- * The button is hidden until the first required question has an answer.
+ * Returns a copy containing only answers for questions visible in the current
+ * answer and metadata state. The source object is left untouched so hidden
+ * answers can be restored if the user reopens a branch.
+ */
+export function getVisibleAnswers(
+  questions: LumiSurveyQuestion[],
+  answers: Record<string, LumiSurveyAnswerValue>,
+  metadata?: Record<string, unknown>,
+): Record<string, LumiSurveyAnswerValue> {
+  const visibleQuestionIds = new Set(
+    getVisibleQuestions(questions, answers, metadata).map(
+      (question) => question.id,
+    ),
+  );
+  const visibleAnswers: Record<string, LumiSurveyAnswerValue> = {};
+
+  for (const [questionId, value] of Object.entries(answers)) {
+    if (visibleQuestionIds.has(questionId)) {
+      visibleAnswers[questionId] = value;
+    }
+  }
+
+  return visibleAnswers;
+}
+
+/**
+ * Checks if the submit button should be shown based on meaningful answers to
+ * questions that are currently visible.
  *
  * @param questions - All questions in the survey
  * @param answers - Current answers map
+ * @param metadata - Optional context metadata used by visibleIf
  * @returns true if the submit button should be visible
  */
 export function shouldShowSubmitButton(
-  _questions: LumiSurveyQuestion[],
+  questions: LumiSurveyQuestion[],
   answers: Record<string, LumiSurveyAnswerValue>,
+  metadata?: Record<string, unknown>,
 ): boolean {
-  const hasAnyMeaningfulAnswer = Object.values(answers).some((value) => {
+  const hasAnyMeaningfulAnswer = Object.values(
+    getVisibleAnswers(questions, answers, metadata),
+  ).some((value) => {
     if (value === undefined || value === null) {
       return false;
     }

--- a/packages/lumi-survey/src/core/index.ts
+++ b/packages/lumi-survey/src/core/index.ts
@@ -17,7 +17,11 @@ export {
   isConditionGroup,
   isLeafCondition,
 } from "./conditionUtils.js";
-export * from "./evaluateVisibility";
+export {
+  evaluateVisibility,
+  getVisibleQuestions,
+  shouldShowSubmitButton,
+} from "./evaluateVisibility";
 export * from "./ratingLabels";
 export * from "./types";
 export * from "./useLumiSurvey";

--- a/packages/lumi-survey/src/core/useLumiSurvey.ts
+++ b/packages/lumi-survey/src/core/useLumiSurvey.ts
@@ -1,6 +1,7 @@
 import { useCallback, useRef, useState } from "react";
 import { cloneAnswers, useAnswerState } from "./answers.js";
 import { generateDeduplicationKey } from "./deduplicationKey.js";
+import { getVisibleAnswers } from "./evaluateVisibility.js";
 import { buildTransportPayload } from "./transportPayload.js";
 import type {
   LumiSurveyAnswerValue,
@@ -99,17 +100,22 @@ export function useLumiSurvey(
       setError(null);
 
       const answerSnapshot = cloneAnswers(answers);
+      const submittedAnswers = getVisibleAnswers(
+        questions,
+        answerSnapshot,
+        context?.tags,
+      );
       const submittedAtTimestamp = new Date().toISOString();
       const deduplicationKey = getDeduplicationKey();
       const submission: LumiSurveySubmission = {
         surveyId,
-        answers: answerSnapshot,
+        answers: submittedAnswers,
         startedAt: startedAtRef.current,
         submittedAt: submittedAtTimestamp,
         context: context ? { ...context } : undefined,
         transportPayload: buildTransportPayload(
           surveyId,
-          answerSnapshot,
+          submittedAnswers,
           questions,
           deduplicationKey,
           surveyType,


### PR DESCRIPTION
## Hva

Innsendinger inkluderte svar (og holdt submit-knappen aktiv) for spørsmål som var **skjult** av `visibleIf` på innsendingstidspunktet. Transport-stien konsulterte aldri synlighet, mens validering gjorde det.

Closes #357

## Løsning

- Ny intern `getVisibleAnswers()` i `evaluateVisibility.ts` filtrerer svar til kun synlige spørsmål, uten å mutere lokal state — skjulte svar gjenopprettes hvis brukeren åpner grenen igjen.
- `useLumiSurvey.submit()` filtrerer både `submission.answers` og transport-payloaden gjennom denne.
- `shouldShowSubmitButton` er nå synlighets-bevisst og bruker samme metadata-tags som display-synligheten (`enrichedContext.tags` via hookens `context`), så METADATA-baserte `visibleIf` evalueres konsistent.
- `getVisibleAnswers` holdes bevisst utenfor public API (`core/index.ts` eksporterer eksplisitt i stedet for `export *`).

## Bevisst valg: definition-blokken beholdes komplett

Issuen foreslo å filtrere svar *eller* feltdefinisjoner. Kun `answers` filtreres her: hadde definisjonen blitt filtrert per innsending, ville `definition_hash` variert med hvilken visibility-gren brukeren tok, og immutability-modellen fra #297 ville gitt spuriøse 409-er. `datakontrakt.md` er oppdatert til å dokumentere dette.

## Test

- 42 tester i `evaluateVisibility.test.ts` + `useLumiSurvey.test.ts` dekker filtrering ved submit, gjenåpning av gren, metadata-betingelser og submit-knapp-gating.
- Hele suiten: 305 tester grønne. `biome check` og `tsc --noEmit` rene.