### PR TITLE
fix(survey): count compatible reachable branches

### DIFF
--- a/packages/lumi-survey/CHANGELOG.md
+++ b/packages/lumi-survey/CHANGELOG.md
@@ -18,6 +18,7 @@ This project follows SemVer.
 
 - `logic` conditions that reference another question via `condition.questionId` are now evaluated against that question's answer instead of the current question's. Cross-question branching (e.g. routing on an earlier answer) now works the same way `visibleIf` already did. (#332)
 - Submissions now omit answers from questions hidden by `visibleIf` at submit time while retaining the complete survey definition. Hidden answers remain in local state so they are restored if the user reopens the branch. (#357)
+- Reachable-step estimates now count overlapping unresolved `visibleIf` branches (such as multiple `NEQ`/`CONTAINS` conditions or overlapping numeric ranges) together while still counting mutually exclusive branches only once. (#358)
 
 ## [1.0.0] - 2026-06-24
 

--- a/packages/lumi-survey/src/core/__tests__/computeReachableSteps.test.ts
+++ b/packages/lumi-survey/src/core/__tests__/computeReachableSteps.test.ts
@@ -65,6 +65,137 @@ describe("computeReachableSteps", () => {
     expect(computeReachableSteps(questions, {})).toBe(3);
   });
 
+  it("counts overlapping NEQ branches from an unanswered parent (#358)", () => {
+    const questions: LumiSurveyQuestion[] = [
+      { id: "q1", type: "text", prompt: "Q1" },
+      {
+        id: "q2",
+        type: "text",
+        prompt: "Q2",
+        visibleIf: { questionId: "q1", operator: "NEQ", value: "a" },
+      },
+      {
+        id: "q3",
+        type: "text",
+        prompt: "Q3",
+        visibleIf: { questionId: "q1", operator: "NEQ", value: "b" },
+      },
+    ];
+
+    expect(
+      getVisibleQuestions(questions, {}).map((question) => question.id),
+    ).toEqual(["q1", "q2", "q3"]);
+    expect(computeReachableSteps(questions, {})).toBe(3);
+  });
+
+  it("distinguishes overlapping and disjoint numeric branches (#358)", () => {
+    const questions = (
+      ltValue: number,
+      gtValue: number,
+    ): LumiSurveyQuestion[] => [
+      { id: "q1", type: "rating", prompt: "Q1" },
+      {
+        id: "q2",
+        type: "text",
+        prompt: "Q2",
+        visibleIf: { questionId: "q1", operator: "LT", value: ltValue },
+      },
+      {
+        id: "q3",
+        type: "text",
+        prompt: "Q3",
+        visibleIf: { questionId: "q1", operator: "GT", value: gtValue },
+      },
+    ];
+
+    expect(computeReachableSteps(questions(4, 3), {})).toBe(3);
+    expect(computeReachableSteps(questions(3, 4), {})).toBe(2);
+  });
+
+  it("distinguishes compatible and exclusive EQ/NEQ branches (#358)", () => {
+    const questions = (
+      eqValue: string,
+      neqValue: string,
+    ): LumiSurveyQuestion[] => [
+      { id: "q1", type: "singleChoice", prompt: "Q1", options: [] },
+      {
+        id: "q2",
+        type: "text",
+        prompt: "Q2",
+        visibleIf: { questionId: "q1", operator: "EQ", value: eqValue },
+      },
+      {
+        id: "q3",
+        type: "text",
+        prompt: "Q3",
+        visibleIf: { questionId: "q1", operator: "NEQ", value: neqValue },
+      },
+    ];
+
+    expect(computeReachableSteps(questions("b", "a"), {})).toBe(3);
+    expect(computeReachableSteps(questions("a", "a"), {})).toBe(2);
+  });
+
+  it("counts compatible CONTAINS branches together (#358)", () => {
+    const questions: LumiSurveyQuestion[] = [
+      {
+        id: "q1",
+        type: "multiChoice",
+        prompt: "Q1",
+        options: [
+          { value: "a", label: "A" },
+          { value: "b", label: "B" },
+        ],
+      },
+      {
+        id: "q2",
+        type: "text",
+        prompt: "Q2",
+        visibleIf: { questionId: "q1", operator: "CONTAINS", value: "a" },
+      },
+      {
+        id: "q3",
+        type: "text",
+        prompt: "Q3",
+        visibleIf: { questionId: "q1", operator: "CONTAINS", value: "b" },
+      },
+    ];
+
+    expect(computeReachableSteps(questions, {})).toBe(3);
+  });
+
+  it("counts descendants of overlapping unresolved branches (#358)", () => {
+    const questions: LumiSurveyQuestion[] = [
+      { id: "q1", type: "text", prompt: "Q1" },
+      {
+        id: "q2",
+        type: "text",
+        prompt: "Q2",
+        visibleIf: { questionId: "q1", operator: "NEQ", value: "a" },
+      },
+      {
+        id: "q3",
+        type: "text",
+        prompt: "Q3",
+        visibleIf: { questionId: "q1", operator: "NEQ", value: "b" },
+      },
+      {
+        id: "q4",
+        type: "text",
+        prompt: "Q4",
+        visibleIf: { questionId: "q2", operator: "EXISTS" },
+      },
+      {
+        id: "q5",
+        type: "text",
+        prompt: "Q5",
+        visibleIf: { questionId: "q3", operator: "EXISTS" },
+      },
+    ];
+
+    expect(computeReachableSteps(questions, {})).toBe(5);
+  });
+
   it("treats METADATA conditions as reachable", () => {
     const questions: LumiSurveyQuestion[] = [
       {
@@ -529,8 +660,8 @@ describe("computeReachableSteps", () => {
 
     const estimate = computeReachableSteps(questions, {});
 
-    expect(estimate).toBeGreaterThan(1);
-    expect(estimate).toBeGreaterThanOrEqual(7);
-    expect(estimate).toBeLessThanOrEqual(9);
+    // `hva-savner-du` (LT 4) and `hva-fungerer` (GT 3) overlap, so both
+    // branches and their shared linear continuation are reachable together.
+    expect(estimate).toBe(questions.length);
   });
 });

--- a/packages/lumi-survey/src/core/branchingEngine.ts
+++ b/packages/lumi-survey/src/core/branchingEngine.ts
@@ -254,8 +254,8 @@ const VISIBILITY_BRANCHING_OPERATORS = new Set<LogicOperator>([
 ]);
 
 /**
- * Checks whether answer-dependent visibility represents mutually exclusive
- * branches that should use step navigation under the automatic layout.
+ * Checks whether answer-dependent visibility represents value-based branches
+ * that should use step navigation under the automatic layout.
  * EXISTS-only progressive disclosure and metadata conditions stay single-page.
  */
 export function surveyHasVisibilityBranching(

--- a/packages/lumi-survey/src/core/computeReachableSteps.ts
+++ b/packages/lumi-survey/src/core/computeReachableSteps.ts
@@ -18,12 +18,72 @@ function isAnswerCondition(
 }
 
 /**
+ * Builds representative answer values for every truth-region expressible by
+ * the value operators. The estimator deliberately considers every supported
+ * answer shape because overestimation is safer than hiding a reachable step.
+ */
+function buildAnswerWitnesses(
+  conditions: LogicLeafCondition[],
+): Array<LumiSurveyAnswerValue | undefined> {
+  const scalarWitnesses = new Set<string | number>([0]);
+  const numericBoundaries = new Set<number>();
+  const stringValues = new Set<string>();
+
+  for (const condition of conditions) {
+    if (typeof condition.value === "number") {
+      scalarWitnesses.add(condition.value);
+      numericBoundaries.add(condition.value);
+    } else if (typeof condition.value === "string") {
+      scalarWitnesses.add(condition.value);
+      stringValues.add(condition.value);
+    }
+
+    if (condition.operator === "CONTAINS") {
+      stringValues.add(String(condition.value));
+    }
+  }
+
+  const sortedBoundaries = [...numericBoundaries]
+    .filter(Number.isFinite)
+    .sort((left, right) => left - right);
+
+  if (sortedBoundaries.length > 0) {
+    const first = sortedBoundaries[0];
+    const last = sortedBoundaries[sortedBoundaries.length - 1];
+    const below = first - Math.max(1, Math.abs(first) * 0.01);
+    const above = last + Math.max(1, Math.abs(last) * 0.01);
+
+    if (Number.isFinite(below) && below < first) scalarWitnesses.add(below);
+    if (Number.isFinite(above) && above > last) scalarWitnesses.add(above);
+
+    for (let index = 1; index < sortedBoundaries.length; index++) {
+      const left = sortedBoundaries[index - 1];
+      const right = sortedBoundaries[index];
+      const midpoint = left + (right - left) / 2;
+      if (Number.isFinite(midpoint) && midpoint > left && midpoint < right) {
+        scalarWitnesses.add(midpoint);
+      }
+    }
+  }
+
+  const expectedStrings = new Set(
+    conditions
+      .map((condition) => condition.value)
+      .filter((value): value is string => typeof value === "string"),
+  );
+  let combinedString = `__lumi_reachability__${[...stringValues].join("__")}__`;
+  while (expectedStrings.has(combinedString)) combinedString += "_";
+  scalarWitnesses.add(combinedString);
+
+  return [undefined, ...scalarWitnesses, [...stringValues]];
+}
+
+/**
  * Estimates reachable questions from the current answer state via the visibleIf graph.
- * For unanswered parents with value operators (EQ/LT/GT/NEQ/CONTAINS),
- * only one unresolved child branch is counted per parent (the longest branch).
- * This avoids counting mutually exclusive paths at once, but overlapping
- * conditions (for example LT 4 and GT 3) can make the estimate lower than
- * the real number of visible questions.
+ * For unanswered parents with value operators (EQ/LT/GT/NEQ/CONTAINS), the
+ * longest compatible combination of child branches is counted. This avoids
+ * counting mutually exclusive paths at once without undercounting overlapping
+ * conditions such as multiple NEQ/CONTAINS branches or LT 4 plus GT 3.
  * METADATA-gated conditions are always treated as reachable to prefer
  * overestimation over underestimation when metadata may arrive or change later.
  * `any`/`all` group conditions are evaluated once every referenced answer is
@@ -169,10 +229,10 @@ export function computeReachableSteps(
     return false;
   };
 
-  const branchLengthFrom = (
+  function branchLengthFrom(
     questionId: string,
     visited: Set<string> = new Set(),
-  ): number => {
+  ): number {
     if (visited.has(questionId)) {
       return 0;
     }
@@ -206,7 +266,7 @@ export function computeReachableSteps(
     let total = 1;
     const children = dependentsByParent.get(questionId) ?? [];
 
-    let bestUnansweredValueBranch = 0;
+    const unansweredValueChildren: LumiSurveyQuestion[] = [];
 
     for (const child of children) {
       const childCondition = child.visibleIf;
@@ -226,15 +286,64 @@ export function computeReachableSteps(
         continue;
       }
 
-      const branchLength = branchLengthFrom(child.id, new Set(visited));
-      if (branchLength > bestUnansweredValueBranch) {
-        bestUnansweredValueBranch = branchLength;
-      }
+      unansweredValueChildren.push(child);
     }
 
-    total += bestUnansweredValueBranch;
+    total += maxCompatibleBranchLength(
+      questionId,
+      unansweredValueChildren,
+      visited,
+    );
     return total;
-  };
+  }
+
+  function maxCompatibleBranchLength(
+    parentId: string,
+    candidates: LumiSurveyQuestion[],
+    visited: Set<string>,
+  ): number {
+    const branches = candidates.flatMap((candidate) => {
+      const condition = candidate.visibleIf;
+      if (!isAnswerCondition(condition) || condition.operator === "EXISTS") {
+        return [];
+      }
+
+      return [
+        {
+          condition,
+          length: branchLengthFrom(candidate.id, new Set(visited)),
+        },
+      ];
+    });
+
+    if (branches.length === 0) return 0;
+
+    const hypotheticalAnswers = { ...answers };
+    let best = 0;
+
+    for (const witness of buildAnswerWitnesses(
+      branches.map((branch) => branch.condition),
+    )) {
+      if (witness === undefined) {
+        delete hypotheticalAnswers[parentId];
+      } else {
+        hypotheticalAnswers[parentId] = witness;
+      }
+
+      let total = 0;
+      for (const branch of branches) {
+        if (
+          evaluateVisibility(branch.condition, hypotheticalAnswers, metadata)
+        ) {
+          total += branch.length;
+        }
+      }
+
+      if (total > best) best = total;
+    }
+
+    return best;
+  }
 
   let reachableCount = 0;
   const unresolvedByParent = new Map<string, LumiSurveyQuestion[]>();
@@ -267,17 +376,12 @@ export function computeReachableSteps(
     unresolvedByParent.set(condition.questionId, unresolved);
   }
 
-  for (const candidates of unresolvedByParent.values()) {
-    let bestBranch = 0;
-
-    for (const candidate of candidates) {
-      const branch = branchLengthFrom(candidate.id);
-      if (branch > bestBranch) {
-        bestBranch = branch;
-      }
-    }
-
-    reachableCount += bestBranch;
+  for (const [parentId, candidates] of unresolvedByParent) {
+    reachableCount += maxCompatibleBranchLength(
+      parentId,
+      candidates,
+      new Set(),
+    );
   }
 
   return reachableCount;


### PR DESCRIPTION
## Oppsummering

- teller flere uavklarte `visibleIf`-grener når de kan være sanne samtidig
- beholder maks én gren for gjensidig utelukkende betingelser
- bruker representative svarverdier for `EQ`, `NEQ`, `LT`, `GT` og `CONTAINS`
- bruker samme kompatibilitetsberegning både på toppnivå og i nøstede grener
- oppdaterer den misvisende «mutually exclusive»-kommentaren og changelog

## Rotårsak

`computeReachableSteps` valgte alltid den lengste uavklarte grenen per forelder. Det var riktig for ulike `EQ`-verdier, men undertelte overlappende `NEQ`, `CONTAINS` og numeriske intervaller. Den samme antakelsen fantes både i toppnivåaggregeringen og rekursivt i `branchLengthFrom`.

Closes #358

## Validering

- `npm --prefix packages/lumi-survey test` — 318 tester
- `npm test` — 302 dashboard-tester
- `npm run lint`
- `npm run typecheck`
- `npm run verify:lumi-survey`
- `pnpm audit --prod --audit-level=high`
- `git diff --check`