### PR TITLE
Fix inconsistent question typography

### DIFF
--- a/packages/lumi-survey/src/components/LumiSurveyDock/LumiSurveyDock.fallback.css
+++ b/packages/lumi-survey/src/components/LumiSurveyDock/LumiSurveyDock.fallback.css
@@ -29,12 +29,7 @@
 }
 
 .lumi-survey-dock__rating-heading {
-  font-size: var(--ax-font-size-xlarge);
   font-weight: var(--ax-font-weight-bold);
-}
-
-.lumi-survey-dock__rating-description {
-  font-size: var(--ax-font-size-small);
 }
 
 .lumi-survey-dock__rating-fieldset {

--- a/packages/lumi-survey/src/components/LumiSurveyDock/LumiSurveyDock.module.css
+++ b/packages/lumi-survey/src/components/LumiSurveyDock/LumiSurveyDock.module.css
@@ -36,12 +36,7 @@
 }
 
 .ratingHeading {
-  font-size: var(--ax-font-size-xlarge);
   font-weight: var(--ax-font-weight-bold);
-}
-
-.ratingDescription {
-  font-size: var(--ax-font-size-small);
 }
 
 .ratingFieldset {

--- a/packages/lumi-survey/src/components/LumiSurveyDock/__tests__/LumiSurveyDock.test.tsx
+++ b/packages/lumi-survey/src/components/LumiSurveyDock/__tests__/LumiSurveyDock.test.tsx
@@ -67,6 +67,48 @@ describe("LumiSurveyDock", () => {
     localStorage.clear();
   });
 
+  it("uses the same typography scale for every question on a single page", async () => {
+    const survey: LumiSurveyConfig = {
+      type: "custom",
+      questions: [
+        {
+          id: "first",
+          type: "text",
+          prompt: "Første spørsmål",
+          description: "Første beskrivelse",
+          required: true,
+        },
+        {
+          id: "second",
+          type: "text",
+          prompt: "Andre spørsmål",
+          description: "Andre beskrivelse",
+          required: true,
+        },
+      ],
+    };
+
+    renderDock({
+      survey,
+      behavior: { questionLayout: "singlePage" },
+    });
+
+    const firstPrompt = await screen.findByRole("heading", {
+      name: "Første spørsmål",
+    });
+    const secondPrompt = screen.getByText("Andre spørsmål");
+    const firstDescription = screen.getByText("Første beskrivelse", {
+      selector: "p",
+    });
+    const secondDescription = screen.getByText("Andre beskrivelse");
+
+    // Aksel Heading xsmall and Label medium both use the 18/24 scale.
+    expect(firstPrompt).toHaveClass("aksel-heading--xsmall");
+    expect(secondPrompt).toHaveClass("aksel-label");
+    expect(firstDescription).toHaveClass("aksel-body-short--medium");
+    expect(secondDescription).toHaveClass("aksel-body-short--medium");
+  });
+
   it("does not show personal data notice when branching submits before any text question", async () => {
     const user = userEvent.setup();
     const transport: LumiSurveyTransport = {

--- a/packages/lumi-survey/src/components/LumiSurveyDock/__tests__/LumiSurveyDock.test.tsx
+++ b/packages/lumi-survey/src/components/LumiSurveyDock/__tests__/LumiSurveyDock.test.tsx
@@ -109,6 +109,42 @@ describe("LumiSurveyDock", () => {
     expect(secondDescription).toHaveClass("aksel-body-short--medium");
   });
 
+  it("keeps compact header typography when questions are shown one at a time", async () => {
+    const survey: LumiSurveyConfig = {
+      type: "custom",
+      questions: [
+        {
+          id: "first-step",
+          type: "text",
+          prompt: "Første steg",
+          description: "Kompakt beskrivelse",
+          required: true,
+        },
+        {
+          id: "second-step",
+          type: "text",
+          prompt: "Andre steg",
+          required: true,
+        },
+      ],
+    };
+
+    renderDock({
+      survey,
+      behavior: { questionLayout: "steps" },
+    });
+
+    const prompt = await screen.findByRole("heading", {
+      name: "Første steg",
+    });
+    const description = screen.getByText("Kompakt beskrivelse", {
+      selector: "p",
+    });
+
+    expect(prompt).toHaveClass("aksel-heading--small");
+    expect(description).toHaveClass("aksel-body-short--small");
+  });
+
   it("does not show personal data notice when branching submits before any text question", async () => {
     const user = userEvent.setup();
     const transport: LumiSurveyTransport = {

--- a/packages/lumi-survey/src/components/LumiSurveyDock/components/DockPanel.tsx
+++ b/packages/lumi-survey/src/components/LumiSurveyDock/components/DockPanel.tsx
@@ -150,7 +150,7 @@ export const DockPanel = ({
               <div className={CLASS_NAMES.headerText} style={{ flex: 1 }}>
                 <Heading
                   level="2"
-                  size="medium"
+                  size="small"
                   className={CLASS_NAMES.ratingHeading}
                   id={introHeadingId}
                 >
@@ -187,7 +187,7 @@ export const DockPanel = ({
                 {isSuccess ? (
                   <Heading
                     level="2"
-                    size="medium"
+                    size="small"
                     className={CLASS_NAMES.ratingHeading}
                     id={successHeadingId}
                   >
@@ -197,7 +197,7 @@ export const DockPanel = ({
                   <>
                     <Heading
                       level="2"
-                      size="medium"
+                      size="xsmall"
                       className={CLASS_NAMES.ratingHeading}
                       id={promptHeadingId}
                       tabIndex={-1}
@@ -206,7 +206,7 @@ export const DockPanel = ({
                     </Heading>
                     {activeQuestion.description && (
                       <BodyShort
-                        size="small"
+                        size="medium"
                         className={CLASS_NAMES.ratingDescription}
                         id={promptDescriptionId}
                       >

--- a/packages/lumi-survey/src/components/LumiSurveyDock/components/DockPanel.tsx
+++ b/packages/lumi-survey/src/components/LumiSurveyDock/components/DockPanel.tsx
@@ -115,6 +115,7 @@ export const DockPanel = ({
 
   const activeQuestion =
     isStepMode && currentStepQuestion ? currentStepQuestion : promptQuestion;
+  const usesFieldTypography = !isStepMode && orderedQuestions.length > 1;
 
   return (
     <div style={{ position: "relative" }}>
@@ -197,7 +198,7 @@ export const DockPanel = ({
                   <>
                     <Heading
                       level="2"
-                      size="xsmall"
+                      size={usesFieldTypography ? "xsmall" : "small"}
                       className={CLASS_NAMES.ratingHeading}
                       id={promptHeadingId}
                       tabIndex={-1}
@@ -206,7 +207,7 @@ export const DockPanel = ({
                     </Heading>
                     {activeQuestion.description && (
                       <BodyShort
-                        size="medium"
+                        size={usesFieldTypography ? "medium" : "small"}
                         className={CLASS_NAMES.ratingDescription}
                         id={promptDescriptionId}
                       >

--- a/scripts/verify-lumi-survey-package.mjs
+++ b/scripts/verify-lumi-survey-package.mjs
@@ -46,6 +46,20 @@ async function scanFileForForbiddenStrings(filePath) {
   }
 }
 
+function assertCssRuleOmitsProperty(css, selector, property) {
+  const escapedSelector = selector.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  const rulePattern = new RegExp(`${escapedSelector}\\s*\\{[^}]*\\}`, "g");
+  const propertyPattern = new RegExp(`\\b${property}\\s*:`);
+
+  for (const match of css.matchAll(rulePattern)) {
+    if (propertyPattern.test(match[0])) {
+      fail(
+        `packages/lumi-survey/dist/index.css must not set ${property} in ${selector}; use Aksel typography props instead`,
+      );
+    }
+  }
+}
+
 async function scanDirRecursive(dirPath, predicate) {
   const entries = await readdir(dirPath, { withFileTypes: true });
   for (const entry of entries) {
@@ -71,6 +85,7 @@ async function main() {
   const distDir = path.join(packageDir, "dist");
   const distIndexJs = path.join(distDir, "index.js");
   const distIndexDts = path.join(distDir, "index.d.ts");
+  const distIndexCss = path.join(distDir, "index.css");
 
   // 1) package.json must not depend on internal workspace-only packages.
   const pkg = JSON.parse(await readText(packageJsonPath));
@@ -109,7 +124,11 @@ async function main() {
   );
 
   // 4) dist must be present and must not reference forbidden packages.
-  if (!(await fileExists(distIndexJs)) || !(await fileExists(distIndexDts))) {
+  if (
+    !(await fileExists(distIndexJs)) ||
+    !(await fileExists(distIndexDts)) ||
+    !(await fileExists(distIndexCss))
+  ) {
     fail(
       "packages/lumi-survey/dist is missing build artifacts. Run: pnpm --filter @navikt/lumi-survey run build",
     );
@@ -117,6 +136,16 @@ async function main() {
 
   await scanFileForForbiddenStrings(distIndexJs);
   await scanFileForForbiddenStrings(distIndexDts);
+
+  const distCss = await readText(distIndexCss);
+  for (const selector of [
+    ".ratingHeading",
+    ".ratingDescription",
+    ".lumi-survey-dock__rating-heading",
+    ".lumi-survey-dock__rating-description",
+  ]) {
+    assertCssRuleOmitsProperty(distCss, selector, "font-size");
+  }
 
   console.log("[verify:lumi-survey] OK");
 }


### PR DESCRIPTION
## Hva

- bruker samme Aksel-typografiskala for alle spørsmål på én side
- beholder første spørsmål som semantisk `h2` med eksisterende fokus- og ARIA-koblinger
- fjerner egne fontstørrelser som overstyrte Aksel-komponentenes valgte størrelser
- legger til en integrasjonstest med to tekstspørsmål og beskrivelser

## Hvorfor

Det første spørsmålet ble rendret i dock-headeren med en annen Heading- og BodyShort-størrelse enn de øvrige skjemafeltene. Modul- og fallback-CSS overstyrte i tillegg Aksel-propene, slik at prompt og beskrivelse fikk inkonsistent typografi.

## Effekt

På `singlePage` bruker første prompt og øvrige feltlabels samme 18/24-skala. Beskrivelsene bruker også samme medium-skala. Intro og suksess beholder en tydeligere heading-størrelse.

## Validering

- `pnpm --filter @navikt/lumi-survey run test` — 327 tester bestått
- `pnpm --filter @navikt/lumi-survey run build`
- `pnpm run verify:lumi-survey`
- `pnpm run lint`
- `pnpm run typecheck`
- `git diff --check`

Closes #335
