### PR TITLE
docs: dokumenter survey-identitet og endringsregler

### DIFF
--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -45,6 +45,10 @@ export default withMermaid({
           text: "Guider",
           items: [
             { text: "Surveytyper", link: "/guider/surveytyper" },
+            {
+              text: "Survey-identitet",
+              link: "/guider/survey-identitet",
+            },
             { text: "Presets & builders", link: "/guider/presets-og-builders" },
             { text: "Spørsmålstyper", link: "/guider/sporsmalstyper" },
             {

--- a/docs/guider/survey-identitet.md
+++ b/docs/guider/survey-identitet.md
@@ -1,0 +1,106 @@
+---
+title: Survey-identitet og endringer
+---
+
+# Survey-identitet og endringer
+
+`surveyId` er en kontrakt med analysen. Behold samme ID når surveyen fortsatt
+måler det samme på en sammenlignbar måte. Bruk en ny ID når du endrer
+strukturen eller betydningen av svarene.
+
+## Hva identifiserer `surveyId`?
+
+En `surveyId` identifiserer én sammenhengende analyseserie innenfor et team.
+ID-en er ikke global, men apper i samme team bør bare dele ID når de med vilje
+skal dele definisjon og analyse.
+
+Etter den første innsendingen lagrer Lumi API surveydefinisjonen. Senere
+innsendinger med samme `surveyId` kontrolleres mot denne definisjonen. En
+strukturelt inkompatibel innsending får HTTP 409 og lagres ikke.
+
+Velg derfor en stabil ID per survey og bruksmønster, for eksempel
+`sykepenger-kvittering`. Ikke lag en ny ID for hver utrulling.
+
+## Kan jeg beholde samme `surveyId`?
+
+Tabellen gjelder den nåværende widgeten, som sender hele surveydefinisjonen med
+`schemaVersion: 2`.
+
+| Endring | Samme `surveyId`? | Hva skjer? |
+| :--- | :--- | :--- |
+| Rette skrivefeil uten å endre betydningen | Ja | Backend godtar endringen. Historiske og nye svar er fortsatt sammenlignbare. |
+| Endre hjelpetekst eller `description` | Ja | Teksten er ikke en del av den låste definisjonen. |
+| Endre visuell styling eller layout | Ja | Endringen påvirker ikke den analytiske strukturen. |
+| Endre spørsmålstekst eller teksten til et svaralternativ uten å endre betydningen | Ja, med varsomhet | Backend godtar endringen, men eldre svar beholder de gamle tekstene. Hold endringen liten. |
+| Endre hva et spørsmål eller svaralternativ betyr | Nei | Backend kan godta en ren tekstendring, men analysen vil blande svar på to ulike spørsmål. |
+| Endre `required`, `visibleIf` eller `logic` | Vurder ny ID | Backend godtar endringen, men den kan endre hvem som får eller besvarer spørsmålet. Bruk ny ID hvis trendene ikke lenger er sammenlignbare. |
+| Endre rekkefølgen på spørsmål | Vanligvis | Backend godtar ren omorganisering. Dashboardet utleder rekkefølgen fra innsendinger, så bruk ny ID hvis rekkefølgen er viktig for tolkningen. |
+| Legge til eller fjerne et spørsmål | Nei | Hele definisjonen sendes med hver innsending. Endringen gir 409. |
+| Endre spørsmål-ID | Nei | Backend ser dette som ett fjernet og ett nytt felt og svarer med 409. |
+| Endre spørsmålstype | Nei | Endring av `fieldType` gir 409. |
+| Endre `surveyType` | Nei | Endringen gir 409. |
+| Endre ratingvariant eller skala | Nei | Endring av `ratingVariant` eller `ratingScale` gir 409. |
+| Legge til, fjerne, bytte eller omorganisere option-ID-er | Nei | Listen med `optionIds`, inkludert rekkefølgen, er låst og endringen gir 409. |
+| Gjenbruke en gammel ID til en ny survey | Nei | Nye svar vil enten bli avvist eller blandet med en historisk analyseserie. |
+
+### Tekster lagres sammen med svarene
+
+Spørsmålstekst og tekstene til svaralternativene er ikke med i den strukturelle definisjonen.
+De lagres likevel i hver innsending og brukes som visningstekst i analysen.
+Hvis teksten endres over tid, kan dashboardet vise en representativ eldre eller
+nyere tekst for svar som aggregeres sammen.
+
+Rett gjerne skrivefeil. Bruk ny `surveyId` når ordlyden endrer hva brukeren blir
+spurt om, eller hva et svaralternativ betyr.
+
+## Slik ruller du ut en strukturell endring
+
+1. Lag en ny, beskrivende ID, for eksempel `sykepenger-kvittering-v2`.
+2. Rull ut den nye surveyen og kontroller at innsendingene vises i dashboardet.
+3. Fjern den gamle surveyen fra konsumentappen når den ikke lenger skal samle
+   inn svar.
+4. Arkiver den gamle surveyen i dashboardet hvis du vil skjule den fra
+   standardvisningen.
+
+Den gamle og den nye ID-en blir separate analyseserier. Lumi kobler dem ikke
+automatisk sammen. Arkivering stopper heller ikke innsendinger; det gjør du ved
+å fjerne eller deaktivere surveyen i konsumentappen.
+
+## Hvis API-et svarer med 409
+
+En 409 betyr at surveydefinisjonen ikke samsvarer med definisjonen som allerede
+er registrert for teamet og `surveyId`-en. Innsendingen er avvist og ikke lagret.
+
+Gjør ett av disse valgene:
+
+- gå tilbake til den registrerte strukturen hvis endringen var utilsiktet
+- bruk en ny `surveyId` hvis endringen var tilsiktet
+
+Et nytt forsøk med samme inkompatible payload løser ikke konflikten. Se
+[runbook for definisjonskonflikter](https://github.com/navikt/lumi/blob/main/apps/lumi-api/docs/runbooks/survey-definition-conflicts.md)
+for operativ feilsøking.
+
+## Tre ulike versjonsbegreper
+
+| Begrep | Betydning |
+| :--- | :--- |
+| `schemaVersion` | Versjonen av transportformatet. Den sier ikke hvilken versjon av surveyen brukeren så. |
+| `surveyVersion` | Et valgfritt felt i API-ets lesemodell. Dagens widget setter det ikke, og backend bruker det ikke til validering eller oppdeling av analyse. |
+| `definitionHash` | Et internt fingeravtrykk av den strukturelle definisjonen. Backend bruker det til å oppdage konflikter. Det er ikke en offentlig surveyversjon. |
+
+Du kan derfor ikke gjøre strukturelle endringer under samme `surveyId` ved å
+sette `surveyVersion`. Bruk en ny `surveyId`.
+
+::: info Eldre widget-versjoner
+Backend godtar fortsatt `schemaVersion: 1` i en overgangsperiode. Slike
+innsendinger kan mangle ubesvarte spørsmål i den avledede definisjonen. Ikke
+bruk denne bakoverkompatibiliteten som en strategi for å endre en live survey.
+:::
+
+## Sjekkliste før utrulling
+
+- Er `surveyId` unik for analyseserien innenfor teamet?
+- Måler alle spørsmål og svaralternativer det samme som før?
+- Er spørsmål-ID-er, typer, ratingoppsett og option-ID-er uendret?
+- Vil gamle og nye svar fortsatt kunne tolkes samlet?
+- Har du valgt en ny ID hvis svaret på ett av punktene er nei?

--- a/docs/kom-i-gang/konfigurer-survey.md
+++ b/docs/kom-i-gang/konfigurer-survey.md
@@ -54,7 +54,7 @@ Tre ting å merke seg:
 - **Vær konkret** — still spørsmål om en spesifikk opplevelse, ikke generell tilfredshet.
 - **Bruk progresjon** — vis oppfølgingsspørsmål med `visibleIf` i stedet for å vise alt på én gang.
 - **Segmentér med tags** — bruk `context.tags` for å skille mellom brukergrupper eller flater. Se [Context og tags](/guider/context-og-tags).
-- **Velg en stabil `surveyId`** — denne identifiserer surveyen på tvers av deploy og brukes til analyse i dashboardet. Bruk ny `surveyId` når du legger til, fjerner, endrer navn på eller endrer type/options for spørsmål, for eksempel `min-flate-feedback-v2`.
+- **Velg en stabil `surveyId`** — denne identifiserer én analyseserie på tvers av utrullinger. Strukturelle eller semantiske endringer krever en ny ID, for eksempel `min-flate-feedback-v2`. Se [Survey-identitet og endringer](/guider/survey-identitet) for beslutningstabellen.
 
 ## Snarvei: Bruk en preset
 

--- a/docs/referanse/datakontrakt.md
+++ b/docs/referanse/datakontrakt.md
@@ -22,7 +22,10 @@ Widgeten samler inn svar og sender en strukturert JSON-payload til backend. Payl
 | `context` | Anbefalt | Nettleser-/brukerkontekst for segmentering |
 
 ::: tip Når skal du endre `surveyId`?
-Bruk ny `surveyId` når du legger til, fjerner, endrer navn på eller endrer type/options for spørsmål. Da unngår du å blande ulike datastrukturer i samme analyse og 409-feil fra backend.
+Behold samme ID når surveyen fortsatt måler det samme med samme struktur. Bruk
+en ny ID ved strukturelle eller semantiske endringer. Se
+[Survey-identitet og endringer](/guider/survey-identitet) for en konkret
+beslutningstabell og forklaring av 409-feil.
 :::
 
 ::: info Deduplication
@@ -169,5 +172,6 @@ Backend mapper `surveyType`-strenger til enums:
 
 ## Se også
 
+- [Survey-identitet og endringer](/guider/survey-identitet) — når du kan beholde samme `surveyId`
 - [API-endepunkter](/referanse/api-endepunkter) — endepunktene som mottar denne payloaden
 - [Context & tags](/guider/context-og-tags) — hvordan du konfigurerer context i widgeten

--- a/packages/lumi-survey/README.md
+++ b/packages/lumi-survey/README.md
@@ -212,7 +212,7 @@ Anbefaling: Start med `rating` eller `discovery`, og gå videre til `topTasks`/`
 - Bruk progresjon: vis fritekst først etter at rating er valgt (`visibleIf`).
 - Bruk `context.tags` for segmentering (lav kardinalitet), og `context.debug` kun for feilsøking (høy kardinalitet).
 - Unngå identifikatorer i `context` (og ikke auto-collect `pathname` på dynamiske ruter).
-- Velg en stabil `surveyId` per flate/bruksmønster (ikke per deploy). Bruk ny `surveyId` når du legger til, fjerner, endrer navn på eller endrer type/options for spørsmål, for eksempel `min-flate-feedback-v2`.
+- Velg en stabil `surveyId` per analyseserie (ikke per utrulling). Strukturelle eller semantiske endringer krever en ny ID, for eksempel `min-flate-feedback-v2`. Se [Survey-identitet og endringer](https://navikt.github.io/lumi/guider/survey-identitet).
 
 **Go-live sjekkliste**
 
@@ -249,7 +249,7 @@ versjonert (`schemaVersion: 2`). Den inkluderer:
 - `answers`: Normalisert struktur per spørsmål
 - `context`: tags/debug/auto-collectet miljøinfo
 
-`surveyId` er en del av datakontrakten. Bruk ny `surveyId` når du legger til, fjerner, endrer navn på eller endrer type/options for spørsmål. Da unngår du å blande ulike datastrukturer i samme analyse og 409-feil fra backend.
+`surveyId` er en del av datakontrakten. Behold samme ID når surveyen fortsatt måler det samme med samme struktur. Bruk en ny ID ved strukturelle eller semantiske endringer. Se [Survey-identitet og endringer](https://navikt.github.io/lumi/guider/survey-identitet) for beslutningstabellen og forklaring av 409-feil.
 
 Du trenger ikke sette `deduplicationKey` selv. Widgeten bruker samme nøkkel når en innsending feiler og brukeren prøver på nytt. Etter en vellykket innsending eller reset lages en ny nøkkel, slik at en ny innsending lagres som en ny tilbakemelding.
 


### PR DESCRIPTION
## Hva endres

- legger til en egen guide for survey-identitet og endringer i live surveys
- dokumenterer hvilke endringer backend avviser med 409, og hvilke endringer som kan svekke sammenlignbarheten selv om backend godtar dem
- skiller mellom `schemaVersion`, `surveyVersion` og `definitionHash`
- lenker guiden fra konfigureringsguiden, datakontrakten, pakkens README og dokumentasjonsmenyen

## Hvorfor

Eksisterende veiledning var spredt og for kategorisk. Etter at immutable schema v2-definisjoner ble innført, trenger konsumentteam en beslutningstabell som samsvarer med både den tekniske guardrailen og hvordan dashboardet faktisk aggregerer historiske svar.

Dette er kun dokumentasjon. Transportformat, validering og runtime-oppførsel endres ikke.

## Validering

- `npm run lint`
- `npm run typecheck`
- `npm --prefix docs run build`
- `./gradlew test --tests 'no.nav.lumi.service.SurveyDefinitionServiceTest'`
- `git diff --check`

Closes #146
