### PR TITLE
Upgrade Ktor without weakening rate limits

### DIFF
--- a/apps/lumi-api/build.gradle.kts
+++ b/apps/lumi-api/build.gradle.kts
@@ -5,7 +5,7 @@ plugins {
     // Keep this at 2.3.0 for now; current CodeQL (linked tools v2.24.1) does not support 2.3.10 yet.
     kotlin("jvm")
     kotlin("plugin.serialization")
-    id("io.ktor.plugin") version "3.5.1"
+    id("io.ktor.plugin") version "3.5.2"
     id("com.gradleup.shadow") version "9.6.1"
     id("com.github.ben-manes.versions") version "0.60.0"
     application
@@ -25,7 +25,7 @@ repositories {
     }
 }
 
-val ktorVersion = "3.5.1"
+val ktorVersion = "3.5.2"
 val logbackVersion = "1.6.1"
 val logstashVersion = "9.0"
 val postgresVersion = "42.7.13"

--- a/apps/lumi-api/src/main/kotlin/no/nav/lumi/config/RateLimiting.kt
+++ b/apps/lumi-api/src/main/kotlin/no/nav/lumi/config/RateLimiting.kt
@@ -4,14 +4,16 @@ import io.ktor.http.*
 import io.ktor.server.application.*
 import io.ktor.server.auth.*
 import io.ktor.server.plugins.ratelimit.*
-import io.ktor.server.response.*
 import io.ktor.server.routing.*
 import io.ktor.util.*
 import io.ktor.util.collections.*
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
+import no.nav.lumi.config.auth.AuthorizationAttributes
 import no.nav.lumi.config.auth.CallerIdentityKey
 import no.nav.lumi.config.auth.UserRateLimitHashKey
+import no.nav.lumi.config.auth.pseudonymizeIdentifier
+import no.nav.lumi.config.exception.ApiErrorException
 import kotlin.time.Duration.Companion.minutes
 
 /**
@@ -26,12 +28,14 @@ import kotlin.time.Duration.Companion.minutes
  *   `requestKey`. These routes are therefore keyed per caller-app and, when a
  *   user hash is present, per hashed user.
  * - Analytics/export routes: `rateLimit` is nested inside `authenticate`, so
- *   [rateLimitKey] uses the validated `BrukerPrincipal` and separates callers.
+ *   [rateLimitKey] uses the validated `BrukerPrincipal` and a pseudonymized
+ *   user identifier to separate dashboard users of the shared client.
  * - Rejected export authentication: Ktor does not execute an inner rate limiter
  *   when authentication rejects the call. [rateLimitRejectedExportAuthentication]
- *   therefore reserves a source-IP permit before auth and refunds it when a
- *   principal is established. Invalid credentials keep the permit and receive
- *   429 after 30 attempts per minute, even when every token value is different.
+ *   therefore reserves a source-IP permit before auth. The permit is refunded
+ *   only after client and team authorization have completed. Rejected requests
+ *   keep the permit and receive 429 after 30 attempts per minute, even when
+ *   every token value is different.
  */
 
 val SubmissionRateLimit = RateLimitName("submission")
@@ -60,15 +64,20 @@ private val RejectedExportAuthenticationRateLimit = createRouteScopedPlugin(
         }
 
         if (!bucket.reserve()) {
-            call.respond(HttpStatusCode.TooManyRequests)
-            return@onCall
+            throw ApiErrorException.TooManyRequestsException(
+                "For mange avviste eksportkall. Prøv igjen senere."
+            )
         }
 
         call.attributes.put(RejectedAuthenticationReservationKey, bucket)
     }
+}
 
+private val AuthorizedExportAuthenticationRefund = createRouteScopedPlugin(
+    "AuthorizedExportAuthenticationRefund"
+) {
     on(AuthenticationChecked) { call ->
-        if (call.principal<Any>() != null) {
+        if (call.attributes.getOrNull(AuthorizationAttributes.AuthorizedPrincipalKey) != null) {
             call.attributes.getOrNull(RejectedAuthenticationReservationKey)?.release()
         }
     }
@@ -103,6 +112,10 @@ internal fun Route.rateLimitRejectedExportAuthentication(build: Route.() -> Unit
         install(RejectedExportAuthenticationRateLimit)
         build()
     }
+
+internal fun Route.refundRejectedExportAuthenticationAfterAuthorization() {
+    install(AuthorizedExportAuthenticationRefund)
+}
 
 fun Application.configureRateLimiting() {
     install(RateLimit) {
@@ -147,10 +160,20 @@ private fun io.ktor.server.application.ApplicationCall.rateLimitKey(): String {
 
     // Ktor 3.5.2 makes the principal available when authenticate wraps rateLimit.
     getBrukerPrincipal()?.let { principal ->
-        extractCallerIdentityFromPrincipal(principal)?.let { identity ->
-            return "${identity.team}:${identity.app}"
+        val clientKey = extractCallerIdentityFromPrincipal(principal)?.let { identity ->
+            "${identity.team}:${identity.app}"
+        } ?: principal.clientId?.takeIf { it.isNotBlank() }
+
+        if (clientKey != null) {
+            val userIdentifier = principal.navIdent?.takeIf { it.isNotBlank() }
+                ?: principal.email?.takeIf { it.isNotBlank() }
+
+            return if (userIdentifier != null) {
+                "$clientKey:user:${pseudonymizeIdentifier(userIdentifier)}"
+            } else {
+                clientKey
+            }
         }
-        principal.clientId?.takeIf { it.isNotBlank() }?.let { return it }
     }
 
     return sourceAddress()

--- a/apps/lumi-api/src/main/kotlin/no/nav/lumi/config/RateLimiting.kt
+++ b/apps/lumi-api/src/main/kotlin/no/nav/lumi/config/RateLimiting.kt
@@ -1,7 +1,15 @@
 package no.nav.lumi.config
 
+import io.ktor.http.*
 import io.ktor.server.application.*
+import io.ktor.server.auth.*
 import io.ktor.server.plugins.ratelimit.*
+import io.ktor.server.response.*
+import io.ktor.server.routing.*
+import io.ktor.util.*
+import io.ktor.util.collections.*
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
 import no.nav.lumi.config.auth.CallerIdentityKey
 import no.nav.lumi.config.auth.UserRateLimitHashKey
 import kotlin.time.Duration.Companion.minutes
@@ -9,27 +17,21 @@ import kotlin.time.Duration.Companion.minutes
 /**
  * Rate limiting to prevent abuse.
  *
- * Keying semantics differ per route family because of *when* identity becomes
- * available relative to the RateLimit plugin.
- *
- * On Ktor 3.5.1 the RateLimit `requestKey` is evaluated before a Ktor
- * `BrukerPrincipal` from the standard `authenticate` flow is available. In this
- * version rejected nested `authenticate` calls also count toward the limit
- * (KTOR-9621) instead of bypassing it.
+ * Keying semantics differ per route family because Ktor 3.5.2 executes
+ * authentication and rate limiting according to their route nesting.
  *
  * - Submission routes: a route-scoped auth plugin
  *   (Token/Azure SubmissionAuthPlugin) sets [CallerIdentityKey] and
  *   [UserRateLimitHashKey] in its `onCall`, which runs before the RateLimit
  *   `requestKey`. These routes are therefore keyed per caller-app and, when a
  *   user hash is present, per hashed user.
- * - Analytics/export routes: authentication happens in the standard Ktor
- *   `authenticate` flow, so no principal is available when `requestKey` runs.
- *   These routes fall back to the caller's source IP (X-Forwarded-For on NAIS,
- *   otherwise the remote address). They are NOT keyed per validated user.
- *
- * The `getBrukerPrincipal()` branch in [rateLimitKey] is a defensive fallback
- * that only fires if a principal is already present when `requestKey` runs; it
- * does not fire for the normal Ktor `authenticate` flow.
+ * - Analytics/export routes: `rateLimit` is nested inside `authenticate`, so
+ *   [rateLimitKey] uses the validated `BrukerPrincipal` and separates callers.
+ * - Rejected export authentication: Ktor does not execute an inner rate limiter
+ *   when authentication rejects the call. [rateLimitRejectedExportAuthentication]
+ *   therefore reserves a source-IP permit before auth and refunds it when a
+ *   principal is established. Invalid credentials keep the permit and receive
+ *   429 after 30 attempts per minute, even when every token value is different.
  */
 
 val SubmissionRateLimit = RateLimitName("submission")
@@ -37,15 +39,80 @@ val UserSubmissionRateLimit = RateLimitName("user-submission")
 val AnalyticsRateLimit = RateLimitName("analytics")
 val ExportRateLimit = RateLimitName("export")
 
+private const val EXPORT_REQUESTS_PER_MINUTE = 30
+private val RATE_LIMIT_REFILL_PERIOD = 1.minutes
+
+private val RejectedExportAuthenticationRateLimit = createRouteScopedPlugin(
+    "RejectedExportAuthenticationRateLimit"
+) {
+    val buckets = ConcurrentMap<String, RejectedAuthenticationBucket>()
+    val pluginApplication = application
+
+    onCall { call ->
+        val key = call.sourceAddress()
+        val bucket = buckets.computeIfAbsent(key) {
+            RejectedAuthenticationBucket(limit = EXPORT_REQUESTS_PER_MINUTE).also { created ->
+                pluginApplication.launch {
+                    delay(RATE_LIMIT_REFILL_PERIOD)
+                    buckets.remove(key, created)
+                }
+            }
+        }
+
+        if (!bucket.reserve()) {
+            call.respond(HttpStatusCode.TooManyRequests)
+            return@onCall
+        }
+
+        call.attributes.put(RejectedAuthenticationReservationKey, bucket)
+    }
+
+    on(AuthenticationChecked) { call ->
+        if (call.principal<Any>() != null) {
+            call.attributes.getOrNull(RejectedAuthenticationReservationKey)?.release()
+        }
+    }
+}
+
+private val RejectedAuthenticationReservationKey =
+    AttributeKey<RejectedAuthenticationBucket>("RejectedAuthenticationReservation")
+
+private class RejectedAuthenticationBucket(private val limit: Int) {
+    private var remaining = limit
+
+    @Synchronized
+    fun reserve(): Boolean {
+        if (remaining == 0) return false
+        remaining--
+        return true
+    }
+
+    @Synchronized
+    fun release() {
+        if (remaining < limit) remaining++
+    }
+}
+
+private object RejectedExportAuthenticationRateLimitSelector : RouteSelector() {
+    override suspend fun evaluate(context: RoutingResolveContext, segmentIndex: Int) =
+        RouteSelectorEvaluation.Transparent
+}
+
+internal fun Route.rateLimitRejectedExportAuthentication(build: Route.() -> Unit): Route =
+    createChild(RejectedExportAuthenticationRateLimitSelector).apply {
+        install(RejectedExportAuthenticationRateLimit)
+        build()
+    }
+
 fun Application.configureRateLimiting() {
     install(RateLimit) {
         register(SubmissionRateLimit) {
-            rateLimiter(limit = 100, refillPeriod = 1.minutes)
+            rateLimiter(limit = 100, refillPeriod = RATE_LIMIT_REFILL_PERIOD)
             requestKey { call -> call.rateLimitKey() }
         }
 
         register(UserSubmissionRateLimit) {
-            rateLimiter(limit = 15, refillPeriod = 1.minutes)
+            rateLimiter(limit = 15, refillPeriod = RATE_LIMIT_REFILL_PERIOD)
             requestKey { call ->
                 call.attributes.getOrNull(UserRateLimitHashKey)
                     ?: call.rateLimitKey()
@@ -56,17 +123,17 @@ fun Application.configureRateLimiting() {
         }
         
         register(AnalyticsRateLimit) {
-            rateLimiter(limit = 300, refillPeriod = 1.minutes)
+            rateLimiter(limit = 300, refillPeriod = RATE_LIMIT_REFILL_PERIOD)
             requestKey { call -> call.rateLimitKey() }
         }
 
         register(ExportRateLimit) {
-            rateLimiter(limit = 30, refillPeriod = 1.minutes)
+            rateLimiter(limit = EXPORT_REQUESTS_PER_MINUTE, refillPeriod = RATE_LIMIT_REFILL_PERIOD)
             requestKey { call -> call.rateLimitKey() }
         }
         
         global {
-            rateLimiter(limit = 1000, refillPeriod = 1.minutes)
+            rateLimiter(limit = 1000, refillPeriod = RATE_LIMIT_REFILL_PERIOD)
         }
     }
 }
@@ -78,9 +145,7 @@ private fun io.ktor.server.application.ApplicationCall.rateLimitKey(): String {
         return "${identity.team}:${identity.app}"
     }
 
-    // Defensive fallback: only fires if a BrukerPrincipal is already present when
-    // this requestKey runs. For the normal Ktor authenticate flow the principal is
-    // not yet set here, so analytics/export fall through to IP below.
+    // Ktor 3.5.2 makes the principal available when authenticate wraps rateLimit.
     getBrukerPrincipal()?.let { principal ->
         extractCallerIdentityFromPrincipal(principal)?.let { identity ->
             return "${identity.team}:${identity.app}"
@@ -88,8 +153,11 @@ private fun io.ktor.server.application.ApplicationCall.rateLimitKey(): String {
         principal.clientId?.takeIf { it.isNotBlank() }?.let { return it }
     }
 
-    val env = ServerEnv.current
-    val forwardedFor = if (env.nais.isNais) {
+    return sourceAddress()
+}
+
+private fun io.ktor.server.application.ApplicationCall.sourceAddress(): String {
+    val forwardedFor = if (ServerEnv.current.nais.isNais) {
         request.headers["X-Forwarded-For"]?.split(",")?.firstOrNull()?.trim()
     } else {
         null

--- a/apps/lumi-api/src/main/kotlin/no/nav/lumi/config/Routing.kt
+++ b/apps/lumi-api/src/main/kotlin/no/nav/lumi/config/Routing.kt
@@ -39,16 +39,7 @@ fun Application.configureRouting() {
         createChild(CorsScopeSelector).apply {
             installCors()
 
-            // Protected analytics API - requires Azure AD from frontend
-            authenticate(AZURE_REALM) {
-                // Validate that caller is the allowed lumi-dashboard frontend
-                install(ClientAuthorizationPlugin) {
-                    allowedClientId = getDashboardClientId()
-                }
-
-                // Enforce team authorization based on user's NAIS team membership.
-                install(TeamAuthorizationPlugin)
-
+            protectedAnalyticsRoutes {
                 rateLimit(AnalyticsRateLimit) {
                     filterRoutes()
                     feedbackRoutes()
@@ -59,14 +50,27 @@ fun Application.configureRouting() {
                     discoveryRoutes()
                     teamsRoutes()
                 }
+            }
 
-                rateLimit(ExportRateLimit) {
-                    exportRoutes()
+            rateLimitRejectedExportAuthentication {
+                protectedAnalyticsRoutes {
+                    rateLimit(ExportRateLimit) {
+                        exportRoutes()
+                    }
                 }
             }
         }
     }
 }
+
+private fun Route.protectedAnalyticsRoutes(build: Route.() -> Unit): Route =
+    authenticate(AZURE_REALM) {
+        install(ClientAuthorizationPlugin) {
+            allowedClientId = getDashboardClientId()
+        }
+        install(TeamAuthorizationPlugin)
+        build()
+    }
 
 /**
  * Transparent route selector used to scope CORS to analytics routes only.

--- a/apps/lumi-api/src/main/kotlin/no/nav/lumi/config/Routing.kt
+++ b/apps/lumi-api/src/main/kotlin/no/nav/lumi/config/Routing.kt
@@ -53,7 +53,7 @@ fun Application.configureRouting() {
             }
 
             rateLimitRejectedExportAuthentication {
-                protectedAnalyticsRoutes {
+                protectedAnalyticsRoutes(refundRejectedExportReservation = true) {
                     rateLimit(ExportRateLimit) {
                         exportRoutes()
                     }
@@ -63,12 +63,18 @@ fun Application.configureRouting() {
     }
 }
 
-private fun Route.protectedAnalyticsRoutes(build: Route.() -> Unit): Route =
+private fun Route.protectedAnalyticsRoutes(
+    refundRejectedExportReservation: Boolean = false,
+    build: Route.() -> Unit,
+): Route =
     authenticate(AZURE_REALM) {
         install(ClientAuthorizationPlugin) {
             allowedClientId = getDashboardClientId()
         }
         install(TeamAuthorizationPlugin)
+        if (refundRejectedExportReservation) {
+            refundRejectedExportAuthenticationAfterAuthorization()
+        }
         build()
     }
 

--- a/apps/lumi-api/src/test/kotlin/no/nav/lumi/config/RateLimitingKeyingTest.kt
+++ b/apps/lumi-api/src/test/kotlin/no/nav/lumi/config/RateLimitingKeyingTest.kt
@@ -13,6 +13,8 @@ import io.ktor.server.testing.*
 import no.nav.lumi.config.auth.BrukerPrincipal
 import no.nav.lumi.config.auth.CallerIdentity
 import no.nav.lumi.config.auth.CallerIdentityKey
+import no.nav.lumi.config.auth.ClientAuthorizationPlugin
+import no.nav.lumi.config.auth.TeamAuthorizationPlugin
 import no.nav.lumi.config.auth.UserRateLimitHashKey
 import no.nav.lumi.config.exception.ApiErrorException
 
@@ -86,24 +88,26 @@ class RateLimitingKeyingTest : FunSpec({
         }
     }
 
-    test("export rate limit uses separate buckets per validated caller identity") {
+    test("export rate limit uses separate buckets per authorized user in the same client") {
         testApplication {
             application {
+                configureSerialization()
+                configureStatusPages()
                 configureRateLimiting()
                 install(Authentication) {
                     bearer(AZURE_REALM) {
                         authenticate { credential ->
-                            val clientId = when (credential.token) {
-                                "client-a" -> "dev-gcp:team-esyfo:app-a"
-                                "client-b" -> "dev-gcp:team-esyfo:app-b"
+                            val navIdent = when (credential.token) {
+                                "user-a" -> "Z111111"
+                                "user-b" -> "Z222222"
                                 else -> null
                             } ?: return@authenticate null
 
                             BrukerPrincipal(
-                                navIdent = "Z123456",
+                                navIdent = navIdent,
                                 name = "Rate Limit Test",
                                 email = "rate.limit.test@nav.no",
-                                clientId = clientId,
+                                clientId = "dev-gcp:team-esyfo:lumi-dashboard",
                             )
                         }
                     }
@@ -112,6 +116,13 @@ class RateLimitingKeyingTest : FunSpec({
                 routing {
                     rateLimitRejectedExportAuthentication {
                         authenticate(AZURE_REALM) {
+                            install(ClientAuthorizationPlugin) {
+                                allowedClientId = "dev-gcp:team-esyfo:lumi-dashboard"
+                            }
+                            install(TeamAuthorizationPlugin) {
+                                naisTeamLookupProvider = { null }
+                            }
+                            refundRejectedExportAuthenticationAfterAuthorization()
                             rateLimit(ExportRateLimit) {
                                 get("/export-test") {
                                     call.respond(HttpStatusCode.OK)
@@ -124,42 +135,42 @@ class RateLimitingKeyingTest : FunSpec({
 
             repeat(30) {
                 val response = client.get("/export-test") {
-                    header(HttpHeaders.Authorization, "Bearer client-a")
+                    header(HttpHeaders.Authorization, "Bearer user-a")
                 }
                 response.status shouldBe HttpStatusCode.OK
             }
 
             val blockedResponse = client.get("/export-test") {
-                header(HttpHeaders.Authorization, "Bearer client-a")
+                header(HttpHeaders.Authorization, "Bearer user-a")
             }
             blockedResponse.status shouldBe HttpStatusCode.TooManyRequests
 
-            // A different validated client has its own bucket under Ktor 3.5.2.
-            val otherClientResponse = client.get("/export-test") {
-                header(HttpHeaders.Authorization, "Bearer client-b")
+            // A different validated user of the same dashboard client has a separate bucket.
+            val otherUserResponse = client.get("/export-test") {
+                header(HttpHeaders.Authorization, "Bearer user-b")
             }
-            otherClientResponse.status shouldBe HttpStatusCode.OK
+            otherUserResponse.status shouldBe HttpStatusCode.OK
         }
     }
 
-    test("analytics rate limit uses separate buckets per validated caller identity") {
+    test("analytics rate limit uses separate buckets per validated user in the same client") {
         testApplication {
             application {
                 configureRateLimiting()
                 install(Authentication) {
                     bearer(AZURE_REALM) {
                         authenticate { credential ->
-                            val clientId = when (credential.token) {
-                                "client-a" -> "dev-gcp:team-esyfo:app-a"
-                                "client-b" -> "dev-gcp:team-esyfo:app-b"
+                            val navIdent = when (credential.token) {
+                                "user-a" -> "Z111111"
+                                "user-b" -> "Z222222"
                                 else -> null
                             } ?: return@authenticate null
 
                             BrukerPrincipal(
-                                navIdent = "Z123456",
+                                navIdent = navIdent,
                                 name = "Rate Limit Test",
                                 email = "rate.limit.test@nav.no",
-                                clientId = clientId,
+                                clientId = "dev-gcp:team-esyfo:lumi-dashboard",
                             )
                         }
                     }
@@ -167,6 +178,12 @@ class RateLimitingKeyingTest : FunSpec({
 
                 routing {
                     authenticate(AZURE_REALM) {
+                        install(ClientAuthorizationPlugin) {
+                            allowedClientId = "dev-gcp:team-esyfo:lumi-dashboard"
+                        }
+                        install(TeamAuthorizationPlugin) {
+                            naisTeamLookupProvider = { null }
+                        }
                         rateLimit(AnalyticsRateLimit) {
                             get("/analytics-test") {
                                 call.respond(HttpStatusCode.OK)
@@ -178,20 +195,20 @@ class RateLimitingKeyingTest : FunSpec({
 
             repeat(300) {
                 val response = client.get("/analytics-test") {
-                    header(HttpHeaders.Authorization, "Bearer client-a")
+                    header(HttpHeaders.Authorization, "Bearer user-a")
                 }
                 response.status shouldBe HttpStatusCode.OK
             }
 
             val blockedResponse = client.get("/analytics-test") {
-                header(HttpHeaders.Authorization, "Bearer client-a")
+                header(HttpHeaders.Authorization, "Bearer user-a")
             }
             blockedResponse.status shouldBe HttpStatusCode.TooManyRequests
 
-            val otherClientResponse = client.get("/analytics-test") {
-                header(HttpHeaders.Authorization, "Bearer client-b")
+            val otherUserResponse = client.get("/analytics-test") {
+                header(HttpHeaders.Authorization, "Bearer user-b")
             }
-            otherClientResponse.status shouldBe HttpStatusCode.OK
+            otherUserResponse.status shouldBe HttpStatusCode.OK
         }
     }
 
@@ -201,6 +218,8 @@ class RateLimitingKeyingTest : FunSpec({
         // tokens in one source-IP bucket without charging validated callers.
         testApplication {
             application {
+                configureSerialization()
+                configureStatusPages()
                 configureRateLimiting()
                 install(Authentication) {
                     bearer(AZURE_REALM) {
@@ -236,6 +255,112 @@ class RateLimitingKeyingTest : FunSpec({
             // 31st rejected call is blocked by the rate limit instead of bypassing it.
             val blockedResponse = client.get("/export-reject-test") {
                 header(HttpHeaders.Authorization, "Bearer invalid-final")
+            }
+            blockedResponse.status shouldBe HttpStatusCode.TooManyRequests
+        }
+    }
+
+    test("client-unauthorized export calls remain source-IP limited") {
+        testApplication {
+            application {
+                configureSerialization()
+                configureStatusPages()
+                configureRateLimiting()
+                install(Authentication) {
+                    bearer(AZURE_REALM) {
+                        authenticate { credential ->
+                            BrukerPrincipal(
+                                navIdent = "Z${credential.token.hashCode()}",
+                                name = "Unauthorized Rate Limit Test",
+                                email = "unauthorized.rate.limit.test@nav.no",
+                                clientId = "dev-gcp:unauthorized:rotating-client-${credential.token}",
+                            )
+                        }
+                    }
+                }
+
+                routing {
+                    rateLimitRejectedExportAuthentication {
+                        authenticate(AZURE_REALM) {
+                            install(ClientAuthorizationPlugin) {
+                                allowedClientId = "dev-gcp:team-esyfo:lumi-dashboard"
+                            }
+                            install(TeamAuthorizationPlugin) {
+                                naisTeamLookupProvider = { null }
+                            }
+                            refundRejectedExportAuthenticationAfterAuthorization()
+                            rateLimit(ExportRateLimit) {
+                                get("/export-unauthorized-test") {
+                                    call.respond(HttpStatusCode.OK)
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+
+            repeat(30) {
+                val response = client.get("/export-unauthorized-test") {
+                    header(HttpHeaders.Authorization, "Bearer valid-but-unauthorized-$it")
+                }
+                response.status shouldBe HttpStatusCode.Forbidden
+            }
+
+            val blockedResponse = client.get("/export-unauthorized-test") {
+                header(HttpHeaders.Authorization, "Bearer valid-but-unauthorized-final")
+            }
+            blockedResponse.status shouldBe HttpStatusCode.TooManyRequests
+        }
+    }
+
+    test("team-unauthorized export calls remain source-IP limited") {
+        testApplication {
+            application {
+                configureSerialization()
+                configureStatusPages()
+                configureRateLimiting()
+                install(Authentication) {
+                    bearer(AZURE_REALM) {
+                        authenticate { credential ->
+                            BrukerPrincipal(
+                                navIdent = "Z${credential.token.hashCode()}",
+                                name = "Team Unauthorized Rate Limit Test",
+                                email = "team.unauthorized.rate.limit.test@nav.no",
+                                clientId = "dev-gcp:team-esyfo:lumi-dashboard",
+                            )
+                        }
+                    }
+                }
+
+                routing {
+                    rateLimitRejectedExportAuthentication {
+                        authenticate(AZURE_REALM) {
+                            install(ClientAuthorizationPlugin) {
+                                allowedClientId = "dev-gcp:team-esyfo:lumi-dashboard"
+                            }
+                            install(TeamAuthorizationPlugin) {
+                                naisTeamLookupProvider = { null }
+                            }
+                            refundRejectedExportAuthenticationAfterAuthorization()
+                            rateLimit(ExportRateLimit) {
+                                get("/export-team-unauthorized-test") {
+                                    call.respond(HttpStatusCode.OK)
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+
+            repeat(30) {
+                val response = client.get("/export-team-unauthorized-test?team=not-authorized") {
+                    header(HttpHeaders.Authorization, "Bearer valid-but-team-unauthorized-$it")
+                }
+                response.status shouldBe HttpStatusCode.Forbidden
+            }
+
+            val blockedResponse = client.get("/export-team-unauthorized-test?team=not-authorized") {
+                header(HttpHeaders.Authorization, "Bearer valid-but-team-unauthorized-final")
             }
             blockedResponse.status shouldBe HttpStatusCode.TooManyRequests
         }

--- a/apps/lumi-api/src/test/kotlin/no/nav/lumi/config/RateLimitingKeyingTest.kt
+++ b/apps/lumi-api/src/test/kotlin/no/nav/lumi/config/RateLimitingKeyingTest.kt
@@ -86,10 +86,63 @@ class RateLimitingKeyingTest : FunSpec({
         }
     }
 
-    test("export rate limit falls back to source IP when principal is unavailable in the RateLimit phase") {
-        // Ktor 3.5.1 runs the RateLimit plugin in the Plugins phase, before the
-        // Authentication phase, so getBrukerPrincipal() is null at requestKey time.
-        // Analytics/export therefore bucket on source IP, NOT per validated client.
+    test("export rate limit uses separate buckets per validated caller identity") {
+        testApplication {
+            application {
+                configureRateLimiting()
+                install(Authentication) {
+                    bearer(AZURE_REALM) {
+                        authenticate { credential ->
+                            val clientId = when (credential.token) {
+                                "client-a" -> "dev-gcp:team-esyfo:app-a"
+                                "client-b" -> "dev-gcp:team-esyfo:app-b"
+                                else -> null
+                            } ?: return@authenticate null
+
+                            BrukerPrincipal(
+                                navIdent = "Z123456",
+                                name = "Rate Limit Test",
+                                email = "rate.limit.test@nav.no",
+                                clientId = clientId,
+                            )
+                        }
+                    }
+                }
+
+                routing {
+                    rateLimitRejectedExportAuthentication {
+                        authenticate(AZURE_REALM) {
+                            rateLimit(ExportRateLimit) {
+                                get("/export-test") {
+                                    call.respond(HttpStatusCode.OK)
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+
+            repeat(30) {
+                val response = client.get("/export-test") {
+                    header(HttpHeaders.Authorization, "Bearer client-a")
+                }
+                response.status shouldBe HttpStatusCode.OK
+            }
+
+            val blockedResponse = client.get("/export-test") {
+                header(HttpHeaders.Authorization, "Bearer client-a")
+            }
+            blockedResponse.status shouldBe HttpStatusCode.TooManyRequests
+
+            // A different validated client has its own bucket under Ktor 3.5.2.
+            val otherClientResponse = client.get("/export-test") {
+                header(HttpHeaders.Authorization, "Bearer client-b")
+            }
+            otherClientResponse.status shouldBe HttpStatusCode.OK
+        }
+    }
+
+    test("analytics rate limit uses separate buckets per validated caller identity") {
         testApplication {
             application {
                 configureRateLimiting()
@@ -114,8 +167,8 @@ class RateLimitingKeyingTest : FunSpec({
 
                 routing {
                     authenticate(AZURE_REALM) {
-                        rateLimit(ExportRateLimit) {
-                            get("/export-test") {
+                        rateLimit(AnalyticsRateLimit) {
+                            get("/analytics-test") {
                                 call.respond(HttpStatusCode.OK)
                             }
                         }
@@ -123,32 +176,29 @@ class RateLimitingKeyingTest : FunSpec({
                 }
             }
 
-            repeat(30) {
-                val response = client.get("/export-test") {
+            repeat(300) {
+                val response = client.get("/analytics-test") {
                     header(HttpHeaders.Authorization, "Bearer client-a")
                 }
                 response.status shouldBe HttpStatusCode.OK
             }
 
-            val blockedResponse = client.get("/export-test") {
+            val blockedResponse = client.get("/analytics-test") {
                 header(HttpHeaders.Authorization, "Bearer client-a")
             }
             blockedResponse.status shouldBe HttpStatusCode.TooManyRequests
 
-            // A different validated client shares the same source-IP bucket, so it is
-            // also blocked. This documents that export is per-IP, not per-client, in 3.5.1.
-            val otherClientResponse = client.get("/export-test") {
+            val otherClientResponse = client.get("/analytics-test") {
                 header(HttpHeaders.Authorization, "Bearer client-b")
             }
-            otherClientResponse.status shouldBe HttpStatusCode.TooManyRequests
+            otherClientResponse.status shouldBe HttpStatusCode.OK
         }
     }
 
-    test("KTOR-9621: rejected auth in nested authenticate still counts toward export rate limit") {
-        // Regression guard for KTOR-9621: before Ktor 3.5.1, a nested authenticate
-        // block that rejected the request bypassed the RateLimit plugin, so an
-        // attacker could spam invalid tokens without ever hitting 429. In 3.5.1 the
-        // rejected calls are counted, so the limit is enforced.
+    test("rejected export authentication remains source-IP limited under Ktor 3.5.2") {
+        // Ktor 3.5.2 deliberately skips a rateLimit nested inside rejected
+        // authentication. The outer failed-auth guard keeps invalid, rotating
+        // tokens in one source-IP bucket without charging validated callers.
         testApplication {
             application {
                 configureRateLimiting()
@@ -162,10 +212,12 @@ class RateLimitingKeyingTest : FunSpec({
                 }
 
                 routing {
-                    authenticate(AZURE_REALM) {
-                        rateLimit(ExportRateLimit) {
-                            get("/export-reject-test") {
-                                call.respond(HttpStatusCode.OK)
+                    rateLimitRejectedExportAuthentication {
+                        authenticate(AZURE_REALM) {
+                            rateLimit(ExportRateLimit) {
+                                get("/export-reject-test") {
+                                    call.respond(HttpStatusCode.OK)
+                                }
                             }
                         }
                     }

--- a/docs/referanse/sikkerhet.md
+++ b/docs/referanse/sikkerhet.md
@@ -32,9 +32,9 @@ API-et håndhever rate limiting på flere nivåer for å beskytte mot misbruk:
 | :--- | :--- | :--- |
 | Innsending | 100 req/min | Per kaller-app |
 | Innsending (per bruker) | 15 req/min | Per hashet sluttbruker innenfor samme kaller-app |
-| Analyse | 300 req/min | Per validert team og app |
-| Eksport | 30 req/min | Per validert team og app |
-| Avvist eksportautentisering | 30 forsøk/min | Per kilde-IP |
+| Analyse | 300 req/min | Per validert team, app og bruker |
+| Eksport | 30 req/min | Per validert team, app og bruker |
+| Avvist eksportautentisering/-autorisasjon | 30 forsøk/min | Per kilde-IP |
 | Global | 1000 req/min | Alle kall samlet |
 
 ::: info Nøkling av analyse og eksport

--- a/docs/referanse/sikkerhet.md
+++ b/docs/referanse/sikkerhet.md
@@ -38,7 +38,7 @@ API-et håndhever rate limiting på flere nivåer for å beskytte mot misbruk:
 | Global | 1000 req/min | Alle kall samlet |
 
 ::: info Nøkling av analyse og eksport
-Ktor autentiserer analyse- og eksportkall før den beregner rate limit-nøkkelen. Gyldige kall nøkles derfor med validert klientidentitet. Eksportkall reserverer i tillegg en tillatelse per kilde-IP før autentisering. Tillatelsen gis tilbake når autentiseringen lykkes, mens avviste kall beholder den. Dermed kan ikke en angriper omgå eksportgrensen ved å bytte ugyldig token for hvert kall. På NAIS hentes kilde-IP fra første verdi i `X-Forwarded-For`.
+Ktor autentiserer analyse- og eksportkall før den beregner rate limit-nøkkelen. Gyldige kall nøkles derfor med validert klientidentitet og pseudonymisert brukeridentitet. Eksportkall reserverer i tillegg en tillatelse per kilde-IP før autentisering. Tillatelsen gis først tilbake når både klient- og teamautorisasjon lykkes, mens avviste kall beholder den. Dermed kan ikke en angriper omgå eksportgrensen ved å bytte ugyldig eller uautorisert token for hvert kall. På NAIS hentes kilde-IP fra første verdi i `X-Forwarded-For`.
 :::
 
 ## Inndatavalidering

--- a/docs/referanse/sikkerhet.md
+++ b/docs/referanse/sikkerhet.md
@@ -32,12 +32,13 @@ API-et håndhever rate limiting på flere nivåer for å beskytte mot misbruk:
 | :--- | :--- | :--- |
 | Innsending | 100 req/min | Per kaller-app |
 | Innsending (per bruker) | 15 req/min | Per hashet sluttbruker innenfor samme kaller-app |
-| Analyse | 300 req/min | Per kilde-IP for dashboard-trafikken |
-| Eksport | 30 req/min | Per kilde-IP for dashboard-trafikken |
+| Analyse | 300 req/min | Per validert team og app |
+| Eksport | 30 req/min | Per validert team og app |
+| Avvist eksportautentisering | 30 forsøk/min | Per kilde-IP |
 | Global | 1000 req/min | Alle kall samlet |
 
 ::: info Nøkling av analyse og eksport
-Analyse- og eksport-endepunktene autentiseres i Ktors auth-fase, som kjører *etter* rate limit-pluginen. Den validerte klient-identiteten er derfor ikke tilgjengelig når rate limit-nøkkelen beregnes, så disse endepunktene nøkles på kilde-IP. På NAIS brukes første IP i `X-Forwarded-For`-headeren. Innsending nøkles derimot per kaller-app, og per hashet sluttbruker, fordi identiteten settes i en route-scoped plugin før rate limit-pluginen.
+Ktor autentiserer analyse- og eksportkall før den beregner rate limit-nøkkelen. Gyldige kall nøkles derfor med validert klientidentitet. Eksportkall reserverer i tillegg en tillatelse per kilde-IP før autentisering. Tillatelsen gis tilbake når autentiseringen lykkes, mens avviste kall beholder den. Dermed kan ikke en angriper omgå eksportgrensen ved å bytte ugyldig token for hvert kall. På NAIS hentes kilde-IP fra første verdi i `X-Forwarded-For`.
 :::
 
 ## Inndatavalidering


### PR DESCRIPTION
## Hva endres

- oppgraderer Ktor-pluginen og alle eksplisitte Ktor-biblioteker samlet fra 3.5.1 til 3.5.2
- nøkkelsetter gyldige analyse- og eksportkall per pseudonymisert bruker innen den validerte klientidentiteten
- beholder en egen grense på 30 avviste eksportautentiseringer eller -autorisasjoner per kilde-IP og minutt
- oppdaterer sikkerhetsreferansen med den nye nøklingen

## Hvorfor

Ktor 3.5.2 lar en rate limiter som ligger innenfor authenticate bruke den validerte principalen. Samtidig kjøres ikke denne indre limiteren når autentisering avvises. Uten en egen ytre vakt kunne en angriper rotere ugyldige tokens og omgå eksportgrensen.

Den ytre vakten reserverer en tillatelse før autentisering og refunderer den først etter at både klient- og teamautorisasjon har lykkes. Dermed deler ikke dashboardbrukere bucket, mens ugyldige tokens, feil klient og feil team fortsatt begrenses per kilde-IP. Texas-valideringen og autorisasjonsmodellen er uendret.

## Validering

- npm run lint
- npm run typecheck
- npm run api:test
- npm --prefix docs run build
- målrettet RateLimitingKeyingTest med produksjonspluginene for gyldig bruker, feil klient, feil team og roterende ugyldige tokens

Closes #422