### PR TITLE
Vis tekstlig stegstatus ved fremdriftsindikatoren

### DIFF
--- a/docs/referanse/props-referanse.md
+++ b/docs/referanse/props-referanse.md
@@ -60,7 +60,7 @@ Styrer åpning, lukking, lagring og layout.
 | `personalDataNotice` | `ReactNode` | ❌ | Tilpasset personverninfo |
 | `collectLocation` | `boolean` | `false` | Auto-collect `pathname` fra URL |
 | `storageStrategy` | `"consent" \| "localStorage" \| "none"` | `"consent"` | Lagringsstrategi for dismissed-tilstand |
-| `showProgress` | `boolean` | `false` | Vis fremdrift fra første spørsmål i stegmodus når surveyen har minst to steg |
+| `showProgress` | `boolean` | `false` | Vis fremdrift med synlig stegtekst fra første spørsmål i stegmodus når surveyen har minst to steg. Lineære løp viser `Steg X av N`; branching viser `Steg X` |
 
 Intro og kvittering regnes ikke som steg. Ved branching viser den visuelle linjen det stabile estimatet, mens tilgjengelig stegtekst bare oppgir sikker informasjon som «Steg 2» uten estimert total.
 

--- a/packages/lumi-survey/CHANGELOG.md
+++ b/packages/lumi-survey/CHANGELOG.md
@@ -14,6 +14,7 @@ This project follows SemVer.
 
 - `createTopTasksSurvey` now expresses its flow with `visibleIf` instead of `logic`. Answer-based value conditions (`EQ`/`NEQ`/`GT`/`LT`/`CONTAINS`) automatically enable step mode under `questionLayout: "auto"`, while `EXISTS`-only progressive disclosure remains single-page. (#359)
 - `behavior.showProgress: true` now shows progress from the first question in step mode. Intro and success screens are not counted, and single-step surveys omit the indicator. Branching exposes only the known step number to assistive technology. (#334)
+- Progress indicators now include visible step text: `Steg X av N` for linear surveys and `Steg X` when branching makes the total uncertain. (#418)
 
 ### Fixed
 

--- a/packages/lumi-survey/src/components/LumiSurveyDock/components/SurveyFormContent.tsx
+++ b/packages/lumi-survey/src/components/LumiSurveyDock/components/SurveyFormContent.tsx
@@ -94,6 +94,10 @@ export const SurveyFormContent = React.memo(
       promptDescriptionId,
       validationErrorMessage,
     } = questionContext;
+    const currentStepNumber = currentStep + 1;
+    const stepStatus = hasBranching
+      ? `Steg ${currentStepNumber}`
+      : `Steg ${currentStepNumber} av ${totalSteps}`;
     // Stable onChange handlers per question-id so React.memo on
     // DockQuestionRenderer can skip re-renders when props haven't changed.
     const onQuestionChangeRef = useRef(onQuestionChange);
@@ -119,31 +123,34 @@ export const SurveyFormContent = React.memo(
 
     return (
       <>
-        {showProgress &&
-          isStepMode &&
-          currentStep >= 0 &&
-          totalSteps > 1 &&
-          (hasBranching ? (
-            <>
+        {showProgress && isStepMode && currentStep >= 0 && totalSteps > 1 && (
+          <VStack gap="space-4">
+            <BodyShort size="small" aria-hidden>
+              {stepStatus}
+            </BodyShort>
+            {hasBranching ? (
               <ProgressBar
-                value={currentStep + 1}
+                value={currentStepNumber}
                 valueMax={totalSteps}
                 size="small"
                 aria-hidden
               />
+            ) : (
+              <ProgressBar
+                value={currentStepNumber}
+                valueMax={totalSteps}
+                size="small"
+                aria-valuetext={stepStatus}
+                aria-label="Fremdrift i undersøkelsen"
+              />
+            )}
+            {hasBranching && (
               <BodyShort as="span" visuallyHidden>
-                {`Fremdrift i undersøkelsen: Steg ${currentStep + 1}`}
+                {`Fremdrift i undersøkelsen: ${stepStatus}`}
               </BodyShort>
-            </>
-          ) : (
-            <ProgressBar
-              value={currentStep + 1}
-              valueMax={totalSteps}
-              size="small"
-              aria-valuetext={`Steg ${currentStep + 1} av ${totalSteps}`}
-              aria-label="Fremdrift i undersøkelsen"
-            />
-          ))}
+            )}
+          </VStack>
+        )}
 
         <form onSubmit={onSubmit} noValidate>
           <VStack gap="space-16">

--- a/packages/lumi-survey/src/components/LumiSurveyDock/components/__tests__/SurveyFormContent.test.tsx
+++ b/packages/lumi-survey/src/components/LumiSurveyDock/components/__tests__/SurveyFormContent.test.tsx
@@ -342,6 +342,12 @@ describe("SurveyFormContent", () => {
     expect(progressBar).toHaveAttribute("aria-valuetext", "Steg 2 av 3");
     expect(progressBar).toHaveAttribute("aria-valuenow", "2");
     expect(progressBar).toHaveAttribute("aria-valuemax", "3");
+
+    const visibleStatus = screen.getByText("Steg 2 av 3");
+    expect(visibleStatus).toHaveClass("aksel-body-short--small");
+    expect(visibleStatus).toHaveAttribute("aria-hidden", "true");
+    expect(visibleStatus).not.toHaveClass("aksel-typo--visually-hidden");
+    expect(visibleStatus.parentElement).toBe(progressBar.parentElement);
   });
 
   it("shows ProgressBar on the first step", () => {
@@ -416,10 +422,16 @@ describe("SurveyFormContent", () => {
       "aksel-typo--visually-hidden",
     );
 
+    const visibleStatus = screen.getByText("Steg 1");
+    expect(visibleStatus).toHaveClass("aksel-body-short--small");
+    expect(visibleStatus).toHaveAttribute("aria-hidden", "true");
+    expect(visibleStatus).not.toHaveClass("aksel-typo--visually-hidden");
+
     const visualProgressBar = screen.getByRole("progressbar", {
       hidden: true,
     });
     expect(visualProgressBar).toHaveAttribute("aria-hidden", "true");
+    expect(visibleStatus.parentElement).toBe(visualProgressBar.parentElement);
   });
 
   it("shows visual branching progress based on currentStep + 1", () => {

--- a/packages/lumi-survey/src/components/LumiSurveyDock/propTypes.ts
+++ b/packages/lumi-survey/src/components/LumiSurveyDock/propTypes.ts
@@ -120,9 +120,9 @@ export interface LumiSurveyBehavior {
 
   /**
    * Show progress from the first question in step mode when there are at least
-   * two reachable steps. Intro and success screens are not counted as steps.
-   * Branching reports the current step without claiming an estimated total to
-   * assistive technology.
+   * two reachable steps, including visible step text above the indicator. Intro
+   * and success screens are not counted as steps. Branching shows only the known
+   * current step because its estimated total may change.
    * @default false
    */
   showProgress?: boolean;

--- a/packages/lumi-survey/src/stories/LumiSurveyDock.custom.stories.tsx
+++ b/packages/lumi-survey/src/stories/LumiSurveyDock.custom.stories.tsx
@@ -150,6 +150,11 @@ const CUSTOM_SURVEY: LumiSurveyConfig = {
   ],
 };
 
+const LINEAR_PROGRESS_SURVEY: LumiSurveyConfig = {
+  type: "custom",
+  questions: CUSTOM_SURVEY.questions.slice(0, 3),
+};
+
 const meta: Meta<typeof LumiSurveyDock> = {
   title: "Components/LumiSurveyDock/Custom",
   component: LumiSurveyDock,
@@ -178,6 +183,28 @@ const meta: Meta<typeof LumiSurveyDock> = {
 export default meta;
 
 type Story = StoryObj<typeof LumiSurveyDock>;
+
+export const LinearProgress: Story = {
+  name: "Lineær fremdrift",
+  render: (args) => <ExamplePage {...args} />,
+  args: {
+    surveyId: "storybook-dock-linear-progress",
+    survey: LINEAR_PROGRESS_SURVEY,
+    behavior: {
+      questionLayout: "steps",
+      storageStrategy: "consent",
+      showProgress: true,
+    },
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "Lineær stegflyt med synlig «Steg X av N»-tekst over fremdriftsindikatoren.",
+      },
+    },
+  },
+};
 
 export const Custom: Story = {
   name: "Custom",


### PR DESCRIPTION
## Hva

- viser `Steg X av N` over fremdriftsindikatoren i lineære stegflyter
- viser bare `Steg X` når branching gjør totalen usikker
- beholder eksisterende tilgjengelig semantikk uten å lese den synlige teksten dobbelt
- bruker kun Aksel `BodyShort`, `VStack` og spacing-token; ingen lokal CSS
- legger til kontrakttester, lineær Storybook-story, dokumentasjon og changelog

## Hvorfor

Fremdriftslinjen alene ga ikke alle brukere et tydelig, tekstlig svar på hvor de var i undersøkelsen. Aksel anbefaler tekst sammen med fremdriftsindikatoren. Branching må samtidig unngå å presentere et estimert totalantall som sikkert.

Closes #418

## Validering

- `npm test` i `packages/lumi-survey` — 26 filer / 332 tester
- `npm run lint`
- `npm run typecheck`
- `npm run verify:lumi-survey`
- `npm run build-storybook`
- visuell QA i 360 px viewport for lineær og branching; ingen horisontal overflow
