### PR TITLE
feat(dashboard): arkiver/gjenopprett surveys ende-til-ende (#394)

### DIFF
--- a/apps/lumi-api/src/main/kotlin/no/nav/lumi/config/Routing.kt
+++ b/apps/lumi-api/src/main/kotlin/no/nav/lumi/config/Routing.kt
@@ -11,6 +11,7 @@ import no.nav.lumi.routes.feedbackRoutes
 import no.nav.lumi.routes.exportRoutes
 import no.nav.lumi.routes.filterRoutes
 import no.nav.lumi.routes.markerRoutes
+import no.nav.lumi.routes.surveyArchiveRoutes
 import no.nav.lumi.routes.surveyFacetRoutes
 import no.nav.lumi.routes.statsRoutes
 import no.nav.lumi.routes.internalRoutes
@@ -52,6 +53,7 @@ fun Application.configureRouting() {
                     filterRoutes()
                     feedbackRoutes()
                     surveyFacetRoutes()
+                    surveyArchiveRoutes()
                     markerRoutes()
                     statsRoutes()
                     discoveryRoutes()

--- a/apps/lumi-api/src/main/kotlin/no/nav/lumi/domain/Models.kt
+++ b/apps/lumi-api/src/main/kotlin/no/nav/lumi/domain/Models.kt
@@ -388,6 +388,8 @@ data class PhraseFilter(
  */
 data class FeedbackQuery(
     val team: String,
+    /** Include feedback belonging to archived surveys. Defaults to active surveys only. */
+    val includeArchived: Boolean = false,
     val app: String? = null,
     val page: Int? = null,
     val size: Int = 10,
@@ -428,6 +430,8 @@ data class FeedbackQuery(
  */
 data class StatsQuery(
     val team: String,
+    /** Include feedback belonging to archived surveys. Defaults to active surveys only. */
+    val includeArchived: Boolean = false,
     val app: String? = null,
     /** Start date (YYYY-MM-DD, Europe/Oslo inclusive) */
     val fromDate: String? = null,

--- a/apps/lumi-api/src/main/kotlin/no/nav/lumi/integrations/valkey/StringCache.kt
+++ b/apps/lumi-api/src/main/kotlin/no/nav/lumi/integrations/valkey/StringCache.kt
@@ -21,6 +21,7 @@ interface StringCache {
     fun set(key: String, value: String, ttl: Duration)
     fun isHealthy(): Boolean
     fun clear()
+    fun clearByPrefix(prefix: String)
 }
 
 class InMemoryStringCache : StringCache {
@@ -47,6 +48,10 @@ class InMemoryStringCache : StringCache {
     override fun clear() {
         cache.clear()
         log.info("In-memory string cache cleared")
+    }
+
+    override fun clearByPrefix(prefix: String) {
+        cache.keys.removeAll { it.startsWith(prefix) }
     }
 }
 
@@ -135,6 +140,20 @@ class ValkeyStringCache private constructor(
         } catch (e: Exception) {
             log.warn("Failed to clear Valkey string cache", e)
             fallback.clear()
+        }
+    }
+
+    override fun clearByPrefix(prefix: String) {
+        try {
+            val keys = redisClient.keys("$keyPrefix$prefix*")
+            if (keys.isNotEmpty()) {
+                redisClient.del(*keys.toTypedArray())
+            }
+            fallback.clearByPrefix(prefix)
+        } catch (e: Exception) {
+            cacheErrorCounter.increment()
+            log.warn("Failed to clear Valkey string cache by prefix", e)
+            fallback.clearByPrefix(prefix)
         }
     }
 

--- a/apps/lumi-api/src/main/kotlin/no/nav/lumi/integrations/valkey/StringCache.kt
+++ b/apps/lumi-api/src/main/kotlin/no/nav/lumi/integrations/valkey/StringCache.kt
@@ -19,6 +19,7 @@ private val log = LoggerFactory.getLogger("StringCache")
 interface StringCache {
     fun get(key: String): String?
     fun set(key: String, value: String, ttl: Duration)
+    fun increment(key: String): Long
     fun isHealthy(): Boolean
     fun clear()
     fun clearByPrefix(prefix: String)
@@ -41,6 +42,20 @@ class InMemoryStringCache : StringCache {
     override fun set(key: String, value: String, ttl: Duration) {
         val expiresAt = System.currentTimeMillis() + ttl.toMillis()
         cache[key] = CacheEntry(expiresAt, value)
+    }
+
+    override fun increment(key: String): Long {
+        var incrementedValue = 0L
+        cache.compute(key) { _, entry ->
+            val currentValue = entry
+                ?.takeIf { System.currentTimeMillis() <= it.expiresAt }
+                ?.value
+                ?.toLongOrNull()
+                ?: 0L
+            incrementedValue = currentValue + 1
+            CacheEntry(Long.MAX_VALUE, incrementedValue.toString())
+        }
+        return incrementedValue
     }
 
     override fun isHealthy(): Boolean = true
@@ -118,6 +133,25 @@ class ValkeyStringCache private constructor(
             cacheErrorCounter.increment()
             log.warn("Unexpected error setting in Valkey string cache", e)
             fallback.set(key, value, ttl)
+        }
+    }
+
+    override fun increment(key: String): Long {
+        val fullKey = keyPrefix + key
+
+        return try {
+            val startTime = System.nanoTime()
+            val value = redisClient.incr(fullKey)
+            cacheOperationTimer.record(Duration.ofNanos(System.nanoTime() - startTime))
+            value
+        } catch (e: JedisConnectionException) {
+            cacheErrorCounter.increment()
+            log.warn("Failed to increment in Valkey string cache, using fallback", e)
+            fallback.increment(key)
+        } catch (e: Exception) {
+            cacheErrorCounter.increment()
+            log.warn("Unexpected error incrementing in Valkey string cache", e)
+            fallback.increment(key)
         }
     }
 

--- a/apps/lumi-api/src/main/kotlin/no/nav/lumi/repository/DiscoveryStatsRepository.kt
+++ b/apps/lumi-api/src/main/kotlin/no/nav/lumi/repository/DiscoveryStatsRepository.kt
@@ -24,6 +24,9 @@ class DiscoveryStatsRepository {
         val records = dbQuery {
             val dbQuery = FeedbackTable.selectAll()
             dbQuery.andWhere { FeedbackTable.team eq query.team }
+            if (!query.includeArchived) {
+                dbQuery.andWhere { SurveyIsNotArchived() }
+            }
             dbQuery.andWhere { 
                 JsonExtract(FeedbackTable.feedbackJson, listOf("surveyType")) eq "discovery" 
             }

--- a/apps/lumi-api/src/main/kotlin/no/nav/lumi/repository/FeedbackRepositorySupport.kt
+++ b/apps/lumi-api/src/main/kotlin/no/nav/lumi/repository/FeedbackRepositorySupport.kt
@@ -22,6 +22,10 @@ internal fun String.escapeLikePattern(): String {
 }
 
 internal fun applyCommonFilters(query: Query, criteria: FeedbackQuery, log: Logger) {
+    if (!criteria.includeArchived) {
+        query.andWhere { SurveyIsNotArchived() }
+    }
+
     // Filter for feedback with text responses
     if (criteria.hasText) {
         query.andWhere {

--- a/apps/lumi-api/src/main/kotlin/no/nav/lumi/repository/FeedbackStatsRepository.kt
+++ b/apps/lumi-api/src/main/kotlin/no/nav/lumi/repository/FeedbackStatsRepository.kt
@@ -523,6 +523,9 @@ class FeedbackStatsRepository {
     
     private fun applyStatsFilters(query: Query, criteria: StatsQuery) {
         query.andWhere { FeedbackTable.team eq criteria.team }
+        if (!criteria.includeArchived) {
+            query.andWhere { SurveyIsNotArchived() }
+        }
         criteria.app?.let { query.andWhere { FeedbackTable.app eq it } }
         
         // Survey ID filter

--- a/apps/lumi-api/src/main/kotlin/no/nav/lumi/repository/FeedbackTable.kt
+++ b/apps/lumi-api/src/main/kotlin/no/nav/lumi/repository/FeedbackTable.kt
@@ -73,6 +73,21 @@ class JsonExtract(val col: Column<*>, val path: List<String>) : Function<String>
 }
 
 /**
+ * Excludes feedback whose team + surveyId has an active archive marker.
+ * Uses feedback_json rather than the nullable feedback.survey_id column so
+ * submissions created before V12 follow the same visibility semantics.
+ */
+class SurveyIsNotArchived : Op<Boolean>() {
+    override fun toQueryBuilder(queryBuilder: QueryBuilder) {
+        queryBuilder.append("NOT EXISTS (SELECT 1 FROM survey_metadata WHERE survey_metadata.team = ")
+        queryBuilder.append(FeedbackTable.team)
+        queryBuilder.append(" AND survey_metadata.survey_id = ")
+        JsonExtract(FeedbackTable.feedbackJson, listOf("surveyId")).toQueryBuilder(queryBuilder)
+        queryBuilder.append(" AND survey_metadata.archived_at IS NOT NULL)")
+    }
+}
+
+/**
  * PostgreSQL COALESCE(expr1, expr2, ...) helper for String expressions.
  */
 class CoalesceString(vararg val expr: Expression<String>) : Function<String>(VarCharColumnType()) {

--- a/apps/lumi-api/src/main/kotlin/no/nav/lumi/repository/SurveyMetadataRepository.kt
+++ b/apps/lumi-api/src/main/kotlin/no/nav/lumi/repository/SurveyMetadataRepository.kt
@@ -1,0 +1,95 @@
+package no.nav.lumi.repository
+
+import org.jetbrains.exposed.v1.core.SortOrder
+import org.jetbrains.exposed.v1.core.and
+import org.jetbrains.exposed.v1.core.eq
+import org.jetbrains.exposed.v1.core.isNotNull
+import org.jetbrains.exposed.v1.jdbc.selectAll
+import org.jetbrains.exposed.v1.jdbc.transactions.TransactionManager
+import org.jetbrains.exposed.v1.jdbc.update
+import java.sql.Connection
+import java.time.OffsetDateTime
+
+/**
+ * Archive state for a survey as seen by the dashboard.
+ * `archivedAt == null` means the survey is active (row kept after unarchive).
+ */
+@kotlinx.serialization.Serializable
+data class SurveyArchiveState(
+    val surveyId: String,
+    val archivedAt: String?,
+    val archivedBy: String?,
+)
+
+class SurveyMetadataRepository {
+    /**
+     * Archive a survey (upsert). Idempotent: re-archiving an already archived
+     * survey keeps the original archived_at/archived_by, so the badge condition
+     * (lastSubmissionAt > archivedAt) cannot be reset by repeated clicks.
+     */
+    suspend fun archive(team: String, surveyId: String, archivedBy: String?): SurveyArchiveState {
+        return dbQuery {
+            val conn = TransactionManager.current().connection.connection as Connection
+
+            val sql = """
+                INSERT INTO survey_metadata (team, survey_id, archived_at, archived_by)
+                VALUES (?, ?, now(), ?)
+                ON CONFLICT (team, survey_id) DO UPDATE SET
+                    archived_at = COALESCE(survey_metadata.archived_at, EXCLUDED.archived_at),
+                    archived_by = CASE
+                        WHEN survey_metadata.archived_at IS NULL THEN EXCLUDED.archived_by
+                        ELSE survey_metadata.archived_by
+                    END,
+                    updated_at = now()
+                RETURNING survey_id, archived_at, archived_by
+            """.trimIndent()
+
+            conn.prepareStatement(sql).use { stmt ->
+                stmt.setString(1, team)
+                stmt.setString(2, surveyId)
+                stmt.setString(3, archivedBy)
+                stmt.executeQuery().use { rs ->
+                    rs.next()
+                    SurveyArchiveState(
+                        surveyId = rs.getString("survey_id"),
+                        archivedAt = rs.getObject("archived_at", OffsetDateTime::class.java)?.toString(),
+                        archivedBy = rs.getString("archived_by"),
+                    )
+                }
+            }
+        }
+    }
+
+    /**
+     * Restore a survey. Clears archive state but keeps the row.
+     * Returns false when the survey was not archived (no change).
+     */
+    suspend fun unarchive(team: String, surveyId: String): Boolean {
+        return dbQuery {
+            SurveyMetadataTable.update({
+                (SurveyMetadataTable.team eq team) and
+                    (SurveyMetadataTable.surveyId eq surveyId) and
+                    SurveyMetadataTable.archivedAt.isNotNull()
+            }) {
+                it[SurveyMetadataTable.archivedAt] = null
+                it[SurveyMetadataTable.archivedBy] = null
+                it[SurveyMetadataTable.updatedAt] = OffsetDateTime.now()
+            } > 0
+        }
+    }
+
+    suspend fun findByTeam(team: String): List<SurveyArchiveState> {
+        return dbQuery {
+            SurveyMetadataTable.selectAll()
+                .where { SurveyMetadataTable.team eq team }
+                .orderBy(SurveyMetadataTable.surveyId to SortOrder.ASC)
+                .map { row ->
+                    SurveyArchiveState(
+                        surveyId = row[SurveyMetadataTable.surveyId],
+                        archivedAt = row[SurveyMetadataTable.archivedAt]?.toString(),
+                        archivedBy = row[SurveyMetadataTable.archivedBy],
+                    )
+                }
+        }
+    }
+}

--- a/apps/lumi-api/src/main/kotlin/no/nav/lumi/repository/SurveyMetadataTable.kt
+++ b/apps/lumi-api/src/main/kotlin/no/nav/lumi/repository/SurveyMetadataTable.kt
@@ -1,0 +1,17 @@
+package no.nav.lumi.repository
+
+import org.jetbrains.exposed.v1.core.Table
+import org.jetbrains.exposed.v1.core.java.javaUUID
+import org.jetbrains.exposed.v1.javatime.timestampWithTimeZone
+
+object SurveyMetadataTable : Table("survey_metadata") {
+    val id = javaUUID("id").autoGenerate()
+    val team = varchar("team", 255)
+    val surveyId = varchar("survey_id", 255)
+    val archivedAt = timestampWithTimeZone("archived_at").nullable()
+    val archivedBy = text("archived_by").nullable()
+    val createdAt = timestampWithTimeZone("created_at")
+    val updatedAt = timestampWithTimeZone("updated_at")
+
+    override val primaryKey = PrimaryKey(id)
+}

--- a/apps/lumi-api/src/main/kotlin/no/nav/lumi/routes/ExportRoutes.kt
+++ b/apps/lumi-api/src/main/kotlin/no/nav/lumi/routes/ExportRoutes.kt
@@ -32,6 +32,7 @@ fun Route.exportRoutes(exportService: ExportService = defaultExportService) {
 
         val query = FeedbackQuery(
             team = team,
+            includeArchived = params.includeArchived ?: false,
             app = params.app?.takeIf { it != FILTER_ALL },
             page = 0,
             size = ExportService.MAX_EXPORT_SIZE,

--- a/apps/lumi-api/src/main/kotlin/no/nav/lumi/routes/FeedbackRoutes.kt
+++ b/apps/lumi-api/src/main/kotlin/no/nav/lumi/routes/FeedbackRoutes.kt
@@ -42,6 +42,7 @@ fun Route.feedbackRoutes(
 
         val query = FeedbackQuery(
             team = team,
+            includeArchived = params.includeArchived ?: false,
             app = params.app?.takeIf { it != FILTER_ALL },
             page = paging.page,
             size = paging.size,

--- a/apps/lumi-api/src/main/kotlin/no/nav/lumi/routes/FilterRoutes.kt
+++ b/apps/lumi-api/src/main/kotlin/no/nav/lumi/routes/FilterRoutes.kt
@@ -60,6 +60,16 @@ internal val sharedBootstrapCache: StringCache by lazy {
 /** Cache-key prefix covering every user's bootstrap entry for a team. */
 internal fun bootstrapCacheTeamPrefix(team: String) = "team=${team.lowercase()}&"
 
+/**
+ * Per-user bootstrap cache key, or null when the principal has no stable user
+ * identity — the response includes `availableTeams`, so a shared key (e.g.
+ * "user=null") could leak one user's team memberships to another.
+ */
+internal fun bootstrapCacheKey(team: String, principal: no.nav.lumi.config.auth.BrukerPrincipal): String? {
+    val userIdentity = principal.navIdent ?: principal.email ?: return null
+    return "${bootstrapCacheTeamPrefix(team)}user=$userIdentity".lowercase()
+}
+
 private val json = Json {
     ignoreUnknownKeys = true
     encodeDefaults = true
@@ -82,10 +92,11 @@ fun Route.filterRoutes(
         val principal = call.authorizedPrincipal
 
         // Cache is shared across users (Valkey). Include user identity to avoid leaking `availableTeams`.
-        // Team comes first so team-scoped invalidation can clear by prefix.
-        val cacheKey = "${bootstrapCacheTeamPrefix(team)}user=${principal.navIdent}".lowercase()
+        // Team comes first so team-scoped invalidation can clear by prefix. Principals without a
+        // stable user identity are served uncached (a shared key would leak team memberships).
+        val cacheKey = bootstrapCacheKey(team, principal)
 
-        bootstrapCache.get(cacheKey)?.let { cachedJson ->
+        cacheKey?.let { bootstrapCache.get(it) }?.let { cachedJson ->
             call.response.headers.append(HttpHeaders.CacheControl, "private, max-age=300")
             call.respondText(cachedJson, ContentType.Application.Json)
             return@get
@@ -109,7 +120,13 @@ fun Route.filterRoutes(
             surveyMeta = surveyMeta,
         )
 
-        bootstrapCache.set(cacheKey, json.encodeToString(response), ttl = Duration.ofMinutes(5))
+        // Known benign race: a GET that read the DB before a concurrent archive/unarchive
+        // invalidated the prefix can write a stale entry back here. The window is the
+        // milliseconds between the DB reads and this set, and the entry expires with the
+        // TTL — accepted rather than introducing per-team generation tokens.
+        cacheKey?.let {
+            bootstrapCache.set(it, json.encodeToString(response), ttl = Duration.ofMinutes(5))
+        }
         call.response.headers.append(HttpHeaders.CacheControl, "private, max-age=300")
 
         call.respond(response)

--- a/apps/lumi-api/src/main/kotlin/no/nav/lumi/routes/FilterRoutes.kt
+++ b/apps/lumi-api/src/main/kotlin/no/nav/lumi/routes/FilterRoutes.kt
@@ -14,12 +14,13 @@ import no.nav.lumi.config.auth.authorizedPrincipal
 import no.nav.lumi.integrations.valkey.StringCache
 import no.nav.lumi.integrations.valkey.ValkeyStringCache
 import no.nav.lumi.repository.FeedbackRepository
+import no.nav.lumi.repository.SurveyMetadataRepository
 import java.time.Instant
 import java.time.Duration
 
 /**
  * Response for GET /api/v1/intern/filters/bootstrap
- * 
+ *
  * Provides all data needed for FilterBar dropdowns in a single request.
  * This endpoint is designed for long caching (5-10 minutes).
  */
@@ -31,11 +32,33 @@ data class FilterBootstrapResponse(
     val deviceTypes: List<String> = listOf("mobile", "tablet", "desktop"),
     val apps: List<String>,
     val surveysByApp: Map<String, List<String>>,
-    val tags: List<String>
+    val tags: List<String>,
+    val surveyMeta: Map<String, SurveyMetaEntry> = emptyMap(),
+)
+
+/**
+ * Per-survey dashboard metadata. Surveys without an entry are active.
+ * `archivedAt == null` means the survey was restored after being archived.
+ */
+@Serializable
+data class SurveyMetaEntry(
+    val archivedAt: String?,
 )
 
 private val defaultRepository = FeedbackRepository()
-private val bootstrapCache: StringCache = ValkeyStringCache.fromEnvOrFallback(keyPrefix = "filters:bootstrap:")
+private val defaultSurveyMetadataRepository = SurveyMetadataRepository()
+
+/**
+ * Shared bootstrap cache instance so mutations (e.g. survey archiving) can
+ * invalidate what the bootstrap route cached. Keys start with "team=<team>&"
+ * — see [bootstrapCacheTeamPrefix].
+ */
+internal val sharedBootstrapCache: StringCache by lazy {
+    ValkeyStringCache.fromEnvOrFallback(keyPrefix = "filters:bootstrap:")
+}
+
+/** Cache-key prefix covering every user's bootstrap entry for a team. */
+internal fun bootstrapCacheTeamPrefix(team: String) = "team=${team.lowercase()}&"
 
 private val json = Json {
     ignoreUnknownKeys = true
@@ -44,12 +67,14 @@ private val json = Json {
 
 /**
  * Routes for filter bootstrap and facets.
- * 
+ *
  * These endpoints provide metadata for FilterBar dropdowns,
  * enabling the frontend to render filter controls before fetching actual data.
  */
 fun Route.filterRoutes(
-    feedbackRepository: FeedbackRepository = defaultRepository
+    feedbackRepository: FeedbackRepository = defaultRepository,
+    surveyMetadataRepository: SurveyMetadataRepository = defaultSurveyMetadataRepository,
+    bootstrapCache: StringCache = sharedBootstrapCache,
 ) {
     get<ApiV1Intern.Filters.Bootstrap> {
         val team = call.authorizedTeam
@@ -57,7 +82,8 @@ fun Route.filterRoutes(
         val principal = call.authorizedPrincipal
 
         // Cache is shared across users (Valkey). Include user identity to avoid leaking `availableTeams`.
-        val cacheKey = "user=${principal.navIdent}&team=${team}".lowercase()
+        // Team comes first so team-scoped invalidation can clear by prefix.
+        val cacheKey = "${bootstrapCacheTeamPrefix(team)}user=${principal.navIdent}".lowercase()
 
         bootstrapCache.get(cacheKey)?.let { cachedJson ->
             call.response.headers.append(HttpHeaders.CacheControl, "private, max-age=300")
@@ -70,19 +96,22 @@ fun Route.filterRoutes(
         val apps = feedbackRepository.findDistinctApps(team)
         val surveysByApp = feedbackRepository.findSurveysByApp(team)
         val tags = feedbackRepository.findAllTags(team)
-        
+        val surveyMeta = surveyMetadataRepository.findByTeam(team)
+            .associate { it.surveyId to SurveyMetaEntry(archivedAt = it.archivedAt) }
+
         val response = FilterBootstrapResponse(
             generatedAt = Instant.now().toString(),
             selectedTeam = team,
             availableTeams = teams.sorted(),
             apps = apps.sorted(),
             surveysByApp = surveysByApp.mapValues { it.value.sorted() }.toSortedMap(),
-            tags = tags.sorted()
+            tags = tags.sorted(),
+            surveyMeta = surveyMeta,
         )
 
         bootstrapCache.set(cacheKey, json.encodeToString(response), ttl = Duration.ofMinutes(5))
         call.response.headers.append(HttpHeaders.CacheControl, "private, max-age=300")
-        
+
         call.respond(response)
     }
 }

--- a/apps/lumi-api/src/main/kotlin/no/nav/lumi/routes/FilterRoutes.kt
+++ b/apps/lumi-api/src/main/kotlin/no/nav/lumi/routes/FilterRoutes.kt
@@ -60,14 +60,52 @@ internal val sharedBootstrapCache: StringCache by lazy {
 /** Cache-key prefix covering every user's bootstrap entry for a team. */
 internal fun bootstrapCacheTeamPrefix(team: String) = "team=${team.lowercase()}&"
 
+private fun bootstrapCacheGenerationKey(team: String) = "generation:team=${team.lowercase()}"
+
 /**
  * Per-user bootstrap cache key, or null when the principal has no stable user
  * identity — the response includes `availableTeams`, so a shared key (e.g.
  * "user=null") could leak one user's team memberships to another.
  */
 internal fun bootstrapCacheKey(team: String, principal: no.nav.lumi.config.auth.BrukerPrincipal): String? {
-    val userIdentity = principal.navIdent ?: principal.email ?: return null
+    val userIdentity = stablePrincipalIdentity(principal) ?: return null
     return "${bootstrapCacheTeamPrefix(team)}user=$userIdentity".lowercase()
+}
+
+internal fun stablePrincipalIdentity(principal: no.nav.lumi.config.auth.BrukerPrincipal): String? =
+    principal.navIdent?.trim()?.takeIf { it.isNotEmpty() }
+        ?: principal.email?.trim()?.takeIf { it.isNotEmpty() }
+
+internal data class BootstrapCacheLookup(
+    val key: String?,
+    val value: String?,
+)
+
+/**
+ * Versioned cache access prevents an in-flight GET from refilling a stale
+ * entry after a concurrent archive/restore invalidation. The mutation first
+ * advances the team generation; late writes remain on the old generation.
+ */
+internal class VersionedBootstrapCache(private val cache: StringCache) {
+    fun lookup(
+        team: String,
+        principal: no.nav.lumi.config.auth.BrukerPrincipal,
+    ): BootstrapCacheLookup {
+        val userKey = bootstrapCacheKey(team, principal)
+            ?: return BootstrapCacheLookup(key = null, value = null)
+        val generation = cache.get(bootstrapCacheGenerationKey(team))?.toLongOrNull() ?: 0L
+        val key = "$userKey&generation=$generation"
+        return BootstrapCacheLookup(key = key, value = cache.get(key))
+    }
+
+    fun set(lookup: BootstrapCacheLookup, value: String, ttl: Duration) {
+        lookup.key?.let { cache.set(it, value, ttl) }
+    }
+
+    fun invalidate(team: String) {
+        cache.increment(bootstrapCacheGenerationKey(team))
+        cache.clearByPrefix(bootstrapCacheTeamPrefix(team))
+    }
 }
 
 private val json = Json {
@@ -86,6 +124,8 @@ fun Route.filterRoutes(
     surveyMetadataRepository: SurveyMetadataRepository = defaultSurveyMetadataRepository,
     bootstrapCache: StringCache = sharedBootstrapCache,
 ) {
+    val versionedBootstrapCache = VersionedBootstrapCache(bootstrapCache)
+
     get<ApiV1Intern.Filters.Bootstrap> {
         val team = call.authorizedTeam
         val teams = call.authorizedTeams
@@ -94,9 +134,9 @@ fun Route.filterRoutes(
         // Cache is shared across users (Valkey). Include user identity to avoid leaking `availableTeams`.
         // Team comes first so team-scoped invalidation can clear by prefix. Principals without a
         // stable user identity are served uncached (a shared key would leak team memberships).
-        val cacheKey = bootstrapCacheKey(team, principal)
+        val cacheLookup = versionedBootstrapCache.lookup(team, principal)
 
-        cacheKey?.let { bootstrapCache.get(it) }?.let { cachedJson ->
+        cacheLookup.value?.let { cachedJson ->
             call.response.headers.append(HttpHeaders.CacheControl, "private, max-age=300")
             call.respondText(cachedJson, ContentType.Application.Json)
             return@get
@@ -120,13 +160,11 @@ fun Route.filterRoutes(
             surveyMeta = surveyMeta,
         )
 
-        // Known benign race: a GET that read the DB before a concurrent archive/unarchive
-        // invalidated the prefix can write a stale entry back here. The window is the
-        // milliseconds between the DB reads and this set, and the entry expires with the
-        // TTL — accepted rather than introducing per-team generation tokens.
-        cacheKey?.let {
-            bootstrapCache.set(it, json.encodeToString(response), ttl = Duration.ofMinutes(5))
-        }
+        versionedBootstrapCache.set(
+            cacheLookup,
+            json.encodeToString(response),
+            ttl = Duration.ofMinutes(5),
+        )
         call.response.headers.append(HttpHeaders.CacheControl, "private, max-age=300")
 
         call.respond(response)

--- a/apps/lumi-api/src/main/kotlin/no/nav/lumi/routes/Resources.kt
+++ b/apps/lumi-api/src/main/kotlin/no/nav/lumi/routes/Resources.kt
@@ -182,6 +182,10 @@ class ApiV1Intern {
                 class Id(val parent: Markers, val id: String)
             }
 
+            @Resource("archive")
+            @Serializable
+            class Archive(val parent: Id)
+
             @Resource("context-tags")
             @Serializable
             class ContextTags(

--- a/apps/lumi-api/src/main/kotlin/no/nav/lumi/routes/Resources.kt
+++ b/apps/lumi-api/src/main/kotlin/no/nav/lumi/routes/Resources.kt
@@ -12,6 +12,8 @@ class ApiV1Intern {
         val parent: ApiV1Intern = ApiV1Intern(),
         /** Optional team scope. If omitted, the backend selects a default authorized team. */
         val team: String? = null,
+        /** Include feedback from archived surveys. Defaults to false. */
+        val includeArchived: Boolean? = null,
         val app: String? = null,
         val page: Int? = null,
         val size: Int? = null,
@@ -81,6 +83,8 @@ class ApiV1Intern {
         val parent: ApiV1Intern = ApiV1Intern(),
         /** Optional team scope. If omitted, the backend selects a default authorized team. */
         val team: String? = null,
+        /** Include feedback from archived surveys. Defaults to false. */
+        val includeArchived: Boolean? = null,
         val app: String? = null,
         /** Start date (YYYY-MM-DD, Europe/Oslo inclusive) */
         val fromDate: String? = null,
@@ -242,6 +246,8 @@ class ApiV1Intern {
         val parent: ApiV1Intern = ApiV1Intern(),
         /** Optional team scope. If omitted, the backend selects a default authorized team. */
         val team: String? = null,
+        /** Include feedback from archived surveys. Defaults to false. */
+        val includeArchived: Boolean? = null,
         val format: String = "CSV",
         val app: String? = null,
         val hasText: Boolean? = null,

--- a/apps/lumi-api/src/main/kotlin/no/nav/lumi/routes/StatsRoutes.kt
+++ b/apps/lumi-api/src/main/kotlin/no/nav/lumi/routes/StatsRoutes.kt
@@ -23,6 +23,7 @@ internal fun ApiV1Intern.Stats.toStatsQuery(
     validateDateRange(fromDate, toDate)
     return StatsQuery(
     team = team,
+    includeArchived = includeArchived ?: false,
     app = app?.takeIf { it != FILTER_ALL },
     fromDate = fromDate,
     toDate = toDate,

--- a/apps/lumi-api/src/main/kotlin/no/nav/lumi/routes/SurveyArchiveRoutes.kt
+++ b/apps/lumi-api/src/main/kotlin/no/nav/lumi/routes/SurveyArchiveRoutes.kt
@@ -1,0 +1,47 @@
+package no.nav.lumi.routes
+
+import io.ktor.http.HttpStatusCode
+import io.ktor.server.resources.delete
+import io.ktor.server.resources.put
+import io.ktor.server.response.respond
+import io.ktor.server.routing.Route
+import no.nav.lumi.config.auth.authorizedPrincipal
+import no.nav.lumi.config.auth.authorizedTeam
+import no.nav.lumi.integrations.valkey.StringCache
+import no.nav.lumi.repository.SurveyMetadataRepository
+
+private val defaultSurveyMetadataRepository = SurveyMetadataRepository()
+
+/**
+ * Archive/restore surveys (team-scoped display metadata).
+ *
+ * Archiving only affects what the dashboard shows — it does not stop
+ * submissions, which are controlled by the consuming app's frontend.
+ */
+fun Route.surveyArchiveRoutes(
+    surveyMetadataRepository: SurveyMetadataRepository = defaultSurveyMetadataRepository,
+    bootstrapCache: StringCache = sharedBootstrapCache,
+) {
+    put<ApiV1Intern.Surveys.Id.Archive> { params ->
+        val team = call.authorizedTeam
+        val archivedBy = call.authorizedPrincipal.navIdent ?: call.authorizedPrincipal.email
+
+        val state = surveyMetadataRepository.archive(
+            team = team,
+            surveyId = params.parent.surveyId,
+            archivedBy = archivedBy,
+        )
+        bootstrapCache.clearByPrefix(bootstrapCacheTeamPrefix(team))
+        call.respond(state)
+    }
+
+    delete<ApiV1Intern.Surveys.Id.Archive> { params ->
+        val team = call.authorizedTeam
+
+        val changed = surveyMetadataRepository.unarchive(team = team, surveyId = params.parent.surveyId)
+        if (changed) {
+            bootstrapCache.clearByPrefix(bootstrapCacheTeamPrefix(team))
+        }
+        call.respond(HttpStatusCode.NoContent)
+    }
+}

--- a/apps/lumi-api/src/main/kotlin/no/nav/lumi/routes/SurveyArchiveRoutes.kt
+++ b/apps/lumi-api/src/main/kotlin/no/nav/lumi/routes/SurveyArchiveRoutes.kt
@@ -9,8 +9,10 @@ import no.nav.lumi.config.auth.authorizedPrincipal
 import no.nav.lumi.config.auth.authorizedTeam
 import no.nav.lumi.integrations.valkey.StringCache
 import no.nav.lumi.repository.SurveyMetadataRepository
+import no.nav.lumi.service.StatsCacheInvalidator
 
 private val defaultSurveyMetadataRepository = SurveyMetadataRepository()
+private val defaultArchiveStatsCacheInvalidator = StatsCacheInvalidator()
 
 /**
  * Archive/restore surveys (team-scoped display metadata).
@@ -21,27 +23,30 @@ private val defaultSurveyMetadataRepository = SurveyMetadataRepository()
 fun Route.surveyArchiveRoutes(
     surveyMetadataRepository: SurveyMetadataRepository = defaultSurveyMetadataRepository,
     bootstrapCache: StringCache = sharedBootstrapCache,
+    statsCacheInvalidator: StatsCacheInvalidator = defaultArchiveStatsCacheInvalidator,
 ) {
+    val versionedBootstrapCache = VersionedBootstrapCache(bootstrapCache)
+
     put<ApiV1Intern.Surveys.Id.Archive> { params ->
         val team = call.authorizedTeam
-        val archivedBy = call.authorizedPrincipal.navIdent ?: call.authorizedPrincipal.email
+        val archivedBy = stablePrincipalIdentity(call.authorizedPrincipal)
 
         val state = surveyMetadataRepository.archive(
             team = team,
             surveyId = params.parent.surveyId,
             archivedBy = archivedBy,
         )
-        bootstrapCache.clearByPrefix(bootstrapCacheTeamPrefix(team))
+        versionedBootstrapCache.invalidate(team)
+        statsCacheInvalidator.invalidateTeam(team)
         call.respond(state)
     }
 
     delete<ApiV1Intern.Surveys.Id.Archive> { params ->
         val team = call.authorizedTeam
 
-        val changed = surveyMetadataRepository.unarchive(team = team, surveyId = params.parent.surveyId)
-        if (changed) {
-            bootstrapCache.clearByPrefix(bootstrapCacheTeamPrefix(team))
-        }
+        surveyMetadataRepository.unarchive(team = team, surveyId = params.parent.surveyId)
+        versionedBootstrapCache.invalidate(team)
+        statsCacheInvalidator.invalidateTeam(team)
         call.respond(HttpStatusCode.NoContent)
     }
 }

--- a/apps/lumi-api/src/main/kotlin/no/nav/lumi/service/StatsService.kt
+++ b/apps/lumi-api/src/main/kotlin/no/nav/lumi/service/StatsService.kt
@@ -61,6 +61,7 @@ class StatsService(
 
         val parts = listOf(
             "team" to team,
+            "includeArchived" to includeArchived.toString(),
             "app" to app,
             "fromDate" to fromDate,
             "toDate" to toDate,

--- a/apps/lumi-api/src/main/resources/db/migration/V13__survey_metadata.sql
+++ b/apps/lumi-api/src/main/resources/db/migration/V13__survey_metadata.sql
@@ -1,0 +1,14 @@
+-- Dashboard-side survey metadata (lifecycle/display state).
+-- Deliberately independent of survey_definitions so surveys without a
+-- definition row (pre-V12 submissions) can also be archived.
+
+CREATE TABLE IF NOT EXISTS survey_metadata (
+    id          UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    team        VARCHAR(255) NOT NULL,
+    survey_id   VARCHAR(255) NOT NULL,
+    archived_at TIMESTAMPTZ,
+    archived_by TEXT,
+    created_at  TIMESTAMPTZ NOT NULL DEFAULT now(),
+    updated_at  TIMESTAMPTZ NOT NULL DEFAULT now(),
+    CONSTRAINT uq_survey_metadata_team_survey UNIQUE (team, survey_id)
+);

--- a/apps/lumi-api/src/test/kotlin/no/nav/lumi/TestDatabase.kt
+++ b/apps/lumi-api/src/test/kotlin/no/nav/lumi/TestDatabase.kt
@@ -80,7 +80,7 @@ object TestDatabase {
     fun clearAllData() {
         dataSource.connection.use { conn ->
             conn.createStatement().use { stmt ->
-                stmt.execute("TRUNCATE TABLE rating_marker, feedback, survey_definitions CASCADE")
+                stmt.execute("TRUNCATE TABLE rating_marker, feedback, survey_definitions, survey_metadata CASCADE")
             }
             conn.commit()
         }

--- a/apps/lumi-api/src/test/kotlin/no/nav/lumi/TestUtils.kt
+++ b/apps/lumi-api/src/test/kotlin/no/nav/lumi/TestUtils.kt
@@ -18,12 +18,15 @@ import no.nav.lumi.config.configureRateLimiting
 import no.nav.lumi.config.DatabaseHolder
 import no.nav.lumi.domain.SaveResult
 import no.nav.lumi.integrations.valkey.InMemoryStatsCache
+import no.nav.lumi.integrations.valkey.InMemoryStringCache
 import no.nav.lumi.repository.FeedbackRepository
 import no.nav.lumi.routes.feedbackRoutes
 import no.nav.lumi.routes.internalRoutes
 import no.nav.lumi.routes.statsRoutes
 import no.nav.lumi.routes.exportRoutes
 import no.nav.lumi.routes.markerRoutes
+import no.nav.lumi.routes.filterRoutes
+import no.nav.lumi.routes.surveyArchiveRoutes
 import no.nav.lumi.routes.surveyFacetRoutes
 import no.nav.lumi.routes.submissionRoutes
 import no.nav.lumi.routes.discoveryRoutes
@@ -279,6 +282,8 @@ fun Application.testModule(
     }
     
     // Create services with the injected repositories/services
+    // Fresh per test application so bootstrap cache state cannot leak between tests
+    val bootstrapCache = InMemoryStringCache()
     val statsCache = InMemoryStatsCache()
     val statsService = StatsService(FeedbackRepository(), statsRepository, statsCache = statsCache)
     val exportService = ExportService(FeedbackRepository())
@@ -299,6 +304,8 @@ fun Application.testModule(
             
             feedbackRoutes(feedbackService, statsCacheInvalidator)
             surveyFacetRoutes(feedbackService, statsCacheInvalidator)
+            surveyArchiveRoutes(bootstrapCache = bootstrapCache)
+            filterRoutes(bootstrapCache = bootstrapCache)
             markerRoutes()
             statsRoutes(statsService)
             exportRoutes(exportService)

--- a/apps/lumi-api/src/test/kotlin/no/nav/lumi/TestUtils.kt
+++ b/apps/lumi-api/src/test/kotlin/no/nav/lumi/TestUtils.kt
@@ -304,7 +304,10 @@ fun Application.testModule(
             
             feedbackRoutes(feedbackService, statsCacheInvalidator)
             surveyFacetRoutes(feedbackService, statsCacheInvalidator)
-            surveyArchiveRoutes(bootstrapCache = bootstrapCache)
+            surveyArchiveRoutes(
+                bootstrapCache = bootstrapCache,
+                statsCacheInvalidator = statsCacheInvalidator,
+            )
             filterRoutes(bootstrapCache = bootstrapCache)
             markerRoutes()
             statsRoutes(statsService)

--- a/apps/lumi-api/src/test/kotlin/no/nav/lumi/repository/FeedbackRepositoryTest.kt
+++ b/apps/lumi-api/src/test/kotlin/no/nav/lumi/repository/FeedbackRepositoryTest.kt
@@ -249,6 +249,22 @@ class FeedbackRepositoryTest : FunSpec({
     }
 
     context("findPaginated") {
+        test("excludes archived surveys from the default result") {
+            insertTestFeedback(id = "active", team = "flex", surveyId = "survey-active")
+            insertTestFeedback(id = "archived", team = "flex", surveyId = "survey-archived")
+            SurveyMetadataRepository().archive("flex", "survey-archived", "A123456")
+
+            val (content, total, _) = repository.findPaginated(FeedbackQuery(team = "flex"))
+            val (allContent, allTotal, _) = repository.findPaginated(
+                FeedbackQuery(team = "flex", includeArchived = true)
+            )
+
+            total shouldBe 1
+            content.map { it.id } shouldBe listOf("active")
+            allTotal shouldBe 2
+            allContent.map { it.id }.toSet() shouldBe setOf("active", "archived")
+        }
+
         test("returns empty list when no feedback exists") {
             val (content, total, _) = repository.findPaginated(FeedbackQuery(team = "nonexistent"))
             

--- a/apps/lumi-api/src/test/kotlin/no/nav/lumi/repository/FeedbackStatsRepositoryTest.kt
+++ b/apps/lumi-api/src/test/kotlin/no/nav/lumi/repository/FeedbackStatsRepositoryTest.kt
@@ -21,6 +21,20 @@ class FeedbackStatsRepositoryTest : FunSpec({
     }
 
     context("getStats") {
+        test("excludes archived surveys from default statistics") {
+            insertTestFeedback(id = "active", team = "flex", surveyId = "survey-active")
+            insertTestFeedback(id = "archived", team = "flex", surveyId = "survey-archived")
+            SurveyMetadataRepository().archive("flex", "survey-archived", "A123456")
+
+            val stats = repository.getStats(StatsQuery(team = "flex"))
+            val allStats = repository.getStats(StatsQuery(team = "flex", includeArchived = true))
+
+            stats.totalCount shouldBe 1L
+            stats.bySurveyId.keys shouldBe setOf("survey-active")
+            allStats.totalCount shouldBe 2L
+            allStats.bySurveyId.keys shouldBe setOf("survey-active", "survey-archived")
+        }
+
         test("returns correct statistics") {
             insertTestFeedback(team = "flex", rating = 4)
             insertTestFeedback(team = "flex", rating = 5)

--- a/apps/lumi-api/src/test/kotlin/no/nav/lumi/repository/SurveyMetadataRepositoryTest.kt
+++ b/apps/lumi-api/src/test/kotlin/no/nav/lumi/repository/SurveyMetadataRepositoryTest.kt
@@ -1,0 +1,65 @@
+package no.nav.lumi.repository
+
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+import no.nav.lumi.TestDatabase
+
+class SurveyMetadataRepositoryTest : FunSpec({
+    val repository = SurveyMetadataRepository()
+
+    beforeSpec {
+        TestDatabase.initialize()
+    }
+
+    beforeTest {
+        TestDatabase.clearAllData()
+    }
+
+    test("archive creates a metadata row with archivedAt and archivedBy") {
+        val state = repository.archive(team = "team-test", surveyId = "survey-1", archivedBy = "A123456")
+
+        state.surveyId shouldBe "survey-1"
+        state.archivedAt shouldNotBe null
+        state.archivedBy shouldBe "A123456"
+    }
+
+    test("archive is idempotent and keeps the original archivedAt and archivedBy") {
+        val first = repository.archive(team = "team-test", surveyId = "survey-1", archivedBy = "A123456")
+        val second = repository.archive(team = "team-test", surveyId = "survey-1", archivedBy = "B999999")
+
+        second.archivedAt shouldBe first.archivedAt
+        second.archivedBy shouldBe "A123456"
+    }
+
+    test("unarchive clears archivedAt but keeps the row") {
+        repository.archive(team = "team-test", surveyId = "survey-1", archivedBy = "A123456")
+
+        repository.unarchive(team = "team-test", surveyId = "survey-1") shouldBe true
+
+        val states = repository.findByTeam("team-test")
+        states.size shouldBe 1
+        states.single().archivedAt shouldBe null
+    }
+
+    test("unarchive without an existing row reports no change") {
+        repository.unarchive(team = "team-test", surveyId = "never-archived") shouldBe false
+    }
+
+    test("re-archive after unarchive sets a fresh archivedAt and archivedBy") {
+        repository.archive(team = "team-test", surveyId = "survey-1", archivedBy = "A123456")
+        repository.unarchive(team = "team-test", surveyId = "survey-1")
+
+        val state = repository.archive(team = "team-test", surveyId = "survey-1", archivedBy = "B999999")
+
+        state.archivedAt shouldNotBe null
+        state.archivedBy shouldBe "B999999"
+    }
+
+    test("findByTeam only returns rows for the given team") {
+        repository.archive(team = "team-test", surveyId = "survey-1", archivedBy = "A123456")
+        repository.archive(team = "flex", surveyId = "survey-2", archivedBy = "A123456")
+
+        repository.findByTeam("team-test").map { it.surveyId } shouldBe listOf("survey-1")
+    }
+})

--- a/apps/lumi-api/src/test/kotlin/no/nav/lumi/routes/FilterRoutesTest.kt
+++ b/apps/lumi-api/src/test/kotlin/no/nav/lumi/routes/FilterRoutesTest.kt
@@ -16,6 +16,7 @@ import kotlinx.serialization.json.JsonNull
 import kotlinx.serialization.json.jsonObject
 import kotlinx.serialization.json.jsonPrimitive
 import no.nav.lumi.TestDatabase
+import no.nav.lumi.config.auth.BrukerPrincipal
 import no.nav.lumi.createTestClient
 import no.nav.lumi.insertTestFeedback
 import no.nav.lumi.repository.SurveyMetadataRepository
@@ -24,6 +25,36 @@ import no.nav.lumi.testModule
 class FilterRoutesTest : FunSpec({
     beforeSpec {
         TestDatabase.initialize()
+    }
+
+    test("bootstrapCacheKey uses navIdent as user identity") {
+        val principal = BrukerPrincipal(
+            navIdent = "A123456",
+            name = null,
+            email = "test@nav.no",
+            clientId = null,
+        )
+        bootstrapCacheKey("Team-Test", principal) shouldBe "team=team-test&user=a123456"
+    }
+
+    test("bootstrapCacheKey falls back to email when navIdent is missing") {
+        val principal = BrukerPrincipal(
+            navIdent = null,
+            name = null,
+            email = "Test.User@nav.no",
+            clientId = null,
+        )
+        bootstrapCacheKey("team-test", principal) shouldBe "team=team-test&user=test.user@nav.no"
+    }
+
+    test("bootstrapCacheKey returns null when the principal has no stable user identity") {
+        val principal = BrukerPrincipal(
+            navIdent = null,
+            name = "Uten Identitet",
+            email = null,
+            clientId = "dev-gcp:team:app",
+        )
+        bootstrapCacheKey("team-test", principal) shouldBe null
     }
 
     beforeTest {

--- a/apps/lumi-api/src/test/kotlin/no/nav/lumi/routes/FilterRoutesTest.kt
+++ b/apps/lumi-api/src/test/kotlin/no/nav/lumi/routes/FilterRoutesTest.kt
@@ -1,0 +1,119 @@
+package no.nav.lumi.routes
+
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+import io.ktor.client.request.delete
+import io.ktor.client.request.get
+import io.ktor.client.request.header
+import io.ktor.client.request.put
+import io.ktor.client.statement.bodyAsText
+import io.ktor.http.HttpHeaders
+import io.ktor.http.HttpStatusCode
+import io.ktor.server.testing.testApplication
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonNull
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
+import no.nav.lumi.TestDatabase
+import no.nav.lumi.createTestClient
+import no.nav.lumi.insertTestFeedback
+import no.nav.lumi.repository.SurveyMetadataRepository
+import no.nav.lumi.testModule
+
+class FilterRoutesTest : FunSpec({
+    beforeSpec {
+        TestDatabase.initialize()
+    }
+
+    beforeTest {
+        TestDatabase.clearAllData()
+    }
+
+    test("bootstrap exposes archive state per survey in surveyMeta") {
+        testApplication {
+            application { testModule() }
+            insertTestFeedback(surveyId = "survey-active")
+            insertTestFeedback(surveyId = "survey-archived")
+            SurveyMetadataRepository().archive(
+                team = "team-test",
+                surveyId = "survey-archived",
+                archivedBy = "A123456",
+            )
+
+            val response = createTestClient().get("/api/v1/intern/filters/bootstrap?team=team-test") {
+                header(HttpHeaders.Authorization, "Bearer test-token")
+            }
+
+            response.status shouldBe HttpStatusCode.OK
+            val body = Json.parseToJsonElement(response.bodyAsText()).jsonObject
+            val surveyMeta = body["surveyMeta"]?.jsonObject
+            surveyMeta shouldNotBe null
+
+            val archivedEntry = surveyMeta!!["survey-archived"]?.jsonObject
+            archivedEntry shouldNotBe null
+            archivedEntry!!["archivedAt"] shouldNotBe JsonNull
+
+            // A survey without metadata must not be reported as archived
+            val activeEntry = surveyMeta["survey-active"]
+            (activeEntry == null || activeEntry.jsonObject["archivedAt"] == JsonNull) shouldBe true
+        }
+    }
+
+    test("archiving a survey is visible in bootstrap without waiting for cache TTL") {
+        testApplication {
+            application { testModule() }
+            insertTestFeedback(surveyId = "survey-1")
+
+            // Populate the bootstrap cache
+            val first = createTestClient().get("/api/v1/intern/filters/bootstrap?team=team-test") {
+                header(HttpHeaders.Authorization, "Bearer test-token")
+            }
+            first.status shouldBe HttpStatusCode.OK
+            Json.parseToJsonElement(first.bodyAsText())
+                .jsonObject["surveyMeta"]?.jsonObject?.get("survey-1") shouldBe null
+
+            createTestClient().put("/api/v1/intern/surveys/survey-1/archive?team=team-test") {
+                header(HttpHeaders.Authorization, "Bearer test-token")
+            }.status shouldBe HttpStatusCode.OK
+
+            val second = createTestClient().get("/api/v1/intern/filters/bootstrap?team=team-test") {
+                header(HttpHeaders.Authorization, "Bearer test-token")
+            }
+            second.status shouldBe HttpStatusCode.OK
+            val entry = Json.parseToJsonElement(second.bodyAsText())
+                .jsonObject["surveyMeta"]?.jsonObject?.get("survey-1")?.jsonObject
+            entry shouldNotBe null
+            entry!!["archivedAt"] shouldNotBe JsonNull
+            entry["archivedAt"]?.jsonPrimitive?.content shouldNotBe null
+        }
+    }
+
+    test("restoring a survey is visible in bootstrap without waiting for cache TTL") {
+        testApplication {
+            application { testModule() }
+            insertTestFeedback(surveyId = "survey-1")
+
+            createTestClient().put("/api/v1/intern/surveys/survey-1/archive?team=team-test") {
+                header(HttpHeaders.Authorization, "Bearer test-token")
+            }.status shouldBe HttpStatusCode.OK
+
+            // Populate the cache with the archived state
+            createTestClient().get("/api/v1/intern/filters/bootstrap?team=team-test") {
+                header(HttpHeaders.Authorization, "Bearer test-token")
+            }.status shouldBe HttpStatusCode.OK
+
+            createTestClient().delete("/api/v1/intern/surveys/survey-1/archive?team=team-test") {
+                header(HttpHeaders.Authorization, "Bearer test-token")
+            }.status shouldBe HttpStatusCode.NoContent
+
+            val response = createTestClient().get("/api/v1/intern/filters/bootstrap?team=team-test") {
+                header(HttpHeaders.Authorization, "Bearer test-token")
+            }
+            val entry = Json.parseToJsonElement(response.bodyAsText())
+                .jsonObject["surveyMeta"]?.jsonObject?.get("survey-1")?.jsonObject
+            entry shouldNotBe null
+            entry!!["archivedAt"] shouldBe JsonNull
+        }
+    }
+})

--- a/apps/lumi-api/src/test/kotlin/no/nav/lumi/routes/FilterRoutesTest.kt
+++ b/apps/lumi-api/src/test/kotlin/no/nav/lumi/routes/FilterRoutesTest.kt
@@ -19,8 +19,10 @@ import no.nav.lumi.TestDatabase
 import no.nav.lumi.config.auth.BrukerPrincipal
 import no.nav.lumi.createTestClient
 import no.nav.lumi.insertTestFeedback
+import no.nav.lumi.integrations.valkey.InMemoryStringCache
 import no.nav.lumi.repository.SurveyMetadataRepository
 import no.nav.lumi.testModule
+import java.time.Duration
 
 class FilterRoutesTest : FunSpec({
     beforeSpec {
@@ -47,6 +49,26 @@ class FilterRoutesTest : FunSpec({
         bootstrapCacheKey("team-test", principal) shouldBe "team=team-test&user=test.user@nav.no"
     }
 
+    test("bootstrapCacheKey falls back to email when navIdent is blank") {
+        val principal = BrukerPrincipal(
+            navIdent = "  ",
+            name = null,
+            email = "Test.User@nav.no",
+            clientId = null,
+        )
+        bootstrapCacheKey("team-test", principal) shouldBe "team=team-test&user=test.user@nav.no"
+    }
+
+    test("bootstrapCacheKey returns null when navIdent and email are blank") {
+        val principal = BrukerPrincipal(
+            navIdent = "",
+            name = "Uten Identitet",
+            email = "  ",
+            clientId = "dev-gcp:team:app",
+        )
+        bootstrapCacheKey("team-test", principal) shouldBe null
+    }
+
     test("bootstrapCacheKey returns null when the principal has no stable user identity") {
         val principal = BrukerPrincipal(
             navIdent = null,
@@ -55,6 +77,22 @@ class FilterRoutesTest : FunSpec({
             clientId = "dev-gcp:team:app",
         )
         bootstrapCacheKey("team-test", principal) shouldBe null
+    }
+
+    test("versioned bootstrap cache ignores a stale write after invalidation") {
+        val cache = VersionedBootstrapCache(InMemoryStringCache())
+        val principal = BrukerPrincipal(
+            navIdent = "A123456",
+            name = null,
+            email = "test@nav.no",
+            clientId = null,
+        )
+        val staleLookup = cache.lookup("team-test", principal)
+
+        cache.invalidate("team-test")
+        cache.set(staleLookup, "stale", Duration.ofMinutes(5))
+
+        cache.lookup("team-test", principal).value shouldBe null
     }
 
     beforeTest {

--- a/apps/lumi-api/src/test/kotlin/no/nav/lumi/routes/SurveyArchiveRoutesTest.kt
+++ b/apps/lumi-api/src/test/kotlin/no/nav/lumi/routes/SurveyArchiveRoutesTest.kt
@@ -4,6 +4,7 @@ import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.shouldNotBe
 import io.ktor.client.request.delete
+import io.ktor.client.request.get
 import io.ktor.client.request.header
 import io.ktor.client.request.put
 import io.ktor.client.statement.bodyAsText
@@ -16,6 +17,7 @@ import kotlinx.serialization.json.jsonObject
 import kotlinx.serialization.json.jsonPrimitive
 import no.nav.lumi.TestDatabase
 import no.nav.lumi.createTestClient
+import no.nav.lumi.insertTestFeedback
 import no.nav.lumi.repository.SurveyMetadataRepository
 import no.nav.lumi.testModule
 
@@ -71,6 +73,47 @@ class SurveyArchiveRoutesTest : FunSpec({
             val states = SurveyMetadataRepository().findByTeam("team-test")
             states.size shouldBe 1
             states.single().archivedAt shouldBe null
+        }
+    }
+
+    test("archive visibility updates cached statistics and can be explicitly included") {
+        insertTestFeedback(id = "active", team = "team-test", surveyId = "survey-active")
+        insertTestFeedback(id = "archived", team = "team-test", surveyId = "survey-archived")
+
+        testApplication {
+            application { testModule() }
+            val authenticatedClient = createTestClient()
+
+            suspend fun totalCount(includeArchived: Boolean = false): Int {
+                val suffix = if (includeArchived) "&includeArchived=true" else ""
+                val response = authenticatedClient.get(
+                    "/api/v1/intern/stats/dashboard?team=team-test$suffix"
+                ) {
+                    header(HttpHeaders.Authorization, "Bearer test-token")
+                }
+                response.status shouldBe HttpStatusCode.OK
+                return Json.parseToJsonElement(response.bodyAsText())
+                    .jsonObject["totalCount"]?.jsonPrimitive?.content?.toInt() ?: -1
+            }
+
+            totalCount() shouldBe 2
+
+            authenticatedClient.put(
+                "/api/v1/intern/surveys/survey-archived/archive?team=team-test"
+            ) {
+                header(HttpHeaders.Authorization, "Bearer test-token")
+            }.status shouldBe HttpStatusCode.OK
+
+            totalCount() shouldBe 1
+            totalCount(includeArchived = true) shouldBe 2
+
+            authenticatedClient.delete(
+                "/api/v1/intern/surveys/survey-archived/archive?team=team-test"
+            ) {
+                header(HttpHeaders.Authorization, "Bearer test-token")
+            }.status shouldBe HttpStatusCode.NoContent
+
+            totalCount() shouldBe 2
         }
     }
 

--- a/apps/lumi-api/src/test/kotlin/no/nav/lumi/routes/SurveyArchiveRoutesTest.kt
+++ b/apps/lumi-api/src/test/kotlin/no/nav/lumi/routes/SurveyArchiveRoutesTest.kt
@@ -1,0 +1,101 @@
+package no.nav.lumi.routes
+
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+import io.ktor.client.request.delete
+import io.ktor.client.request.header
+import io.ktor.client.request.put
+import io.ktor.client.statement.bodyAsText
+import io.ktor.http.HttpHeaders
+import io.ktor.http.HttpStatusCode
+import io.ktor.server.testing.testApplication
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonNull
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
+import no.nav.lumi.TestDatabase
+import no.nav.lumi.createTestClient
+import no.nav.lumi.repository.SurveyMetadataRepository
+import no.nav.lumi.testModule
+
+class SurveyArchiveRoutesTest : FunSpec({
+    beforeSpec {
+        TestDatabase.initialize()
+    }
+
+    beforeTest {
+        TestDatabase.clearAllData()
+    }
+
+    test("PUT archive requires authentication") {
+        testApplication {
+            application { testModule() }
+
+            val response = client.put("/api/v1/intern/surveys/survey-1/archive?team=team-test")
+
+            response.status shouldBe HttpStatusCode.Unauthorized
+        }
+    }
+
+    test("PUT archive archives the survey with the authenticated user as archivedBy") {
+        testApplication {
+            application { testModule() }
+
+            val response = createTestClient().put("/api/v1/intern/surveys/survey-1/archive?team=team-test") {
+                header(HttpHeaders.Authorization, "Bearer test-token")
+            }
+
+            response.status shouldBe HttpStatusCode.OK
+            val body = Json.parseToJsonElement(response.bodyAsText()).jsonObject
+            body["surveyId"]?.jsonPrimitive?.content shouldBe "survey-1"
+            body["archivedAt"] shouldNotBe null
+            body["archivedAt"] shouldNotBe JsonNull
+            body["archivedBy"]?.jsonPrimitive?.content shouldBe "A123456"
+        }
+    }
+
+    test("DELETE archive restores the survey and keeps the metadata row") {
+        testApplication {
+            application { testModule() }
+
+            createTestClient().put("/api/v1/intern/surveys/survey-1/archive?team=team-test") {
+                header(HttpHeaders.Authorization, "Bearer test-token")
+            }
+
+            val response = createTestClient().delete("/api/v1/intern/surveys/survey-1/archive?team=team-test") {
+                header(HttpHeaders.Authorization, "Bearer test-token")
+            }
+
+            response.status shouldBe HttpStatusCode.NoContent
+            val states = SurveyMetadataRepository().findByTeam("team-test")
+            states.size shouldBe 1
+            states.single().archivedAt shouldBe null
+        }
+    }
+
+    test("DELETE archive on a never-archived survey is idempotent") {
+        testApplication {
+            application { testModule() }
+
+            val response = createTestClient().delete("/api/v1/intern/surveys/never-archived/archive?team=team-test") {
+                header(HttpHeaders.Authorization, "Bearer test-token")
+            }
+
+            response.status shouldBe HttpStatusCode.NoContent
+        }
+    }
+
+    test("PUT archive rejects a team the user is not authorized for") {
+        testApplication {
+            application { testModule() }
+
+            val response = createTestClient().put("/api/v1/intern/surveys/survey-1/archive?team=team-unknown") {
+                header(HttpHeaders.Authorization, "Bearer test-token")
+            }
+
+            response.status shouldBe HttpStatusCode.Forbidden
+            SurveyMetadataRepository().findByTeam("team-unknown") shouldBe emptyList()
+        }
+    }
+})

--- a/apps/lumi-dashboard/app/components/dashboard/ArchiveSurveyDialog.tsx
+++ b/apps/lumi-dashboard/app/components/dashboard/ArchiveSurveyDialog.tsx
@@ -1,9 +1,9 @@
 import { ArchiveIcon } from "@navikt/aksel-icons";
 import {
-  Alert,
   BodyLong,
   Button,
   HStack,
+  InlineMessage,
   Modal,
   VStack,
 } from "@navikt/ds-react";
@@ -25,12 +25,17 @@ export function ArchiveSurveyDialog({
   isOpen,
   onClose,
 }: ArchiveSurveyDialogProps) {
-  const { archiveMutation } = useArchiveSurvey();
+  const { archiveMutation } = useArchiveSurvey(surveyId);
+
+  const handleClose = () => {
+    archiveMutation.reset();
+    onClose();
+  };
 
   const handleArchive = async () => {
     try {
       await archiveMutation.mutateAsync(surveyId);
-      onClose();
+      handleClose();
     } catch (_error) {
       // Error is handled by mutation state
     }
@@ -39,7 +44,7 @@ export function ArchiveSurveyDialog({
   return (
     <Modal
       open={isOpen}
-      onClose={onClose}
+      onClose={handleClose}
       header={{
         heading: "Arkiver survey",
         icon: <ArchiveIcon aria-hidden />,
@@ -55,20 +60,20 @@ export function ArchiveSurveyDialog({
           </BodyLong>
 
           <BodyLong>
-            Ingen data slettes, og surveyen kan når som helst gjenopprettes via
-            «Vis arkiverte»-filteret.
+            Ingen data slettes. Du finner surveyen igjen ved å slå på
+            «Arkiverte» i filterlinjen.
           </BodyLong>
 
           {archiveMutation.isError && (
-            <Alert variant="error">
+            <InlineMessage status="error">
               Kunne ikke arkivere survey. Prøv igjen senere.
-            </Alert>
+            </InlineMessage>
           )}
         </VStack>
       </Modal.Body>
       <Modal.Footer>
         <HStack gap="space-8" justify="end">
-          <Button variant="secondary" onClick={onClose}>
+          <Button variant="secondary" onClick={handleClose}>
             Avbryt
           </Button>
           <Button

--- a/apps/lumi-dashboard/app/components/dashboard/ArchiveSurveyDialog.tsx
+++ b/apps/lumi-dashboard/app/components/dashboard/ArchiveSurveyDialog.tsx
@@ -1,0 +1,85 @@
+import { ArchiveIcon } from "@navikt/aksel-icons";
+import {
+  Alert,
+  BodyLong,
+  Button,
+  HStack,
+  Modal,
+  VStack,
+} from "@navikt/ds-react";
+import { useArchiveSurvey } from "~/hooks/useArchiveSurvey";
+
+interface ArchiveSurveyDialogProps {
+  surveyId: string;
+  isOpen: boolean;
+  onClose: () => void;
+}
+
+/**
+ * Confirmation dialog for archiving a survey. Deliberately explicit about
+ * what archiving does NOT do: submissions continue until the consuming
+ * app removes the widget from its frontend.
+ */
+export function ArchiveSurveyDialog({
+  surveyId,
+  isOpen,
+  onClose,
+}: ArchiveSurveyDialogProps) {
+  const { archiveMutation } = useArchiveSurvey();
+
+  const handleArchive = async () => {
+    try {
+      await archiveMutation.mutateAsync(surveyId);
+      onClose();
+    } catch (_error) {
+      // Error is handled by mutation state
+    }
+  };
+
+  return (
+    <Modal
+      open={isOpen}
+      onClose={onClose}
+      header={{
+        heading: "Arkiver survey",
+        icon: <ArchiveIcon aria-hidden />,
+      }}
+      width="small"
+    >
+      <Modal.Body>
+        <VStack gap="space-16">
+          <BodyLong>
+            Arkivering skjuler <strong>{surveyId}</strong> i dashboardet for
+            hele teamet. Den stopper ikke innsendinger — fjern surveyen fra
+            frontend-koden for å stoppe datainnsamling.
+          </BodyLong>
+
+          <BodyLong>
+            Ingen data slettes, og surveyen kan når som helst gjenopprettes via
+            «Vis arkiverte»-filteret.
+          </BodyLong>
+
+          {archiveMutation.isError && (
+            <Alert variant="error">
+              Kunne ikke arkivere survey. Prøv igjen senere.
+            </Alert>
+          )}
+        </VStack>
+      </Modal.Body>
+      <Modal.Footer>
+        <HStack gap="space-8" justify="end">
+          <Button variant="secondary" onClick={onClose}>
+            Avbryt
+          </Button>
+          <Button
+            variant="primary"
+            onClick={handleArchive}
+            loading={archiveMutation.isPending}
+          >
+            Arkiver survey
+          </Button>
+        </HStack>
+      </Modal.Footer>
+    </Modal>
+  );
+}

--- a/apps/lumi-dashboard/app/components/dashboard/DeleteSurveyDialog.tsx
+++ b/apps/lumi-dashboard/app/components/dashboard/DeleteSurveyDialog.tsx
@@ -33,12 +33,16 @@ export function DeleteSurveyDialog({
   const deleteMutation = useDeleteSurvey();
 
   // Fetch actual total count for this survey (ignoring other filters)
-  const { data: totalCount, isLoading: isLoadingTotal } = useSurveyTotalCount(
-    surveyId,
-    isOpen,
-  );
+  const {
+    data: totalCount,
+    isLoading: isLoadingTotal,
+    isError: isTotalCountError,
+  } = useSurveyTotalCount(surveyId, isOpen);
+  const totalCountUnavailable = isTotalCountError || totalCount === undefined;
 
   const handleDelete = async () => {
+    if (totalCountUnavailable) return;
+
     try {
       await deleteMutation.mutateAsync(surveyId);
       setConfirmed(false);
@@ -55,8 +59,7 @@ export function DeleteSurveyDialog({
   };
 
   // Check if user is viewing a filtered subset
-  const actualTotal = totalCount ?? filteredCount;
-  const isFiltered = actualTotal !== filteredCount;
+  const isFiltered = totalCount !== undefined && totalCount !== filteredCount;
 
   return (
     <Modal
@@ -70,20 +73,25 @@ export function DeleteSurveyDialog({
     >
       <Modal.Body>
         <VStack gap="space-16">
-          <Alert variant="warning">
+          <Alert variant={isTotalCountError ? "error" : "warning"}>
             {isLoadingTotal ? (
               <Skeleton width="100%" height="24px" />
+            ) : isTotalCountError || totalCount === undefined ? (
+              <>
+                Kunne ikke hente totalt antall svar. Last antallet på nytt før
+                surveyen kan slettes.
+              </>
             ) : (
               <>
                 Du er i ferd med å{" "}
-                <strong>permanent slette alle {actualTotal} svar</strong> for
+                <strong>permanent slette alle {totalCount} svar</strong> for
                 survey <strong>"{surveyId}"</strong>.
                 {isFiltered && (
                   <>
                     {" "}
-                    Du ser nå {filteredCount} av {actualTotal} svar pga.
+                    Du ser nå {filteredCount} av {totalCount} svar pga.
                     filtrering, men{" "}
-                    <strong>alle {actualTotal} svar vil bli slettet</strong>.
+                    <strong>alle {totalCount} svar vil bli slettet</strong>.
                   </>
                 )}
               </>
@@ -98,8 +106,12 @@ export function DeleteSurveyDialog({
           <ConfirmationPanel
             checked={confirmed}
             onChange={() => setConfirmed(!confirmed)}
-            label={`Ja, slett permanent alle ${actualTotal} svar`}
-            disabled={isLoadingTotal}
+            label={
+              totalCount === undefined
+                ? "Antall svar må lastes før sletting"
+                : `Ja, slett permanent alle ${totalCount} svar`
+            }
+            disabled={isLoadingTotal || totalCountUnavailable}
           />
 
           {deleteMutation.isError && (
@@ -118,10 +130,12 @@ export function DeleteSurveyDialog({
             data-color="danger"
             variant="primary"
             onClick={handleDelete}
-            disabled={!confirmed || isLoadingTotal}
+            disabled={!confirmed || isLoadingTotal || totalCountUnavailable}
             loading={deleteMutation.isPending}
           >
-            Slett {actualTotal} svar permanent
+            {totalCount === undefined
+              ? "Slett svar permanent"
+              : `Slett ${totalCount} svar permanent`}
           </Button>
         </HStack>
       </Modal.Footer>

--- a/apps/lumi-dashboard/app/components/dashboard/__tests__/DeleteSurveyDialog.test.tsx
+++ b/apps/lumi-dashboard/app/components/dashboard/__tests__/DeleteSurveyDialog.test.tsx
@@ -1,0 +1,45 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { DeleteSurveyDialog } from "../DeleteSurveyDialog";
+
+const { mockMutateAsync } = vi.hoisted(() => ({
+  mockMutateAsync: vi.fn(),
+}));
+
+vi.mock("~/hooks/useDeleteSurvey", () => ({
+  useDeleteSurvey: () => ({
+    mutateAsync: mockMutateAsync,
+    isError: false,
+    isPending: false,
+  }),
+}));
+
+vi.mock("~/hooks/useSurveyTotalCount", () => ({
+  useSurveyTotalCount: () => ({
+    data: undefined,
+    isLoading: false,
+    isError: true,
+  }),
+}));
+
+describe("DeleteSurveyDialog", () => {
+  it("blocks deletion when the authoritative total count cannot be loaded", () => {
+    render(
+      <DeleteSurveyDialog
+        surveyId="survey-old"
+        filteredCount={0}
+        isOpen
+        onClose={vi.fn()}
+      />,
+    );
+
+    expect(
+      screen.getByText(/Kunne ikke hente totalt antall svar/i),
+    ).toBeInTheDocument();
+    expect(screen.getByRole("checkbox")).toBeDisabled();
+    expect(
+      screen.getByRole("button", { name: /Slett svar permanent/i }),
+    ).toBeDisabled();
+    expect(mockMutateAsync).not.toHaveBeenCalled();
+  });
+});

--- a/apps/lumi-dashboard/app/components/export/Panel.tsx
+++ b/apps/lumi-dashboard/app/components/export/Panel.tsx
@@ -42,6 +42,7 @@ export function ExportPanel() {
         data: {
           format,
           team: params.team,
+          includeArchived: params.showArchived === "true" ? "true" : undefined,
           app: params.app,
           surveyId: params.surveyId,
           fromDate: params.fromDate,

--- a/apps/lumi-dashboard/app/components/feedback/FeedbackTable/index.tsx
+++ b/apps/lumi-dashboard/app/components/feedback/FeedbackTable/index.tsx
@@ -1,4 +1,8 @@
-import { TrashIcon } from "@navikt/aksel-icons";
+import {
+  ArchiveIcon,
+  ArrowCirclepathIcon,
+  TrashIcon,
+} from "@navikt/aksel-icons";
 import {
   Alert,
   BodyShort,
@@ -14,9 +18,13 @@ import {
 } from "@navikt/ds-react";
 import React, { useState } from "react";
 
+import { useArchiveSurvey } from "~/hooks/useArchiveSurvey";
 import { useDeleteFeedback } from "~/hooks/useDeleteFeedback";
 import { useFeedback } from "~/hooks/useFeedback";
+import { useFilterBootstrap } from "~/hooks/useFilterBootstrap";
 import { useSearchParams } from "~/hooks/useSearchParams";
+import { isSurveyArchived } from "~/utils/surveyArchiveUtils";
+import { ArchiveSurveyDialog } from "../../dashboard/ArchiveSurveyDialog";
 import { DeleteSurveyDialog } from "../../dashboard/DeleteSurveyDialog";
 import { DeleteFeedbackDialog } from "../DeleteFeedbackDialog";
 import { FeedbackCard } from "./FeedbackCard";
@@ -36,8 +44,11 @@ export function FeedbackTable() {
   const { data, error, isPending } = useFeedback();
   const [expandedRows, setExpandedRows] = useState<Set<string>>(new Set());
   const [deleteDialogOpen, setDeleteDialogOpen] = useState(false);
+  const [archiveDialogOpen, setArchiveDialogOpen] = useState(false);
   const [feedbackToDelete, setFeedbackToDelete] = useState<string | null>(null);
   const deleteFeedbackMutation = useDeleteFeedback();
+  const { data: bootstrap } = useFilterBootstrap();
+  const { restoreMutation } = useArchiveSurvey();
 
   const toggleExpanded = (id: string) => {
     setExpandedRows((prev) => {
@@ -67,6 +78,8 @@ export function FeedbackTable() {
   const totalPages = data?.totalPages || 1;
   const totalElements = data?.totalElements || 0;
   const selectedSurvey = params.surveyId;
+  const selectedSurveyIsArchived =
+    !!selectedSurvey && isSurveyArchived(selectedSurvey, bootstrap?.surveyMeta);
   return (
     <div className={styles.table}>
       {/* Toolbar with bulk actions when survey is selected */}
@@ -74,6 +87,10 @@ export function FeedbackTable() {
         <SurveyToolbar
           surveyId={selectedSurvey}
           totalCount={totalElements}
+          isArchived={selectedSurveyIsArchived}
+          onArchive={() => setArchiveDialogOpen(true)}
+          onRestore={() => restoreMutation.mutate(selectedSurvey)}
+          isRestoring={restoreMutation.isPending}
           onDelete={() => setDeleteDialogOpen(true)}
         />
       )}
@@ -151,6 +168,15 @@ export function FeedbackTable() {
         </>
       )}
 
+      {/* Archive survey confirmation dialog */}
+      {selectedSurvey && (
+        <ArchiveSurveyDialog
+          surveyId={selectedSurvey}
+          isOpen={archiveDialogOpen}
+          onClose={() => setArchiveDialogOpen(false)}
+        />
+      )}
+
       {/* Delete survey confirmation dialog */}
       {selectedSurvey && (
         <DeleteSurveyDialog
@@ -185,10 +211,18 @@ export function FeedbackTable() {
 function SurveyToolbar({
   surveyId,
   totalCount,
+  isArchived,
+  onArchive,
+  onRestore,
+  isRestoring,
   onDelete,
 }: {
   surveyId: string;
   totalCount: number;
+  isArchived: boolean;
+  onArchive: () => void;
+  onRestore: () => void;
+  isRestoring: boolean;
   onDelete: () => void;
 }) {
   return (
@@ -196,21 +230,48 @@ function SurveyToolbar({
       <HStack justify="space-between" align="center" wrap gap="space-8">
         <BodyShort size="small" textColor="subtle">
           Viser {totalCount} svar for <strong>{surveyId}</strong>
+          {isArchived && <> (arkivert)</>}
         </BodyShort>
-        <Tooltip content="Slett hele surveyen (alle svar, uavhengig av filtrering)">
-          <Button
-            data-color="danger"
-            variant="primary"
-            size="small"
-            icon={<TrashIcon aria-hidden />}
-            onClick={onDelete}
-          >
-            <Hide below="sm" asChild>
-              <span>Slett alle svar</span>
-            </Hide>
-            <Show below="sm">Slett</Show>
-          </Button>
-        </Tooltip>
+        <HStack gap="space-8" align="center">
+          {isArchived ? (
+            <Tooltip content="Gjenopprett surveyen fra arkivet">
+              <Button
+                variant="secondary"
+                size="small"
+                icon={<ArrowCirclepathIcon aria-hidden />}
+                onClick={onRestore}
+                loading={isRestoring}
+              >
+                Gjenopprett
+              </Button>
+            </Tooltip>
+          ) : (
+            <Tooltip content="Skjul surveyen i dashboardet — innsendinger stoppes ikke">
+              <Button
+                variant="secondary"
+                size="small"
+                icon={<ArchiveIcon aria-hidden />}
+                onClick={onArchive}
+              >
+                Arkiver
+              </Button>
+            </Tooltip>
+          )}
+          <Tooltip content="Slett hele surveyen (alle svar, uavhengig av filtrering)">
+            <Button
+              data-color="danger"
+              variant="primary"
+              size="small"
+              icon={<TrashIcon aria-hidden />}
+              onClick={onDelete}
+            >
+              <Hide below="sm" asChild>
+                <span>Slett alle svar</span>
+              </Hide>
+              <Show below="sm">Slett</Show>
+            </Button>
+          </Tooltip>
+        </HStack>
       </HStack>
     </div>
   );

--- a/apps/lumi-dashboard/app/components/feedback/FeedbackTable/index.tsx
+++ b/apps/lumi-dashboard/app/components/feedback/FeedbackTable/index.tsx
@@ -8,6 +8,7 @@ import {
   BodyShort,
   Box,
   Button,
+  ErrorMessage,
   Hide,
   HStack,
   Pagination,
@@ -82,8 +83,10 @@ export function FeedbackTable() {
     !!selectedSurvey && isSurveyArchived(selectedSurvey, bootstrap?.surveyMeta);
   return (
     <div className={styles.table}>
-      {/* Toolbar with bulk actions when survey is selected */}
-      {selectedSurvey && totalElements > 0 && (
+      {/* Toolbar with bulk actions when survey is selected. Not gated on
+          totalElements: old surveys without hits in the current period are
+          exactly the ones users want to archive. */}
+      {selectedSurvey && (
         <SurveyToolbar
           surveyId={selectedSurvey}
           totalCount={totalElements}
@@ -91,6 +94,7 @@ export function FeedbackTable() {
           onArchive={() => setArchiveDialogOpen(true)}
           onRestore={() => restoreMutation.mutate(selectedSurvey)}
           isRestoring={restoreMutation.isPending}
+          restoreFailed={restoreMutation.isError}
           onDelete={() => setDeleteDialogOpen(true)}
         />
       )}
@@ -215,6 +219,7 @@ function SurveyToolbar({
   onArchive,
   onRestore,
   isRestoring,
+  restoreFailed,
   onDelete,
 }: {
   surveyId: string;
@@ -223,15 +228,23 @@ function SurveyToolbar({
   onArchive: () => void;
   onRestore: () => void;
   isRestoring: boolean;
+  restoreFailed: boolean;
   onDelete: () => void;
 }) {
   return (
     <div className={styles.toolbar}>
       <HStack justify="space-between" align="center" wrap gap="space-8">
-        <BodyShort size="small" textColor="subtle">
-          Viser {totalCount} svar for <strong>{surveyId}</strong>
-          {isArchived && <> (arkivert)</>}
-        </BodyShort>
+        <HStack gap="space-8" align="center">
+          <BodyShort size="small" textColor="subtle">
+            Viser {totalCount} svar for <strong>{surveyId}</strong>
+            {isArchived && <> (arkivert)</>}
+          </BodyShort>
+          {restoreFailed && (
+            <ErrorMessage size="small">
+              Kunne ikke gjenopprette surveyen. Prøv igjen.
+            </ErrorMessage>
+          )}
+        </HStack>
         <HStack gap="space-8" align="center">
           {isArchived ? (
             <Tooltip content="Gjenopprett surveyen fra arkivet">

--- a/apps/lumi-dashboard/app/components/feedback/FeedbackTable/index.tsx
+++ b/apps/lumi-dashboard/app/components/feedback/FeedbackTable/index.tsx
@@ -49,7 +49,7 @@ export function FeedbackTable() {
   const [feedbackToDelete, setFeedbackToDelete] = useState<string | null>(null);
   const deleteFeedbackMutation = useDeleteFeedback();
   const { data: bootstrap } = useFilterBootstrap();
-  const { restoreMutation } = useArchiveSurvey();
+  const { restoreMutation } = useArchiveSurvey(params.surveyId);
 
   const toggleExpanded = (id: string) => {
     setExpandedRows((prev) => {

--- a/apps/lumi-dashboard/app/components/shared/FilterBar/__tests__/FilterBar.archive.test.tsx
+++ b/apps/lumi-dashboard/app/components/shared/FilterBar/__tests__/FilterBar.archive.test.tsx
@@ -1,0 +1,144 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { FilterBar } from "../index";
+
+const { mockParams, mockSetParams, mockBootstrap } = vi.hoisted(() => ({
+  mockParams: {
+    team: "team-test",
+    app: undefined as string | undefined,
+    surveyId: "survey-archived" as string | undefined,
+    showArchived: undefined as string | undefined,
+  },
+  mockSetParams: vi.fn(),
+  mockBootstrap: {
+    data: undefined as unknown,
+    isPending: false,
+  },
+}));
+
+vi.mock("~/hooks/useSearchParams", () => ({
+  useSearchParams: () => ({
+    params: mockParams,
+    setParam: vi.fn(),
+    setParams: mockSetParams,
+    resetParams: vi.fn(),
+  }),
+}));
+
+vi.mock("~/hooks/useFilterBootstrap", () => ({
+  useFilterBootstrap: () => mockBootstrap,
+}));
+
+function loadedBootstrapData() {
+  return {
+    selectedTeam: "team-test",
+    availableTeams: ["team-test"],
+    apps: ["app-test", "app-archived"],
+    surveysByApp: {
+      "app-test": ["survey-active", "survey-archived"],
+      "app-archived": ["survey-only-archived"],
+    },
+    tags: [],
+    surveyMeta: {
+      "survey-archived": { archivedAt: "2026-08-01T10:00:00Z" },
+      "survey-only-archived": { archivedAt: "2026-08-02T10:00:00Z" },
+    },
+  };
+}
+
+vi.mock("~/hooks/useStats", () => ({
+  useStats: () => ({ data: undefined, isPending: false }),
+}));
+
+vi.mock("~/hooks/useThemes", () => ({
+  useThemes: () => ({ themes: [] }),
+}));
+
+describe("FilterBar archive state", () => {
+  beforeEach(() => {
+    mockParams.app = undefined;
+    mockParams.surveyId = "survey-archived";
+    mockParams.showArchived = undefined;
+    mockBootstrap.data = loadedBootstrapData();
+    mockBootstrap.isPending = false;
+    mockSetParams.mockClear();
+  });
+
+  it("does not clear an app filter while bootstrap is still loading", () => {
+    mockParams.app = "app-test";
+    mockParams.surveyId = "survey-active";
+    mockBootstrap.data = undefined;
+    mockBootstrap.isPending = true;
+
+    render(<FilterBar />);
+
+    expect(mockSetParams).not.toHaveBeenCalled();
+  });
+
+  it("hides and clears a selected archived survey while the toggle is off", async () => {
+    render(<FilterBar />);
+
+    expect(
+      screen.queryByRole("option", { name: "survey-archived" }),
+    ).not.toBeInTheDocument();
+    await waitFor(() =>
+      expect(mockSetParams).toHaveBeenCalledWith({
+        surveyId: undefined,
+        choice: undefined,
+        rating: undefined,
+        phrase: undefined,
+        page: "1",
+      }),
+    );
+  });
+
+  it("persists archive visibility in the URL and reveals archive-only apps", () => {
+    mockParams.surveyId = undefined;
+    mockParams.showArchived = "true";
+    render(<FilterBar />);
+
+    expect(
+      screen.getAllByRole("option", { name: "app-archived" }),
+    ).toHaveLength(2);
+    expect(
+      screen.getAllByRole("option", { name: "survey-only-archived" }),
+    ).toHaveLength(2);
+    const archiveSwitches = screen.getAllByRole("checkbox", {
+      name: "Arkiverte (2)",
+    });
+    expect(archiveSwitches[0]).toBeChecked();
+
+    fireEvent.click(archiveSwitches[0]);
+    expect(mockSetParams).toHaveBeenCalledWith({ showArchived: undefined });
+  });
+
+  it("writes archive visibility to the URL when the switch is enabled", () => {
+    mockParams.surveyId = undefined;
+    render(<FilterBar />);
+
+    const archiveSwitches = screen.getAllByRole("checkbox", {
+      name: "Arkiverte (2)",
+    });
+    expect(archiveSwitches[0]).not.toBeChecked();
+
+    fireEvent.click(archiveSwitches[0]);
+    expect(mockSetParams).toHaveBeenCalledWith({ showArchived: "true" });
+  });
+
+  it("clears the app when its final visible survey is archived", async () => {
+    mockParams.app = "app-archived";
+    mockParams.surveyId = "survey-only-archived";
+    render(<FilterBar />);
+
+    await waitFor(() =>
+      expect(mockSetParams).toHaveBeenCalledWith({
+        app: undefined,
+        surveyId: undefined,
+        choice: undefined,
+        rating: undefined,
+        phrase: undefined,
+        page: "1",
+      }),
+    );
+  });
+});

--- a/apps/lumi-dashboard/app/components/shared/FilterBar/index.tsx
+++ b/apps/lumi-dashboard/app/components/shared/FilterBar/index.tsx
@@ -6,11 +6,13 @@ import {
   HStack,
   Select,
   Show,
+  Switch,
   TextField,
   Tooltip,
   VStack,
 } from "@navikt/ds-react";
 import dayjs from "dayjs";
+import { useState } from "react";
 import { PeriodSelector } from "~/components/dashboard/PeriodSelector";
 import { getSurveyFeatures } from "~/config/surveyConfig";
 import { useFilterBootstrap } from "~/hooks/useFilterBootstrap";
@@ -18,6 +20,7 @@ import { useSearchParams } from "~/hooks/useSearchParams";
 import { useStats } from "~/hooks/useStats";
 import { useThemes } from "~/hooks/useThemes";
 import { getFilterLabels } from "~/utils/filterLabels";
+import { partitionSurveyOptions } from "~/utils/surveyArchiveUtils";
 import styles from "./FilterBar.module.css";
 import { FilterMenu } from "./FilterMenu";
 import { Skeleton as FilterBarSkeleton } from "./Skeleton";
@@ -72,8 +75,59 @@ export function FilterBar({ showDetails = false }: FilterBarProps) {
     return Array.from(allSurveys);
   };
 
+  const [showArchived, setShowArchived] = useState(false);
   const availableSurveys = getAvailableSurveys();
-  const surveys = ["alle", ...availableSurveys];
+  const {
+    active: activeSurveys,
+    archived: archivedSurveys,
+    hasArchived,
+  } = partitionSurveyOptions({
+    availableSurveys,
+    surveyMeta: bootstrap?.surveyMeta,
+    showArchived,
+    selectedSurveyId: params.surveyId,
+  });
+
+  // Grouped options when archived surveys are visible, flat list otherwise
+  const surveyOptions =
+    archivedSurveys.length > 0 ? (
+      <>
+        <option value="alle">Alle surveys</option>
+        <optgroup label="Aktive">
+          {activeSurveys.map((survey) => (
+            <option key={survey} value={survey}>
+              {survey}
+            </option>
+          ))}
+        </optgroup>
+        <optgroup label="Arkiverte">
+          {archivedSurveys.map((survey) => (
+            <option key={survey} value={survey}>
+              {survey}
+            </option>
+          ))}
+        </optgroup>
+      </>
+    ) : (
+      <>
+        <option value="alle">Alle surveys</option>
+        {activeSurveys.map((survey) => (
+          <option key={survey} value={survey}>
+            {survey}
+          </option>
+        ))}
+      </>
+    );
+
+  const archivedToggle = hasArchived ? (
+    <Switch
+      size="small"
+      checked={showArchived}
+      onChange={(e) => setShowArchived(e.target.checked)}
+    >
+      Vis arkiverte
+    </Switch>
+  ) : null;
 
   const handleAppChange = (newApp: string | undefined) => {
     const shouldClearSurvey =
@@ -232,12 +286,10 @@ export function FilterBar({ showDetails = false }: FilterBarProps) {
                 }
                 className={styles.desktopSurveySelect}
               >
-                {surveys.map((survey) => (
-                  <option key={survey} value={survey}>
-                    {survey === "alle" ? "Alle surveys" : survey}
-                  </option>
-                ))}
+                {surveyOptions}
               </Select>
+
+              {archivedToggle}
 
               {showDetails && features.showTextFilter && (
                 <TextField
@@ -339,12 +391,10 @@ export function FilterBar({ showDetails = false }: FilterBarProps) {
                 }
                 className={styles.mobileSurveySelect}
               >
-                {surveys.map((survey) => (
-                  <option key={survey} value={survey}>
-                    {survey === "alle" ? "Alle surveys" : survey}
-                  </option>
-                ))}
+                {surveyOptions}
               </Select>
+
+              {archivedToggle}
             </HStack>
 
             <HStack gap="space-8" justify="space-between" align="center">

--- a/apps/lumi-dashboard/app/components/shared/FilterBar/index.tsx
+++ b/apps/lumi-dashboard/app/components/shared/FilterBar/index.tsx
@@ -12,7 +12,7 @@ import {
   VStack,
 } from "@navikt/ds-react";
 import dayjs from "dayjs";
-import { useState } from "react";
+import { useEffect } from "react";
 import { PeriodSelector } from "~/components/dashboard/PeriodSelector";
 import { getSurveyFeatures } from "~/config/surveyConfig";
 import { useFilterBootstrap } from "~/hooks/useFilterBootstrap";
@@ -20,7 +20,10 @@ import { useSearchParams } from "~/hooks/useSearchParams";
 import { useStats } from "~/hooks/useStats";
 import { useThemes } from "~/hooks/useThemes";
 import { getFilterLabels } from "~/utils/filterLabels";
-import { partitionSurveyOptions } from "~/utils/surveyArchiveUtils";
+import {
+  isSurveyArchived,
+  partitionSurveyOptions,
+} from "~/utils/surveyArchiveUtils";
 import styles from "./FilterBar.module.css";
 import { FilterMenu } from "./FilterMenu";
 import { Skeleton as FilterBarSkeleton } from "./Skeleton";
@@ -51,13 +54,28 @@ export function FilterBar({ showDetails = false }: FilterBarProps) {
     : [];
 
   const availableApps = bootstrap?.apps ?? [];
-  const apps = ["alle", ...availableApps];
 
   const availableTeams = bootstrap?.availableTeams ?? [];
   const selectedTeam = params.team ?? bootstrap?.selectedTeam;
 
   const surveysByApp = bootstrap?.surveysByApp ?? {};
   const allTags = bootstrap?.tags ?? [];
+  const showArchived = params.showArchived === "true";
+
+  const allAvailableSurveys = Array.from(
+    new Set(Object.values(surveysByApp).flat()),
+  );
+  const archivedSurveyCount = allAvailableSurveys.filter((surveyId) =>
+    isSurveyArchived(surveyId, bootstrap?.surveyMeta),
+  ).length;
+  const visibleApps = showArchived
+    ? availableApps
+    : availableApps.filter((app) =>
+        (surveysByApp[app] ?? []).some(
+          (surveyId) => !isSurveyArchived(surveyId, bootstrap?.surveyMeta),
+        ),
+      );
+  const apps = ["alle", ...visibleApps];
 
   const getAvailableSurveys = (): string[] => {
     if (!surveysByApp || Object.keys(surveysByApp).length === 0) return [];
@@ -75,31 +93,28 @@ export function FilterBar({ showDetails = false }: FilterBarProps) {
     return Array.from(allSurveys);
   };
 
-  const [showArchived, setShowArchived] = useState(false);
   const availableSurveys = getAvailableSurveys();
-  const {
-    active: activeSurveys,
-    archived: archivedSurveys,
-    hasArchived,
-  } = partitionSurveyOptions({
-    availableSurveys,
-    surveyMeta: bootstrap?.surveyMeta,
-    showArchived,
-    selectedSurveyId: params.surveyId,
-  });
+  const { active: activeSurveys, archived: archivedSurveys } =
+    partitionSurveyOptions({
+      availableSurveys,
+      surveyMeta: bootstrap?.surveyMeta,
+      showArchived,
+    });
 
   // Grouped options when archived surveys are visible, flat list otherwise
   const surveyOptions =
     archivedSurveys.length > 0 ? (
       <>
         <option value="alle">Alle surveys</option>
-        <optgroup label="Aktive">
-          {activeSurveys.map((survey) => (
-            <option key={survey} value={survey}>
-              {survey}
-            </option>
-          ))}
-        </optgroup>
+        {activeSurveys.length > 0 && (
+          <optgroup label="Aktive">
+            {activeSurveys.map((survey) => (
+              <option key={survey} value={survey}>
+                {survey}
+              </option>
+            ))}
+          </optgroup>
+        )}
         <optgroup label="Arkiverte">
           {archivedSurveys.map((survey) => (
             <option key={survey} value={survey}>
@@ -119,15 +134,18 @@ export function FilterBar({ showDetails = false }: FilterBarProps) {
       </>
     );
 
-  const archivedToggle = hasArchived ? (
-    <Switch
-      size="small"
-      checked={showArchived}
-      onChange={(e) => setShowArchived(e.target.checked)}
-    >
-      Vis arkiverte
-    </Switch>
-  ) : null;
+  const archiveToggle =
+    archivedSurveyCount > 0 ? (
+      <Switch
+        size="small"
+        checked={showArchived}
+        onChange={(event) =>
+          setParams({ showArchived: event.target.checked ? "true" : undefined })
+        }
+      >
+        Arkiverte ({archivedSurveyCount})
+      </Switch>
+    ) : null;
 
   const handleAppChange = (newApp: string | undefined) => {
     const shouldClearSurvey =
@@ -160,6 +178,38 @@ export function FilterBar({ showDetails = false }: FilterBarProps) {
       page: "1",
     });
   };
+
+  const selectedSurveyIsArchived =
+    !!params.surveyId &&
+    isSurveyArchived(params.surveyId, bootstrap?.surveyMeta);
+  // Guarded on loaded bootstrap: while data is pending visibleApps is empty,
+  // and an unguarded check would wipe the app filter from bookmarked URLs.
+  const selectedAppIsHidden =
+    !!bootstrap &&
+    !!params.app &&
+    !showArchived &&
+    !visibleApps.includes(params.app);
+
+  useEffect(() => {
+    if (selectedAppIsHidden) {
+      setParams({
+        app: undefined,
+        surveyId: undefined,
+        choice: undefined,
+        rating: undefined,
+        phrase: undefined,
+        page: "1",
+      });
+    } else if (!showArchived && selectedSurveyIsArchived) {
+      setParams({
+        surveyId: undefined,
+        choice: undefined,
+        rating: undefined,
+        phrase: undefined,
+        page: "1",
+      });
+    }
+  }, [showArchived, selectedAppIsHidden, selectedSurveyIsArchived, setParams]);
 
   const handleReset = () => {
     const team = params.team;
@@ -289,8 +339,6 @@ export function FilterBar({ showDetails = false }: FilterBarProps) {
                 {surveyOptions}
               </Select>
 
-              {archivedToggle}
-
               {showDetails && features.showTextFilter && (
                 <TextField
                   label="Søk"
@@ -322,6 +370,7 @@ export function FilterBar({ showDetails = false }: FilterBarProps) {
             </HStack>
 
             <HStack gap="space-8" align="end">
+              {archiveToggle}
               <PeriodSelector />
               {hasActiveFilters && (
                 <Tooltip content="Nullstill alle filtre til standard (siste 30 dager)">
@@ -393,12 +442,11 @@ export function FilterBar({ showDetails = false }: FilterBarProps) {
               >
                 {surveyOptions}
               </Select>
-
-              {archivedToggle}
             </HStack>
 
             <HStack gap="space-8" justify="space-between" align="center">
               <HStack gap="space-8" align="center">
+                {archiveToggle}
                 <PeriodSelector />
                 {showDetails && (
                   <FilterMenu

--- a/apps/lumi-dashboard/app/hooks/__tests__/useArchiveSurvey.test.tsx
+++ b/apps/lumi-dashboard/app/hooks/__tests__/useArchiveSurvey.test.tsx
@@ -1,5 +1,5 @@
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
-import { act, renderHook } from "@testing-library/react";
+import { act, renderHook, waitFor } from "@testing-library/react";
 import type { ReactNode } from "react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
@@ -8,11 +8,16 @@ vi.mock("~/server/actions", () => ({
   unarchiveSurveyServerFn: vi.fn(),
 }));
 
+const { mockParams, mockSetParams } = vi.hoisted(() => ({
+  mockParams: { team: "team-test", surveyId: "survey-1" },
+  mockSetParams: vi.fn(),
+}));
+
 vi.mock("~/hooks/useSearchParams", () => ({
   useSearchParams: vi.fn(() => ({
-    params: { team: "team-test" },
+    params: mockParams,
     setParam: vi.fn(),
-    setParams: vi.fn(),
+    setParams: mockSetParams,
     resetParams: vi.fn(),
   })),
 }));
@@ -72,6 +77,7 @@ describe("useArchiveSurvey", () => {
     expect(invalidateSpy).toHaveBeenCalledWith({
       queryKey: ["filterBootstrap"],
     });
+    expect(mockSetParams).toHaveBeenCalledWith({ showArchived: "true" });
   });
 
   it("restores the survey for the selected team and refreshes bootstrap data", async () => {
@@ -93,5 +99,31 @@ describe("useArchiveSurvey", () => {
     expect(invalidateSpy).toHaveBeenCalledWith({
       queryKey: ["filterBootstrap"],
     });
+  });
+
+  it("resets a restore error when the selected survey changes", async () => {
+    const queryClient = createQueryClient();
+    mockUnarchive.mockRejectedValueOnce(new Error("restore failed"));
+
+    const { result, rerender } = renderHook(
+      ({ surveyId }) => useArchiveSurvey(surveyId),
+      {
+        initialProps: { surveyId: "survey-1" },
+        wrapper: createWrapper(queryClient),
+      },
+    );
+
+    act(() => {
+      result.current.restoreMutation.mutate("survey-1");
+    });
+    await waitFor(() =>
+      expect(result.current.restoreMutation.isError).toBe(true),
+    );
+
+    rerender({ surveyId: "survey-2" });
+
+    await waitFor(() =>
+      expect(result.current.restoreMutation.isError).toBe(false),
+    );
   });
 });

--- a/apps/lumi-dashboard/app/hooks/__tests__/useArchiveSurvey.test.tsx
+++ b/apps/lumi-dashboard/app/hooks/__tests__/useArchiveSurvey.test.tsx
@@ -1,0 +1,97 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { act, renderHook } from "@testing-library/react";
+import type { ReactNode } from "react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("~/server/actions", () => ({
+  archiveSurveyServerFn: vi.fn(),
+  unarchiveSurveyServerFn: vi.fn(),
+}));
+
+vi.mock("~/hooks/useSearchParams", () => ({
+  useSearchParams: vi.fn(() => ({
+    params: { team: "team-test" },
+    setParam: vi.fn(),
+    setParams: vi.fn(),
+    resetParams: vi.fn(),
+  })),
+}));
+
+import {
+  archiveSurveyServerFn,
+  unarchiveSurveyServerFn,
+} from "~/server/actions";
+import { useArchiveSurvey } from "../useArchiveSurvey";
+
+const mockArchive = archiveSurveyServerFn as unknown as ReturnType<
+  typeof vi.fn
+>;
+const mockUnarchive = unarchiveSurveyServerFn as unknown as ReturnType<
+  typeof vi.fn
+>;
+
+function createWrapper(queryClient: QueryClient) {
+  return ({ children }: { children: ReactNode }) => (
+    <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+  );
+}
+
+function createQueryClient() {
+  return new QueryClient({
+    defaultOptions: {
+      mutations: { retry: false },
+    },
+  });
+}
+
+describe("useArchiveSurvey", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("archives the survey for the selected team and refreshes bootstrap data", async () => {
+    const queryClient = createQueryClient();
+    const invalidateSpy = vi.spyOn(queryClient, "invalidateQueries");
+    mockArchive.mockResolvedValueOnce({
+      surveyId: "survey-1",
+      archivedAt: "2026-08-09T12:00:00Z",
+      archivedBy: "A123456",
+    });
+
+    const { result } = renderHook(() => useArchiveSurvey(), {
+      wrapper: createWrapper(queryClient),
+    });
+
+    await act(async () => {
+      await result.current.archiveMutation.mutateAsync("survey-1");
+    });
+
+    expect(mockArchive).toHaveBeenCalledWith({
+      data: { surveyId: "survey-1", team: "team-test" },
+    });
+    expect(invalidateSpy).toHaveBeenCalledWith({
+      queryKey: ["filterBootstrap"],
+    });
+  });
+
+  it("restores the survey for the selected team and refreshes bootstrap data", async () => {
+    const queryClient = createQueryClient();
+    const invalidateSpy = vi.spyOn(queryClient, "invalidateQueries");
+    mockUnarchive.mockResolvedValueOnce(undefined);
+
+    const { result } = renderHook(() => useArchiveSurvey(), {
+      wrapper: createWrapper(queryClient),
+    });
+
+    await act(async () => {
+      await result.current.restoreMutation.mutateAsync("survey-1");
+    });
+
+    expect(mockUnarchive).toHaveBeenCalledWith({
+      data: { surveyId: "survey-1", team: "team-test" },
+    });
+    expect(invalidateSpy).toHaveBeenCalledWith({
+      queryKey: ["filterBootstrap"],
+    });
+  });
+});

--- a/apps/lumi-dashboard/app/hooks/__tests__/useFeedback.test.tsx
+++ b/apps/lumi-dashboard/app/hooks/__tests__/useFeedback.test.tsx
@@ -11,7 +11,11 @@ vi.mock("~/server/actions", () => ({
 // Mock useSearchParams to control URL params
 vi.mock("~/hooks/useSearchParams", () => ({
   useSearchParams: vi.fn(() => ({
-    params: { app: "test-app", surveyId: "test-survey" },
+    params: {
+      app: "test-app",
+      surveyId: "test-survey",
+      showArchived: "true",
+    },
     setParam: vi.fn(),
     setParams: vi.fn(),
     resetParams: vi.fn(),
@@ -77,6 +81,7 @@ describe("useFeedback", () => {
       data: expect.objectContaining({
         app: "test-app",
         surveyId: "test-survey",
+        includeArchived: "true",
       }),
     });
   });

--- a/apps/lumi-dashboard/app/hooks/__tests__/useStats.test.tsx
+++ b/apps/lumi-dashboard/app/hooks/__tests__/useStats.test.tsx
@@ -11,7 +11,11 @@ vi.mock("~/server/actions", () => ({
 // Mock useSearchParams
 vi.mock("~/hooks/useSearchParams", () => ({
   useSearchParams: vi.fn(() => ({
-    params: { app: "test-app", surveyId: "test-survey" },
+    params: {
+      app: "test-app",
+      surveyId: "test-survey",
+      showArchived: "true",
+    },
     setParam: vi.fn(),
     setParams: vi.fn(),
     resetParams: vi.fn(),
@@ -70,6 +74,9 @@ describe("useStats", () => {
     expect(result.current.data).toEqual(mockData);
     expect(result.current.data?.totalCount).toBe(100);
     expect(result.current.data?.surveyType).toBe("rating");
+    expect(mockFetchStats).toHaveBeenCalledWith({
+      data: expect.objectContaining({ includeArchived: "true" }),
+    });
   });
 
   it("correctly calculates averageRating from data", async () => {

--- a/apps/lumi-dashboard/app/hooks/useArchiveSurvey.ts
+++ b/apps/lumi-dashboard/app/hooks/useArchiveSurvey.ts
@@ -1,4 +1,5 @@
 import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { useEffect, useRef } from "react";
 import { useSearchParams } from "~/hooks/useSearchParams";
 import {
   archiveSurveyServerFn,
@@ -10,9 +11,9 @@ import {
  * Archiving only hides the survey in the dashboard — submissions continue
  * until the consuming app removes the widget.
  */
-export function useArchiveSurvey() {
+export function useArchiveSurvey(selectedSurveyId?: string) {
   const queryClient = useQueryClient();
-  const { params } = useSearchParams();
+  const { params, setParams } = useSearchParams();
 
   const invalidateBootstrap = () => {
     queryClient.invalidateQueries({ queryKey: ["filterBootstrap"] });
@@ -21,7 +22,15 @@ export function useArchiveSurvey() {
   const archiveMutation = useMutation({
     mutationFn: (surveyId: string) =>
       archiveSurveyServerFn({ data: { surveyId, team: params.team } }),
-    onSuccess: invalidateBootstrap,
+    onSuccess: (_state, surveyId) => {
+      invalidateBootstrap();
+      if (params.surveyId === surveyId) {
+        // Keep the user's app/survey context after archiving. The toolbar's
+        // archive trigger then becomes the restore trigger, so modal focus has
+        // a valid return target instead of falling back to the document body.
+        setParams({ showArchived: "true" });
+      }
+    },
   });
 
   const restoreMutation = useMutation({
@@ -29,6 +38,16 @@ export function useArchiveSurvey() {
       unarchiveSurveyServerFn({ data: { surveyId, team: params.team } }),
     onSuccess: invalidateBootstrap,
   });
+
+  const resetArchiveMutation = archiveMutation.reset;
+  const resetRestoreMutation = restoreMutation.reset;
+  const previousSurveyId = useRef(selectedSurveyId);
+  useEffect(() => {
+    if (previousSurveyId.current === selectedSurveyId) return;
+    previousSurveyId.current = selectedSurveyId;
+    resetArchiveMutation();
+    resetRestoreMutation();
+  }, [selectedSurveyId, resetArchiveMutation, resetRestoreMutation]);
 
   return { archiveMutation, restoreMutation };
 }

--- a/apps/lumi-dashboard/app/hooks/useArchiveSurvey.ts
+++ b/apps/lumi-dashboard/app/hooks/useArchiveSurvey.ts
@@ -1,0 +1,34 @@
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { useSearchParams } from "~/hooks/useSearchParams";
+import {
+  archiveSurveyServerFn,
+  unarchiveSurveyServerFn,
+} from "~/server/actions";
+
+/**
+ * Mutations for archiving/restoring a survey (team-scoped display metadata).
+ * Archiving only hides the survey in the dashboard — submissions continue
+ * until the consuming app removes the widget.
+ */
+export function useArchiveSurvey() {
+  const queryClient = useQueryClient();
+  const { params } = useSearchParams();
+
+  const invalidateBootstrap = () => {
+    queryClient.invalidateQueries({ queryKey: ["filterBootstrap"] });
+  };
+
+  const archiveMutation = useMutation({
+    mutationFn: (surveyId: string) =>
+      archiveSurveyServerFn({ data: { surveyId, team: params.team } }),
+    onSuccess: invalidateBootstrap,
+  });
+
+  const restoreMutation = useMutation({
+    mutationFn: (surveyId: string) =>
+      unarchiveSurveyServerFn({ data: { surveyId, team: params.team } }),
+    onSuccess: invalidateBootstrap,
+  });
+
+  return { archiveMutation, restoreMutation };
+}

--- a/apps/lumi-dashboard/app/hooks/useBlockerStats.ts
+++ b/apps/lumi-dashboard/app/hooks/useBlockerStats.ts
@@ -13,6 +13,7 @@ export function useBlockerStats() {
     queryKey: [
       "blockerStats",
       params.team,
+      params.showArchived,
       params.app,
       params.fromDate,
       params.toDate,
@@ -26,6 +27,7 @@ export function useBlockerStats() {
       fetchBlockerServerFn({
         data: {
           team: params.team,
+          includeArchived: params.showArchived === "true" ? "true" : undefined,
           app: params.app,
           surveyId: params.surveyId,
           fromDate: params.fromDate,

--- a/apps/lumi-dashboard/app/hooks/useDiscoveryStats.ts
+++ b/apps/lumi-dashboard/app/hooks/useDiscoveryStats.ts
@@ -13,6 +13,7 @@ export function useDiscoveryStats() {
     queryKey: [
       "discoveryStats",
       params.team,
+      params.showArchived,
       params.app,
       params.fromDate,
       params.toDate,
@@ -25,6 +26,7 @@ export function useDiscoveryStats() {
       fetchDiscoveryServerFn({
         data: {
           team: params.team,
+          includeArchived: params.showArchived === "true" ? "true" : undefined,
           app: params.app,
           surveyId: params.surveyId,
           fromDate: params.fromDate,

--- a/apps/lumi-dashboard/app/hooks/useFeedback.ts
+++ b/apps/lumi-dashboard/app/hooks/useFeedback.ts
@@ -17,6 +17,7 @@ export function useFeedback() {
     queryKey: [
       "feedback",
       params.team,
+      params.showArchived,
       params.app,
       params.surveyId,
       params.page,
@@ -39,6 +40,7 @@ export function useFeedback() {
       fetchFeedbackServerFn({
         data: {
           team: params.team,
+          includeArchived: params.showArchived === "true" ? "true" : undefined,
           app: params.app,
           surveyId: params.surveyId,
           page: params.page,

--- a/apps/lumi-dashboard/app/hooks/useStats.ts
+++ b/apps/lumi-dashboard/app/hooks/useStats.ts
@@ -13,6 +13,7 @@ export function useStats() {
     queryKey: [
       "stats",
       params.team,
+      params.showArchived,
       params.app,
       params.fromDate,
       params.toDate,
@@ -27,6 +28,7 @@ export function useStats() {
       fetchStatsServerFn({
         data: {
           team: params.team,
+          includeArchived: params.showArchived === "true" ? "true" : undefined,
           app: params.app,
           fromDate: params.fromDate,
           toDate: params.toDate,

--- a/apps/lumi-dashboard/app/hooks/useSurveyTotalCount.ts
+++ b/apps/lumi-dashboard/app/hooks/useSurveyTotalCount.ts
@@ -21,6 +21,9 @@ export function useSurveyTotalCount(surveyId: string, enabled = true) {
         data: {
           team: params.team,
           surveyId,
+          // Destructive confirmation must count the complete survey even when
+          // its responses are hidden from the default archive view.
+          includeArchived: "true",
           // fetchFeedbackServerFn expects 1-indexed pages (it converts to backend 0-indexed)
           page: "1",
           size: "1", // Minimal data transfer, just need totalElements

--- a/apps/lumi-dashboard/app/hooks/useSurveyTypeDistribution.ts
+++ b/apps/lumi-dashboard/app/hooks/useSurveyTypeDistribution.ts
@@ -18,9 +18,17 @@ export function useSurveyTypeDistribution() {
   const { params } = useSearchParams();
 
   return useQuery({
-    queryKey: ["surveyTypeDistribution", { team: params.team }],
+    queryKey: [
+      "surveyTypeDistribution",
+      { team: params.team, showArchived: params.showArchived },
+    ],
     queryFn: () =>
-      fetchSurveyTypeDistributionServerFn({ data: { team: params.team } }),
+      fetchSurveyTypeDistributionServerFn({
+        data: {
+          team: params.team,
+          includeArchived: params.showArchived === "true" ? "true" : undefined,
+        },
+      }),
     placeholderData: keepPreviousData,
   });
 }

--- a/apps/lumi-dashboard/app/hooks/useTaskPriorityStats.ts
+++ b/apps/lumi-dashboard/app/hooks/useTaskPriorityStats.ts
@@ -13,6 +13,7 @@ export function useTaskPriorityStats() {
     queryKey: [
       "taskPriorityStats",
       params.team,
+      params.showArchived,
       params.app,
       params.fromDate,
       params.toDate,
@@ -26,6 +27,7 @@ export function useTaskPriorityStats() {
       fetchTaskPriorityServerFn({
         data: {
           team: params.team,
+          includeArchived: params.showArchived === "true" ? "true" : undefined,
           app: params.app,
           surveyId: params.surveyId,
           fromDate: params.fromDate,

--- a/apps/lumi-dashboard/app/hooks/useTopTasksStats.ts
+++ b/apps/lumi-dashboard/app/hooks/useTopTasksStats.ts
@@ -13,6 +13,7 @@ export function useTopTasksStats() {
     queryKey: [
       "topTasksStats",
       params.team,
+      params.showArchived,
       params.app,
       params.fromDate,
       params.toDate,
@@ -26,6 +27,7 @@ export function useTopTasksStats() {
       fetchTopTasksServerFn({
         data: {
           team: params.team,
+          includeArchived: params.showArchived === "true" ? "true" : undefined,
           app: params.app,
           surveyId: params.surveyId,
           fromDate: params.fromDate,

--- a/apps/lumi-dashboard/app/mock/mockData.test.ts
+++ b/apps/lumi-dashboard/app/mock/mockData.test.ts
@@ -3,11 +3,26 @@ import {
   generateSurveyData,
   getMockBlockerStats,
   getMockDiscoveryStats,
+  getMockFeedback,
+  getMockStats,
   getMockTaskPriorityStats,
   getMockTopTasksStats,
 } from "~/mock/mockData";
 
 describe("Mock Data Generation", () => {
+  it("excludes archived survey data unless includeArchived is enabled", () => {
+    const activeOnly = new URLSearchParams({ surveyId: "survey-thumbs" });
+    const withArchived = new URLSearchParams({
+      surveyId: "survey-thumbs",
+      includeArchived: "true",
+    });
+
+    expect(getMockFeedback(activeOnly).totalElements).toBe(0);
+    expect(getMockStats(activeOnly).totalCount).toBe(0);
+    expect(getMockFeedback(withArchived).totalElements).toBeGreaterThan(0);
+    expect(getMockStats(withArchived).totalCount).toBeGreaterThan(0);
+  });
+
   it("should generate items from topics", () => {
     const items = generateSurveyData(10, {
       app: "test-app",

--- a/apps/lumi-dashboard/app/mock/mockData.ts
+++ b/apps/lumi-dashboard/app/mock/mockData.ts
@@ -450,17 +450,11 @@ export function filterFeedback(
 // ============================================
 
 export function getMockStats(params: URLSearchParams): FeedbackStats {
-  return calculateStats(
-    getMockItemsForTeam(params.get("team") ?? undefined),
-    params,
-  );
+  return calculateStats(getMockAnalyticsItems(params), params);
 }
 
 export function getMockFeedback(params: URLSearchParams): FeedbackPage {
-  return filterFeedback(
-    getMockItemsForTeam(params.get("team") ?? undefined),
-    params,
-  );
+  return filterFeedback(getMockAnalyticsItems(params), params);
 }
 
 export function getMockTeams(): TeamsAndApps {
@@ -487,45 +481,39 @@ export function getMockTags(team?: string): string[] {
 export function getMockTopTasksStats(
   params: URLSearchParams,
 ): TopTasksResponse {
-  return calculateTopTasksStats(
-    getMockItemsForTeam(params.get("team") ?? undefined),
-    params,
-  );
+  return calculateTopTasksStats(getMockAnalyticsItems(params), params);
 }
 
 export function getMockDiscoveryStats(
   params: URLSearchParams,
 ): DiscoveryResponse {
-  return calculateDiscoveryStats(
-    getMockItemsForTeam(params.get("team") ?? undefined),
-    params,
-  );
+  return calculateDiscoveryStats(getMockAnalyticsItems(params), params);
 }
 
 export function getMockTaskPriorityStats(
   params: URLSearchParams,
 ): TaskPriorityResponse {
-  return calculateTaskPriorityStats(
-    getMockItemsForTeam(params.get("team") ?? undefined),
-    params,
-  );
+  return calculateTaskPriorityStats(getMockAnalyticsItems(params), params);
 }
 
 export function getMockBlockerStats(params: URLSearchParams): BlockerResponse {
-  return calculateBlockerStats(
-    getMockItemsForTeam(params.get("team") ?? undefined),
-    params,
-  );
+  return calculateBlockerStats(getMockAnalyticsItems(params), params);
 }
 
-export function getMockSurveyTypeDistribution(team?: string): {
+export function getMockSurveyTypeDistribution(
+  team?: string,
+  includeArchived = false,
+): {
   totalSurveys: number;
   distribution: { type: string; count: number; percentage: number }[];
 } {
   const typeCounts: Record<string, number> = {};
   const seenSurveys = new Set<string>();
 
-  for (const item of getMockItemsForTeam(team)) {
+  for (const item of filterMockArchiveVisibility(
+    getMockItemsForTeam(team),
+    includeArchived,
+  )) {
     const surveyId = item.surveyId;
     if (seenSurveys.has(surveyId)) continue;
     seenSurveys.add(surveyId);
@@ -592,6 +580,23 @@ export function getMockSurveysByApp(team?: string): Record<string, string[]> {
 const mockSurveyMeta: Record<string, { archivedAt: string | null }> = {
   "survey-thumbs": { archivedAt: "2026-07-01T10:00:00.000Z" },
 };
+
+export function filterMockArchiveVisibility(
+  items: FeedbackDto[],
+  includeArchived: boolean,
+): FeedbackDto[] {
+  if (includeArchived) return items;
+  return items.filter(
+    (item) => mockSurveyMeta[item.surveyId]?.archivedAt == null,
+  );
+}
+
+function getMockAnalyticsItems(params: URLSearchParams): FeedbackDto[] {
+  return filterMockArchiveVisibility(
+    getMockItemsForTeam(params.get("team") ?? undefined),
+    params.get("includeArchived") === "true",
+  );
+}
 
 export function archiveMockSurvey(surveyId: string): {
   surveyId: string;

--- a/apps/lumi-dashboard/app/mock/mockData.ts
+++ b/apps/lumi-dashboard/app/mock/mockData.ts
@@ -587,6 +587,34 @@ export function getMockSurveysByApp(team?: string): Record<string, string[]> {
  * Get filter bootstrap data for mock mode.
  * Provides all data needed for FilterBar dropdowns.
  */
+// Mutable so mock archive/restore behaves like the real backend in demo mode.
+// survey-thumbs starts archived to showcase the "Vis arkiverte" toggle.
+const mockSurveyMeta: Record<string, { archivedAt: string | null }> = {
+  "survey-thumbs": { archivedAt: "2026-07-01T10:00:00.000Z" },
+};
+
+export function archiveMockSurvey(surveyId: string): {
+  surveyId: string;
+  archivedAt: string | null;
+  archivedBy: string | null;
+} {
+  const existing = mockSurveyMeta[surveyId];
+  if (!existing || existing.archivedAt == null) {
+    mockSurveyMeta[surveyId] = { archivedAt: new Date().toISOString() };
+  }
+  return {
+    surveyId,
+    archivedAt: mockSurveyMeta[surveyId].archivedAt,
+    archivedBy: "Z999999",
+  };
+}
+
+export function unarchiveMockSurvey(surveyId: string): void {
+  if (mockSurveyMeta[surveyId]) {
+    mockSurveyMeta[surveyId] = { archivedAt: null };
+  }
+}
+
 export function getMockFilterBootstrap(team?: string): {
   generatedAt: string;
   selectedTeam: string;
@@ -595,6 +623,7 @@ export function getMockFilterBootstrap(team?: string): {
   apps: string[];
   surveysByApp: Record<string, string[]>;
   tags: string[];
+  surveyMeta: Record<string, { archivedAt: string | null }>;
 } {
   void team;
   const availableTeams = ["team-esyfo"];
@@ -612,6 +641,7 @@ export function getMockFilterBootstrap(team?: string): {
     apps,
     surveysByApp,
     tags,
+    surveyMeta: { ...mockSurveyMeta },
   };
 }
 

--- a/apps/lumi-dashboard/app/schemas/searchSchema.ts
+++ b/apps/lumi-dashboard/app/schemas/searchSchema.ts
@@ -17,6 +17,7 @@ export const searchSchema = z
     query: optionalStringParam,
     tag: optionalStringParam,
     surveyId: optionalStringParam,
+    showArchived: optionalStringParam,
     lowRating: optionalStringParam,
     deviceType: optionalStringParam,
     theme: optionalStringParam,

--- a/apps/lumi-dashboard/app/server/actions/__tests__/export.test.ts
+++ b/apps/lumi-dashboard/app/server/actions/__tests__/export.test.ts
@@ -63,6 +63,7 @@ describe("export helpers", () => {
   it("transformToBackendParams trims and normalizes filters", () => {
     const params = transformToBackendParams({
       format: "csv",
+      includeArchived: "true",
       tag: "  a, b , ,  ",
       hasText: "true",
       lowRating: "false",
@@ -75,6 +76,7 @@ describe("export helpers", () => {
     });
 
     expect(params.tag).toEqual(["a", "b"]);
+    expect(params.includeArchived).toBe("true");
     expect(params.hasText).toBe("true");
     expect(params.lowRating).toBeUndefined();
     expect(params.segment).toEqual(["k:v", "x:y"]);

--- a/apps/lumi-dashboard/app/server/actions/__tests__/fetchFeedback.test.ts
+++ b/apps/lumi-dashboard/app/server/actions/__tests__/fetchFeedback.test.ts
@@ -6,6 +6,7 @@ describe("fetchFeedback helpers", () => {
   it("transforms frontend params to backend params including theme/task", () => {
     const params = transformToBackendParams({
       page: "2",
+      includeArchived: "true",
       size: "25",
       tag: " a, b ",
       segment: "k:v,,x:y",
@@ -18,6 +19,7 @@ describe("fetchFeedback helpers", () => {
     });
 
     expect(params.page).toBe("1");
+    expect(params.includeArchived).toBe("true");
     expect(params.size).toBe("25");
     expect(params.tag).toEqual(["a", "b"]);
     expect(params.segment).toEqual(["k:v", "x:y"]);

--- a/apps/lumi-dashboard/app/server/actions/__tests__/fetchStats.contract.test.ts
+++ b/apps/lumi-dashboard/app/server/actions/__tests__/fetchStats.contract.test.ts
@@ -15,6 +15,7 @@ describe("fetchStats contract", () => {
   it("maps dashboard filters to backend query params", () => {
     const params = transformStatsToBackendParams({
       team: "team-1",
+      includeArchived: "true",
       app: "app-1",
       surveyId: "survey-1",
       fromDate: "2026-01-01",
@@ -28,6 +29,7 @@ describe("fetchStats contract", () => {
 
     expect(params).toEqual({
       team: "team-1",
+      includeArchived: "true",
       app: "app-1",
       surveyId: "survey-1",
       fromDate: "2026-01-01",
@@ -43,6 +45,7 @@ describe("fetchStats contract", () => {
   it("builds a URL with repeated segment, rating and choice params", () => {
     const url = buildStatsDashboardUrl("https://backend.example", {
       team: "team-1",
+      includeArchived: "true",
       segment: "a:b,,c:d",
       rating: ["rating-1:5", "thumbs-1:2"],
       choice: ["choice-1:opt-a", "choice-2:opt-b"],
@@ -51,6 +54,7 @@ describe("fetchStats contract", () => {
     const parsed = new URL(url);
     expect(parsed.pathname).toBe(STATS_DASHBOARD_PATH);
     expect(parsed.searchParams.get("team")).toBe("team-1");
+    expect(parsed.searchParams.get("includeArchived")).toBe("true");
     expect(parsed.searchParams.getAll("segment")).toEqual(["a:b", "c:d"]);
     expect(parsed.searchParams.getAll("rating")).toEqual([
       "rating-1:5",

--- a/apps/lumi-dashboard/app/server/actions/archiveSurvey.ts
+++ b/apps/lumi-dashboard/app/server/actions/archiveSurvey.ts
@@ -1,0 +1,73 @@
+import { createServerFn } from "@tanstack/react-start";
+import { zodValidator } from "@tanstack/zod-adapter";
+import { authMiddleware } from "~/server/middleware/auth";
+import {
+  type AuthContext,
+  buildUrl,
+  getHeaders,
+  isMockMode,
+  mockDelay,
+} from "~/server/utils";
+import type { SurveyArchiveState } from "~/types/schemas";
+import { ArchiveSurveySchema } from "~/types/schemas";
+import { handleApiResponse } from "../fetchUtils";
+
+/**
+ * Archive a survey (team-scoped display metadata).
+ * Archiving only hides the survey in the dashboard — it does not stop submissions.
+ */
+export const archiveSurveyServerFn = createServerFn({ method: "POST" })
+  .middleware([authMiddleware])
+  .inputValidator(zodValidator(ArchiveSurveySchema))
+  .handler(async ({ data, context }): Promise<SurveyArchiveState> => {
+    const { backendUrl, oboToken } = context as AuthContext;
+
+    if (isMockMode()) {
+      const { archiveMockSurvey } = await import("~/mock/mockData");
+      await mockDelay();
+      return archiveMockSurvey(data.surveyId);
+    }
+
+    const url = buildUrl(
+      backendUrl,
+      `/api/v1/intern/surveys/${encodeURIComponent(data.surveyId)}/archive`,
+      { team: data.team },
+    );
+    const response = await fetch(url, {
+      method: "PUT",
+      headers: getHeaders(oboToken),
+    });
+
+    await handleApiResponse(response);
+
+    return response.json() as Promise<SurveyArchiveState>;
+  });
+
+/**
+ * Restore an archived survey.
+ */
+export const unarchiveSurveyServerFn = createServerFn({ method: "POST" })
+  .middleware([authMiddleware])
+  .inputValidator(zodValidator(ArchiveSurveySchema))
+  .handler(async ({ data, context }): Promise<void> => {
+    const { backendUrl, oboToken } = context as AuthContext;
+
+    if (isMockMode()) {
+      const { unarchiveMockSurvey } = await import("~/mock/mockData");
+      await mockDelay();
+      unarchiveMockSurvey(data.surveyId);
+      return;
+    }
+
+    const url = buildUrl(
+      backendUrl,
+      `/api/v1/intern/surveys/${encodeURIComponent(data.surveyId)}/archive`,
+      { team: data.team },
+    );
+    const response = await fetch(url, {
+      method: "DELETE",
+      headers: getHeaders(oboToken),
+    });
+
+    await handleApiResponse(response);
+  });

--- a/apps/lumi-dashboard/app/server/actions/export.ts
+++ b/apps/lumi-dashboard/app/server/actions/export.ts
@@ -1,7 +1,10 @@
 import { createServerFn } from "@tanstack/react-start";
 import { zodValidator } from "@tanstack/zod-adapter";
 import ExcelJS from "exceljs";
-import { mockFeedbackItems } from "~/mock/mockData";
+import {
+  filterMockArchiveVisibility,
+  mockFeedbackItems,
+} from "~/mock/mockData";
 import { applyFeedbackFilters } from "~/mock/utils/filters";
 import { authMiddleware } from "~/server/middleware/auth";
 import {
@@ -178,6 +181,7 @@ function transformToBackendParams(data: ExportParams) {
   return {
     format: data.format,
     team: data.team,
+    includeArchived: data.includeArchived === "true" ? "true" : undefined,
     app: data.app,
     surveyId: data.surveyId,
     fromDate: data.fromDate,
@@ -208,7 +212,10 @@ export const exportServerFn = createServerFn({ method: "POST" })
       await mockDelay();
 
       const filtered = applyFeedbackFilters(
-        mockFeedbackItems,
+        filterMockArchiveVisibility(
+          mockFeedbackItems,
+          data.includeArchived === "true",
+        ),
         toMockSearchParams(data),
       ).slice(0, 10_000);
 

--- a/apps/lumi-dashboard/app/server/actions/fetchBlocker.ts
+++ b/apps/lumi-dashboard/app/server/actions/fetchBlocker.ts
@@ -15,6 +15,7 @@ import { handleApiResponse } from "../fetchUtils";
 
 interface BlockerActionParams {
   team?: string;
+  includeArchived?: string;
   app?: string;
   surveyId?: string;
   fromDate?: string;
@@ -55,6 +56,7 @@ export const fetchBlockerServerFn = createServerFn({ method: "GET" })
 
     const backendParams = {
       team: data.team,
+      includeArchived: data.includeArchived === "true" ? "true" : undefined,
       app: data.app,
       surveyId: data.surveyId,
       fromDate: data.fromDate,

--- a/apps/lumi-dashboard/app/server/actions/fetchDiscovery.ts
+++ b/apps/lumi-dashboard/app/server/actions/fetchDiscovery.ts
@@ -15,6 +15,7 @@ import { handleApiResponse } from "../fetchUtils";
 
 interface DiscoveryActionParams {
   team?: string;
+  includeArchived?: string;
   app?: string;
   surveyId?: string;
   fromDate?: string;
@@ -54,6 +55,7 @@ export const fetchDiscoveryServerFn = createServerFn({ method: "GET" })
 
     const backendParams = {
       team: data.team,
+      includeArchived: data.includeArchived === "true" ? "true" : undefined,
       app: data.app,
       surveyId: data.surveyId,
       fromDate: data.fromDate,

--- a/apps/lumi-dashboard/app/server/actions/fetchFeedback.ts
+++ b/apps/lumi-dashboard/app/server/actions/fetchFeedback.ts
@@ -15,6 +15,7 @@ import { handleApiResponse } from "../fetchUtils";
 
 interface FeedbackActionParams {
   team?: string;
+  includeArchived?: string;
   app?: string;
   surveyId?: string;
   page?: string;
@@ -66,6 +67,7 @@ function transformToBackendParams(data: FeedbackActionParams) {
 
   return {
     team: data.team,
+    includeArchived: data.includeArchived === "true" ? "true" : undefined,
     app: data.app,
     surveyId: data.surveyId,
     page,

--- a/apps/lumi-dashboard/app/server/actions/fetchStats.ts
+++ b/apps/lumi-dashboard/app/server/actions/fetchStats.ts
@@ -17,6 +17,7 @@ export const STATS_DASHBOARD_PATH = "/api/v1/intern/stats/dashboard" as const;
 
 interface StatsActionParams {
   team?: string;
+  includeArchived?: string;
   app?: string;
   surveyId?: string;
   fromDate?: string;
@@ -48,6 +49,7 @@ function toMockSearchParams(data: StatsActionParams): URLSearchParams {
 export function transformStatsToBackendParams(data: StatsActionParams) {
   return {
     team: data.team,
+    includeArchived: data.includeArchived === "true" ? "true" : undefined,
     app: data.app,
     surveyId: data.surveyId,
     fromDate: data.fromDate,

--- a/apps/lumi-dashboard/app/server/actions/fetchSurveyTypeDistribution.ts
+++ b/apps/lumi-dashboard/app/server/actions/fetchSurveyTypeDistribution.ts
@@ -38,11 +38,15 @@ export const fetchSurveyTypeDistributionServerFn = createServerFn({
 
       if (isMockMode()) {
         await mockDelay();
-        return getMockSurveyTypeDistribution(data.team);
+        return getMockSurveyTypeDistribution(
+          data.team,
+          data.includeArchived === "true",
+        );
       }
 
       const url = buildUrl(backendUrl, "/api/v1/intern/stats/survey-types", {
         team: data.team,
+        includeArchived: data.includeArchived === "true" ? "true" : undefined,
       });
       const response = await fetch(url, {
         headers: getHeaders(oboToken),

--- a/apps/lumi-dashboard/app/server/actions/fetchTaskPriority.ts
+++ b/apps/lumi-dashboard/app/server/actions/fetchTaskPriority.ts
@@ -15,6 +15,7 @@ import { handleApiResponse } from "../fetchUtils";
 
 interface TaskPriorityActionParams {
   team?: string;
+  includeArchived?: string;
   app?: string;
   surveyId?: string;
   fromDate?: string;
@@ -55,6 +56,7 @@ export const fetchTaskPriorityServerFn = createServerFn({ method: "GET" })
 
     const backendParams = {
       team: data.team,
+      includeArchived: data.includeArchived === "true" ? "true" : undefined,
       app: data.app,
       surveyId: data.surveyId,
       fromDate: data.fromDate,

--- a/apps/lumi-dashboard/app/server/actions/fetchTopTasks.ts
+++ b/apps/lumi-dashboard/app/server/actions/fetchTopTasks.ts
@@ -15,6 +15,7 @@ import { handleApiResponse } from "../fetchUtils";
 
 interface TopTasksActionParams {
   team?: string;
+  includeArchived?: string;
   app?: string;
   surveyId?: string;
   fromDate?: string;
@@ -55,6 +56,7 @@ export const fetchTopTasksServerFn = createServerFn({ method: "GET" })
 
     const backendParams = {
       team: data.team,
+      includeArchived: data.includeArchived === "true" ? "true" : undefined,
       app: data.app,
       surveyId: data.surveyId,
       fromDate: data.fromDate,

--- a/apps/lumi-dashboard/app/server/actions/index.ts
+++ b/apps/lumi-dashboard/app/server/actions/index.ts
@@ -6,6 +6,10 @@
  */
 
 // Delete
+export {
+  archiveSurveyServerFn,
+  unarchiveSurveyServerFn,
+} from "./archiveSurvey";
 export { deleteFeedbackServerFn, deleteSurveyServerFn } from "./delete";
 // Export
 export { exportServerFn } from "./export";

--- a/apps/lumi-dashboard/app/utils/__tests__/surveyArchiveUtils.test.ts
+++ b/apps/lumi-dashboard/app/utils/__tests__/surveyArchiveUtils.test.ts
@@ -1,0 +1,88 @@
+import { describe, expect, it } from "vitest";
+import {
+  isSurveyArchived,
+  partitionSurveyOptions,
+} from "../surveyArchiveUtils";
+
+const surveyMeta = {
+  "survey-archived": { archivedAt: "2026-08-01T10:00:00Z" },
+  "survey-restored": { archivedAt: null },
+};
+
+describe("isSurveyArchived", () => {
+  it("is true only for surveys with a non-null archivedAt", () => {
+    expect(isSurveyArchived("survey-archived", surveyMeta)).toBe(true);
+    expect(isSurveyArchived("survey-restored", surveyMeta)).toBe(false);
+    expect(isSurveyArchived("survey-unknown", surveyMeta)).toBe(false);
+  });
+
+  it("treats missing surveyMeta as active", () => {
+    expect(isSurveyArchived("survey-archived", undefined)).toBe(false);
+  });
+});
+
+describe("partitionSurveyOptions", () => {
+  const availableSurveys = ["survey-a", "survey-archived", "survey-restored"];
+
+  it("hides archived surveys by default", () => {
+    const result = partitionSurveyOptions({
+      availableSurveys,
+      surveyMeta,
+      showArchived: false,
+    });
+
+    expect(result.active).toEqual(["survey-a", "survey-restored"]);
+    expect(result.archived).toEqual([]);
+  });
+
+  it("lists archived surveys separately when showArchived is on", () => {
+    const result = partitionSurveyOptions({
+      availableSurveys,
+      surveyMeta,
+      showArchived: true,
+    });
+
+    expect(result.active).toEqual(["survey-a", "survey-restored"]);
+    expect(result.archived).toEqual(["survey-archived"]);
+  });
+
+  it("keeps the selected archived survey visible even when showArchived is off", () => {
+    const result = partitionSurveyOptions({
+      availableSurveys,
+      surveyMeta,
+      showArchived: false,
+      selectedSurveyId: "survey-archived",
+    });
+
+    expect(result.archived).toEqual(["survey-archived"]);
+  });
+
+  it("reports hasArchived so the toggle only renders when relevant", () => {
+    expect(
+      partitionSurveyOptions({
+        availableSurveys,
+        surveyMeta,
+        showArchived: false,
+      }).hasArchived,
+    ).toBe(true);
+    expect(
+      partitionSurveyOptions({
+        availableSurveys: ["survey-a", "survey-restored"],
+        surveyMeta,
+        showArchived: false,
+      }).hasArchived,
+    ).toBe(false);
+  });
+
+  it("treats all surveys as active when surveyMeta is missing", () => {
+    const result = partitionSurveyOptions({
+      availableSurveys,
+      surveyMeta: undefined,
+      showArchived: false,
+    });
+
+    expect(result.active).toEqual(availableSurveys);
+    expect(result.archived).toEqual([]);
+    expect(result.hasArchived).toBe(false);
+  });
+});

--- a/apps/lumi-dashboard/app/utils/__tests__/surveyArchiveUtils.test.ts
+++ b/apps/lumi-dashboard/app/utils/__tests__/surveyArchiveUtils.test.ts
@@ -46,15 +46,14 @@ describe("partitionSurveyOptions", () => {
     expect(result.archived).toEqual(["survey-archived"]);
   });
 
-  it("keeps the selected archived survey visible even when showArchived is off", () => {
+  it("hides the selected archived survey when showArchived is off", () => {
     const result = partitionSurveyOptions({
       availableSurveys,
       surveyMeta,
       showArchived: false,
-      selectedSurveyId: "survey-archived",
     });
 
-    expect(result.archived).toEqual(["survey-archived"]);
+    expect(result.archived).toEqual([]);
   });
 
   it("reports hasArchived so the toggle only renders when relevant", () => {

--- a/apps/lumi-dashboard/app/utils/surveyArchiveUtils.ts
+++ b/apps/lumi-dashboard/app/utils/surveyArchiveUtils.ts
@@ -27,20 +27,16 @@ export interface SurveyOptionGroups {
 /**
  * Splits the available surveys into active and archived dropdown groups.
  *
- * Archived surveys are hidden unless `showArchived` is on — except the
- * currently selected survey, which must stay in the list so the select
- * keeps a valid value (e.g. when opened from a bookmarked URL).
+ * Archived surveys are hidden unless `showArchived` is on.
  */
 export function partitionSurveyOptions({
   availableSurveys,
   surveyMeta,
   showArchived,
-  selectedSurveyId,
 }: {
   availableSurveys: string[];
   surveyMeta: SurveyMetaMap | undefined;
   showArchived: boolean;
-  selectedSurveyId?: string;
 }): SurveyOptionGroups {
   const active: string[] = [];
   const allArchived: string[] = [];
@@ -53,9 +49,7 @@ export function partitionSurveyOptions({
     }
   }
 
-  const archived = showArchived
-    ? allArchived
-    : allArchived.filter((surveyId) => surveyId === selectedSurveyId);
+  const archived = showArchived ? allArchived : [];
 
   return { active, archived, hasArchived: allArchived.length > 0 };
 }

--- a/apps/lumi-dashboard/app/utils/surveyArchiveUtils.ts
+++ b/apps/lumi-dashboard/app/utils/surveyArchiveUtils.ts
@@ -1,0 +1,61 @@
+/**
+ * Helpers for survey archive state (per-team display metadata from
+ * the filter bootstrap's `surveyMeta`). Archiving only affects what the
+ * dashboard shows — submissions are unaffected.
+ */
+
+export interface SurveyMetaEntry {
+  archivedAt: string | null;
+}
+
+export type SurveyMetaMap = Record<string, SurveyMetaEntry>;
+
+export function isSurveyArchived(
+  surveyId: string,
+  surveyMeta: SurveyMetaMap | undefined,
+): boolean {
+  return surveyMeta?.[surveyId]?.archivedAt != null;
+}
+
+export interface SurveyOptionGroups {
+  active: string[];
+  archived: string[];
+  /** True when any available survey is archived — drives the toggle's visibility. */
+  hasArchived: boolean;
+}
+
+/**
+ * Splits the available surveys into active and archived dropdown groups.
+ *
+ * Archived surveys are hidden unless `showArchived` is on — except the
+ * currently selected survey, which must stay in the list so the select
+ * keeps a valid value (e.g. when opened from a bookmarked URL).
+ */
+export function partitionSurveyOptions({
+  availableSurveys,
+  surveyMeta,
+  showArchived,
+  selectedSurveyId,
+}: {
+  availableSurveys: string[];
+  surveyMeta: SurveyMetaMap | undefined;
+  showArchived: boolean;
+  selectedSurveyId?: string;
+}): SurveyOptionGroups {
+  const active: string[] = [];
+  const allArchived: string[] = [];
+
+  for (const surveyId of availableSurveys) {
+    if (isSurveyArchived(surveyId, surveyMeta)) {
+      allArchived.push(surveyId);
+    } else {
+      active.push(surveyId);
+    }
+  }
+
+  const archived = showArchived
+    ? allArchived
+    : allArchived.filter((surveyId) => surveyId === selectedSurveyId);
+
+  return { active, archived, hasArchived: allArchived.length > 0 };
+}

--- a/apps/lumi-dashboard/e2e/dashboard.spec.ts
+++ b/apps/lumi-dashboard/e2e/dashboard.spec.ts
@@ -14,6 +14,39 @@ test.describe("Dashboard", () => {
     // Check for main element
     await expect(page.locator("main")).toBeVisible({ timeout: 15000 });
   });
+
+  test("archive visibility survives navigation and reload", async ({
+    page,
+  }) => {
+    await page.goto("/");
+
+    const surveySelect = page.getByRole("combobox", { name: "Survey" });
+    const archiveSwitch = page.getByRole("checkbox", {
+      name: /Arkiverte \(\d+\)/,
+    });
+
+    await expect(archiveSwitch).not.toBeChecked();
+    await expect(
+      surveySelect.locator('option[value="survey-thumbs"]'),
+    ).toHaveCount(0);
+
+    await archiveSwitch.check();
+    await expect(page).toHaveURL(/showArchived=true/);
+    await expect(
+      surveySelect.locator('option[value="survey-thumbs"]'),
+    ).toHaveCount(1);
+
+    await page.getByRole("link", { name: "Tilbakemeldinger" }).click();
+    await expect(page).toHaveURL(/\/feedback.*showArchived=true/);
+    await expect(
+      page.getByRole("checkbox", { name: /Arkiverte \(\d+\)/ }),
+    ).toBeChecked();
+
+    await page.reload();
+    await expect(
+      page.getByRole("checkbox", { name: /Arkiverte \(\d+\)/ }),
+    ).toBeChecked();
+  });
 });
 
 test.describe("Feedback", () => {
@@ -22,5 +55,51 @@ test.describe("Feedback", () => {
 
     // Check URL
     await expect(page).toHaveURL(/\/feedback/);
+  });
+
+  test("hides archived survey responses when archive visibility is off", async ({
+    page,
+  }) => {
+    await page.goto(
+      "/feedback?surveyId=survey-thumbs&showArchived=true&fromDate=2025-01-01&toDate=2026-12-31",
+    );
+
+    const feedbackTable = page.getByRole("table");
+    await expect(
+      feedbackTable.getByText("survey-thumbs", { exact: true }).first(),
+    ).toBeVisible();
+
+    await page.getByRole("checkbox", { name: /Arkiverte \(\d+\)/ }).uncheck();
+
+    await expect(page).not.toHaveURL(/showArchived=true/);
+    await expect(page).not.toHaveURL(/surveyId=survey-thumbs/);
+    await expect(
+      feedbackTable.getByText("survey-thumbs", { exact: true }),
+    ).toHaveCount(0);
+  });
+
+  test("keeps context and a valid focus target after archiving", async ({
+    page,
+  }) => {
+    await page.goto("/feedback?surveyId=archive-focus-test");
+
+    await page
+      .getByRole("button", {
+        name: "Skjul surveyen i dashboardet — innsendinger stoppes ikke",
+      })
+      .click();
+    await page
+      .getByRole("button", { name: "Arkiver survey", exact: true })
+      .click();
+
+    await expect(page).toHaveURL(/surveyId=archive-focus-test/);
+    await expect(page).toHaveURL(/showArchived=true/);
+    const restoreButton = page.getByRole("button", {
+      name: "Gjenopprett surveyen fra arkivet",
+    });
+    await expect(restoreButton).toBeVisible();
+    await expect(restoreButton).toBeFocused();
+
+    await restoreButton.click();
   });
 });

--- a/docs/adr/0002-arkivering-er-visningsmetadata.md
+++ b/docs/adr/0002-arkivering-er-visningsmetadata.md
@@ -23,7 +23,7 @@ Uten intake-kontroll er faren at arkivering *misforstås* som stopp: en PO arkiv
 
 ## Beslutning
 
-1. **Arkivering er per-team visningsmetadata.** Et `archived_at`-felt i en ny `survey_metadata`-tabell (team + surveyId unik), satt fra dashboardet, som kun påvirker hva dashboardet viser. Data, stats, eksport og intake er uberørt. Design og produktvalg er specet i #339.
+1. **Arkivering er per-team visningsmetadata.** Et `archived_at`-felt i en ny `survey_metadata`-tabell (team + surveyId unik), satt fra dashboardet, påvirker alle dashboardets leseflater konsekvent. Tilbakemeldingslister, statistikk og eksport utelater arkiverte surveys som standard; `includeArchived=true` inkluderer dem igjen når brukeren slår på «Arkiverte». Lagrede data og intake er uberørt. Design og produktvalg er specet i #339.
 
 2. **Misforståelsesfaren håndteres med ærlighet, ikke mekanikk.** Arkiver-dialogen sier eksplisitt at arkivering ikke stopper innsendinger, og en arkivert survey som fortsatt mottar data merkes med badge (utledet av `lastSubmissionAt > archived_at` — ingen nye flagg eller jobber).
 
@@ -36,12 +36,14 @@ Uten intake-kontroll er faren at arkivering *misforstås* som stopp: en PO arkiv
 **Positivt**
 
 - Arkivering leveres som to små slices (#394, #395) uten å røre widget, datakontrakt eller konsumentteam.
+- «Arkiverte»-bryteren styrer faktisk datagrunnlaget i liste, statistikk og eksport, ikke bare hvilke valg som vises i filteret.
 - Survey-metadata får endelig et hjem på dashboard-siden — det delte åpne spørsmålet fra #338/#339 om hvor survey-identitet bor, er besvart.
 - Ingen falske løfter: UI-et sier eksplisitt hva arkivering *ikke* gjør.
 
 **Negativt / kostnad**
 
 - Lumi kan fortsatt ikke stoppe en survey sentralt — avvikling krever fortsatt endring i konsumentens frontend. Dette er en reell begrensning vi aksepterer og dokumenterer.
+- Nye innsendinger til en arkivert survey lagres fortsatt, men er skjult fra standardvisningen frem til arkivvisningen slås på eller surveyen gjenopprettes.
 - «Mottar fortsatt innsendinger»-badgen er et symptomvarsel, ikke en løsning; oppfølgingen (be teamet fjerne widgeten) er manuell.
 - To «survey finnes»-begreper består (avledet liste + definisjonstabell), nå med en tredje tabell ved siden av. Konsolidering til ett register er bevisst skjøvet til #338.
 

--- a/packages/lumi-types/src/schemas.ts
+++ b/packages/lumi-types/src/schemas.ts
@@ -6,12 +6,14 @@ import { z } from "zod";
 
 export const TeamParamsSchema = z.object({
   team: z.string().optional(),
+  includeArchived: z.string().optional(),
 });
 
 export type TeamParams = z.infer<typeof TeamParamsSchema>;
 
 export const StatsParamsSchema = z.object({
   team: z.string().optional(),
+  includeArchived: z.string().optional(),
   app: z.string().optional(),
   fromDate: z.string().optional(),
   toDate: z.string().optional(),
@@ -35,6 +37,7 @@ export type StatsParams = z.infer<typeof StatsParamsSchema>;
  */
 export const FeedbackParamsSchema = z.object({
   team: z.string().optional(),
+  includeArchived: z.string().optional(),
   app: z.string().optional(),
   surveyId: z.string().optional(),
   page: z.string().optional(),
@@ -66,6 +69,7 @@ export type FeedbackParams = z.infer<typeof FeedbackParamsSchema>;
 
 export const TopTasksParamsSchema = z.object({
   team: z.string().optional(),
+  includeArchived: z.string().optional(),
   app: z.string().optional(),
   surveyId: z.string().optional(),
   fromDate: z.string().optional(),
@@ -83,6 +87,7 @@ export type TopTasksParams = z.infer<typeof TopTasksParamsSchema>;
 
 export const DiscoveryParamsSchema = z.object({
   team: z.string().optional(),
+  includeArchived: z.string().optional(),
   app: z.string().optional(),
   surveyId: z.string().optional(),
   fromDate: z.string().optional(),
@@ -98,6 +103,7 @@ export type DiscoveryParams = z.infer<typeof DiscoveryParamsSchema>;
 
 export const BlockerParamsSchema = z.object({
   team: z.string().optional(),
+  includeArchived: z.string().optional(),
   app: z.string().optional(),
   surveyId: z.string().optional(),
   fromDate: z.string().optional(),
@@ -115,6 +121,7 @@ export type BlockerParams = z.infer<typeof BlockerParamsSchema>;
 
 export const TaskPriorityParamsSchema = z.object({
   team: z.string().optional(),
+  includeArchived: z.string().optional(),
   app: z.string().optional(),
   surveyId: z.string().optional(),
   fromDate: z.string().optional(),
@@ -346,6 +353,7 @@ export type ContextTagsParams = z.infer<typeof ContextTagsParamsSchema>;
 export const ExportParamsSchema = z.object({
   format: z.enum(["csv", "json", "excel"]),
   team: z.string().optional(),
+  includeArchived: z.string().optional(),
   app: z.string().optional(),
   surveyId: z.string().optional(),
   fromDate: z.string().optional(),

--- a/packages/lumi-types/src/schemas.ts
+++ b/packages/lumi-types/src/schemas.ts
@@ -148,6 +148,16 @@ export type DeleteSurvey = z.infer<typeof DeleteSurveySchema>;
 // Filter Bootstrap Response Schema
 // ============================================
 
+/**
+ * Per-survey dashboard metadata. Surveys without an entry are active;
+ * `archivedAt === null` means the survey was restored after being archived.
+ */
+export const SurveyMetaEntrySchema = z.object({
+  archivedAt: z.string().nullable(),
+});
+
+export type SurveyMetaEntry = z.infer<typeof SurveyMetaEntrySchema>;
+
 export const FilterBootstrapResponseSchema = z.object({
   generatedAt: z.string(),
   selectedTeam: z.string(),
@@ -156,6 +166,7 @@ export const FilterBootstrapResponseSchema = z.object({
   apps: z.array(z.string()),
   surveysByApp: z.record(z.string(), z.array(z.string())),
   tags: z.array(z.string()),
+  surveyMeta: z.record(z.string(), SurveyMetaEntrySchema).optional(),
 });
 
 export type FilterBootstrapResponse = z.infer<
@@ -167,6 +178,22 @@ export const FilterBootstrapParamsSchema = z.object({
 });
 
 export type FilterBootstrapParams = z.infer<typeof FilterBootstrapParamsSchema>;
+
+export const ArchiveSurveySchema = z.object({
+  surveyId: z.string(),
+  team: z.string().optional(),
+});
+
+export type ArchiveSurvey = z.infer<typeof ArchiveSurveySchema>;
+
+/** Response from PUT /surveys/{surveyId}/archive. */
+export const SurveyArchiveStateSchema = z.object({
+  surveyId: z.string(),
+  archivedAt: z.string().nullable(),
+  archivedBy: z.string().nullable(),
+});
+
+export type SurveyArchiveState = z.infer<typeof SurveyArchiveStateSchema>;
 
 export const DeleteFeedbackSchema = z.object({
   id: z.string(),


### PR DESCRIPTION
## Hva

Implementerer slice 1 av arkiveringsspec-en i #339: team-medlemmer kan arkivere/gjenopprette surveys fra dashboardet. Arkiverte surveys skjules i survey-dropdownen (hentes frem med «Vis arkiverte»-toggle), og all data/stats/eksport er uberørt.

Closes #394

## Backend

- **Ny tabell `survey_metadata` (V13)** — bevisst uavhengig av `survey_definitions`, slik at legacy-surveys uten definisjonsrad (pre-V12) også kan arkiveres. `UNIQUE(team, survey_id)`, `archived_at NULL` = aktiv, raden beholdes ved gjenoppretting.
- **`PUT`/`DELETE /api/v1/intern/surveys/{surveyId}/archive`** — samme team-autorisasjon som øvrig intern-flate; `archived_by` fra token. Arkivering er **idempotent**: `ON CONFLICT` bevarer original `archived_at`/`archived_by`, så badge-betingelsen i #395 (`lastSubmissionAt > archivedAt`) ikke kan nullstilles ved gjenklikk.
- **Bootstrap** utvides med `surveyMeta: { [surveyId]: { archivedAt } }`. Cache-nøkkelen er lagt om til team-først og `StringCache` har fått `clearByPrefix` (speiler `StatsCache`-mønsteret), slik at arkiver/gjenopprett invaliderer alle brukeres bootstrap-cache for teamet umiddelbart.

## Dashboard

- **FilterBar**: dropdownen grupperes i «Aktive»/«Arkiverte» optgroups; arkiverte vises kun med toggle på. Valgt arkivert survey forblir alltid synlig så select-en beholder gyldig verdi (bokmerkede URL-er).
- **SurveyToolbar**: Arkiver-knapp med bekreftelsesdialog — copy sier eksplisitt at *arkivering ikke stopper innsendinger*; Gjenopprett-knapp for arkiverte. `(arkivert)`-markering i toolbar-teksten.
- **Demo-modus**: stateful mock-arkivering (`survey-thumbs` starter arkivert for å vise frem togglen).

## Test (TDD, rød→grønn per lag)

- Backend: 14 nye tester (repository 6, archive-ruter 5, bootstrap/cache-invalidering 3). Full suite: **636 tester grønne**.
- Dashboard: 9 nye tester (partisjonerings-util 7, `useArchiveSurvey`-hook 2). Full suite: **282 tester grønne**.
- `pnpm run typecheck` og `biome check` rene.

Merk: #394 nevner «komponenttester» — repoet har ingen komponenttest-oppsett (kun hooks/utils-tester), så grupperings- og gating-logikken er i stedet trukket ut i `surveyArchiveUtils` og dekket uttømmende der, i tråd med eksisterende testmønster.

## Utenfor scope (bevisst)

- Recency-signal + «mottar fortsatt innsendinger»-badge → #395 (bygger på `surveyMeta`-strukturen herfra).
- Toolbar-gatingen på `totalElements > 0` (#253) er uendret.
- ADR 0002 (retningsvalget) ligger i #396.


---

## Revidert etter manuell testing: konsistent datavirkning

Manuell testing avdekket at ren dropdown-skjuling var inkonsistent: en arkivert survey forsvant fra filteret, men dataene lå igjen i alle lister, statistikk og eksport. Siste commit utvider derfor semantikken (produktvalget i #339 er revidert tilsvarende):

- **Backend**: `includeArchived`-param (default `false`) på feedback-, stats- og eksport-flatene. `SurveyIsNotArchived`-predikatet bruker `feedback_json` slik at pre-V12-rader følger samme semantikk. Stats-cachen nøkles på parameteren, og arkiver/gjenopprett invaliderer også team-statscachen. `VersionedBootstrapCache` (generasjonstoken per team) lukker set-racet som tidligere var dokumentert som akseptert.
- **Dashboard**: `showArchived` som URL-param driver `includeArchived` i alle datahooks; apper uten aktive surveys skjules; arkivering av valgt survey slår på arkivvisning så kontekst og modal-fokus består; `DeleteSurveyDialog` teller alltid inkl. arkiverte og nekter sletting uten totalantall.
- **Review-fiks underveis**: rydde-effekten i FilterBar er gatet på lastet bootstrap — uten guard ble app-filteret i bokmerkede URL-er slettet før dataene ankom (regresjonstest lagt til).
- **Test**: 645 backend (6 nye), 290 dashboard (komponenttester for FilterBar/DeleteSurveyDialog), 34 e2e grønne inkl. tre nye arkiv-scenarioer.

ADR 0002 oppdateres i samme commit (leseflatene, ikke bare filteret).