### PR TITLE
fix(survey): expose context to metadata conditions

### DIFF
--- a/docs/guider/betinget-synlighet.md
+++ b/docs/guider/betinget-synlighet.md
@@ -182,6 +182,23 @@ Du kan også vise spørsmål basert på metadata (kontekst-verdier) i stedet for
 }
 ```
 
+`key` slås opp i et flatt metadata-kart med disse verdiene:
+
+| Nøkkel | Kilde | Merknad |
+| :--- | :--- | :--- |
+| `deviceType` | Automatisk | `mobile`, `tablet` eller `desktop` |
+| `viewport` | Automatisk | Objekt med `width` og `height`; bruk `EXISTS` for å sjekke at det finnes |
+| `screenResolution` | Automatisk | Objekt med `width` og `height`; bruk `EXISTS` for å sjekke at det finnes |
+| `userAgent` | Automatisk | Nettleserens user agent-streng |
+| `pathname` | Context / opt-in | Manuelt sanitert verdi, eller automatisk når `collectLocation` er aktivert |
+| `url` | Context | Samles aldri inn automatisk |
+| Egendefinerte tag-nøkler | `context.tags` | Eksempel: `rolle`, `tjeneste` eller `abTest` |
+
+Tag-nøklene ligger på toppnivå, så `context.tags.rolle` brukes som
+`key: "rolle"`. Når et systemfelt har en definert verdi, har det prioritet over
+en tag med samme navn. `context.debug` er bevisst ikke tilgjengelig for
+synlighetsregler; debug-data er kun ment for diagnostikk av innsendinger.
+
 ## Når trenger du noe mer?
 
 `visibleIf` er perfekt for progressiv disclosure — vis/skjul oppfølgingsspørsmål basert på tidligere svar. Men noen ganger trenger du å faktisk *endre flyten*: hoppe til et annet spørsmål, skippe neste steg, eller avslutte surveyen tidlig.

--- a/docs/guider/branching.md
+++ b/docs/guider/branching.md
@@ -61,6 +61,11 @@ type LogicCondition =
     };
 ```
 
+`METADATA` bruker det samme flate kontekstkartet som `visibleIf`: automatiske
+systemfelt og nøklene fra `context.tags`, men ikke `context.debug`. Se
+[Metadata-betingelser](/guider/betinget-synlighet#metadata-betingelser) for hele
+nøkkellisten og kollisjonsreglene.
+
 For `logic` evalueres betingelsen vanligvis mot *det gjeldende spørsmålets* svar — `questionId` er valgfri her (i motsetning til `visibleIf` der du alltid refererer til et annet spørsmål).
 
 > **Merk:** `logic`-betingelser støtter ikke `any`/`all`-grupper — kun enkeltbetingelser.

--- a/packages/lumi-survey/CHANGELOG.md
+++ b/packages/lumi-survey/CHANGELOG.md
@@ -19,6 +19,7 @@ This project follows SemVer.
 - `logic` conditions that reference another question via `condition.questionId` are now evaluated against that question's answer instead of the current question's. Cross-question branching (e.g. routing on an earlier answer) now works the same way `visibleIf` already did. (#332)
 - Submissions now omit answers from questions hidden by `visibleIf` at submit time while retaining the complete survey definition. Hidden answers remain in local state so they are restored if the user reopens the branch. (#357)
 - Reachable-step estimates now count overlapping unresolved `visibleIf` branches (such as multiple `NEQ`/`CONTAINS` conditions or overlapping numeric ranges) together while still counting mutually exclusive branches only once. (#358)
+- `METADATA` conditions now receive auto-collected context fields (`deviceType`, `viewport`, `screenResolution`, `userAgent`) and opt-in location fields in addition to flattened `context.tags`. Submission-time visibility uses the same metadata map; `context.debug` remains excluded. (#144)
 
 ## [1.0.0] - 2026-06-24
 

--- a/packages/lumi-survey/src/components/LumiSurveyDock/LumiSurveyDock.tsx
+++ b/packages/lumi-survey/src/components/LumiSurveyDock/LumiSurveyDock.tsx
@@ -13,6 +13,7 @@ import {
   shouldShowSubmitButton,
   useLumiSurvey,
 } from "../../core";
+import { getVisibilityMetadata } from "../../core/visibilityMetadata.js";
 
 import { buildCanonicalSurvey } from "../shared/canonicalSurvey.js";
 import type { LumiSurveyConfig } from "../surveyTypes.js";
@@ -169,6 +170,10 @@ export const LumiSurveyDock = ({
   const enrichedContext = useEnrichedContext(context, {
     collectLocation: config.collectLocation,
   });
+  const visibilityMetadata = useMemo(
+    () => getVisibilityMetadata(enrichedContext),
+    [enrichedContext],
+  );
 
   const { answers, status, error, setAnswer, submit, reset } = useLumiSurvey({
     surveyId,
@@ -198,7 +203,7 @@ export const LumiSurveyDock = ({
   } = useStepNavigation({
     questions,
     answers,
-    metadata: enrichedContext?.tags,
+    metadata: visibilityMetadata,
     forceStepMode,
     onStepChange: forceSinglePage ? undefined : events?.onStepChange,
   });
@@ -234,15 +239,15 @@ export const LumiSurveyDock = ({
 
   // Filter questions based on visibleIf conditions (progressive disclosure)
   const visibleQuestions = useMemo(
-    () => getVisibleQuestions(questions, answers, enrichedContext?.tags),
-    [questions, answers, enrichedContext?.tags],
+    () => getVisibleQuestions(questions, answers, visibilityMetadata),
+    [questions, answers, visibilityMetadata],
   );
 
   // Progressive submit: hide the button until a currently visible question has
   // at least one meaningful answer. Required-answer validation happens on submit.
   const isSubmitBlocked = useMemo(
-    () => !shouldShowSubmitButton(questions, answers, enrichedContext?.tags),
-    [questions, answers, enrichedContext?.tags],
+    () => !shouldShowSubmitButton(questions, answers, visibilityMetadata),
+    [questions, answers, visibilityMetadata],
   );
 
   // In step mode with branching, only validate questions the user actually visited
@@ -254,7 +259,7 @@ export const LumiSurveyDock = ({
       const visited = uniqueIndices
         .map((index) => questions[index])
         .filter(Boolean);
-      return getVisibleQuestions(visited, answers, enrichedContext?.tags);
+      return getVisibleQuestions(visited, answers, visibilityMetadata);
     }
     // Non-step mode: only validate visible questions (hidden questions are
     // excluded regardless of whether they were previously visible).
@@ -265,7 +270,7 @@ export const LumiSurveyDock = ({
     questions,
     visibleQuestions,
     answers,
-    enrichedContext?.tags,
+    visibilityMetadata,
   ]);
 
   const showPersonalDataNotice = useMemo(() => {

--- a/packages/lumi-survey/src/components/LumiSurveyDock/__tests__/LumiSurveyDock.test.tsx
+++ b/packages/lumi-survey/src/components/LumiSurveyDock/__tests__/LumiSurveyDock.test.tsx
@@ -294,6 +294,40 @@ describe("LumiSurveyDock", () => {
     expect(screen.getByRole("radio", { name: /^ja$/i })).toBeInTheDocument();
   });
 
+  it("uses auto-collected context in METADATA visibility conditions", async () => {
+    const survey: LumiSurveyConfig = {
+      type: "custom",
+      questions: [
+        {
+          id: "rating",
+          type: "rating",
+          prompt: "Hvor fornøyd er du?",
+          required: true,
+        },
+        {
+          id: "desktop-feedback",
+          type: "text",
+          prompt: "Tilbakemelding fra desktop",
+          required: false,
+          visibleIf: {
+            field: "METADATA",
+            key: "deviceType",
+            operator: "EQ",
+            value: "desktop",
+          },
+        },
+      ],
+    };
+
+    renderDock({ survey });
+
+    expect(
+      await screen.findByRole("textbox", {
+        name: /tilbakemelding fra desktop/i,
+      }),
+    ).toBeInTheDocument();
+  });
+
   it("supports step layout without branching when questionLayout is steps", async () => {
     const user = userEvent.setup();
     renderDock({ behavior: { questionLayout: "steps" } });

--- a/packages/lumi-survey/src/core/__tests__/useLumiSurvey.test.ts
+++ b/packages/lumi-survey/src/core/__tests__/useLumiSurvey.test.ts
@@ -386,6 +386,44 @@ describe("useLumiSurvey", () => {
     });
   });
 
+  it("retains answers visible through context metadata at submission time", async () => {
+    const questions: LumiSurveyQuestion[] = [
+      {
+        id: "details",
+        type: "text",
+        prompt: "Mobile details",
+        required: false,
+        maxLength: 500,
+        visibleIf: {
+          field: "METADATA",
+          key: "deviceType",
+          operator: "EQ",
+          value: "mobile",
+        },
+      },
+    ];
+    const submitMock = vi.fn(async (_: LumiSurveySubmission) => {});
+    const { result } = renderHook(() =>
+      useLumiSurvey({
+        surveyId: SURVEY_ID,
+        questions,
+        transport: { submit: submitMock },
+        context: { deviceType: "mobile" },
+      }),
+    );
+
+    await act(() => {
+      result.current.setAnswer("details", "Visible mobile answer");
+    });
+    await act(async () => {
+      await result.current.submit();
+    });
+
+    expect(submitMock.mock.calls[0][0].answers).toEqual({
+      details: "Visible mobile answer",
+    });
+  });
+
   it("surfaces transport failures and triggers error callbacks", async () => {
     const transportError = new Error("Transport failed");
     const transport: LumiSurveyTransport = {

--- a/packages/lumi-survey/src/core/__tests__/visibilityMetadata.test.ts
+++ b/packages/lumi-survey/src/core/__tests__/visibilityMetadata.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from "vitest";
+import { getVisibilityMetadata } from "../visibilityMetadata.js";
+
+describe("getVisibilityMetadata", () => {
+  it("flattens tags, prefers defined context fields, and excludes debug data", () => {
+    expect(
+      getVisibilityMetadata({
+        deviceType: "desktop",
+        pathname: "/survey",
+        tags: {
+          role: "caseworker",
+          deviceType: "mobile",
+          url: "tag-only-url",
+        },
+        debug: { sessionId: "not-for-conditions" },
+      }),
+    ).toEqual({
+      role: "caseworker",
+      deviceType: "desktop",
+      pathname: "/survey",
+      url: "tag-only-url",
+    });
+  });
+});

--- a/packages/lumi-survey/src/core/useLumiSurvey.ts
+++ b/packages/lumi-survey/src/core/useLumiSurvey.ts
@@ -17,6 +17,7 @@ import type {
   SurveyType,
 } from "./types";
 import { validateAnswers } from "./validation.js";
+import { getVisibilityMetadata } from "./visibilityMetadata.js";
 
 export interface UseLumiSurveyOptions {
   surveyId: string;
@@ -103,7 +104,7 @@ export function useLumiSurvey(
       const submittedAnswers = getVisibleAnswers(
         questions,
         answerSnapshot,
-        context?.tags,
+        getVisibilityMetadata(context),
       );
       const submittedAtTimestamp = new Date().toISOString();
       const deduplicationKey = getDeduplicationKey();

--- a/packages/lumi-survey/src/core/visibilityMetadata.ts
+++ b/packages/lumi-survey/src/core/visibilityMetadata.ts
@@ -1,0 +1,32 @@
+import type { LumiSurveyContext } from "./types.js";
+
+/**
+ * Builds the flat metadata map used by visibleIf and branching conditions.
+ *
+ * Tags keep their existing top-level keys. Defined context fields take
+ * precedence over tags with the same name, while debug data is deliberately
+ * excluded because it is intended only for submission diagnostics.
+ */
+export function getVisibilityMetadata(
+  context: LumiSurveyContext | undefined,
+): Record<string, unknown> | undefined {
+  if (!context) return undefined;
+
+  const metadata: Record<string, unknown> = { ...context.tags };
+  const contextFields: Record<string, unknown> = {
+    url: context.url,
+    pathname: context.pathname,
+    viewport: context.viewport,
+    screenResolution: context.screenResolution,
+    deviceType: context.deviceType,
+    userAgent: context.userAgent,
+  };
+
+  for (const [key, value] of Object.entries(contextFields)) {
+    if (value !== undefined) {
+      metadata[key] = value;
+    }
+  }
+
+  return metadata;
+}


### PR DESCRIPTION
## Hva

- bygger ett felles, flatt metadata-kart av auto-innsamlet context og `context.tags`
- bruker samme kart i step-navigasjon, synlighetsfiltrering, validering og submit-filtrering
- holder `context.debug` utenfor betingelsesspråket
- dokumenterer tilgjengelige nøkler og kollisjonsregelen

## Rotårsak

`LumiSurveyDock` og `useLumiSurvey.submit()` sendte bare `context.tags` til synlighetsevaluatorene. Felter som `deviceType`, `viewport`, `screenResolution`, `userAgent` og opt-in location nådde derfor aldri `METADATA`-regler.

Tags beholdes som flate nøkler. Når et definert systemfelt og en tag har samme navn, vinner systemfeltet.

Closes #144

## Validering

- `pnpm --filter @navikt/lumi-survey test` — 26 filer / 326 tester
- `pnpm run test` — 48 filer / 302 dashboard-tester
- `pnpm run lint`
- `pnpm run typecheck`
- `pnpm run verify:lumi-survey`
- `pnpm run docs:build`
- `git diff --check`
