### PR TITLE
Flytt fokus ved steg-navigasjon

### DIFF
--- a/packages/lumi-survey/CHANGELOG.md
+++ b/packages/lumi-survey/CHANGELOG.md
@@ -17,6 +17,7 @@ This project follows SemVer.
 
 ### Fixed
 
+- Step navigation now moves focus to the newly rendered question heading after both Next and Back, without stealing focus when an answer changes. (#417)
 - `logic` conditions that reference another question via `condition.questionId` are now evaluated against that question's answer instead of the current question's. Cross-question branching (e.g. routing on an earlier answer) now works the same way `visibleIf` already did. (#332)
 - Submissions now omit answers from questions hidden by `visibleIf` at submit time while retaining the complete survey definition. Hidden answers remain in local state so they are restored if the user reopens the branch. (#357)
 - Reachable-step estimates now count overlapping unresolved `visibleIf` branches (such as multiple `NEQ`/`CONTAINS` conditions or overlapping numeric ranges) together while still counting mutually exclusive branches only once. (#358)

--- a/packages/lumi-survey/src/components/LumiSurveyDock/LumiSurveyDock.tsx
+++ b/packages/lumi-survey/src/components/LumiSurveyDock/LumiSurveyDock.tsx
@@ -142,6 +142,7 @@ export const LumiSurveyDock = ({
 
   // Track previous showIntro value to detect intro → question transition
   const prevShowIntroRef = useRef(showIntro);
+  const pendingStepFocusQuestionIdRef = useRef<string | null>(null);
 
   /*
    * Use the new flexible survey builder.
@@ -219,6 +220,20 @@ export const LumiSurveyDock = ({
     ? `${surveyId}-${activeDescriptionQuestion.id}-dock-description`
     : undefined;
 
+  // Move focus only after an explicit step-navigation action has rendered its
+  // target question. Answer-driven visibility updates must not steal focus.
+  useEffect(() => {
+    if (
+      !currentStepQuestion ||
+      pendingStepFocusQuestionIdRef.current !== currentStepQuestion.id
+    ) {
+      return;
+    }
+
+    pendingStepFocusQuestionIdRef.current = null;
+    document.getElementById(promptHeadingId)?.focus();
+  }, [currentStepQuestion, promptHeadingId]);
+
   // Combined reset: clears survey answers, resets step navigation, and restores intro screen
   const handleFullReset = useCallback(() => {
     reset();
@@ -290,7 +305,15 @@ export const LumiSurveyDock = ({
 
   const handleNext = useCallback(async () => {
     const result = goToNext();
-    if (!result || result.nextIndex !== -1) {
+    if (result?.nextIndex !== undefined && result.nextIndex !== -1) {
+      const targetQuestionId = questions[result.nextIndex]?.id;
+      if (targetQuestionId !== currentStepQuestion?.id) {
+        pendingStepFocusQuestionIdRef.current = targetQuestionId ?? null;
+      }
+      return;
+    }
+
+    if (!result) {
       return;
     }
 
@@ -299,7 +322,17 @@ export const LumiSurveyDock = ({
     } catch {
       // useLumiSurvey sets error state; avoid unhandled rejections
     }
-  }, [goToNext, submit, visitedQuestions]);
+  }, [currentStepQuestion?.id, goToNext, questions, submit, visitedQuestions]);
+
+  const handleBack = useCallback(() => {
+    const previousIndex = goToPrevious();
+    if (previousIndex === null) return;
+
+    const targetQuestionId = questions[previousIndex]?.id;
+    if (targetQuestionId !== currentStepQuestion?.id) {
+      pendingStepFocusQuestionIdRef.current = targetQuestionId ?? null;
+    }
+  }, [currentStepQuestion?.id, goToPrevious, questions]);
 
   const handleSubmit = useCallback(
     async (event: React.FormEvent<HTMLFormElement>) => {
@@ -419,7 +452,7 @@ export const LumiSurveyDock = ({
             canGoNext,
             isLastStep,
             onNext: handleNext,
-            onBack: goToPrevious,
+            onBack: handleBack,
           }}
           progress={{
             showProgress: config.showProgress,

--- a/packages/lumi-survey/src/components/LumiSurveyDock/__tests__/accessibility.test.tsx
+++ b/packages/lumi-survey/src/components/LumiSurveyDock/__tests__/accessibility.test.tsx
@@ -230,4 +230,56 @@ describe("LumiSurveyDock Accessibility", () => {
       expect(questionHeading).toHaveFocus();
     });
   });
+
+  it("moves focus to the new question heading after Next and Back", async () => {
+    const user = userEvent.setup();
+    render(
+      <LumiSurveyDock
+        surveyId="focus-step-test"
+        survey={survey}
+        transport={mockTransport}
+        behavior={{ questionLayout: "steps" }}
+      />,
+    );
+
+    const rating = await screen.findByRole("radio", { name: /5\./i });
+    await user.click(rating);
+    expect(rating).toHaveFocus();
+
+    await user.click(screen.getByRole("button", { name: /neste/i }));
+
+    await waitFor(() => {
+      expect(
+        screen.getByRole("heading", { name: /hva kan vi forbedre/i }),
+      ).toHaveFocus();
+    });
+
+    await user.click(screen.getByRole("button", { name: /tilbake/i }));
+
+    await waitFor(() => {
+      expect(
+        screen.getByRole("heading", { name: /hvor fornøyd er du/i }),
+      ).toHaveFocus();
+    });
+  });
+
+  it("does not move focus to the heading for an ordinary answer change", async () => {
+    const user = userEvent.setup();
+    render(
+      <LumiSurveyDock
+        surveyId="focus-answer-test"
+        survey={survey}
+        transport={mockTransport}
+        behavior={{ questionLayout: "steps" }}
+      />,
+    );
+
+    const rating = await screen.findByRole("radio", { name: /5\./i });
+    await user.click(rating);
+
+    expect(rating).toHaveFocus();
+    expect(
+      screen.getByRole("heading", { name: /hvor fornøyd er du/i }),
+    ).not.toHaveFocus();
+  });
 });

--- a/packages/lumi-survey/src/components/LumiSurveyDock/hooks/useStepNavigation.ts
+++ b/packages/lumi-survey/src/components/LumiSurveyDock/hooks/useStepNavigation.ts
@@ -52,8 +52,8 @@ export interface UseStepNavigationReturn {
   isLastStep: boolean;
   /** Navigate to the next question based on branching logic */
   goToNext: () => BranchingResult | null;
-  /** Navigate to the previous question in history */
-  goToPrevious: () => void;
+  /** Navigate to the previous question in history and return its question index */
+  goToPrevious: () => number | null;
   /** Reset navigation to the first question */
   resetNavigation: () => void;
   /** Whether the survey contains logic or answer-dependent visibility branching */
@@ -291,7 +291,7 @@ export function useStepNavigation(
   // become hidden since they were visited (e.g. because the user changed an
   // earlier answer that affected visibleIf conditions).
   const goToPrevious = useCallback(() => {
-    if (visitedSteps.length <= 1) return;
+    if (visitedSteps.length <= 1) return null;
 
     // Remove current step and search backward for a still-visible step
     const previousHistory = visitedSteps.slice(0, -1);
@@ -306,15 +306,16 @@ export function useStepNavigation(
       setVisitedSteps(result.history);
       setCurrentStep(result.step);
       setDisplayedTotal(reachableStepsRef.current);
-      return;
+      return result.step;
     }
 
     // No visited steps are visible — fall back to first visible question
     const firstVisible = findNextVisibleIndex(questions, answers, metadata, 0);
-    if (firstVisible === -1) return;
+    if (firstVisible === -1) return null;
     setVisitedSteps([firstVisible]);
     setCurrentStep(firstVisible);
     setDisplayedTotal(reachableStepsRef.current);
+    return firstVisible;
   }, [visitedSteps, questions, answers, metadata]);
 
   // Reset to the beginning — used when the survey definition changes or


### PR DESCRIPTION
## Hva

- flytter fokus til overskriften for det nye spørsmålet etter «Neste» og «Tilbake»
- lar vanlige svarendringer beholde fokus på skjemakontrollen
- lar navigasjonshooken returnere den faktiske tilbake-destinasjonen, slik at fokus bare flyttes ved reell navigasjon
- legger til regresjonstester og changelog

## Hvorfor

I stegmodus ble innholdet byttet uten at tastatur- og skjermleserbrukere ble flyttet til starten av det nye spørsmålet. Overskriften hadde allerede `tabIndex={-1}`, men fokuslogikken fantes bare for intro → første spørsmål.

Closes #417

## Validering

- `npm test` i `packages/lumi-survey` — 26 filer / 334 tester
- `npm run lint`
- `npm run typecheck`
- `npm run verify:lumi-survey`
- axe-regresjoner
- rendret Storybook-flyt: aktivt fokus er H2 etter både Neste og Tilbake; tilgjengelighetstreet viser riktig overskrift
