### PR TITLE
fix(deps): override nanoid to patched version

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,6 +8,7 @@ overrides:
   tmp: ^0.2.6
   vite: ^7.3.5
   undici: ^7.28.0
+  nanoid: ^3.3.18
 
 importers:
 
@@ -3053,8 +3054,8 @@ packages:
   mz@2.7.0:
     resolution: {integrity: sha512-z81GNO7nnYMEhrGh9LeymoE4+Yr0Wn5McHIZMK5cfQCl+NDX08sCZgUc9/6MHni9IWuFLm1Z3HTCXu2z9fN62Q==}
 
-  nanoid@3.3.17:
-    resolution: {integrity: sha512-xQLf0A3HOMlgHq0n247/LRuAOYmB7dXJ/DvAxGvsSBij45XtBSmQycu+F8ODbHwns/XyFZagyL1+J0Offw1E0g==}
+  nanoid@3.3.18:
+    resolution: {integrity: sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
 
@@ -6922,7 +6923,7 @@ snapshots:
       object-assign: 4.1.1
       thenify-all: 1.6.0
 
-  nanoid@3.3.17: {}
+  nanoid@3.3.18: {}
 
   nf3@0.3.16: {}
 
@@ -7198,7 +7199,7 @@ snapshots:
 
   postcss@8.5.26:
     dependencies:
-      nanoid: 3.3.17
+      nanoid: 3.3.18
       picocolors: 1.1.1
       source-map-js: 1.2.1
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -11,10 +11,12 @@ blockExoticSubdeps: true
 # tmp <0.2.6: Path Traversal (GHSA-ph9p-34f9-6g65), via lumi-dashboard>exceljs>tmp
 # vite 7.0.0-7.3.4: server.fs.deny bypass, via lumi-dashboard>@tanstack/react-start>...>vite
 # undici <7.28.0: TLS bypass / WebSocket DoS / cross-origin routing, via cheerio + nitro
+# nanoid <3.3.18: custom generators can loop indefinitely for size=0, via postcss
 overrides:
   tmp: "^0.2.6"
   vite: "^7.3.5"
   undici: "^7.28.0"
+  nanoid: "^3.3.18"
 
 allowBuilds:
   esbuild: true


### PR DESCRIPTION
## Oppsummering

- overstyrer transitive `nanoid` fra 3.3.17 til 3.3.18
- lukker GHSA-2v37-7h3g-55p8 som blokkerer Node-CI og merge gate
- holder endringen til workspace-konfigurasjon og lockfil

## Rotårsak

En ny high-severity advisory for `nanoid <3.3.18` gjør at `pnpm audit --prod --audit-level=high` feiler på alle nye PR-kjøringer.

## Validering

- `pnpm audit --prod --audit-level=high`
- `npm run lint`
- `npm run typecheck`
- `npm test` — 302 dashboard-tester
- `npm --prefix packages/lumi-survey test` — 305 survey-tester
- `npm run verify:lumi-survey`
- `git diff --check`