### PR TITLE
feat(dashboard): recency-signal og «mottar fortsatt innsendinger»-badge (#395)

### DIFF
--- a/apps/lumi-api/src/main/kotlin/no/nav/lumi/repository/FeedbackContextTagsRepository.kt
+++ b/apps/lumi-api/src/main/kotlin/no/nav/lumi/repository/FeedbackContextTagsRepository.kt
@@ -9,61 +9,52 @@ import org.jetbrains.exposed.v1.core.VarCharColumnType
 import org.jetbrains.exposed.v1.core.eq
 import org.jetbrains.exposed.v1.jdbc.*
 import org.jetbrains.exposed.v1.jdbc.transactions.TransactionManager
+import java.time.Instant
+
+data class SurveyOverview(
+    val surveysByApp: Map<String, List<String>>,
+    val lastSubmissionBySurvey: Map<String, String>,
+)
 
 class FeedbackContextTagsRepository {
-    suspend fun findSurveysByApp(team: String): Map<String, List<String>> {
+    /**
+     * Surveys grouped by app and their latest submission timestamps.
+     * Both views are derived from the same result set so bootstrap cannot
+     * cache a survey list and recency metadata from different DB snapshots.
+     */
+    suspend fun findSurveyOverview(team: String): SurveyOverview {
         return dbQuery {
             val sql = """
-                SELECT DISTINCT
+                SELECT
                     app,
-                    feedback_json::jsonb->>'surveyId' as survey_id
+                    feedback_json::jsonb->>'surveyId' as survey_id,
+                    MAX(opprettet) as last_submission_at
                 FROM feedback
                 WHERE team = ?
                   AND app IS NOT NULL
                   AND feedback_json::jsonb->>'surveyId' IS NOT NULL
+                GROUP BY app, feedback_json::jsonb->>'surveyId'
                 ORDER BY app, survey_id
             """.trimIndent()
 
-            val result = mutableMapOf<String, MutableList<String>>()
+            val surveysByApp = mutableMapOf<String, MutableList<String>>()
+            val lastSubmissionInstants = mutableMapOf<String, Instant>()
             val transaction = TransactionManager.current()
             transaction.exec(sql, listOf(VarCharColumnType() to team)) { rs ->
                 while (rs.next()) {
                     val app = rs.getString("app") ?: continue
                     val surveyId = rs.getString("survey_id") ?: continue
-                    result.getOrPut(app) { mutableListOf() }.add(surveyId)
+                    val lastSubmissionAt = rs.getTimestamp("last_submission_at")?.toInstant() ?: continue
+                    surveysByApp.getOrPut(app) { mutableListOf() }.add(surveyId)
+                    lastSubmissionInstants.merge(surveyId, lastSubmissionAt) { current, candidate ->
+                        maxOf(current, candidate)
+                    }
                 }
             }
-            result
-        }
-    }
-
-    /**
-     * Latest submission timestamp (ISO-8601, UTC) per surveyId for a team.
-     * Reads surveyId from feedback_json so pre-V12 rows (NULL survey_id column)
-     * are included — same semantics as the derived survey list above.
-     */
-    suspend fun findLastSubmissionBySurvey(team: String): Map<String, String> {
-        return dbQuery {
-            val sql = """
-                SELECT
-                    feedback_json::jsonb->>'surveyId' as survey_id,
-                    MAX(opprettet) as last_submission_at
-                FROM feedback
-                WHERE team = ?
-                  AND feedback_json::jsonb->>'surveyId' IS NOT NULL
-                GROUP BY feedback_json::jsonb->>'surveyId'
-            """.trimIndent()
-
-            val result = mutableMapOf<String, String>()
-            val transaction = TransactionManager.current()
-            transaction.exec(sql, listOf(VarCharColumnType() to team)) { rs ->
-                while (rs.next()) {
-                    val surveyId = rs.getString("survey_id") ?: continue
-                    val lastSubmissionAt = rs.getTimestamp("last_submission_at") ?: continue
-                    result[surveyId] = lastSubmissionAt.toInstant().toString()
-                }
-            }
-            result
+            SurveyOverview(
+                surveysByApp = surveysByApp,
+                lastSubmissionBySurvey = lastSubmissionInstants.mapValues { (_, instant) -> instant.toString() },
+            )
         }
     }
 

--- a/apps/lumi-api/src/main/kotlin/no/nav/lumi/repository/FeedbackContextTagsRepository.kt
+++ b/apps/lumi-api/src/main/kotlin/no/nav/lumi/repository/FeedbackContextTagsRepository.kt
@@ -37,6 +37,36 @@ class FeedbackContextTagsRepository {
         }
     }
 
+    /**
+     * Latest submission timestamp (ISO-8601, UTC) per surveyId for a team.
+     * Reads surveyId from feedback_json so pre-V12 rows (NULL survey_id column)
+     * are included — same semantics as the derived survey list above.
+     */
+    suspend fun findLastSubmissionBySurvey(team: String): Map<String, String> {
+        return dbQuery {
+            val sql = """
+                SELECT
+                    feedback_json::jsonb->>'surveyId' as survey_id,
+                    MAX(opprettet) as last_submission_at
+                FROM feedback
+                WHERE team = ?
+                  AND feedback_json::jsonb->>'surveyId' IS NOT NULL
+                GROUP BY feedback_json::jsonb->>'surveyId'
+            """.trimIndent()
+
+            val result = mutableMapOf<String, String>()
+            val transaction = TransactionManager.current()
+            transaction.exec(sql, listOf(VarCharColumnType() to team)) { rs ->
+                while (rs.next()) {
+                    val surveyId = rs.getString("survey_id") ?: continue
+                    val lastSubmissionAt = rs.getTimestamp("last_submission_at") ?: continue
+                    result[surveyId] = lastSubmissionAt.toInstant().toString()
+                }
+            }
+            result
+        }
+    }
+
     suspend fun findMetadataKeysForSurvey(surveyId: String, team: String): Map<String, Set<String>> {
         return dbQuery {
             val sql = """

--- a/apps/lumi-api/src/main/kotlin/no/nav/lumi/repository/FeedbackRepository.kt
+++ b/apps/lumi-api/src/main/kotlin/no/nav/lumi/repository/FeedbackRepository.kt
@@ -425,12 +425,12 @@ class FeedbackRepository(
      * Find all surveys (surveyIds) grouped by app for a specific team.
      * Used by filter bootstrap endpoint and survey list.
      */
-    suspend fun findLastSubmissionBySurvey(team: String): Map<String, String> {
-        return contextTagsRepository.findLastSubmissionBySurvey(team)
+    suspend fun findSurveyOverview(team: String): SurveyOverview {
+        return contextTagsRepository.findSurveyOverview(team)
     }
 
     suspend fun findSurveysByApp(team: String): Map<String, List<String>> {
-        return contextTagsRepository.findSurveysByApp(team)
+        return contextTagsRepository.findSurveyOverview(team).surveysByApp
     }
     
     suspend fun findMetadataKeysForSurvey(surveyId: String, team: String): Map<String, Set<String>> {

--- a/apps/lumi-api/src/main/kotlin/no/nav/lumi/repository/FeedbackRepository.kt
+++ b/apps/lumi-api/src/main/kotlin/no/nav/lumi/repository/FeedbackRepository.kt
@@ -425,6 +425,10 @@ class FeedbackRepository(
      * Find all surveys (surveyIds) grouped by app for a specific team.
      * Used by filter bootstrap endpoint and survey list.
      */
+    suspend fun findLastSubmissionBySurvey(team: String): Map<String, String> {
+        return contextTagsRepository.findLastSubmissionBySurvey(team)
+    }
+
     suspend fun findSurveysByApp(team: String): Map<String, List<String>> {
         return contextTagsRepository.findSurveysByApp(team)
     }

--- a/apps/lumi-api/src/main/kotlin/no/nav/lumi/routes/FilterRoutes.kt
+++ b/apps/lumi-api/src/main/kotlin/no/nav/lumi/routes/FilterRoutes.kt
@@ -38,11 +38,14 @@ data class FilterBootstrapResponse(
 
 /**
  * Per-survey dashboard metadata. Surveys without an entry are active.
- * `archivedAt == null` means the survey was restored after being archived.
+ * `archivedAt == null` means active (or restored after being archived).
+ * `lastSubmissionAt` drives the recency signal and, for archived surveys,
+ * the "still receiving submissions" badge (lastSubmissionAt > archivedAt).
  */
 @Serializable
 data class SurveyMetaEntry(
     val archivedAt: String?,
+    val lastSubmissionAt: String? = null,
 )
 
 private val defaultRepository = FeedbackRepository()
@@ -147,8 +150,14 @@ fun Route.filterRoutes(
         val apps = feedbackRepository.findDistinctApps(team)
         val surveysByApp = feedbackRepository.findSurveysByApp(team)
         val tags = feedbackRepository.findAllTags(team)
-        val surveyMeta = surveyMetadataRepository.findByTeam(team)
-            .associate { it.surveyId to SurveyMetaEntry(archivedAt = it.archivedAt) }
+        val archiveStates = surveyMetadataRepository.findByTeam(team).associateBy { it.surveyId }
+        val lastSubmissionBySurvey = feedbackRepository.findLastSubmissionBySurvey(team)
+        val surveyMeta = (archiveStates.keys + lastSubmissionBySurvey.keys).associateWith { surveyId ->
+            SurveyMetaEntry(
+                archivedAt = archiveStates[surveyId]?.archivedAt,
+                lastSubmissionAt = lastSubmissionBySurvey[surveyId],
+            )
+        }
 
         val response = FilterBootstrapResponse(
             generatedAt = Instant.now().toString(),

--- a/apps/lumi-api/src/main/kotlin/no/nav/lumi/routes/FilterRoutes.kt
+++ b/apps/lumi-api/src/main/kotlin/no/nav/lumi/routes/FilterRoutes.kt
@@ -145,13 +145,13 @@ fun Route.filterRoutes(
             return@get
         }
 
-        // Each repository call manages its own transaction.
-        // This endpoint is designed for long caching, so multiple DB round-trips are acceptable.
+        // Each repository call manages its own transaction. Survey options and
+        // recency metadata deliberately share one aggregation/snapshot.
         val apps = feedbackRepository.findDistinctApps(team)
-        val surveysByApp = feedbackRepository.findSurveysByApp(team)
+        val surveyOverview = feedbackRepository.findSurveyOverview(team)
         val tags = feedbackRepository.findAllTags(team)
         val archiveStates = surveyMetadataRepository.findByTeam(team).associateBy { it.surveyId }
-        val lastSubmissionBySurvey = feedbackRepository.findLastSubmissionBySurvey(team)
+        val lastSubmissionBySurvey = surveyOverview.lastSubmissionBySurvey
         val surveyMeta = (archiveStates.keys + lastSubmissionBySurvey.keys).associateWith { surveyId ->
             SurveyMetaEntry(
                 archivedAt = archiveStates[surveyId]?.archivedAt,
@@ -164,7 +164,7 @@ fun Route.filterRoutes(
             selectedTeam = team,
             availableTeams = teams.sorted(),
             apps = apps.sorted(),
-            surveysByApp = surveysByApp.mapValues { it.value.sorted() }.toSortedMap(),
+            surveysByApp = surveyOverview.surveysByApp.mapValues { it.value.sorted() }.toSortedMap(),
             tags = tags.sorted(),
             surveyMeta = surveyMeta,
         )

--- a/apps/lumi-api/src/test/kotlin/no/nav/lumi/repository/FeedbackRepositoryTest.kt
+++ b/apps/lumi-api/src/test/kotlin/no/nav/lumi/repository/FeedbackRepositoryTest.kt
@@ -248,6 +248,27 @@ class FeedbackRepositoryTest : FunSpec({
         }
     }
 
+    context("findLastSubmissionBySurvey") {
+        test("returns the newest submission timestamp per survey, team-scoped") {
+            val old = OffsetDateTime.parse("2026-06-01T10:00:00+02:00")
+            val newer = OffsetDateTime.parse("2026-08-01T10:00:00+02:00")
+            insertTestFeedback(id = "a1", team = "flex", surveyId = "survey-a", opprettet = old)
+            insertTestFeedback(id = "a2", team = "flex", surveyId = "survey-a", opprettet = newer)
+            insertTestFeedback(id = "b1", team = "flex", surveyId = "survey-b", opprettet = old)
+            insertTestFeedback(id = "other", team = "team-test", surveyId = "survey-a", opprettet = newer)
+
+            val result = repository.findLastSubmissionBySurvey("flex")
+
+            result.keys shouldBe setOf("survey-a", "survey-b")
+            java.time.Instant.parse(result["survey-a"]) shouldBe newer.toInstant()
+            java.time.Instant.parse(result["survey-b"]) shouldBe old.toInstant()
+        }
+
+        test("returns empty map for a team without feedback") {
+            repository.findLastSubmissionBySurvey("nonexistent") shouldBe emptyMap()
+        }
+    }
+
     context("findPaginated") {
         test("excludes archived surveys from the default result") {
             insertTestFeedback(id = "active", team = "flex", surveyId = "survey-active")

--- a/apps/lumi-api/src/test/kotlin/no/nav/lumi/repository/FeedbackRepositoryTest.kt
+++ b/apps/lumi-api/src/test/kotlin/no/nav/lumi/repository/FeedbackRepositoryTest.kt
@@ -248,24 +248,31 @@ class FeedbackRepositoryTest : FunSpec({
         }
     }
 
-    context("findLastSubmissionBySurvey") {
-        test("returns the newest submission timestamp per survey, team-scoped") {
+    context("findSurveyOverview") {
+        test("returns surveys by app and newest submission timestamps from one team-scoped aggregation") {
             val old = OffsetDateTime.parse("2026-06-01T10:00:00+02:00")
             val newer = OffsetDateTime.parse("2026-08-01T10:00:00+02:00")
-            insertTestFeedback(id = "a1", team = "flex", surveyId = "survey-a", opprettet = old)
-            insertTestFeedback(id = "a2", team = "flex", surveyId = "survey-a", opprettet = newer)
-            insertTestFeedback(id = "b1", team = "flex", surveyId = "survey-b", opprettet = old)
+            insertTestFeedback(id = "a1", team = "flex", app = "app-a", surveyId = "survey-a", opprettet = old)
+            insertTestFeedback(id = "a2", team = "flex", app = "app-a", surveyId = "survey-a", opprettet = newer)
+            insertTestFeedback(id = "b1", team = "flex", app = "app-b", surveyId = "survey-b", opprettet = old)
             insertTestFeedback(id = "other", team = "team-test", surveyId = "survey-a", opprettet = newer)
 
-            val result = repository.findLastSubmissionBySurvey("flex")
+            val result = repository.findSurveyOverview("flex")
 
-            result.keys shouldBe setOf("survey-a", "survey-b")
-            java.time.Instant.parse(result["survey-a"]) shouldBe newer.toInstant()
-            java.time.Instant.parse(result["survey-b"]) shouldBe old.toInstant()
+            result.surveysByApp shouldBe mapOf(
+                "app-a" to listOf("survey-a"),
+                "app-b" to listOf("survey-b"),
+            )
+            result.lastSubmissionBySurvey.keys shouldBe setOf("survey-a", "survey-b")
+            java.time.Instant.parse(result.lastSubmissionBySurvey["survey-a"]) shouldBe newer.toInstant()
+            java.time.Instant.parse(result.lastSubmissionBySurvey["survey-b"]) shouldBe old.toInstant()
         }
 
-        test("returns empty map for a team without feedback") {
-            repository.findLastSubmissionBySurvey("nonexistent") shouldBe emptyMap()
+        test("returns empty maps for a team without feedback") {
+            val result = repository.findSurveyOverview("nonexistent")
+
+            result.surveysByApp shouldBe emptyMap()
+            result.lastSubmissionBySurvey shouldBe emptyMap()
         }
     }
 

--- a/apps/lumi-api/src/test/kotlin/no/nav/lumi/routes/FilterRoutesTest.kt
+++ b/apps/lumi-api/src/test/kotlin/no/nav/lumi/routes/FilterRoutesTest.kt
@@ -129,6 +129,69 @@ class FilterRoutesTest : FunSpec({
         }
     }
 
+    test("bootstrap exposes lastSubmissionAt for every survey with feedback") {
+        testApplication {
+            application { testModule() }
+            insertTestFeedback(surveyId = "survey-1")
+            insertTestFeedback(surveyId = "survey-archived")
+            SurveyMetadataRepository().archive(
+                team = "team-test",
+                surveyId = "survey-archived",
+                archivedBy = "A123456",
+            )
+
+            val response = createTestClient().get("/api/v1/intern/filters/bootstrap?team=team-test") {
+                header(HttpHeaders.Authorization, "Bearer test-token")
+            }
+
+            response.status shouldBe HttpStatusCode.OK
+            val surveyMeta = Json.parseToJsonElement(response.bodyAsText())
+                .jsonObject["surveyMeta"]!!.jsonObject
+
+            // Active survey with feedback gets an entry with recency but no archive state
+            val activeEntry = surveyMeta["survey-1"]!!.jsonObject
+            activeEntry["archivedAt"] shouldBe JsonNull
+            activeEntry["lastSubmissionAt"] shouldNotBe JsonNull
+            activeEntry["lastSubmissionAt"] shouldNotBe null
+
+            // Archived survey keeps both fields
+            val archivedEntry = surveyMeta["survey-archived"]!!.jsonObject
+            archivedEntry["archivedAt"] shouldNotBe JsonNull
+            archivedEntry["lastSubmissionAt"] shouldNotBe JsonNull
+        }
+    }
+
+    test("bootstrap gives the badge its data: submission after archiving moves lastSubmissionAt past archivedAt") {
+        testApplication {
+            application { testModule() }
+            insertTestFeedback(
+                surveyId = "survey-zombie",
+                opprettet = java.time.OffsetDateTime.now().minusDays(10),
+            )
+
+            createTestClient().put("/api/v1/intern/surveys/survey-zombie/archive?team=team-test") {
+                header(HttpHeaders.Authorization, "Bearer test-token")
+            }.status shouldBe HttpStatusCode.OK
+
+            // New submission arrives after archiving (widget still deployed)
+            insertTestFeedback(surveyId = "survey-zombie")
+
+            val response = createTestClient().get("/api/v1/intern/filters/bootstrap?team=team-test") {
+                header(HttpHeaders.Authorization, "Bearer test-token")
+            }
+            val entry = Json.parseToJsonElement(response.bodyAsText())
+                .jsonObject["surveyMeta"]!!.jsonObject["survey-zombie"]!!.jsonObject
+
+            val archivedAt = java.time.OffsetDateTime.parse(
+                entry["archivedAt"]!!.jsonPrimitive.content,
+            ).toInstant()
+            val lastSubmissionAt = java.time.Instant.parse(
+                entry["lastSubmissionAt"]!!.jsonPrimitive.content,
+            )
+            (lastSubmissionAt > archivedAt) shouldBe true
+        }
+    }
+
     test("archiving a survey is visible in bootstrap without waiting for cache TTL") {
         testApplication {
             application { testModule() }
@@ -140,7 +203,8 @@ class FilterRoutesTest : FunSpec({
             }
             first.status shouldBe HttpStatusCode.OK
             Json.parseToJsonElement(first.bodyAsText())
-                .jsonObject["surveyMeta"]?.jsonObject?.get("survey-1") shouldBe null
+                .jsonObject["surveyMeta"]?.jsonObject?.get("survey-1")
+                ?.jsonObject?.get("archivedAt") shouldBe JsonNull
 
             createTestClient().put("/api/v1/intern/surveys/survey-1/archive?team=team-test") {
                 header(HttpHeaders.Authorization, "Bearer test-token")

--- a/apps/lumi-dashboard/app/components/feedback/FeedbackTable/__tests__/FeedbackTable.recency.test.tsx
+++ b/apps/lumi-dashboard/app/components/feedback/FeedbackTable/__tests__/FeedbackTable.recency.test.tsx
@@ -1,0 +1,140 @@
+import { render, screen } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { FeedbackTable } from "../index";
+
+const DAY_MS = 24 * 60 * 60 * 1000;
+
+const { mockParams, mockBootstrap } = vi.hoisted(() => ({
+  mockParams: {
+    team: "team-test",
+    surveyId: "survey-1" as string | undefined,
+    page: "1" as string | undefined,
+    showArchived: undefined as string | undefined,
+  },
+  mockBootstrap: {
+    data: undefined as unknown,
+    isPending: false,
+  },
+}));
+
+vi.mock("~/hooks/useSearchParams", () => ({
+  useSearchParams: () => ({
+    params: mockParams,
+    setParam: vi.fn(),
+    setParams: vi.fn(),
+    resetParams: vi.fn(),
+  }),
+}));
+
+vi.mock("~/hooks/useFeedback", () => ({
+  useFeedback: () => ({
+    data: { content: [], totalPages: 1, totalElements: 0, size: 10 },
+    error: null,
+    isPending: false,
+  }),
+}));
+
+vi.mock("~/hooks/useFilterBootstrap", () => ({
+  useFilterBootstrap: () => mockBootstrap,
+}));
+
+vi.mock("~/hooks/useDeleteFeedback", () => ({
+  useDeleteFeedback: () => ({ mutate: vi.fn(), isPending: false }),
+}));
+
+vi.mock("~/hooks/useDeleteSurvey", () => ({
+  useDeleteSurvey: () => ({
+    mutateAsync: vi.fn(),
+    isError: false,
+    isPending: false,
+  }),
+}));
+
+vi.mock("~/hooks/useSurveyTotalCount", () => ({
+  useSurveyTotalCount: () => ({
+    data: 0,
+    isLoading: false,
+    isError: false,
+  }),
+}));
+
+vi.mock("~/hooks/useArchiveSurvey", () => ({
+  useArchiveSurvey: () => ({
+    archiveMutation: {
+      mutateAsync: vi.fn(),
+      reset: vi.fn(),
+      isError: false,
+      isPending: false,
+    },
+    restoreMutation: {
+      mutate: vi.fn(),
+      isError: false,
+      isPending: false,
+    },
+  }),
+}));
+
+function bootstrapWith(surveyMeta: Record<string, unknown>) {
+  return {
+    selectedTeam: "team-test",
+    availableTeams: ["team-test"],
+    apps: ["app-test"],
+    surveysByApp: { "app-test": ["survey-1"] },
+    tags: [],
+    surveyMeta,
+  };
+}
+
+describe("FeedbackTable recency and badge", () => {
+  beforeEach(() => {
+    mockParams.surveyId = "survey-1";
+    mockBootstrap.isPending = false;
+  });
+
+  it("shows relative last-submission time for the selected survey", () => {
+    mockBootstrap.data = bootstrapWith({
+      "survey-1": {
+        archivedAt: null,
+        lastSubmissionAt: new Date(
+          Date.now() - 26 * 60 * 60 * 1000,
+        ).toISOString(),
+      },
+    });
+
+    render(<FeedbackTable />);
+
+    expect(screen.getByText(/Sist svar i går/)).toBeInTheDocument();
+  });
+
+  it("shows the still-receiving badge for an archived survey with newer submissions", () => {
+    const archivedAt = new Date(Date.now() - 10 * DAY_MS).toISOString();
+    mockBootstrap.data = bootstrapWith({
+      "survey-1": {
+        archivedAt,
+        lastSubmissionAt: new Date(Date.now() - 2 * DAY_MS).toISOString(),
+      },
+    });
+
+    render(<FeedbackTable />);
+
+    expect(
+      screen.getByText("Mottar fortsatt innsendinger"),
+    ).toBeInTheDocument();
+  });
+
+  it("does not show the badge when the archived survey has no newer submissions", () => {
+    const archivedAt = new Date(Date.now() - 2 * DAY_MS).toISOString();
+    mockBootstrap.data = bootstrapWith({
+      "survey-1": {
+        archivedAt,
+        lastSubmissionAt: new Date(Date.now() - 10 * DAY_MS).toISOString(),
+      },
+    });
+
+    render(<FeedbackTable />);
+
+    expect(
+      screen.queryByText("Mottar fortsatt innsendinger"),
+    ).not.toBeInTheDocument();
+  });
+});

--- a/apps/lumi-dashboard/app/components/feedback/FeedbackTable/index.tsx
+++ b/apps/lumi-dashboard/app/components/feedback/FeedbackTable/index.tsx
@@ -14,6 +14,7 @@ import {
   Pagination,
   Show,
   Table,
+  Tag,
   Tooltip,
   VStack,
 } from "@navikt/ds-react";
@@ -24,7 +25,11 @@ import { useDeleteFeedback } from "~/hooks/useDeleteFeedback";
 import { useFeedback } from "~/hooks/useFeedback";
 import { useFilterBootstrap } from "~/hooks/useFilterBootstrap";
 import { useSearchParams } from "~/hooks/useSearchParams";
-import { isSurveyArchived } from "~/utils/surveyArchiveUtils";
+import {
+  formatRelativeSubmissionTime,
+  isReceivingAfterArchive,
+  isSurveyArchived,
+} from "~/utils/surveyArchiveUtils";
 import { ArchiveSurveyDialog } from "../../dashboard/ArchiveSurveyDialog";
 import { DeleteSurveyDialog } from "../../dashboard/DeleteSurveyDialog";
 import { DeleteFeedbackDialog } from "../DeleteFeedbackDialog";
@@ -79,6 +84,9 @@ export function FeedbackTable() {
   const totalPages = data?.totalPages || 1;
   const totalElements = data?.totalElements || 0;
   const selectedSurvey = params.surveyId;
+  const selectedSurveyMeta = selectedSurvey
+    ? bootstrap?.surveyMeta?.[selectedSurvey]
+    : undefined;
   const selectedSurveyIsArchived =
     !!selectedSurvey && isSurveyArchived(selectedSurvey, bootstrap?.surveyMeta);
   return (
@@ -91,6 +99,8 @@ export function FeedbackTable() {
           surveyId={selectedSurvey}
           totalCount={totalElements}
           isArchived={selectedSurveyIsArchived}
+          lastSubmissionAt={selectedSurveyMeta?.lastSubmissionAt ?? null}
+          receivingAfterArchive={isReceivingAfterArchive(selectedSurveyMeta)}
           onArchive={() => setArchiveDialogOpen(true)}
           onRestore={() => restoreMutation.mutate(selectedSurvey)}
           isRestoring={restoreMutation.isPending}
@@ -216,6 +226,8 @@ function SurveyToolbar({
   surveyId,
   totalCount,
   isArchived,
+  lastSubmissionAt,
+  receivingAfterArchive,
   onArchive,
   onRestore,
   isRestoring,
@@ -225,6 +237,8 @@ function SurveyToolbar({
   surveyId: string;
   totalCount: number;
   isArchived: boolean;
+  lastSubmissionAt: string | null;
+  receivingAfterArchive: boolean;
   onArchive: () => void;
   onRestore: () => void;
   isRestoring: boolean;
@@ -239,6 +253,18 @@ function SurveyToolbar({
             Viser {totalCount} svar for <strong>{surveyId}</strong>
             {isArchived && <> (arkivert)</>}
           </BodyShort>
+          {lastSubmissionAt && (
+            <BodyShort size="small" textColor="subtle">
+              · Sist svar {formatRelativeSubmissionTime(lastSubmissionAt)}
+            </BodyShort>
+          )}
+          {receivingAfterArchive && (
+            <Tooltip content="Surveyen er arkivert, men frontenden sender fortsatt inn svar. Fjern widgeten fra frontend-koden for å stoppe datainnsamling.">
+              <Tag size="small" variant="warning">
+                Mottar fortsatt innsendinger
+              </Tag>
+            </Tooltip>
+          )}
           {restoreFailed && (
             <ErrorMessage size="small">
               Kunne ikke gjenopprette surveyen. Prøv igjen.

--- a/apps/lumi-dashboard/app/mock/mockData.ts
+++ b/apps/lumi-dashboard/app/mock/mockData.ts
@@ -628,7 +628,10 @@ export function getMockFilterBootstrap(team?: string): {
   apps: string[];
   surveysByApp: Record<string, string[]>;
   tags: string[];
-  surveyMeta: Record<string, { archivedAt: string | null }>;
+  surveyMeta: Record<
+    string,
+    { archivedAt: string | null; lastSubmissionAt?: string }
+  >;
 } {
   void team;
   const availableTeams = ["team-esyfo"];
@@ -638,6 +641,32 @@ export function getMockFilterBootstrap(team?: string): {
   const apps = Object.keys(surveysByApp).sort();
   const tags = getMockTags(selectedTeam);
 
+  // Mirrors the backend's MAX(opprettet)-per-survey aggregation
+  const lastSubmissionBySurvey: Record<string, string> = {};
+  for (const item of getMockItemsForTeam(selectedTeam)) {
+    if (!item.surveyId) continue;
+    const current = lastSubmissionBySurvey[item.surveyId];
+    if (!current || item.submittedAt > current) {
+      lastSubmissionBySurvey[item.surveyId] = item.submittedAt;
+    }
+  }
+
+  const surveyMeta: Record<
+    string,
+    { archivedAt: string | null; lastSubmissionAt?: string }
+  > = {};
+  for (const [surveyId, lastSubmissionAt] of Object.entries(
+    lastSubmissionBySurvey,
+  )) {
+    surveyMeta[surveyId] = { archivedAt: null, lastSubmissionAt };
+  }
+  for (const [surveyId, meta] of Object.entries(mockSurveyMeta)) {
+    surveyMeta[surveyId] = {
+      ...(surveyMeta[surveyId] ?? {}),
+      archivedAt: meta.archivedAt,
+    };
+  }
+
   return {
     generatedAt: new Date().toISOString(),
     selectedTeam,
@@ -646,7 +675,7 @@ export function getMockFilterBootstrap(team?: string): {
     apps,
     surveysByApp,
     tags,
-    surveyMeta: { ...mockSurveyMeta },
+    surveyMeta,
   };
 }
 

--- a/apps/lumi-dashboard/app/utils/__tests__/surveyArchiveUtils.test.ts
+++ b/apps/lumi-dashboard/app/utils/__tests__/surveyArchiveUtils.test.ts
@@ -1,5 +1,7 @@
 import { describe, expect, it } from "vitest";
 import {
+  formatRelativeSubmissionTime,
+  isReceivingAfterArchive,
   isSurveyArchived,
   partitionSurveyOptions,
 } from "../surveyArchiveUtils";
@@ -83,5 +85,83 @@ describe("partitionSurveyOptions", () => {
     expect(result.active).toEqual(availableSurveys);
     expect(result.archived).toEqual([]);
     expect(result.hasArchived).toBe(false);
+  });
+});
+
+describe("formatRelativeSubmissionTime", () => {
+  const now = new Date("2026-08-11T12:00:00Z");
+
+  it("labels same-day submissions as today", () => {
+    expect(formatRelativeSubmissionTime("2026-08-11T08:00:00Z", now)).toBe(
+      "i dag",
+    );
+  });
+
+  it("labels one day ago as yesterday", () => {
+    expect(formatRelativeSubmissionTime("2026-08-10T08:00:00Z", now)).toBe(
+      "i går",
+    );
+  });
+
+  it("uses days below one month", () => {
+    expect(formatRelativeSubmissionTime("2026-08-01T08:00:00Z", now)).toBe(
+      "for 10 dager siden",
+    );
+  });
+
+  it("uses months below one year", () => {
+    expect(formatRelativeSubmissionTime("2026-05-11T08:00:00Z", now)).toBe(
+      "for 3 md. siden",
+    );
+  });
+
+  it("uses years beyond one year", () => {
+    expect(formatRelativeSubmissionTime("2024-05-11T08:00:00Z", now)).toBe(
+      "for 2 år siden",
+    );
+  });
+});
+
+describe("isReceivingAfterArchive", () => {
+  it("is true only when a submission arrived after archiving", () => {
+    expect(
+      isReceivingAfterArchive({
+        archivedAt: "2026-08-01T10:00:00Z",
+        lastSubmissionAt: "2026-08-05T10:00:00Z",
+      }),
+    ).toBe(true);
+    expect(
+      isReceivingAfterArchive({
+        archivedAt: "2026-08-01T10:00:00Z",
+        lastSubmissionAt: "2026-07-20T10:00:00Z",
+      }),
+    ).toBe(false);
+  });
+
+  it("compares timestamps across offset formats", () => {
+    // Backend emits archivedAt as OffsetDateTime (+02:00) and
+    // lastSubmissionAt as UTC Instant — string comparison would be wrong.
+    expect(
+      isReceivingAfterArchive({
+        archivedAt: "2026-08-01T12:00:00+02:00",
+        lastSubmissionAt: "2026-08-01T10:30:00Z",
+      }),
+    ).toBe(true);
+  });
+
+  it("is false for active surveys and missing data", () => {
+    expect(
+      isReceivingAfterArchive({
+        archivedAt: null,
+        lastSubmissionAt: "2026-08-05T10:00:00Z",
+      }),
+    ).toBe(false);
+    expect(
+      isReceivingAfterArchive({
+        archivedAt: "2026-08-01T10:00:00Z",
+        lastSubmissionAt: null,
+      }),
+    ).toBe(false);
+    expect(isReceivingAfterArchive(undefined)).toBe(false);
   });
 });

--- a/apps/lumi-dashboard/app/utils/__tests__/surveyArchiveUtils.test.ts
+++ b/apps/lumi-dashboard/app/utils/__tests__/surveyArchiveUtils.test.ts
@@ -103,6 +103,17 @@ describe("formatRelativeSubmissionTime", () => {
     );
   });
 
+  it("uses the Europe/Oslo calendar date across midnight", () => {
+    const justAfterMidnightInOslo = new Date("2026-08-10T22:15:00Z");
+
+    expect(
+      formatRelativeSubmissionTime(
+        "2026-08-10T21:45:00Z",
+        justAfterMidnightInOslo,
+      ),
+    ).toBe("i går");
+  });
+
   it("uses days below one month", () => {
     expect(formatRelativeSubmissionTime("2026-08-01T08:00:00Z", now)).toBe(
       "for 10 dager siden",

--- a/apps/lumi-dashboard/app/utils/surveyArchiveUtils.ts
+++ b/apps/lumi-dashboard/app/utils/surveyArchiveUtils.ts
@@ -56,6 +56,20 @@ export function partitionSurveyOptions({
 }
 
 const DAY_MS = 24 * 60 * 60 * 1000;
+const OSLO_DATE_FORMATTER = new Intl.DateTimeFormat("en-CA", {
+  timeZone: "Europe/Oslo",
+  year: "numeric",
+  month: "2-digit",
+  day: "2-digit",
+});
+
+function osloCalendarDay(date: Date): number {
+  const parts = OSLO_DATE_FORMATTER.formatToParts(date);
+  const part = (type: Intl.DateTimeFormatPartTypes) =>
+    Number(parts.find((candidate) => candidate.type === type)?.value);
+
+  return Date.UTC(part("year"), part("month") - 1, part("day")) / DAY_MS;
+}
 
 /**
  * Relative wording for a survey's newest submission ("i dag", "i går",
@@ -66,8 +80,9 @@ export function formatRelativeSubmissionTime(
   lastSubmissionAt: string,
   now: Date = new Date(),
 ): string {
-  const days = Math.floor(
-    (now.getTime() - new Date(lastSubmissionAt).getTime()) / DAY_MS,
+  const days = Math.max(
+    0,
+    osloCalendarDay(now) - osloCalendarDay(new Date(lastSubmissionAt)),
   );
   if (days < 1) return "i dag";
   if (days === 1) return "i går";

--- a/apps/lumi-dashboard/app/utils/surveyArchiveUtils.ts
+++ b/apps/lumi-dashboard/app/utils/surveyArchiveUtils.ts
@@ -6,6 +6,7 @@
 
 export interface SurveyMetaEntry {
   archivedAt: string | null;
+  lastSubmissionAt?: string | null;
 }
 
 export type SurveyMetaMap = Record<string, SurveyMetaEntry>;
@@ -52,4 +53,41 @@ export function partitionSurveyOptions({
   const archived = showArchived ? allArchived : [];
 
   return { active, archived, hasArchived: allArchived.length > 0 };
+}
+
+const DAY_MS = 24 * 60 * 60 * 1000;
+
+/**
+ * Relative wording for a survey's newest submission ("i dag", "i går",
+ * "for N dager/md./år siden"). Coarse on purpose — decision support for
+ * archiving, not an exact timestamp.
+ */
+export function formatRelativeSubmissionTime(
+  lastSubmissionAt: string,
+  now: Date = new Date(),
+): string {
+  const days = Math.floor(
+    (now.getTime() - new Date(lastSubmissionAt).getTime()) / DAY_MS,
+  );
+  if (days < 1) return "i dag";
+  if (days === 1) return "i går";
+  if (days < 30) return `for ${days} dager siden`;
+  if (days < 365) return `for ${Math.max(1, Math.floor(days / 30))} md. siden`;
+  return `for ${Math.floor(days / 365)} år siden`;
+}
+
+/**
+ * True when an archived survey has received submissions after it was
+ * archived — archiving hides data but does not stop intake, and this is
+ * how the dashboard makes that visible. Parses timestamps because the
+ * backend emits archivedAt with offset and lastSubmissionAt in UTC.
+ */
+export function isReceivingAfterArchive(
+  entry: SurveyMetaEntry | undefined,
+): boolean {
+  if (!entry?.archivedAt || !entry.lastSubmissionAt) return false;
+  return (
+    new Date(entry.lastSubmissionAt).getTime() >
+    new Date(entry.archivedAt).getTime()
+  );
 }

--- a/packages/lumi-types/src/schemas.ts
+++ b/packages/lumi-types/src/schemas.ts
@@ -161,6 +161,8 @@ export type DeleteSurvey = z.infer<typeof DeleteSurveySchema>;
  */
 export const SurveyMetaEntrySchema = z.object({
   archivedAt: z.string().nullable(),
+  /** Newest submission for the survey (ISO-8601). Absent for surveys without feedback. */
+  lastSubmissionAt: z.string().nullable().optional(),
 });
 
 export type SurveyMetaEntry = z.infer<typeof SurveyMetaEntrySchema>;


### PR DESCRIPTION
## Hva

Slice 2 av arkiveringsspec-en i #339: recency-signal som beslutningsstøtte, og ærlighets-badgen for arkiverte surveys som fortsatt mottar data.

Closes #395

## Endringer

- **Bootstrap `surveyMeta` utvides med `lastSubmissionAt`** — `MAX(opprettet)` per survey via `feedback_json`-stien (pre-V12-rader med NULL `survey_id`-kolonne følger samme semantikk som den avledede survey-listen). Alle surveys med feedback får nå en entry; `archivedAt: null` = aktiv.
- **SurveyToolbar**: «Sist svar i dag / i går / for N dager siden» for valgt survey, og warning-Tag **«Mottar fortsatt innsendinger»** på arkiverte surveys når `lastSubmissionAt > archivedAt` — rent utledet, ingen nye flagg eller jobber. Tooltip forklarer at widgeten må fjernes fra frontend-koden for å stoppe intake.
- **Betingelsen parser tidsstempler**: backend emitterer `archivedAt` som OffsetDateTime (+02:00) og `lastSubmissionAt` som UTC-Instant — strengsammenligning ville vært feil. Egen test dekker kryss-format-tilfellet.
- **Demo-modus** speiler aggregeringen fra mock-items: `survey-thumbs` (mock-arkivert, ferske innsendinger) viser badgen out-of-the-box.

## Test (TDD, rød→grønn)

- Backend: 4 nye (aggregering m/team-isolasjon, bootstrap-felt for aktive+arkiverte, badge-datagrunnlag ende-til-ende via archive-endepunktet). Full suite: **649 grønne**.
- Dashboard: 8 util-tester (relativ tid, badge-betingelse inkl. offset-formater) + 3 komponenttester for toolbaren. Full suite: **301 grønne**.
- E2e: hele suiten grønn (34).
- Typecheck + biome rene.

## Etterpå

Med denne merget er begge slices fra #339 levert — spec-issuen kan lukkes.