### PR TITLE
feat(api): varsle om survey-definisjonskonflikter

### DIFF
--- a/.github/workflows/deploy-api.yaml
+++ b/.github/workflows/deploy-api.yaml
@@ -95,5 +95,5 @@ jobs:
       - uses: nais/deploy/actions/deploy@2d18f050f07b6a007864c6a57070ed915d571beb
         env:
           CLUSTER: prod-gcp
-          RESOURCE: apps/lumi-api/nais/app/prod.yaml
+          RESOURCE: apps/lumi-api/nais/app/prod.yaml,apps/lumi-api/nais/alerts/prod.yaml
           VAR: image=${{ needs.build.outputs.image }}

--- a/apps/lumi-api/docs/runbooks/survey-definition-conflicts.md
+++ b/apps/lumi-api/docs/runbooks/survey-definition-conflicts.md
@@ -1,0 +1,45 @@
+# Survey-definisjonskonflikter
+
+Alarmen `LumiSurveyDefinitionConflict` betyr at Lumi har avvist minst én innsending
+med HTTP 409 fordi den innsendte survey-definisjonen ikke er strukturelt kompatibel
+med definisjonen som allerede er registrert for samme `team` og `surveyId`.
+Innsendingen blir ikke lagret.
+
+## Finn den berørte surveyen
+
+Åpne Loki i Grafana og søk i tidsrommet alarmen gjelder:
+
+```logql
+{app="lumi-api", namespace="team-esyfo"}
+| json
+| event_type="survey_definition_conflict"
+```
+
+Hendelsen inneholder disse strukturerte feltene:
+
+- `caller_team`: teamet som eier surveyen
+- `caller_app`: appen som sendte inn svaret
+- `survey_id`: surveyen som har inkompatible definisjoner
+- `path`: submission-endepunktet
+- `conflict_details`: feltene eller egenskapene som er endret
+
+Prometheus-telleren kan brukes for å se omfanget:
+
+```promql
+sum(increase(lumi_survey_definition_conflicts_total{app="lumi-api"}[30m]))
+```
+
+## Stans nye avvisninger
+
+Kontakt teamet og velg ett av disse tiltakene:
+
+1. Rull tilbake den strukturelle endringen slik at appen igjen sender samme
+   `fieldType`, `optionIds`, rating-konfigurasjon og feltsett som tidligere.
+2. Hvis endringen er tilsiktet, gi den nye surveyen en ny `surveyId`.
+
+Ikke endre eller slette den registrerte definisjonen i databasen. Den beskytter
+historiske svar mot å bli aggregert med en inkompatibel struktur.
+
+Bekreft etter utrulling at appen får en vellykket submission-respons og at telleren
+ikke øker videre. Et tidligere avvist svar kan bare gjenopprettes ved at klienten
+sender det på nytt.

--- a/apps/lumi-api/nais/alerts/prod.yaml
+++ b/apps/lumi-api/nais/alerts/prod.yaml
@@ -1,0 +1,21 @@
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: lumi-api-definition-conflicts
+  namespace: team-esyfo
+  labels:
+    team: team-esyfo
+spec:
+  groups:
+    - name: lumi-api-definition-conflicts
+      rules:
+        - alert: LumiSurveyDefinitionConflict
+          expr: sum(increase(lumi_survey_definition_conflicts_total{app="lumi-api"}[5m])) > 0
+          annotations:
+            summary: "Lumi avviser innsendinger på grunn av definisjonskonflikt"
+            consequence: "Minst én survey-innsending er avvist med 409 og er ikke lagret."
+            action: "Finn team, app og survey_id i de strukturerte loggene og følg runbooken."
+            runbook_url: "https://github.com/navikt/lumi/blob/main/apps/lumi-api/docs/runbooks/survey-definition-conflicts.md"
+          labels:
+            severity: warning
+            namespace: team-esyfo

--- a/apps/lumi-api/src/main/kotlin/no/nav/lumi/config/DefinitionConflictObservability.kt
+++ b/apps/lumi-api/src/main/kotlin/no/nav/lumi/config/DefinitionConflictObservability.kt
@@ -1,0 +1,40 @@
+package no.nav.lumi.config
+
+import io.micrometer.core.instrument.Counter
+import io.micrometer.core.instrument.MeterRegistry
+import no.nav.lumi.config.exception.ApiErrorException
+import org.slf4j.LoggerFactory
+
+class DefinitionConflictObservability(
+    meterRegistry: MeterRegistry = appMicrometerRegistry
+) {
+    private val conflictCounter = Counter.builder(METRIC_NAME)
+        .description("Number of submissions rejected because a survey definition changed structurally")
+        .register(meterRegistry)
+
+    fun record(
+        conflict: ApiErrorException.DefinitionConflictException,
+        path: String,
+        app: String?
+    ) {
+        conflictCounter.increment()
+        val logEvent = definitionConflictLog.atWarn()
+            .addKeyValue("event_type", "survey_definition_conflict")
+            .addKeyValue("caller_team", conflict.team)
+            .addKeyValue("survey_id", conflict.surveyId)
+            .addKeyValue("path", path)
+            .addKeyValue("conflict_details", conflict.errorMessage)
+
+        if (app != null) {
+            logEvent.addKeyValue("caller_app", app)
+        }
+
+        logEvent
+            .log("Survey submission rejected because its definition conflicts with the registered definition")
+    }
+
+    private companion object {
+        const val METRIC_NAME = "lumi_survey_definition_conflicts_total"
+        val definitionConflictLog = LoggerFactory.getLogger("SurveyDefinitionConflict")
+    }
+}

--- a/apps/lumi-api/src/main/kotlin/no/nav/lumi/config/StatusPages.kt
+++ b/apps/lumi-api/src/main/kotlin/no/nav/lumi/config/StatusPages.kt
@@ -9,14 +9,26 @@ import io.ktor.server.response.*
 import no.nav.lumi.config.exception.ApiError
 import no.nav.lumi.config.exception.ApiErrorException
 import no.nav.lumi.config.exception.ErrorType
+import no.nav.lumi.config.auth.CallerIdentityKey
 import org.slf4j.LoggerFactory
 
 private val statusPageLog = LoggerFactory.getLogger("StatusPages")
+private val defaultDefinitionConflictObservability = DefinitionConflictObservability()
 
-fun Application.configureStatusPages() {
+fun Application.configureStatusPages(
+    definitionConflictObservability: DefinitionConflictObservability = defaultDefinitionConflictObservability
+) {
     install(StatusPages) {
         exception<Throwable> { call, cause ->
-            logException(call, cause)
+            if (cause is ApiErrorException.DefinitionConflictException) {
+                definitionConflictObservability.record(
+                    conflict = cause,
+                    path = call.request.path(),
+                    app = call.attributes.getOrNull(CallerIdentityKey)?.app
+                )
+            } else {
+                logException(call, cause)
+            }
             val apiError = determineApiError(cause, call.request.path())
             call.respond(HttpStatusCode.fromValue(apiError.status), apiError)
         }

--- a/apps/lumi-api/src/main/kotlin/no/nav/lumi/config/exception/Exceptions.kt
+++ b/apps/lumi-api/src/main/kotlin/no/nav/lumi/config/exception/Exceptions.kt
@@ -127,6 +127,21 @@ sealed class ApiErrorException(
         )
     }
 
+    class DefinitionConflictException(
+        val team: String,
+        val surveyId: String,
+        val errorMessage: String,
+        cause: Throwable? = null
+    ) : ApiErrorException(errorMessage, ErrorType.CONFLICT, cause) {
+        override fun toApiError(path: String?) = ApiError(
+            status = HttpStatusCode.Conflict.value,
+            type = ErrorType.CONFLICT,
+            message = errorMessage,
+            timestamp = java.time.Instant.now().toString(),
+            path = path,
+        )
+    }
+
     class TooManyRequestsException(
         val errorMessage: String = "Too many requests",
         cause: Throwable? = null,

--- a/apps/lumi-api/src/main/kotlin/no/nav/lumi/service/SurveyDefinitionService.kt
+++ b/apps/lumi-api/src/main/kotlin/no/nav/lumi/service/SurveyDefinitionService.kt
@@ -191,7 +191,7 @@ class SurveyDefinitionService(
             val definitionDiff = diff(stored.definition, incomingDefinition)
             if (stored.source == SurveyDefinitionSource.AUTO && incomingSource == SurveyDefinitionSource.API) {
                 if (definitionDiff.changedFields.isNotEmpty() || definitionDiff.removedFields.isNotEmpty()) {
-                    throwDefinitionConflict(stored.surveyId, definitionDiff, redactIdentifiers = true)
+                    throwDefinitionConflict(team, stored.surveyId, definitionDiff, redactIdentifiers = true)
                 }
 
                 val incomingHash = incomingDefinition.computeHash()
@@ -206,7 +206,7 @@ class SurveyDefinitionService(
             }
 
             if (definitionDiff.hasChanges()) {
-                throwDefinitionConflict(stored.surveyId, definitionDiff, redactIdentifiers = true)
+                throwDefinitionConflict(team, stored.surveyId, definitionDiff, redactIdentifiers = true)
             }
 
             return ExistingDefinitionResult.Resolved(
@@ -217,7 +217,7 @@ class SurveyDefinitionService(
         if (stored.source == SurveyDefinitionSource.API) {
             val definitionDiff = diff(stored.definition, incomingDefinition)
             if (definitionDiff.changedFields.isNotEmpty() || definitionDiff.addedFields.isNotEmpty()) {
-                throwDefinitionConflict(stored.surveyId, definitionDiff)
+                throwDefinitionConflict(team, stored.surveyId, definitionDiff)
             }
 
             return ExistingDefinitionResult.Resolved(
@@ -228,7 +228,7 @@ class SurveyDefinitionService(
         val mergedDefinition = stored.definition.mergeWith(incomingDefinition)
         val definitionDiff = diff(stored.definition, mergedDefinition)
         if (definitionDiff.changedFields.isNotEmpty()) {
-            throwDefinitionConflict(stored.surveyId, definitionDiff)
+            throwDefinitionConflict(team, stored.surveyId, definitionDiff)
         }
 
         if (definitionDiff.addedFields.isEmpty()) {
@@ -264,12 +264,15 @@ class SurveyDefinitionService(
     }
 
     private fun throwDefinitionConflict(
+        team: String,
         surveyId: String,
         definitionDiff: DefinitionDiff,
         redactIdentifiers: Boolean = false
     ): Nothing {
-        throw ApiErrorException.ConflictException(
-            "Survey definition conflict for surveyId=$surveyId: ${
+        throw ApiErrorException.DefinitionConflictException(
+            team = team,
+            surveyId = surveyId,
+            errorMessage = "Survey definition conflict for surveyId=$surveyId: ${
                 if (redactIdentifiers) definitionDiff.describeRedacted() else definitionDiff.describe()
             }. Use a new surveyId for structural changes."
         )

--- a/apps/lumi-api/src/test/kotlin/no/nav/lumi/config/DefinitionConflictObservabilityTest.kt
+++ b/apps/lumi-api/src/test/kotlin/no/nav/lumi/config/DefinitionConflictObservabilityTest.kt
@@ -1,0 +1,85 @@
+package no.nav.lumi.config
+
+import ch.qos.logback.classic.Level
+import ch.qos.logback.classic.Logger
+import ch.qos.logback.classic.spi.ILoggingEvent
+import ch.qos.logback.core.read.ListAppender
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.doubles.shouldBeExactly
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.string.shouldContain
+import io.ktor.client.request.get
+import io.ktor.http.HttpStatusCode
+import io.ktor.server.response.respondText
+import io.ktor.server.routing.get
+import io.ktor.server.routing.routing
+import io.ktor.server.testing.testApplication
+import io.micrometer.prometheusmetrics.PrometheusConfig
+import io.micrometer.prometheusmetrics.PrometheusMeterRegistry
+import no.nav.lumi.config.exception.ApiErrorException
+import no.nav.lumi.config.auth.CallerIdentity
+import no.nav.lumi.config.auth.CallerIdentityKey
+import org.slf4j.LoggerFactory
+
+class DefinitionConflictObservabilityTest : FunSpec({
+    test("only structural definition conflicts increment the conflict counter") {
+        val meterRegistry = PrometheusMeterRegistry(PrometheusConfig.DEFAULT)
+        val definitionConflictLogger = LoggerFactory.getLogger("SurveyDefinitionConflict") as Logger
+        val logAppender = ListAppender<ILoggingEvent>().apply { start() }
+        definitionConflictLogger.addAppender(logAppender)
+
+        try {
+            testApplication {
+                application {
+                    configureSerialization()
+                    configureStatusPages(DefinitionConflictObservability(meterRegistry))
+                    routing {
+                        get("/definition-conflict") {
+                            call.attributes.put(
+                                CallerIdentityKey,
+                                CallerIdentity("team-a", "app-a", null, null)
+                            )
+                            throw ApiErrorException.DefinitionConflictException(
+                                team = "team-a",
+                                surveyId = "survey-1",
+                                errorMessage = "Survey definition conflict"
+                            )
+                        }
+                        get("/other-conflict") {
+                            throw ApiErrorException.ConflictException("Another conflict")
+                        }
+                        get("/ok") {
+                            call.respondText("OK")
+                        }
+                    }
+                }
+
+                client.get("/definition-conflict").status shouldBe HttpStatusCode.Conflict
+                client.get("/other-conflict").status shouldBe HttpStatusCode.Conflict
+                client.get("/ok").status shouldBe HttpStatusCode.OK
+            }
+        } finally {
+            definitionConflictLogger.detachAppender(logAppender)
+            logAppender.stop()
+        }
+
+        meterRegistry.get("lumi_survey_definition_conflicts_total")
+            .counter()
+            .count()
+            .shouldBeExactly(1.0)
+        meterRegistry.scrape() shouldContain "lumi_survey_definition_conflicts_total 1.0"
+
+        val conflictLog = logAppender.list.first { event ->
+            event.keyValuePairs.any { it.key == "survey_id" && it.value == "survey-1" }
+        }
+        conflictLog.level shouldBe Level.WARN
+        conflictLog.keyValuePairs.associate { it.key to it.value } shouldBe mapOf(
+            "event_type" to "survey_definition_conflict",
+            "caller_team" to "team-a",
+            "survey_id" to "survey-1",
+            "path" to "/definition-conflict",
+            "conflict_details" to "Survey definition conflict",
+            "caller_app" to "app-a"
+        )
+    }
+})

--- a/apps/lumi-api/src/test/kotlin/no/nav/lumi/service/SurveyDefinitionServiceTest.kt
+++ b/apps/lumi-api/src/test/kotlin/no/nav/lumi/service/SurveyDefinitionServiceTest.kt
@@ -81,6 +81,8 @@ class SurveyDefinitionServiceTest : FunSpec({
 
         exception.message shouldContain "Survey definition conflict for surveyId=survey-choice"
         exception.message shouldContain "optionIds [apply] -> [apply, follow-up]"
+        exception.team shouldBe "team-a"
+        exception.surveyId shouldBe "survey-choice"
     }
 
     test("label changes are accepted without 409") {
@@ -982,11 +984,11 @@ private fun shouldThrowBadRequest(block: suspend () -> Unit): ApiErrorException.
     }
 }
 
-private fun shouldThrowConflict(block: suspend () -> Unit): ApiErrorException.ConflictException {
+private fun shouldThrowConflict(block: suspend () -> Unit): ApiErrorException.DefinitionConflictException {
     return try {
         kotlinx.coroutines.runBlocking { block() }
-        throw AssertionError("Expected ConflictException")
-    } catch (exception: ApiErrorException.ConflictException) {
+        throw AssertionError("Expected DefinitionConflictException")
+    } catch (exception: ApiErrorException.DefinitionConflictException) {
         exception
     }
 }


### PR DESCRIPTION
## Hva

- introduserer en egen `DefinitionConflictException` for strukturelle survey-konflikter
- eksponerer lavkardinalitetsmetrikken `lumi_survey_definition_conflicts_total`
- logger en strukturert, PII-fri hendelse med `caller_team`, `caller_app`, `survey_id`, path og konfliktdetaljer
- legger til en produksjonsalarm som varsler på enhver avvist innsending
- dokumenterer konkret Loki-/Prometheus-feilsøking og riktig retting i en runbook

## Hvorfor

En inkompatibel definisjon blir avvist med 409 og svaret lagres ikke. Tidligere var dette bare en generell warning/transportfeil, slik at reelt datatap kunne forbli uoppdaget. Denne endringen gjør konflikten operasjonelt synlig uten å endre immutability-modellen, lagringsskjemaet eller API-responsen.

Dette leverer den første, høyest prioriterte delen av #337. Lineage og eventuell versjonering er bevisst ikke med.

## Operativ effekt

Enhver konflikt øker telleren nøyaktig én gang. En `PrometheusRule` varsler Team eSyfo via eksisterende NAIS-ruting når telleren øker i produksjon. Generelle 409-responser og vellykkede submissions påvirker ikke signalet.

## Verifisering

- `pnpm run lint`
- `pnpm run typecheck`
- `pnpm run test` — 302 tester
- `TESTCONTAINERS_RYUK_DISABLED=true pnpm run api:test` — full API-suite
- eksakt Prometheus-navn og strukturerte loggfelter er dekket av regresjonstest
- Application-manifest validert med NAIS CLI; alarm- og workflow-YAML er syntaksvalidert
