### PR TITLE
Show survey progress from first question

### DIFF
--- a/docs/referanse/props-referanse.md
+++ b/docs/referanse/props-referanse.md
@@ -60,7 +60,9 @@ Styrer åpning, lukking, lagring og layout.
 | `personalDataNotice` | `ReactNode` | ❌ | Tilpasset personverninfo |
 | `collectLocation` | `boolean` | `false` | Auto-collect `pathname` fra URL |
 | `storageStrategy` | `"consent" \| "localStorage" \| "none"` | `"consent"` | Lagringsstrategi for dismissed-tilstand |
-| `showProgress` | `boolean` | `false` | Vis fremdriftslinje i step-modus |
+| `showProgress` | `boolean` | `false` | Vis fremdrift fra første spørsmål i stegmodus når surveyen har minst to steg |
+
+Intro og kvittering regnes ikke som steg. Ved branching viser den visuelle linjen det stabile estimatet, mens tilgjengelig stegtekst bare oppgir sikker informasjon som «Steg 2» uten estimert total.
 
 ::: details questionLayout-verdier
 - **`"auto"`** (default): Step-modus brukes automatisk når branching-logikk (`logic`) finnes. Ellers vises alle synlige spørsmål på én side.

--- a/packages/lumi-survey/CHANGELOG.md
+++ b/packages/lumi-survey/CHANGELOG.md
@@ -13,6 +13,7 @@ This project follows SemVer.
 ### Changed
 
 - `createTopTasksSurvey` now expresses its flow with `visibleIf` instead of `logic`. Answer-based value conditions (`EQ`/`NEQ`/`GT`/`LT`/`CONTAINS`) automatically enable step mode under `questionLayout: "auto"`, while `EXISTS`-only progressive disclosure remains single-page. (#359)
+- `behavior.showProgress: true` now shows progress from the first question in step mode. Intro and success screens are not counted, and single-step surveys omit the indicator. Branching exposes only the known step number to assistive technology. (#334)
 
 ### Fixed
 

--- a/packages/lumi-survey/src/components/LumiSurveyDock/LumiSurveyDock.tsx
+++ b/packages/lumi-survey/src/components/LumiSurveyDock/LumiSurveyDock.tsx
@@ -425,7 +425,6 @@ export const LumiSurveyDock = ({
             showProgress: config.showProgress,
             totalSteps: totalVisibleSteps,
             hasBranching,
-            hasIntro: !!config.introTitle,
           }}
           questionContext={{
             promptQuestionId: promptQuestion.id,

--- a/packages/lumi-survey/src/components/LumiSurveyDock/__tests__/LumiSurveyDock.test.tsx
+++ b/packages/lumi-survey/src/components/LumiSurveyDock/__tests__/LumiSurveyDock.test.tsx
@@ -431,6 +431,52 @@ describe("LumiSurveyDock", () => {
     ).toBeInTheDocument();
   });
 
+  it("shows progress from the first question when explicitly enabled", async () => {
+    const user = userEvent.setup();
+    renderDock({
+      behavior: { questionLayout: "steps", showProgress: true },
+    });
+
+    const progressBar = await screen.findByRole("progressbar", {
+      name: "Fremdrift i undersøkelsen",
+    });
+
+    expect(progressBar).toHaveAttribute("aria-valuenow", "1");
+    expect(progressBar).toHaveAttribute("aria-valuemax", "3");
+    expect(progressBar).toHaveAttribute("aria-valuetext", "Steg 1 av 3");
+
+    await user.click(screen.getByRole("radio", { name: /5\./i }));
+    await user.click(screen.getByRole("button", { name: /neste/i }));
+    expect(progressBar).toHaveAttribute("aria-valuetext", "Steg 2 av 3");
+
+    await user.click(screen.getByRole("button", { name: /tilbake/i }));
+    expect(progressBar).toHaveAttribute("aria-valuetext", "Steg 1 av 3");
+  });
+
+  it("shows first-question progress after intro without counting intro as a step", async () => {
+    const user = userEvent.setup();
+    render(
+      <LumiSurveyDock
+        surveyId="dock-progress-with-intro"
+        survey={createSurvey()}
+        transport={{ submit: vi.fn().mockResolvedValue(undefined) }}
+        behavior={{ questionLayout: "steps", showProgress: true }}
+        intro={{ title: "Velkommen", body: "Kort intro" }}
+      />,
+    );
+
+    await screen.findByRole("heading", { name: "Velkommen" });
+    expect(screen.queryByRole("progressbar")).not.toBeInTheDocument();
+
+    await user.click(await screen.findByRole("button", { name: /start/i }));
+
+    expect(
+      await screen.findByRole("progressbar", {
+        name: "Fremdrift i undersøkelsen",
+      }),
+    ).toBeInTheDocument();
+  });
+
   it("displays validation errors when required questions are missing", async () => {
     const user = userEvent.setup();
     const events: LumiSurveyEvents = {

--- a/packages/lumi-survey/src/components/LumiSurveyDock/components/SurveyFormContent.tsx
+++ b/packages/lumi-survey/src/components/LumiSurveyDock/components/SurveyFormContent.tsx
@@ -1,4 +1,11 @@
-import { Alert, Button, HStack, ProgressBar, VStack } from "@navikt/ds-react";
+import {
+  Alert,
+  BodyShort,
+  Button,
+  HStack,
+  ProgressBar,
+  VStack,
+} from "@navikt/ds-react";
 import React, { useCallback, useRef } from "react";
 import type { LumiSurveyAnswerValue, LumiSurveyQuestion } from "../../../core";
 import { CLASS_NAMES } from "../classNames.js";
@@ -112,19 +119,31 @@ export const SurveyFormContent = React.memo(
 
     return (
       <>
-        {showProgress && isStepMode && totalSteps > 1 && (
-          <ProgressBar
-            value={currentStep + 1}
-            valueMax={totalSteps}
-            size="small"
-            aria-valuetext={
-              hasBranching
-                ? `Steg ${currentStep + 1}`
-                : `Steg ${currentStep + 1} av ${totalSteps}`
-            }
-            aria-label="Fremdrift i undersøkelsen"
-          />
-        )}
+        {showProgress &&
+          isStepMode &&
+          currentStep >= 0 &&
+          totalSteps > 1 &&
+          (hasBranching ? (
+            <>
+              <ProgressBar
+                value={currentStep + 1}
+                valueMax={totalSteps}
+                size="small"
+                aria-hidden
+              />
+              <BodyShort as="span" visuallyHidden>
+                {`Fremdrift i undersøkelsen: Steg ${currentStep + 1}`}
+              </BodyShort>
+            </>
+          ) : (
+            <ProgressBar
+              value={currentStep + 1}
+              valueMax={totalSteps}
+              size="small"
+              aria-valuetext={`Steg ${currentStep + 1} av ${totalSteps}`}
+              aria-label="Fremdrift i undersøkelsen"
+            />
+          ))}
 
         <form onSubmit={onSubmit} noValidate>
           <VStack gap="space-16">

--- a/packages/lumi-survey/src/components/LumiSurveyDock/components/SurveyFormContent.tsx
+++ b/packages/lumi-survey/src/components/LumiSurveyDock/components/SurveyFormContent.tsx
@@ -79,7 +79,6 @@ export const SurveyFormContent = React.memo(
       showProgress = false,
       totalSteps = 0,
       hasBranching = false,
-      hasIntro = false,
     } = progress;
 
     const {
@@ -113,21 +112,19 @@ export const SurveyFormContent = React.memo(
 
     return (
       <>
-        {showProgress &&
-          isStepMode &&
-          totalSteps > 0 &&
-          (hasIntro || currentStep > 0) && (
-            <ProgressBar
-              value={currentStep + 1}
-              valueMax={totalSteps}
-              size="small"
-              aria-label={
-                hasBranching
-                  ? `Steg ${currentStep + 1}`
-                  : `Steg ${currentStep + 1} av ${totalSteps}`
-              }
-            />
-          )}
+        {showProgress && isStepMode && totalSteps > 1 && (
+          <ProgressBar
+            value={currentStep + 1}
+            valueMax={totalSteps}
+            size="small"
+            aria-valuetext={
+              hasBranching
+                ? `Steg ${currentStep + 1}`
+                : `Steg ${currentStep + 1} av ${totalSteps}`
+            }
+            aria-label="Fremdrift i undersøkelsen"
+          />
+        )}
 
         <form onSubmit={onSubmit} noValidate>
           <VStack gap="space-16">

--- a/packages/lumi-survey/src/components/LumiSurveyDock/components/__tests__/SurveyFormContent.test.tsx
+++ b/packages/lumi-survey/src/components/LumiSurveyDock/components/__tests__/SurveyFormContent.test.tsx
@@ -315,7 +315,7 @@ describe("SurveyFormContent", () => {
 
   // ---- ProgressBar ----
 
-  it("shows ProgressBar when showProgress is true in step mode (after step 1)", () => {
+  it("shows ProgressBar when showProgress is true in step mode", () => {
     render(
       <SurveyFormContent
         {...defaultProps({
@@ -333,15 +333,18 @@ describe("SurveyFormContent", () => {
       />,
     );
 
-    // ProgressBar should be present with aria-label "Steg 2 av 3" (currentStep + 1)
     const progressBar = screen.getByRole("progressbar");
     expect(progressBar).toBeInTheDocument();
-    expect(progressBar).toHaveAttribute("aria-label", "Steg 2 av 3");
+    expect(progressBar).toHaveAttribute(
+      "aria-label",
+      "Fremdrift i undersøkelsen",
+    );
+    expect(progressBar).toHaveAttribute("aria-valuetext", "Steg 2 av 3");
     expect(progressBar).toHaveAttribute("aria-valuenow", "2");
     expect(progressBar).toHaveAttribute("aria-valuemax", "3");
   });
 
-  it("does NOT show ProgressBar on the first step (step 0)", () => {
+  it("shows ProgressBar on the first step", () => {
     render(
       <SurveyFormContent
         {...defaultProps({
@@ -353,6 +356,34 @@ describe("SurveyFormContent", () => {
           progress: {
             showProgress: true,
             totalSteps: 3,
+            hasBranching: false,
+          },
+        })}
+      />,
+    );
+
+    const progressBar = screen.getByRole("progressbar");
+    expect(progressBar).toHaveAttribute(
+      "aria-label",
+      "Fremdrift i undersøkelsen",
+    );
+    expect(progressBar).toHaveAttribute("aria-valuenow", "1");
+    expect(progressBar).toHaveAttribute("aria-valuemax", "3");
+    expect(progressBar).toHaveAttribute("aria-valuetext", "Steg 1 av 3");
+  });
+
+  it("does not show ProgressBar when the survey has only one step", () => {
+    render(
+      <SurveyFormContent
+        {...defaultProps({
+          stepNavigation: {
+            isStepMode: true,
+            currentStep: 0,
+            currentStepQuestion: ratingQuestion,
+          },
+          progress: {
+            showProgress: true,
+            totalSteps: 1,
             hasBranching: false,
           },
         })}
@@ -362,37 +393,13 @@ describe("SurveyFormContent", () => {
     expect(screen.queryByRole("progressbar")).not.toBeInTheDocument();
   });
 
-  it("shows ProgressBar on step 0 when survey has intro (hasIntro)", () => {
+  it("does not expose an estimated total as accessible text for branching", () => {
     render(
       <SurveyFormContent
         {...defaultProps({
           stepNavigation: {
             isStepMode: true,
             currentStep: 0,
-            currentStepQuestion: ratingQuestion,
-          },
-          progress: {
-            showProgress: true,
-            totalSteps: 3,
-            hasBranching: false,
-            hasIntro: true,
-          },
-        })}
-      />,
-    );
-
-    const progressBar = screen.getByRole("progressbar");
-    expect(progressBar).toBeInTheDocument();
-    expect(progressBar).toHaveAttribute("aria-label", "Steg 1 av 3");
-  });
-
-  it("shows ProgressBar with branching-aware label when hasBranching is true (after step 1)", () => {
-    render(
-      <SurveyFormContent
-        {...defaultProps({
-          stepNavigation: {
-            isStepMode: true,
-            currentStep: 1,
             currentStepQuestion: ratingQuestion,
           },
           progress: {
@@ -405,8 +412,11 @@ describe("SurveyFormContent", () => {
     );
 
     const progressBar = screen.getByRole("progressbar");
-    // When branching, label omits " av X" since total is unpredictable
-    expect(progressBar).toHaveAttribute("aria-label", "Steg 2");
+    expect(progressBar).toHaveAttribute(
+      "aria-label",
+      "Fremdrift i undersøkelsen",
+    );
+    expect(progressBar).toHaveAttribute("aria-valuetext", "Steg 1");
   });
 
   it("shows ProgressBar value based on currentStep + 1", () => {
@@ -445,6 +455,21 @@ describe("SurveyFormContent", () => {
           },
           progress: {
             showProgress: false,
+            totalSteps: 3,
+          },
+        })}
+      />,
+    );
+
+    expect(screen.queryByRole("progressbar")).not.toBeInTheDocument();
+  });
+
+  it("does not show ProgressBar outside step mode", () => {
+    render(
+      <SurveyFormContent
+        {...defaultProps({
+          progress: {
+            showProgress: true,
             totalSteps: 3,
           },
         })}

--- a/packages/lumi-survey/src/components/LumiSurveyDock/components/__tests__/SurveyFormContent.test.tsx
+++ b/packages/lumi-survey/src/components/LumiSurveyDock/components/__tests__/SurveyFormContent.test.tsx
@@ -411,15 +411,18 @@ describe("SurveyFormContent", () => {
       />,
     );
 
-    const progressBar = screen.getByRole("progressbar");
-    expect(progressBar).toHaveAttribute(
-      "aria-label",
-      "Fremdrift i undersøkelsen",
+    expect(screen.queryByRole("progressbar")).not.toBeInTheDocument();
+    expect(screen.getByText("Fremdrift i undersøkelsen: Steg 1")).toHaveClass(
+      "aksel-typo--visually-hidden",
     );
-    expect(progressBar).toHaveAttribute("aria-valuetext", "Steg 1");
+
+    const visualProgressBar = screen.getByRole("progressbar", {
+      hidden: true,
+    });
+    expect(visualProgressBar).toHaveAttribute("aria-hidden", "true");
   });
 
-  it("shows ProgressBar value based on currentStep + 1", () => {
+  it("shows visual branching progress based on currentStep + 1", () => {
     render(
       <SurveyFormContent
         {...defaultProps({
@@ -438,7 +441,7 @@ describe("SurveyFormContent", () => {
       />,
     );
 
-    const progressBar = screen.getByRole("progressbar");
+    const progressBar = screen.getByRole("progressbar", { hidden: true });
     // Value is always currentStep + 1, no isLastStep override
     expect(progressBar).toHaveAttribute("aria-valuenow", "5");
     expect(progressBar).toHaveAttribute("aria-valuemax", "5");
@@ -477,5 +480,45 @@ describe("SurveyFormContent", () => {
     );
 
     expect(screen.queryByRole("progressbar")).not.toBeInTheDocument();
+  });
+
+  it("waits to show ProgressBar until a question becomes visible", () => {
+    const { rerender } = render(
+      <SurveyFormContent
+        {...defaultProps({
+          stepNavigation: {
+            isStepMode: true,
+            currentStep: -1,
+          },
+          progress: {
+            showProgress: true,
+            totalSteps: 2,
+          },
+        })}
+      />,
+    );
+
+    expect(screen.queryByRole("progressbar")).not.toBeInTheDocument();
+
+    rerender(
+      <SurveyFormContent
+        {...defaultProps({
+          stepNavigation: {
+            isStepMode: true,
+            currentStep: 0,
+            currentStepQuestion: ratingQuestion,
+          },
+          progress: {
+            showProgress: true,
+            totalSteps: 2,
+          },
+        })}
+      />,
+    );
+
+    expect(screen.getByRole("progressbar")).toHaveAttribute(
+      "aria-valuetext",
+      "Steg 1 av 2",
+    );
   });
 });

--- a/packages/lumi-survey/src/components/LumiSurveyDock/dockTypes.ts
+++ b/packages/lumi-survey/src/components/LumiSurveyDock/dockTypes.ts
@@ -18,7 +18,6 @@ export interface ProgressProps {
   showProgress?: boolean;
   totalSteps?: number;
   hasBranching?: boolean;
-  hasIntro?: boolean;
 }
 
 export interface QuestionContextProps {

--- a/packages/lumi-survey/src/components/LumiSurveyDock/propTypes.ts
+++ b/packages/lumi-survey/src/components/LumiSurveyDock/propTypes.ts
@@ -119,8 +119,10 @@ export interface LumiSurveyBehavior {
   storageStrategy?: StorageStrategy;
 
   /**
-   * Show a progress bar in step mode.
-   * Only visible when questionLayout is "steps" or branching is active.
+   * Show progress from the first question in step mode when there are at least
+   * two reachable steps. Intro and success screens are not counted as steps.
+   * Branching reports the current step without claiming an estimated total to
+   * assistive technology.
    * @default false
    */
   showProgress?: boolean;

--- a/packages/lumi-survey/src/stories/LumiSurveyDock.custom.stories.tsx
+++ b/packages/lumi-survey/src/stories/LumiSurveyDock.custom.stories.tsx
@@ -193,7 +193,7 @@ export const Custom: Story = {
     docs: {
       description: {
         story:
-          "Step-by-step survey uten intro – hopper direkte til første spørsmål. Viser singleChoice, multiChoice, text og visibleIf (velg «Annet» på spørsmål 4 for å se oppfølgingsspørsmål).",
+          "Step-by-step survey uten intro. Fremdrift vises fra første spørsmål. Viser singleChoice, multiChoice, text og visibleIf (velg «Annet» på spørsmål 4 for å se oppfølgingsspørsmål).",
       },
     },
   },
@@ -225,7 +225,7 @@ export const MedIntro: Story = {
     docs: {
       description: {
         story:
-          "Samme survey med intro-skjerm, progress bar og visibleIf. Klikk «Start» for å se spørsmålene.",
+          "Samme survey med intro-skjerm, fremdrift og visibleIf. Introen regnes ikke som et steg; klikk «Start» for å se første spørsmål som steg 1.",
       },
     },
   },


### PR DESCRIPTION
## Hva endres

- viser fremdrift fra første spørsmål når `behavior.showProgress` er aktivert
- skjuler indikatoren for ettstegs-surveys, intro, kvittering og single-page-visning
- fjerner intro som intern betingelse for fremdrift
- bruker stabilt tilgjengelig navn og `aria-valuetext` med bare kjent stegnummer ved branching
- oppdaterer tester, stories, props-referanse og changelog

## Hvorfor

`showProgress: true` skjulte tidligere indikatoren på første spørsmål uten intro. Den dukket først opp som for eksempel «Steg 2 av 3», noe som ga en overraskende kontrakt og layoutskift underveis.

Standardverdien er fortsatt `false`, så endringen gjelder bare konsumenter som eksplisitt har valgt fremdrift.

## Validering

- 26 testfiler / 331 tester
- lint
- typecheck
- survey build og pakkeverifikasjon
- diff-check

Closes #334

Oppfølginger: #417 (fokus ved steg-navigasjon) og #418 (synlig stegtekst).
