### PR TITLE
Fix empty survey deletion

### DIFF
--- a/apps/lumi-api/src/main/kotlin/no/nav/lumi/repository/FeedbackRepository.kt
+++ b/apps/lumi-api/src/main/kotlin/no/nav/lumi/repository/FeedbackRepository.kt
@@ -180,7 +180,7 @@ class FeedbackRepository(
     }
 
     /**
-     * Atomically deletes markers and feedback for a survey within one transaction.
+     * Atomically deletes markers, feedback, and dashboard metadata for a survey within one transaction.
      * Returns number of deleted feedback rows.
      */
     suspend fun deleteSurveyWithMarkers(surveyId: String, team: String): Int {
@@ -190,10 +190,17 @@ class FeedbackRepository(
                     (RatingMarkerTable.surveyId eq surveyId)
             }
 
-            FeedbackTable.deleteWhere {
+            val deletedCount = FeedbackTable.deleteWhere {
                 (JsonExtract(FeedbackTable.feedbackJson, listOf("surveyId")) eq surveyId) and
                     (FeedbackTable.team eq team)
             }
+
+            SurveyMetadataTable.deleteWhere {
+                (SurveyMetadataTable.team eq team) and
+                    (SurveyMetadataTable.surveyId eq surveyId)
+            }
+
+            deletedCount
         }
     }
 

--- a/apps/lumi-api/src/main/kotlin/no/nav/lumi/routes/FeedbackRoutes.kt
+++ b/apps/lumi-api/src/main/kotlin/no/nav/lumi/routes/FeedbackRoutes.kt
@@ -20,6 +20,7 @@ import no.nav.lumi.repository.FeedbackRepository
 import no.nav.lumi.service.FeedbackService
 import no.nav.lumi.service.StatsCacheInvalidator
 import no.nav.lumi.integrations.valkey.ValkeyStatsCache
+import no.nav.lumi.integrations.valkey.StringCache
 import org.slf4j.LoggerFactory
 
 private val log = LoggerFactory.getLogger("FeedbackRoutes")
@@ -175,7 +176,10 @@ fun Route.feedbackRoutes(
 fun Route.surveyFacetRoutes(
     service: FeedbackService = defaultFeedbackService,
     statsCacheInvalidator: StatsCacheInvalidator = defaultStatsCacheInvalidator,
+    bootstrapCache: StringCache = sharedBootstrapCache,
 ) {
+    val versionedBootstrapCache = VersionedBootstrapCache(bootstrapCache)
+
     // Delete all feedback for a survey (team-scoped)
     delete<ApiV1Intern.Surveys.Id> { params ->
         val team = call.authorizedTeam
@@ -183,6 +187,7 @@ fun Route.surveyFacetRoutes(
         if (deletedCount > 0) {
             statsCacheInvalidator.invalidateTeam(team)
         }
+        versionedBootstrapCache.invalidate(team)
         call.respond(DeleteSurveyResult(surveyId = params.surveyId, deletedCount = deletedCount))
     }
 

--- a/apps/lumi-api/src/main/kotlin/no/nav/lumi/service/FeedbackService.kt
+++ b/apps/lumi-api/src/main/kotlin/no/nav/lumi/service/FeedbackService.kt
@@ -92,7 +92,7 @@ class FeedbackService(
     }
 
     /**
-     * Permanently delete all markers and feedback for a surveyId in the given team.
+     * Permanently delete all markers, feedback, and dashboard metadata for a surveyId in the given team.
      * Returns number of deleted feedback rows.
      */
     suspend fun deleteSurveyWithMarkers(surveyId: String, team: String): Int {

--- a/apps/lumi-api/src/test/kotlin/no/nav/lumi/TestUtils.kt
+++ b/apps/lumi-api/src/test/kotlin/no/nav/lumi/TestUtils.kt
@@ -19,6 +19,7 @@ import no.nav.lumi.config.DatabaseHolder
 import no.nav.lumi.domain.SaveResult
 import no.nav.lumi.integrations.valkey.InMemoryStatsCache
 import no.nav.lumi.integrations.valkey.InMemoryStringCache
+import no.nav.lumi.integrations.valkey.StringCache
 import no.nav.lumi.repository.FeedbackRepository
 import no.nav.lumi.routes.feedbackRoutes
 import no.nav.lumi.routes.internalRoutes
@@ -237,7 +238,8 @@ fun insertTestRatingMarker(
  */
 fun Application.testModule(
     feedbackService: FeedbackService = FeedbackService(),
-    statsRepository: FeedbackStatsRepository = FeedbackStatsRepository()
+    statsRepository: FeedbackStatsRepository = FeedbackStatsRepository(),
+    bootstrapCache: StringCache = InMemoryStringCache(),
 ) {
     // Initialize test database
     DatabaseHolder.initializeForTesting(TestDatabase.dataSource)
@@ -283,7 +285,6 @@ fun Application.testModule(
     
     // Create services with the injected repositories/services
     // Fresh per test application so bootstrap cache state cannot leak between tests
-    val bootstrapCache = InMemoryStringCache()
     val statsCache = InMemoryStatsCache()
     val statsService = StatsService(FeedbackRepository(), statsRepository, statsCache = statsCache)
     val exportService = ExportService(FeedbackRepository())
@@ -303,7 +304,7 @@ fun Application.testModule(
             }
             
             feedbackRoutes(feedbackService, statsCacheInvalidator)
-            surveyFacetRoutes(feedbackService, statsCacheInvalidator)
+            surveyFacetRoutes(feedbackService, statsCacheInvalidator, bootstrapCache)
             surveyArchiveRoutes(
                 bootstrapCache = bootstrapCache,
                 statsCacheInvalidator = statsCacheInvalidator,

--- a/apps/lumi-api/src/test/kotlin/no/nav/lumi/routes/FeedbackRoutesTest.kt
+++ b/apps/lumi-api/src/test/kotlin/no/nav/lumi/routes/FeedbackRoutesTest.kt
@@ -19,6 +19,7 @@ import no.nav.lumi.createTestClient
 import no.nav.lumi.insertTestFeedback
 import no.nav.lumi.insertTestFeedbackWithJson
 import no.nav.lumi.insertTestRatingMarker
+import no.nav.lumi.repository.SurveyMetadataRepository
 import no.nav.lumi.testModule
 import java.time.LocalDate
 import java.time.OffsetDateTime
@@ -699,6 +700,47 @@ class FeedbackRoutesTest : FunSpec({
         }
     }
 
+    test("DELETE /api/v1/intern/surveys/{surveyId} invalidates cached bootstrap even when survey is already empty") {
+        testApplication {
+            application { testModule() }
+
+            val surveyId = "survey-empty-cached"
+            val feedbackId = UUID.randomUUID().toString()
+            val client = createTestClient()
+            insertTestFeedback(
+                id = feedbackId,
+                team = "team-test",
+                app = "app-test",
+                surveyId = surveyId,
+            )
+
+            val before = client.get("/api/v1/intern/filters/bootstrap?team=team-test") {
+                header(HttpHeaders.Authorization, "Bearer test-token")
+            }
+            val beforeSurveys = Json.parseToJsonElement(before.bodyAsText())
+                .jsonObject["surveysByApp"]!!.jsonObject["app-test"]!!.jsonArray
+            beforeSurveys.any { it.jsonPrimitive.content == surveyId } shouldBe true
+
+            client.delete("/api/v1/intern/feedback/$feedbackId?team=team-test") {
+                header(HttpHeaders.Authorization, "Bearer test-token")
+            }.status shouldBe HttpStatusCode.NoContent
+
+            val deleteSurvey = client.delete("/api/v1/intern/surveys/$surveyId?team=team-test") {
+                header(HttpHeaders.Authorization, "Bearer test-token")
+            }
+            Json.parseToJsonElement(deleteSurvey.bodyAsText())
+                .jsonObject["deletedCount"]!!.jsonPrimitive.int shouldBe 0
+
+            val after = client.get("/api/v1/intern/filters/bootstrap?team=team-test") {
+                header(HttpHeaders.Authorization, "Bearer test-token")
+            }
+            val afterApps = Json.parseToJsonElement(after.bodyAsText())
+                .jsonObject["surveysByApp"]!!.jsonObject
+            val afterSurveys = afterApps["app-test"]?.jsonArray.orEmpty()
+            afterSurveys.any { it.jsonPrimitive.content == surveyId } shouldBe false
+        }
+    }
+
     test("DELETE /api/v1/intern/surveys/{surveyId} does not delete another team's survey") {
         testApplication {
             application { testModule() }
@@ -783,6 +825,7 @@ class FeedbackRoutesTest : FunSpec({
                 markerDate = LocalDate.parse("2026-02-02"),
                 label = "Skal bli igjen",
             )
+            SurveyMetadataRepository().archive(team, surveyId, "A123456")
 
             val response = createTestClient().delete("/api/v1/intern/surveys/$surveyId?team=$team") {
                 header(HttpHeaders.Authorization, "Bearer test-token")
@@ -825,6 +868,7 @@ class FeedbackRoutesTest : FunSpec({
                 }
             }
             rowsForOtherSurvey shouldBe 1
+            SurveyMetadataRepository().findByTeam(team).none { it.surveyId == surveyId } shouldBe true
         }
     }
 

--- a/apps/lumi-dashboard/app/components/dashboard/DeleteSurveyDialog.tsx
+++ b/apps/lumi-dashboard/app/components/dashboard/DeleteSurveyDialog.tsx
@@ -39,6 +39,7 @@ export function DeleteSurveyDialog({
     isError: isTotalCountError,
   } = useSurveyTotalCount(surveyId, isOpen);
   const totalCountUnavailable = isTotalCountError || totalCount === undefined;
+  const hasNoAnswers = totalCount === 0;
 
   const handleDelete = async () => {
     if (totalCountUnavailable) return;
@@ -81,6 +82,11 @@ export function DeleteSurveyDialog({
                 Kunne ikke hente totalt antall svar. Last antallet på nytt før
                 surveyen kan slettes.
               </>
+            ) : hasNoAnswers ? (
+              <>
+                Surveyen <strong>"{surveyId}"</strong> har ingen lagrede svar.
+                Du kan fortsatt slette surveyen permanent fra dashboardet.
+              </>
             ) : (
               <>
                 Du er i ferd med å{" "}
@@ -99,8 +105,9 @@ export function DeleteSurveyDialog({
           </Alert>
 
           <BodyLong>
-            Denne handlingen kan ikke angres. All data for denne surveyen vil
-            bli permanent fjernet fra databasen.
+            {hasNoAnswers
+              ? "Denne handlingen kan ikke angres. Surveyen og eventuelle markører vil bli permanent fjernet fra dashboardet."
+              : "Denne handlingen kan ikke angres. All data for denne surveyen vil bli permanent fjernet fra databasen."}
           </BodyLong>
 
           <ConfirmationPanel
@@ -109,7 +116,9 @@ export function DeleteSurveyDialog({
             label={
               totalCount === undefined
                 ? "Antall svar må lastes før sletting"
-                : `Ja, slett permanent alle ${totalCount} svar`
+                : hasNoAnswers
+                  ? "Ja, slett surveyen permanent"
+                  : `Ja, slett permanent alle ${totalCount} svar`
             }
             disabled={isLoadingTotal || totalCountUnavailable}
           />
@@ -135,7 +144,9 @@ export function DeleteSurveyDialog({
           >
             {totalCount === undefined
               ? "Slett svar permanent"
-              : `Slett ${totalCount} svar permanent`}
+              : hasNoAnswers
+                ? "Slett survey permanent"
+                : `Slett ${totalCount} svar permanent`}
           </Button>
         </HStack>
       </Modal.Footer>

--- a/apps/lumi-dashboard/app/components/dashboard/DeleteSurveyDialog.tsx
+++ b/apps/lumi-dashboard/app/components/dashboard/DeleteSurveyDialog.tsx
@@ -9,7 +9,7 @@ import {
   Skeleton,
   VStack,
 } from "@navikt/ds-react";
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { useDeleteSurvey } from "~/hooks/useDeleteSurvey";
 import { useSurveyTotalCount } from "~/hooks/useSurveyTotalCount";
 
@@ -43,6 +43,10 @@ export function DeleteSurveyDialog({
   const totalCountUnavailable =
     isRefreshingTotal || isTotalCountError || totalCount === undefined;
   const hasNoAnswers = totalCount === 0;
+
+  useEffect(() => {
+    if (isFetchingTotal) setConfirmed(false);
+  }, [isFetchingTotal]);
 
   const handleDelete = async () => {
     if (totalCountUnavailable) return;

--- a/apps/lumi-dashboard/app/components/dashboard/DeleteSurveyDialog.tsx
+++ b/apps/lumi-dashboard/app/components/dashboard/DeleteSurveyDialog.tsx
@@ -36,9 +36,12 @@ export function DeleteSurveyDialog({
   const {
     data: totalCount,
     isLoading: isLoadingTotal,
+    isFetching: isFetchingTotal,
     isError: isTotalCountError,
   } = useSurveyTotalCount(surveyId, isOpen);
-  const totalCountUnavailable = isTotalCountError || totalCount === undefined;
+  const isRefreshingTotal = isLoadingTotal || isFetchingTotal;
+  const totalCountUnavailable =
+    isRefreshingTotal || isTotalCountError || totalCount === undefined;
   const hasNoAnswers = totalCount === 0;
 
   const handleDelete = async () => {
@@ -75,7 +78,7 @@ export function DeleteSurveyDialog({
       <Modal.Body>
         <VStack gap="space-16">
           <Alert variant={isTotalCountError ? "error" : "warning"}>
-            {isLoadingTotal ? (
+            {isRefreshingTotal ? (
               <Skeleton width="100%" height="24px" />
             ) : isTotalCountError || totalCount === undefined ? (
               <>
@@ -114,13 +117,13 @@ export function DeleteSurveyDialog({
             checked={confirmed}
             onChange={() => setConfirmed(!confirmed)}
             label={
-              totalCount === undefined
+              totalCountUnavailable
                 ? "Antall svar må lastes før sletting"
                 : hasNoAnswers
                   ? "Ja, slett surveyen permanent"
                   : `Ja, slett permanent alle ${totalCount} svar`
             }
-            disabled={isLoadingTotal || totalCountUnavailable}
+            disabled={totalCountUnavailable}
           />
 
           {deleteMutation.isError && (
@@ -139,10 +142,10 @@ export function DeleteSurveyDialog({
             data-color="danger"
             variant="primary"
             onClick={handleDelete}
-            disabled={!confirmed || isLoadingTotal || totalCountUnavailable}
+            disabled={!confirmed || totalCountUnavailable}
             loading={deleteMutation.isPending}
           >
-            {totalCount === undefined
+            {totalCountUnavailable
               ? "Slett svar permanent"
               : hasNoAnswers
                 ? "Slett survey permanent"

--- a/apps/lumi-dashboard/app/components/dashboard/__tests__/DeleteSurveyDialog.test.tsx
+++ b/apps/lumi-dashboard/app/components/dashboard/__tests__/DeleteSurveyDialog.test.tsx
@@ -1,9 +1,10 @@
 import { render, screen } from "@testing-library/react";
-import { describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import { DeleteSurveyDialog } from "../DeleteSurveyDialog";
 
-const { mockMutateAsync } = vi.hoisted(() => ({
+const { mockMutateAsync, mockUseSurveyTotalCount } = vi.hoisted(() => ({
   mockMutateAsync: vi.fn(),
+  mockUseSurveyTotalCount: vi.fn(),
 }));
 
 vi.mock("~/hooks/useDeleteSurvey", () => ({
@@ -15,14 +16,19 @@ vi.mock("~/hooks/useDeleteSurvey", () => ({
 }));
 
 vi.mock("~/hooks/useSurveyTotalCount", () => ({
-  useSurveyTotalCount: () => ({
-    data: undefined,
-    isLoading: false,
-    isError: true,
-  }),
+  useSurveyTotalCount: mockUseSurveyTotalCount,
 }));
 
 describe("DeleteSurveyDialog", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockUseSurveyTotalCount.mockReturnValue({
+      data: undefined,
+      isLoading: false,
+      isError: true,
+    });
+  });
+
   it("blocks deletion when the authoritative total count cannot be loaded", () => {
     render(
       <DeleteSurveyDialog
@@ -41,5 +47,33 @@ describe("DeleteSurveyDialog", () => {
       screen.getByRole("button", { name: /Slett svar permanent/i }),
     ).toBeDisabled();
     expect(mockMutateAsync).not.toHaveBeenCalled();
+  });
+
+  it("describes permanent survey deletion without referring to zero answers", () => {
+    mockUseSurveyTotalCount.mockReturnValue({
+      data: 0,
+      isLoading: false,
+      isError: false,
+    });
+
+    render(
+      <DeleteSurveyDialog
+        surveyId="survey-empty"
+        filteredCount={0}
+        isOpen
+        onClose={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByText(/surveyen har ingen lagrede svar/i)).toBeVisible();
+    expect(
+      screen.getByRole("checkbox", {
+        name: /ja, slett surveyen permanent/i,
+      }),
+    ).toBeEnabled();
+    expect(
+      screen.getByRole("button", { name: /slett survey permanent/i }),
+    ).toBeDisabled();
+    expect(screen.queryByText(/slette alle 0 svar/i)).not.toBeInTheDocument();
   });
 });

--- a/apps/lumi-dashboard/app/components/dashboard/__tests__/DeleteSurveyDialog.test.tsx
+++ b/apps/lumi-dashboard/app/components/dashboard/__tests__/DeleteSurveyDialog.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from "@testing-library/react";
+import { fireEvent, render, screen } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { DeleteSurveyDialog } from "../DeleteSurveyDialog";
 
@@ -101,5 +101,49 @@ describe("DeleteSurveyDialog", () => {
       screen.getByRole("button", { name: /Slett svar permanent/i }),
     ).toBeDisabled();
     expect(screen.queryByText(/alle 5 svar/i)).not.toBeInTheDocument();
+  });
+
+  it("requires new confirmation when the refreshed total count changes", () => {
+    mockUseSurveyTotalCount.mockReturnValue({
+      data: 5,
+      isLoading: false,
+      isFetching: false,
+      isError: false,
+    });
+
+    const props = {
+      surveyId: "survey-changing",
+      filteredCount: 5,
+      isOpen: true,
+      onClose: vi.fn(),
+    };
+    const { rerender } = render(<DeleteSurveyDialog {...props} />);
+
+    fireEvent.click(screen.getByRole("checkbox"));
+    expect(screen.getByRole("checkbox")).toBeChecked();
+    expect(
+      screen.getByRole("button", { name: /Slett 5 svar permanent/i }),
+    ).toBeEnabled();
+
+    mockUseSurveyTotalCount.mockReturnValue({
+      data: 5,
+      isLoading: false,
+      isFetching: true,
+      isError: false,
+    });
+    rerender(<DeleteSurveyDialog {...props} />);
+
+    mockUseSurveyTotalCount.mockReturnValue({
+      data: 4,
+      isLoading: false,
+      isFetching: false,
+      isError: false,
+    });
+    rerender(<DeleteSurveyDialog {...props} />);
+
+    expect(screen.getByRole("checkbox")).not.toBeChecked();
+    expect(
+      screen.getByRole("button", { name: /Slett 4 svar permanent/i }),
+    ).toBeDisabled();
   });
 });

--- a/apps/lumi-dashboard/app/components/dashboard/__tests__/DeleteSurveyDialog.test.tsx
+++ b/apps/lumi-dashboard/app/components/dashboard/__tests__/DeleteSurveyDialog.test.tsx
@@ -25,6 +25,7 @@ describe("DeleteSurveyDialog", () => {
     mockUseSurveyTotalCount.mockReturnValue({
       data: undefined,
       isLoading: false,
+      isFetching: false,
       isError: true,
     });
   });
@@ -53,6 +54,7 @@ describe("DeleteSurveyDialog", () => {
     mockUseSurveyTotalCount.mockReturnValue({
       data: 0,
       isLoading: false,
+      isFetching: false,
       isError: false,
     });
 
@@ -75,5 +77,29 @@ describe("DeleteSurveyDialog", () => {
       screen.getByRole("button", { name: /slett survey permanent/i }),
     ).toBeDisabled();
     expect(screen.queryByText(/slette alle 0 svar/i)).not.toBeInTheDocument();
+  });
+
+  it("blocks deletion while a cached total count is being refreshed", () => {
+    mockUseSurveyTotalCount.mockReturnValue({
+      data: 5,
+      isLoading: false,
+      isFetching: true,
+      isError: false,
+    });
+
+    render(
+      <DeleteSurveyDialog
+        surveyId="survey-stale"
+        filteredCount={5}
+        isOpen
+        onClose={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByRole("checkbox")).toBeDisabled();
+    expect(
+      screen.getByRole("button", { name: /Slett svar permanent/i }),
+    ).toBeDisabled();
+    expect(screen.queryByText(/alle 5 svar/i)).not.toBeInTheDocument();
   });
 });

--- a/apps/lumi-dashboard/app/hooks/__tests__/useDeleteFeedback.test.tsx
+++ b/apps/lumi-dashboard/app/hooks/__tests__/useDeleteFeedback.test.tsx
@@ -4,22 +4,19 @@ import type { ReactNode } from "react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 vi.mock("~/server/actions", () => ({
-  deleteSurveyServerFn: vi.fn(),
+  deleteFeedbackServerFn: vi.fn(),
 }));
 
 vi.mock("~/hooks/useSearchParams", () => ({
   useSearchParams: vi.fn(() => ({
     params: { team: "team-test" },
-    setParam: vi.fn(),
-    setParams: vi.fn(),
-    resetParams: vi.fn(),
   })),
 }));
 
-import { deleteSurveyServerFn } from "~/server/actions";
-import { useDeleteSurvey } from "../useDeleteSurvey";
+import { deleteFeedbackServerFn } from "~/server/actions";
+import { useDeleteFeedback } from "../useDeleteFeedback";
 
-const mockDeleteSurvey = deleteSurveyServerFn as unknown as ReturnType<
+const mockDeleteFeedback = deleteFeedbackServerFn as unknown as ReturnType<
   typeof vi.fn
 >;
 
@@ -29,46 +26,36 @@ function createWrapper(queryClient: QueryClient) {
   );
 }
 
-describe("useDeleteSurvey", () => {
+describe("useDeleteFeedback", () => {
   beforeEach(() => {
     vi.clearAllMocks();
   });
 
-  it("deletes survey and invalidates related queries including markers", async () => {
+  it("invalidates feedback, stats, bootstrap, and survey count after deletion", async () => {
     const queryClient = new QueryClient({
-      defaultOptions: {
-        mutations: { retry: false },
-      },
+      defaultOptions: { mutations: { retry: false } },
     });
-
     const invalidateSpy = vi.spyOn(queryClient, "invalidateQueries");
-    mockDeleteSurvey.mockResolvedValueOnce({
-      surveyId: "survey-1",
-      deletedCount: 10,
-    });
+    mockDeleteFeedback.mockResolvedValueOnce(undefined);
 
-    const { result } = renderHook(() => useDeleteSurvey(), {
+    const { result } = renderHook(() => useDeleteFeedback(), {
       wrapper: createWrapper(queryClient),
     });
 
     await act(async () => {
-      await result.current.mutateAsync("survey-1");
+      await result.current.mutateAsync("feedback-1");
     });
 
-    expect(mockDeleteSurvey).toHaveBeenCalledWith({
-      data: {
-        surveyId: "survey-1",
-        team: "team-test",
-      },
+    expect(mockDeleteFeedback).toHaveBeenCalledWith({
+      data: { id: "feedback-1", team: "team-test" },
     });
-
     expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: ["feedback"] });
     expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: ["stats"] });
-    expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: ["surveysByApp"] });
-    expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: ["filterOptions"] });
     expect(invalidateSpy).toHaveBeenCalledWith({
       queryKey: ["filterBootstrap"],
     });
-    expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: ["markers"] });
+    expect(invalidateSpy).toHaveBeenCalledWith({
+      queryKey: ["survey-total-count"],
+    });
   });
 });

--- a/apps/lumi-dashboard/app/hooks/__tests__/useDeleteSurvey.test.tsx
+++ b/apps/lumi-dashboard/app/hooks/__tests__/useDeleteSurvey.test.tsx
@@ -69,6 +69,9 @@ describe("useDeleteSurvey", () => {
     expect(invalidateSpy).toHaveBeenCalledWith({
       queryKey: ["filterBootstrap"],
     });
+    expect(invalidateSpy).toHaveBeenCalledWith({
+      queryKey: ["survey-total-count"],
+    });
     expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: ["markers"] });
   });
 });

--- a/apps/lumi-dashboard/app/hooks/useDeleteFeedback.ts
+++ b/apps/lumi-dashboard/app/hooks/useDeleteFeedback.ts
@@ -13,6 +13,8 @@ export function useDeleteFeedback() {
       // Invalidate feedback queries to refresh the list
       queryClient.invalidateQueries({ queryKey: ["feedback"] });
       queryClient.invalidateQueries({ queryKey: ["stats"] });
+      queryClient.invalidateQueries({ queryKey: ["filterBootstrap"] });
+      queryClient.invalidateQueries({ queryKey: ["survey-total-count"] });
     },
   });
 }

--- a/apps/lumi-dashboard/app/hooks/useDeleteSurvey.ts
+++ b/apps/lumi-dashboard/app/hooks/useDeleteSurvey.ts
@@ -15,6 +15,7 @@ export function useDeleteSurvey() {
       queryClient.invalidateQueries({ queryKey: ["stats"] });
       queryClient.invalidateQueries({ queryKey: ["surveysByApp"] });
       queryClient.invalidateQueries({ queryKey: ["filterOptions"] });
+      queryClient.invalidateQueries({ queryKey: ["filterBootstrap"] });
       queryClient.invalidateQueries({ queryKey: ["markers"] });
     },
   });

--- a/apps/lumi-dashboard/app/hooks/useDeleteSurvey.ts
+++ b/apps/lumi-dashboard/app/hooks/useDeleteSurvey.ts
@@ -16,6 +16,7 @@ export function useDeleteSurvey() {
       queryClient.invalidateQueries({ queryKey: ["surveysByApp"] });
       queryClient.invalidateQueries({ queryKey: ["filterOptions"] });
       queryClient.invalidateQueries({ queryKey: ["filterBootstrap"] });
+      queryClient.invalidateQueries({ queryKey: ["survey-total-count"] });
       queryClient.invalidateQueries({ queryKey: ["markers"] });
     },
   });


### PR DESCRIPTION
## Hva

- oppdaterer bootstrap- og totalantall-queries etter enkeltsletting og survey-sletting
- invaliderer teamets versjonerte bootstrap-cache selv når surveyen allerede har 0 svar
- sletter survey-metadata atomisk sammen med svar og ratingmarkører
- viser tydelig slettetekst for surveyer uten lagrede svar

## Hvorfor

En survey kunne bli stående i nedtrekkslisten etter at alle svar var slettet enkeltvis. Årsaken var en kombinasjon av manglende frontend-invalideringer, bootstrap-cache som ikke ble invalidert ved en tom bulk-sletting, og arkivmetadata som fortsatt kunne holde surveyen synlig.

## Effekt

En tom survey kan nå slettes permanent fra dashboardet og forsvinner umiddelbart fra surveyvelgeren, også når den tidligere har vært arkivert.

## Validering

- `npm run lint`
- `npm run typecheck`
- `npm test` — 304 tester bestått
- `npm run api:test`
- `npm run e2e` — 34 bestått, 1 hoppet over
- `git diff --check`

Closes #253
