### PR TITLE
Wire screen resolution through analytics

### DIFF
--- a/apps/lumi-api/src/main/kotlin/no/nav/lumi/domain/Models.kt
+++ b/apps/lumi-api/src/main/kotlin/no/nav/lumi/domain/Models.kt
@@ -150,6 +150,8 @@ data class SubmissionContext(
     val deviceType: DeviceType? = null,
     val viewportWidth: Int? = null,
     val viewportHeight: Int? = null,
+    val screenWidth: Int? = null,
+    val screenHeight: Int? = null,
     /** Context tags from widget (low-cardinality segmentation) */
     val tags: Map<String, String>? = null
 )
@@ -258,6 +260,10 @@ data class FeedbackStats(
     @OptIn(ExperimentalSerializationApi::class)
     @EncodeDefault(EncodeDefault.Mode.ALWAYS)
     val byDevice: Map<String, DeviceStats> = emptyMap(),
+    /** Coarse groups by the screen's longest edge, avoiding high-cardinality exact resolutions. */
+    @OptIn(ExperimentalSerializationApi::class)
+    @EncodeDefault(EncodeDefault.Mode.ALWAYS)
+    val byScreenResolution: Map<String, Int> = emptyMap(),
     @OptIn(ExperimentalSerializationApi::class)
     @EncodeDefault(EncodeDefault.Mode.ALWAYS)
     val byPathname: Map<String, PathnameStats> = emptyMap(),

--- a/apps/lumi-api/src/main/kotlin/no/nav/lumi/repository/Extensions.kt
+++ b/apps/lumi-api/src/main/kotlin/no/nav/lumi/repository/Extensions.kt
@@ -67,6 +67,7 @@ fun FeedbackDbRecord.toDto(tags: List<String> = emptyList()): FeedbackDto {
     
     val context = jsonObj["context"]?.jsonObject?.let { ctxObj ->
         val viewportObj = ctxObj["viewport"]?.jsonObject
+        val screenResolutionObj = ctxObj["screenResolution"] as? JsonObject
 
         val viewportWidth =
             ctxObj["viewportWidth"]?.jsonPrimitive?.intOrNull
@@ -75,6 +76,14 @@ fun FeedbackDbRecord.toDto(tags: List<String> = emptyList()): FeedbackDto {
         val viewportHeight =
             ctxObj["viewportHeight"]?.jsonPrimitive?.intOrNull
                 ?: viewportObj?.get("height")?.jsonPrimitive?.intOrNull
+
+        val screenWidth =
+            ctxObj["screenWidth"]?.jsonPrimitive?.intOrNull
+                ?: screenResolutionObj?.get("width")?.jsonPrimitive?.intOrNull
+
+        val screenHeight =
+            ctxObj["screenHeight"]?.jsonPrimitive?.intOrNull
+                ?: screenResolutionObj?.get("height")?.jsonPrimitive?.intOrNull
 
         val tags = ctxObj["tags"]?.jsonObject?.entries?.associate { (key, value) ->
             key to (value.jsonPrimitive.contentOrNull ?: value.toString())
@@ -88,6 +97,8 @@ fun FeedbackDbRecord.toDto(tags: List<String> = emptyList()): FeedbackDto {
             },
             viewportWidth = viewportWidth,
             viewportHeight = viewportHeight,
+            screenWidth = screenWidth,
+            screenHeight = screenHeight,
             tags = tags
         )
     }

--- a/apps/lumi-api/src/main/kotlin/no/nav/lumi/repository/FeedbackStatsHelpers.kt
+++ b/apps/lumi-api/src/main/kotlin/no/nav/lumi/repository/FeedbackStatsHelpers.kt
@@ -9,11 +9,25 @@ import java.time.OffsetDateTime
 internal data class AnalyticsSnapshot(
     val ratingByDateRows: List<AvgCountRow>,
     val deviceRows: List<AvgCountRow>,
+    val screenResolutionRows: List<ScreenResolutionCountRow>,
     val pathnameRows: List<AvgCountRow>,
     val fieldRecords: List<FeedbackDbRecord>
 )
 
 internal data class AvgCountRow(val key: String, val count: Int, val average: Double)
+
+internal data class ScreenResolutionCountRow(val width: Int, val height: Int, val count: Int)
+
+internal fun screenResolutionBucket(width: Int, height: Int): String? {
+    if (width <= 0 || height <= 0) return null
+
+    return when (maxOf(width, height)) {
+        in 1 until 1280 -> "under-1280"
+        in 1280 until 1920 -> "1280-1919"
+        in 1920 until 2560 -> "1920-2559"
+        else -> "2560-plus"
+    }
+}
 
 internal data class SurveyTypeRow(
     val surveyId: String,

--- a/apps/lumi-api/src/main/kotlin/no/nav/lumi/repository/FeedbackStatsRepository.kt
+++ b/apps/lumi-api/src/main/kotlin/no/nav/lumi/repository/FeedbackStatsRepository.kt
@@ -30,6 +30,7 @@ class FeedbackStatsRepository {
     data class FeedbackAnalyticsStats(
         val ratingByDate: Map<String, RatingByDateEntry> = emptyMap(),
         val byDevice: Map<String, DeviceStats> = emptyMap(),
+        val byScreenResolution: Map<String, Int> = emptyMap(),
         val byPathname: Map<String, PathnameStats> = emptyMap(),
         val lowestRatingPaths: Map<String, PathnameStats> = emptyMap(),
         val fieldStats: List<FieldStat> = emptyList(),
@@ -163,6 +164,30 @@ class FeedbackStatsRepository {
                     )
                 }
 
+            val screenWidthExpr = JsonExtract(
+                FeedbackTable.feedbackJson,
+                listOf("context", "screenResolution", "width")
+            )
+            val screenHeightExpr = JsonExtract(
+                FeedbackTable.feedbackJson,
+                listOf("context", "screenResolution", "height")
+            )
+            val screenCountExpr = FeedbackTable.id.count()
+            val screenResolutionQuery = FeedbackTable.select(screenWidthExpr, screenHeightExpr, screenCountExpr)
+            applyStatsFilters(screenResolutionQuery, query)
+            screenResolutionQuery.andWhere { screenWidthExpr.isNotNull() and screenHeightExpr.isNotNull() }
+            val screenResolutionRows = screenResolutionQuery
+                .groupBy(screenWidthExpr, screenHeightExpr)
+                .mapNotNull { row ->
+                    val width = row[screenWidthExpr].toIntOrNull() ?: return@mapNotNull null
+                    val height = row[screenHeightExpr].toIntOrNull() ?: return@mapNotNull null
+                    ScreenResolutionCountRow(
+                        width = width,
+                        height = height,
+                        count = row[screenCountExpr].toInt(),
+                    )
+                }
+
             val pathnameExpr = JsonExtract(FeedbackTable.feedbackJson, listOf("context", "pathname"))
             val pathnameQuery = FeedbackTable.select(pathnameExpr, ratingCountExpr, ratingAvgExpr)
             applyStatsFilters(pathnameQuery, query)
@@ -188,6 +213,7 @@ class FeedbackStatsRepository {
             AnalyticsSnapshot(
                 ratingByDateRows = ratingByDateRows,
                 deviceRows = deviceRows,
+                screenResolutionRows = screenResolutionRows,
                 pathnameRows = pathnameRows,
                 fieldRecords = fieldRecords
             )
@@ -202,6 +228,13 @@ class FeedbackStatsRepository {
             .associate { row ->
                 row.key.lowercase() to DeviceStats(count = row.count, averageRating = row.average)
             }
+
+        val byScreenResolution = snapshot.screenResolutionRows
+            .mapNotNull { row ->
+                screenResolutionBucket(row.width, row.height)?.let { bucket -> bucket to row.count }
+            }
+            .groupingBy { it.first }
+            .fold(0) { total, (_, count) -> total + count }
 
         val byPathname = snapshot.pathnameRows
             .filter { it.key.isNotBlank() }
@@ -228,6 +261,7 @@ class FeedbackStatsRepository {
         return FeedbackAnalyticsStats(
             ratingByDate = ratingByDate,
             byDevice = byDevice,
+            byScreenResolution = byScreenResolution,
             byPathname = byPathname,
             lowestRatingPaths = lowestRatingPaths,
             fieldStats = fieldStats,

--- a/apps/lumi-api/src/main/kotlin/no/nav/lumi/service/ExportService.kt
+++ b/apps/lumi-api/src/main/kotlin/no/nav/lumi/service/ExportService.kt
@@ -35,7 +35,9 @@ class ExportService(
     fun exportToCsv(feedbacks: List<FeedbackDto>): String {
         return buildString {
             // Header
-            appendLine("id,submittedAt,app,surveyId,rating,feedback,sensitiveDataRedacted")
+            appendLine(
+                "id,submittedAt,app,surveyId,rating,feedback,sensitiveDataRedacted,screenWidth,screenHeight"
+            )
             
             // Data rows
             feedbacks.forEach { feedback ->
@@ -53,7 +55,9 @@ class ExportService(
                     feedback.surveyId,
                     rating,
                     feedbackText,
-                    feedback.sensitiveDataRedacted.toString()
+                    feedback.sensitiveDataRedacted.toString(),
+                    feedback.context?.screenWidth?.toString() ?: "",
+                    feedback.context?.screenHeight?.toString() ?: "",
                 ).joinToString(",") { it.escapeCsv() }
 
                 appendLine(row)
@@ -78,7 +82,17 @@ class ExportService(
         
         // Header row
         val headerRow = sheet.createRow(0)
-        val headers = listOf("ID", "Tidspunkt", "App", "Survey", "Vurdering", "Tilbakemelding", "Sensitiv data fjernet")
+        val headers = listOf(
+            "ID",
+            "Tidspunkt",
+            "App",
+            "Survey",
+            "Vurdering",
+            "Tilbakemelding",
+            "Sensitiv data fjernet",
+            "Skjermbredde",
+            "Skjermhøyde",
+        )
         val maxColumnChars = headers.map { it.length }.toMutableList()
         headers.forEachIndexed { index, header ->
             headerRow.createCell(index).setCellValue(header)
@@ -109,6 +123,8 @@ class ExportService(
                 rating,
                 feedbackText,
                 sensitiveDataRedacted,
+                feedback.context?.screenWidth?.toString() ?: "",
+                feedback.context?.screenHeight?.toString() ?: "",
             )
 
             values.forEachIndexed { columnIndex, value ->

--- a/apps/lumi-api/src/main/kotlin/no/nav/lumi/service/StatsService.kt
+++ b/apps/lumi-api/src/main/kotlin/no/nav/lumi/service/StatsService.kt
@@ -160,6 +160,7 @@ class StatsService(
             },
             ratingByDate = if (stats.masked) emptyMap() else analytics?.ratingByDate.orEmpty(),
             byDevice = if (stats.masked) emptyMap() else analytics?.byDevice.orEmpty(),
+            byScreenResolution = if (stats.masked) emptyMap() else analytics?.byScreenResolution.orEmpty(),
             byPathname = if (stats.masked) emptyMap() else analytics?.byPathname.orEmpty(),
             lowestRatingPaths = if (stats.masked) emptyMap() else analytics?.lowestRatingPaths.orEmpty(),
             fieldStats = if (stats.masked) emptyList() else analytics?.fieldStats.orEmpty(),

--- a/apps/lumi-api/src/test/kotlin/no/nav/lumi/routes/FeedbackRoutesTest.kt
+++ b/apps/lumi-api/src/test/kotlin/no/nav/lumi/routes/FeedbackRoutesTest.kt
@@ -872,7 +872,7 @@ class FeedbackRoutesTest : FunSpec({
         }
     }
 
-    test("GET /api/v1/intern/feedback/{id} parses nested context.viewport") {
+    test("GET /api/v1/intern/feedback/{id} parses viewport and screen resolution") {
         testApplication {
             application { testModule() }
 
@@ -886,7 +886,10 @@ class FeedbackRoutesTest : FunSpec({
                 feedbackJson = """
                     {
                                             "surveyId": "$surveyId",
-                      "context": {"viewport": {"width": 777, "height": 555}},
+                      "context": {
+                        "viewport": {"width": 777, "height": 555},
+                        "screenResolution": {"width": 1920, "height": 1080}
+                      },
                       "answers": [
                                                 {"fieldId": "rating", "fieldType": "RATING", "question": {"label": "Hvordan?"}, "value": {"type": "rating", "rating": 4}}
                       ]
@@ -906,6 +909,30 @@ class FeedbackRoutesTest : FunSpec({
 
             context["viewportWidth"].shouldNotBeNull().jsonPrimitive.int shouldBe 777
             context["viewportHeight"].shouldNotBeNull().jsonPrimitive.int shouldBe 555
+            context["screenWidth"].shouldNotBeNull().jsonPrimitive.int shouldBe 1920
+            context["screenHeight"].shouldNotBeNull().jsonPrimitive.int shouldBe 1080
+
+            val nullResolutionRowId = UUID.randomUUID().toString()
+            insertTestFeedbackWithJson(
+                id = nullResolutionRowId,
+                team = "team-test",
+                app = "app-test",
+                feedbackJson = """
+                    {
+                      "surveyId": "survey-null-resolution",
+                      "context": {"screenResolution": null},
+                      "answers": []
+                    }
+                """.trimIndent(),
+            )
+
+            val nullResolutionResponse = createTestClient().get(
+                "/api/v1/intern/feedback/$nullResolutionRowId?team=team-test"
+            ) {
+                header(HttpHeaders.Authorization, "Bearer test-token")
+            }
+
+            nullResolutionResponse.status shouldBe HttpStatusCode.OK
         }
     }
 

--- a/apps/lumi-api/src/test/kotlin/no/nav/lumi/routes/StatsDashboardRoutesTest.kt
+++ b/apps/lumi-api/src/test/kotlin/no/nav/lumi/routes/StatsDashboardRoutesTest.kt
@@ -46,6 +46,8 @@ class StatsDashboardRoutesTest : FunSpec({
         text: String,
         startedAt: OffsetDateTime,
         submittedAt: OffsetDateTime,
+        screenWidth: Int? = null,
+        screenHeight: Int? = null,
     ): String {
         val payload = buildJsonObject {
             put("schemaVersion", 1)
@@ -54,6 +56,12 @@ class StatsDashboardRoutesTest : FunSpec({
             putJsonObject("context") {
                 put("pathname", pathname)
                 put("deviceType", deviceType)
+                if (screenWidth != null && screenHeight != null) {
+                    putJsonObject("screenResolution") {
+                        put("width", screenWidth)
+                        put("height", screenHeight)
+                    }
+                }
             }
             putJsonArray("answers") {
                 add(
@@ -118,6 +126,8 @@ class StatsDashboardRoutesTest : FunSpec({
                     text = "bra",
                     startedAt = day1.minusMinutes(1),
                     submittedAt = day1,
+                    screenWidth = 390,
+                    screenHeight = 844,
                 ),
                 opprettet = day1,
             )
@@ -132,6 +142,8 @@ class StatsDashboardRoutesTest : FunSpec({
                     text = "ok",
                     startedAt = day1.minusMinutes(2),
                     submittedAt = day1,
+                    screenWidth = 1366,
+                    screenHeight = 768,
                 ),
                 opprettet = day1,
             )
@@ -146,6 +158,8 @@ class StatsDashboardRoutesTest : FunSpec({
                     text = "drlig",
                     startedAt = day1.minusMinutes(3),
                     submittedAt = day1,
+                    screenWidth = 1920,
+                    screenHeight = 1080,
                 ),
                 opprettet = day1,
             )
@@ -160,6 +174,8 @@ class StatsDashboardRoutesTest : FunSpec({
                     text = "ikke bra",
                     startedAt = day2.minusMinutes(1),
                     submittedAt = day2,
+                    screenWidth = 2560,
+                    screenHeight = 1440,
                 ),
                 opprettet = day2,
             )
@@ -174,6 +190,8 @@ class StatsDashboardRoutesTest : FunSpec({
                     text = "fin",
                     startedAt = day2.minusMinutes(2),
                     submittedAt = day2,
+                    screenWidth = 3440,
+                    screenHeight = 1440,
                 ),
                 opprettet = day2,
             )
@@ -199,6 +217,13 @@ class StatsDashboardRoutesTest : FunSpec({
             stats.byDevice["desktop"]?.averageRating shouldBe (4.0 plusOrMinus 0.0001)
             // avg(mobile) = (1 + 2) / 2 = 1.5
             stats.byDevice["mobile"]?.averageRating shouldBe (1.5 plusOrMinus 0.0001)
+
+            stats.byScreenResolution shouldBe mapOf(
+                "under-1280" to 1,
+                "1280-1919" to 1,
+                "1920-2559" to 1,
+                "2560-plus" to 2,
+            )
 
             stats.byPathname.size shouldBe 2
             stats.byPathname shouldContainKey "/a"

--- a/apps/lumi-api/src/test/kotlin/no/nav/lumi/service/ExportServiceTest.kt
+++ b/apps/lumi-api/src/test/kotlin/no/nav/lumi/service/ExportServiceTest.kt
@@ -13,7 +13,9 @@ class ExportServiceTest : FunSpec({
 
     test("exportToCsv generates correct header") {
         val csv = service.exportToCsv(emptyList())
-        csv.shouldStartWith("id,submittedAt,app,surveyId,rating,feedback,sensitiveDataRedacted")
+        csv.shouldStartWith(
+            "id,submittedAt,app,surveyId,rating,feedback,sensitiveDataRedacted,screenWidth,screenHeight"
+        )
     }
 
     test("exportToCsv includes feedback data") {
@@ -23,6 +25,13 @@ class ExportServiceTest : FunSpec({
                 submittedAt = "2024-01-15T10:00:00Z",
                 app = "test-app",
                 surveyId = "survey-1",
+                context = SubmissionContext(
+                    deviceType = DeviceType.DESKTOP,
+                    viewportWidth = 1440,
+                    viewportHeight = 900,
+                    screenWidth = 1920,
+                    screenHeight = 1080,
+                ),
                 answers = listOf(
                     Answer(
                         fieldId = "rating",
@@ -47,6 +56,7 @@ class ExportServiceTest : FunSpec({
         csv.shouldContain("test-app")
         csv.shouldContain(",4,")
         csv.shouldContain("Great service!")
+        csv.shouldContain("false,1920,1080")
     }
 
     test("exportToCsv escapes commas in text") {
@@ -179,6 +189,35 @@ class ExportServiceTest : FunSpec({
         val sheet = workbook.getSheetAt(0)
         val feedbackCell = sheet.getRow(1).getCell(5).stringCellValue
         feedbackCell shouldBe "'=cmd|' /C calc'!A0"
+        workbook.close()
+    }
+
+    test("exportToExcel includes viewport and screen resolution columns") {
+        val feedbacks = listOf(
+            FeedbackDto(
+                id = "test-id",
+                submittedAt = "2024-01-15T10:00:00Z",
+                app = "app",
+                surveyId = "survey",
+                context = SubmissionContext(
+                    deviceType = DeviceType.MOBILE,
+                    viewportWidth = 390,
+                    viewportHeight = 844,
+                    screenWidth = 1170,
+                    screenHeight = 2532,
+                ),
+                answers = emptyList(),
+                sensitiveDataRedacted = false
+            )
+        )
+
+        val workbook = org.apache.poi.xssf.usermodel.XSSFWorkbook(
+            java.io.ByteArrayInputStream(service.exportToExcel(feedbacks))
+        )
+        val row = workbook.getSheetAt(0).getRow(1)
+
+        row.getCell(7).stringCellValue shouldBe "1170"
+        row.getCell(8).stringCellValue shouldBe "2532"
         workbook.close()
     }
 })

--- a/apps/lumi-dashboard/app/components/dashboard/views/Overview/Dashboard.tsx
+++ b/apps/lumi-dashboard/app/components/dashboard/views/Overview/Dashboard.tsx
@@ -34,7 +34,7 @@ export function OverviewDashboard() {
           <VStack gap="space-16">
             <Heading size="small">Enheter</Heading>
             <div className={styles.chartContainer}>
-              <DeviceBreakdownChart />
+              <DeviceBreakdownChart showScreenResolution={false} />
             </div>
           </VStack>
         </DashboardCard>

--- a/apps/lumi-dashboard/app/components/feedback/FeedbackTable/FeedbackCard.tsx
+++ b/apps/lumi-dashboard/app/components/feedback/FeedbackTable/FeedbackCard.tsx
@@ -186,6 +186,14 @@ export function FeedbackCard({
                     }
                   />
                 )}
+                {(feedback.context?.screenWidth ||
+                  feedback.context?.screenHeight) && (
+                  <ContextItem
+                    icon="🖥️"
+                    label="Skjermoppløsning"
+                    value={`${feedback.context.screenWidth || "?"}×${feedback.context.screenHeight || "?"}`}
+                  />
+                )}
               </HGrid>
             </ExpandedSection>
 

--- a/apps/lumi-dashboard/app/components/feedback/FeedbackTable/FeedbackDetailParts.tsx
+++ b/apps/lumi-dashboard/app/components/feedback/FeedbackTable/FeedbackDetailParts.tsx
@@ -86,6 +86,13 @@ export function ContextGrid({
           value={`${context.viewportWidth || "?"}×${context.viewportHeight || "?"}`}
         />
       )}
+      {(context.screenWidth || context.screenHeight) && (
+        <ContextItem
+          icon="🖥️"
+          label="Skjermoppløsning"
+          value={`${context.screenWidth || "?"}×${context.screenHeight || "?"}`}
+        />
+      )}
     </HGrid>
   );
 }

--- a/apps/lumi-dashboard/app/components/feedback/FeedbackTable/FeedbackRow.tsx
+++ b/apps/lumi-dashboard/app/components/feedback/FeedbackTable/FeedbackRow.tsx
@@ -97,7 +97,7 @@ export function FeedbackRow({
           <HStack gap="space-8" align="center">
             {feedback.context?.deviceType && (
               <Tooltip
-                content={`${feedback.context.deviceType}${feedback.context.viewportWidth ? ` (${feedback.context.viewportWidth}px)` : ""}`}
+                content={`${feedback.context.deviceType}${feedback.context.viewportWidth ? ` (viewport ${feedback.context.viewportWidth}px)` : ""}${feedback.context.screenWidth ? `, skjerm ${feedback.context.screenWidth}×${feedback.context.screenHeight ?? "?"}` : ""}`}
               >
                 <span className={styles.deviceIcon}>
                   {deviceToIcon(feedback.context.deviceType)}

--- a/apps/lumi-dashboard/app/components/shared/Charts/DeviceBreakdownChart.tsx
+++ b/apps/lumi-dashboard/app/components/shared/Charts/DeviceBreakdownChart.tsx
@@ -1,4 +1,12 @@
-import { BodyShort, Hide, HStack, Label, Show, VStack } from "@navikt/ds-react";
+import {
+  BodyShort,
+  Heading,
+  Hide,
+  HStack,
+  Label,
+  Show,
+  VStack,
+} from "@navikt/ds-react";
 import { ChartEmptyState } from "~/components/shared/Charts/ChartEmptyState";
 import { ChartLoadingState } from "~/components/shared/Charts/ChartLoadingState";
 import { useSearchParams } from "~/hooks/useSearchParams";
@@ -7,6 +15,11 @@ import {
   getNpsCategory,
   inferRatingVariantFromDistribution,
 } from "~/utils/ratingDisplay";
+import {
+  SCREEN_RESOLUTION_BUCKET_ORDER,
+  SCREEN_RESOLUTION_LABELS,
+  type ScreenResolutionBucket,
+} from "~/utils/screenResolution";
 import styles from "./Charts.module.css";
 
 const DEVICE_ICONS: Record<string, string> = {
@@ -33,6 +46,8 @@ const DEVICE_COLOR_CLASS_BY_KEY: Record<string, string> = {
 interface DeviceBreakdownChartProps {
   /** Override rating visibility. If not provided, auto-detects based on survey type. */
   showRating?: boolean;
+  /** Show coarse screen resolution groups below the device breakdown. */
+  showScreenResolution?: boolean;
 }
 
 function clamp01(value: number) {
@@ -108,6 +123,7 @@ function ratingToneClass(
 
 export function DeviceBreakdownChart({
   showRating,
+  showScreenResolution = true,
 }: DeviceBreakdownChartProps = {}) {
   const { data: stats, isPending } = useStats();
   const { setParams } = useSearchParams();
@@ -149,8 +165,21 @@ export function DeviceBreakdownChart({
     }))
     .sort((a, b) => b.count - a.count);
 
-  if (data.length === 0) {
+  const byScreenResolution = stats?.byScreenResolution || {};
+  const screenResolutionData = showScreenResolution
+    ? SCREEN_RESOLUTION_BUCKET_ORDER.map((bucket) => ({
+        bucket,
+        label: SCREEN_RESOLUTION_LABELS[bucket],
+        count: byScreenResolution[bucket] ?? 0,
+      })).filter(({ count }) => count > 0)
+    : [];
+
+  if (data.length === 0 && screenResolutionData.length === 0) {
     return <ChartEmptyState message="Ingen enhetsdata tilgjengelig" />;
+  }
+
+  if (data.length === 0) {
+    return <ScreenResolutionBreakdown data={screenResolutionData} />;
   }
 
   const totalCount = data.reduce((sum, d) => sum + d.count, 0);
@@ -254,6 +283,70 @@ export function DeviceBreakdownChart({
           ))}
         </HStack>
       </Show>
+
+      <ScreenResolutionBreakdown data={screenResolutionData} />
     </VStack>
+  );
+}
+
+function ScreenResolutionBreakdown({
+  data,
+}: {
+  data: Array<{
+    bucket: ScreenResolutionBucket;
+    label: string;
+    count: number;
+  }>;
+}) {
+  if (data.length === 0) return null;
+
+  const totalCount = data.reduce((sum, entry) => sum + entry.count, 0);
+
+  return (
+    <VStack gap="space-8" className={styles.fullWidth}>
+      <Heading size="xsmall" level="3">
+        Skjermstørrelse
+      </Heading>
+      {data.map(({ bucket, label, count }) => (
+        <ScreenResolutionRow
+          key={bucket}
+          bucket={bucket}
+          label={label}
+          count={count}
+          totalCount={totalCount}
+        />
+      ))}
+    </VStack>
+  );
+}
+
+function ScreenResolutionRow({
+  bucket,
+  label,
+  count,
+  totalCount,
+}: {
+  bucket: ScreenResolutionBucket;
+  label: string;
+  count: number;
+  totalCount: number;
+}) {
+  const percentage = Math.round((count / totalCount) * 100);
+
+  return (
+    <div className={styles.fullWidth} data-resolution-bucket={bucket}>
+      <HStack justify="space-between" align="center" gap="space-8">
+        <BodyShort size="small">{label}</BodyShort>
+        <BodyShort size="small" className={styles.deviceMutedText}>
+          {count} ({percentage}%)
+        </BodyShort>
+      </HStack>
+      <progress
+        className={styles.deviceProgress}
+        value={percentage}
+        max={100}
+        aria-label={`Andel med skjermstørrelse ${label}`}
+      />
+    </div>
   );
 }

--- a/apps/lumi-dashboard/app/components/shared/Charts/__tests__/DeviceBreakdownChart.test.tsx
+++ b/apps/lumi-dashboard/app/components/shared/Charts/__tests__/DeviceBreakdownChart.test.tsx
@@ -1,0 +1,62 @@
+import { render, screen } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { useSearchParams } from "~/hooks/useSearchParams";
+import type { FeedbackStats } from "~/hooks/useStats";
+import { useStats } from "~/hooks/useStats";
+import { DeviceBreakdownChart } from "../DeviceBreakdownChart";
+
+vi.mock("~/hooks/useStats", () => ({
+  useStats: vi.fn(),
+}));
+
+vi.mock("~/hooks/useSearchParams", () => ({
+  useSearchParams: vi.fn(),
+}));
+
+const mockUseStats = vi.mocked(useStats);
+const mockUseSearchParams = vi.mocked(useSearchParams);
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockUseSearchParams.mockReturnValue({ setParams: vi.fn() } as never);
+});
+
+function givenStats(stats: Partial<FeedbackStats>) {
+  mockUseStats.mockReturnValue({
+    data: stats as FeedbackStats,
+    isPending: false,
+  } as never);
+}
+
+describe("DeviceBreakdownChart", () => {
+  it("shows coarse screen resolution groups without exposing exact values", () => {
+    givenStats({
+      surveyType: "rating",
+      byRating: { "4": 6 },
+      byDevice: { desktop: { count: 6, averageRating: 4 } },
+      byScreenResolution: {
+        "1280-1919": 2,
+        "1920-2559": 4,
+      },
+    });
+
+    render(<DeviceBreakdownChart showScreenResolution />);
+
+    expect(screen.getByText("Skjermstørrelse")).toBeInTheDocument();
+    expect(screen.getByText("1280–1919 px")).toBeInTheDocument();
+    expect(screen.getByText("1920–2559 px")).toBeInTheDocument();
+    expect(screen.queryByText(/1920×1080/)).not.toBeInTheDocument();
+  });
+
+  it("can omit screen resolution groups in compact overview cards", () => {
+    givenStats({
+      byDevice: { mobile: { count: 5, averageRating: 0 } },
+      byScreenResolution: { "under-1280": 5 },
+    });
+
+    render(<DeviceBreakdownChart showScreenResolution={false} />);
+
+    expect(screen.queryByText("Skjermstørrelse")).not.toBeInTheDocument();
+  });
+});

--- a/apps/lumi-dashboard/app/mock/helpers.ts
+++ b/apps/lumi-dashboard/app/mock/helpers.ts
@@ -100,6 +100,8 @@ export function createContext(
 ): SubmissionContext {
   const defaultWidths = { mobile: 375, tablet: 768, desktop: 1440 };
   const defaultHeights = { mobile: 812, tablet: 1024, desktop: 900 };
+  const defaultScreenWidths = { mobile: 390, tablet: 1024, desktop: 1920 };
+  const defaultScreenHeights = { mobile: 844, tablet: 1366, desktop: 1080 };
   const width = viewportWidth || defaultWidths[deviceType];
   const height = viewportHeight || defaultHeights[deviceType];
   return {
@@ -108,6 +110,8 @@ export function createContext(
     deviceType,
     viewportWidth: width,
     viewportHeight: height,
+    screenWidth: defaultScreenWidths[deviceType],
+    screenHeight: defaultScreenHeights[deviceType],
   };
 }
 

--- a/apps/lumi-dashboard/app/mock/stats.ts
+++ b/apps/lumi-dashboard/app/mock/stats.ts
@@ -13,6 +13,7 @@ import type {
 } from "~/types/api";
 import { parseChoiceParam } from "~/utils/choiceFilterUtils";
 import { parseRatingParam } from "~/utils/ratingFilterUtils";
+import { getScreenResolutionBucket } from "~/utils/screenResolution";
 import { getTopKeywords, IGNORED_WORDS } from "~/utils/wordAnalysis";
 import { getRating, hasTextResponse } from "./helpers";
 import { extractPhrases } from "./stats/phrases";
@@ -447,6 +448,7 @@ export function calculateStats(
   const ratingByDateAccum: Record<string, { total: number; count: number }> =
     {};
   const byDeviceAccum: Record<string, { total: number; count: number }> = {};
+  const byScreenResolution: Record<string, number> = {};
   const byPathnameAccum: Record<string, { total: number; count: number }> = {};
 
   let totalRating = 0;
@@ -460,6 +462,15 @@ export function calculateStats(
       byDeviceAccum[device] = { total: 0, count: 0 };
     }
     byDeviceAccum[device].count++;
+
+    const screenResolutionBucket = getScreenResolutionBucket(
+      item.context?.screenWidth,
+      item.context?.screenHeight,
+    );
+    if (screenResolutionBucket) {
+      byScreenResolution[screenResolutionBucket] =
+        (byScreenResolution[screenResolutionBucket] ?? 0) + 1;
+    }
 
     // Pathname stats - always track regardless of rating
     const pathname = item.context?.pathname || "unknown";
@@ -597,6 +608,7 @@ export function calculateStats(
         : null,
     ratingByDate: shouldMask ? {} : ratingByDate,
     byDevice: shouldMask ? {} : byDevice,
+    byScreenResolution: shouldMask ? {} : byScreenResolution,
     byPathname: shouldMask ? {} : byPathname,
     lowestRatingPaths: shouldMask ? {} : lowestRatingPaths,
     fieldStats: shouldMask ? [] : fieldStats,

--- a/apps/lumi-dashboard/app/server/actions/__tests__/export.test.ts
+++ b/apps/lumi-dashboard/app/server/actions/__tests__/export.test.ts
@@ -17,6 +17,10 @@ function makeFeedback(partial: Partial<FeedbackDto> = {}): FeedbackDto {
     surveyType: partial.surveyType ?? "rating",
     context: partial.context ?? {
       deviceType: "mobile",
+      viewportWidth: 390,
+      viewportHeight: 844,
+      screenWidth: 1170,
+      screenHeight: 2532,
       url: "https://example.test/foo",
       pathname: "/foo",
     },
@@ -109,9 +113,11 @@ describe("export helpers", () => {
     const lines = csv.split("\n");
 
     expect(lines[0]).toContain("submittedAt,id,app,surveyId");
+    expect(lines[0]).toContain("metadata,screenWidth,screenHeight");
     expect(lines).toHaveLength(2);
     expect(lines[1]).toContain("2026-01-01T12:00:00Z");
     expect(lines[1]).toContain('"Hei, verden"');
+    expect(lines[1]).toContain("1170,2532");
   });
 
   it("toMockExcelBase64 returns an .xlsx payload (ZIP magic bytes)", async () => {

--- a/apps/lumi-dashboard/app/server/actions/__tests__/fetchStats.contract.test.ts
+++ b/apps/lumi-dashboard/app/server/actions/__tests__/fetchStats.contract.test.ts
@@ -80,6 +80,7 @@ describe("fetchStats contract", () => {
         "2026-01-21": { average: 3.2, count: 10 },
       },
       byDevice: { mobile: { count: 10, averageRating: 3.2 } },
+      byScreenResolution: { "1920-2559": 10 },
       byPathname: { "/": { count: 10, averageRating: 3.2 } },
       lowestRatingPaths: {},
       fieldStats: [],
@@ -105,6 +106,7 @@ describe("fetchStats contract", () => {
         "2026-01-21": { average: 3.2, count: 10 },
       },
       byDevice: { mobile: { count: 10, averageRating: 3.2 } },
+      byScreenResolution: { "1920-2559": 10 },
       byPathname: { "/": { count: 10, averageRating: 3.2 } },
       lowestRatingPaths: {},
       fieldStats: [
@@ -151,6 +153,7 @@ describe("fetchStats contract", () => {
       averageRating: null,
       ratingByDate: {},
       byDevice: {},
+      byScreenResolution: {},
       byPathname: {},
       lowestRatingPaths: {},
       fieldStats: [

--- a/apps/lumi-dashboard/app/server/actions/__tests__/fetchStats.contract.test.ts
+++ b/apps/lumi-dashboard/app/server/actions/__tests__/fetchStats.contract.test.ts
@@ -92,6 +92,27 @@ describe("fetchStats contract", () => {
     expect(() => FeedbackStatsSchema.parse(payload)).not.toThrow();
   });
 
+  it("defaults screen resolution stats during a rolling API deployment", () => {
+    const payload = {
+      totalCount: 0,
+      countWithText: 0,
+      countWithoutText: 0,
+      byRating: {},
+      byApp: {},
+      byDate: {},
+      bySurveyId: {},
+      averageRating: null,
+      ratingByDate: {},
+      byDevice: {},
+      byPathname: {},
+      lowestRatingPaths: {},
+      fieldStats: [],
+      period: { fromDate: null, toDate: null, days: 0 },
+    };
+
+    expect(FeedbackStatsSchema.parse(payload).byScreenResolution).toEqual({});
+  });
+
   it("accepts TextStats field with topPhrases", () => {
     const payload = {
       totalCount: 10,

--- a/apps/lumi-dashboard/app/server/actions/export.ts
+++ b/apps/lumi-dashboard/app/server/actions/export.ts
@@ -87,6 +87,8 @@ export function toMockCsv(items: typeof mockFeedbackItems): string {
     "url",
     "pathname",
     "metadata",
+    "screenWidth",
+    "screenHeight",
   ].join(",");
 
   const rows = items.map((item) => {
@@ -109,6 +111,8 @@ export function toMockCsv(items: typeof mockFeedbackItems): string {
       csvEscape(url),
       csvEscape(pathname),
       csvEscape(metadata),
+      csvEscape(item.context?.screenWidth ?? ""),
+      csvEscape(item.context?.screenHeight ?? ""),
     ].join(",");
   });
 
@@ -133,6 +137,8 @@ export async function toMockExcelBase64(
     { header: "url", key: "url", width: 40 },
     { header: "pathname", key: "pathname", width: 28 },
     { header: "metadata", key: "metadata", width: 40 },
+    { header: "screenWidth", key: "screenWidth", width: 14 },
+    { header: "screenHeight", key: "screenHeight", width: 14 },
   ];
 
   const sanitize = (v: string) => (isPotentialCsvFormula(v) ? `'${v}` : v);
@@ -143,6 +149,8 @@ export async function toMockExcelBase64(
     const app = item.app ?? "";
     const surveyId = item.surveyId;
     const deviceType = item.context?.deviceType ?? "";
+    const screenWidth = String(item.context?.screenWidth ?? "");
+    const screenHeight = String(item.context?.screenHeight ?? "");
     const rating = String(getFirstRating(item) ?? "");
     const text = getFirstText(item);
     const tags = item.tags?.join("|") ?? "";
@@ -156,6 +164,8 @@ export async function toMockExcelBase64(
       app: sanitize(app),
       surveyId: sanitize(surveyId),
       deviceType: sanitize(deviceType),
+      screenWidth: sanitize(screenWidth),
+      screenHeight: sanitize(screenHeight),
       rating: sanitize(rating),
       text: sanitize(text),
       tags: sanitize(tags),

--- a/apps/lumi-dashboard/app/utils/__tests__/filterLabels.test.ts
+++ b/apps/lumi-dashboard/app/utils/__tests__/filterLabels.test.ts
@@ -23,6 +23,7 @@ function makeStats(
     averageRating: null,
     ratingByDate: {},
     byDevice: {},
+    byScreenResolution: {},
     byPathname: {},
     lowestRatingPaths: {},
     fieldStats,

--- a/apps/lumi-dashboard/app/utils/screenResolution.ts
+++ b/apps/lumi-dashboard/app/utils/screenResolution.ts
@@ -1,0 +1,30 @@
+export const SCREEN_RESOLUTION_BUCKET_ORDER = [
+  "under-1280",
+  "1280-1919",
+  "1920-2559",
+  "2560-plus",
+] as const;
+
+export type ScreenResolutionBucket =
+  (typeof SCREEN_RESOLUTION_BUCKET_ORDER)[number];
+
+export const SCREEN_RESOLUTION_LABELS: Record<ScreenResolutionBucket, string> =
+  {
+    "under-1280": "Under 1280 px",
+    "1280-1919": "1280–1919 px",
+    "1920-2559": "1920–2559 px",
+    "2560-plus": "2560 px eller mer",
+  };
+
+export function getScreenResolutionBucket(
+  width: number | undefined,
+  height: number | undefined,
+): ScreenResolutionBucket | undefined {
+  if (!width || !height || width <= 0 || height <= 0) return undefined;
+
+  const longestEdge = Math.max(width, height);
+  if (longestEdge < 1280) return "under-1280";
+  if (longestEdge < 1920) return "1280-1919";
+  if (longestEdge < 2560) return "1920-2559";
+  return "2560-plus";
+}

--- a/docs/guider/context-og-tags.md
+++ b/docs/guider/context-og-tags.md
@@ -13,6 +13,7 @@ Widgeten samler automatisk disse verdiene fra browseren:
 | Felt | Type | Beskrivelse |
 | :--- | :--- | :--- |
 | `viewport` | `{ width, height }` | Nettleservinduets dimensjoner |
+| `screenResolution` | `{ width, height }` | Skjermens dimensjoner rapportert av nettleseren |
 | `deviceType` | `"mobile" \| "tablet" \| "desktop"` | Basert på viewport-bredde (ikke fysisk enhet) |
 | `userAgent` | `string` | Nettleserens user agent-streng |
 

--- a/docs/referanse/bruksvilkar.md
+++ b/docs/referanse/bruksvilkar.md
@@ -44,7 +44,8 @@ Widgeten samler kontekstdata for segmentering i dashboardet. Ingen av feltene id
 | Felt | Beskrivelse | Alltid sendt? |
 | :--- | :--- | :--- |
 | `deviceType` | Enhetstype (mobil, nettbrett, desktop) | Ja |
-| `viewport` | Skjermstørrelse i piksler | Ja |
+| `viewport` | Nettleservinduets størrelse i piksler | Ja |
+| `screenResolution` | Skjermens størrelse rapportert av nettleseren | Ja |
 | `userAgent` | Nettleser og OS | Ja |
 | `url` | Siden brukeren er på (full URL) | Nei, kun hvis du setter den manuelt i context |
 | `pathname` | URL-pathname | Nei, opt-in via `collectLocation` |

--- a/docs/referanse/datakontrakt.md
+++ b/docs/referanse/datakontrakt.md
@@ -78,6 +78,7 @@ interface LumiContext {
   // Auto-samlet av widgeten
   deviceType?: DeviceType;   // "mobile" | "tablet" | "desktop"
   viewport?: { width: number; height: number };
+  screenResolution?: { width: number; height: number };
   userAgent?: string;
 
   // Opt-in (krever collectLocation: true)
@@ -143,6 +144,8 @@ Backend mapper `surveyType`-strenger til enums:
     "url": "https://nav.no/sykepenger",
     "pathname": "/sykepenger",
     "deviceType": "mobile",
+    "viewport": { "width": 390, "height": 844 },
+    "screenResolution": { "width": 390, "height": 844 },
     "tags": {
       "abTest": "A",
       "rolle": "bruker"

--- a/packages/lumi-survey/README.md
+++ b/packages/lumi-survey/README.md
@@ -260,6 +260,7 @@ Backend-oppsett (token exchange, NAIS-tilgang) er beskrevet i [Koble til backend
 Auto-collectes i browser:
 
 - `viewport` (bredde/høyde)
+- `screenResolution` (skjermens bredde/høyde)
 - `deviceType` (mobile/tablet/desktop)
 - `userAgent`
 

--- a/packages/lumi-types/src/api.ts
+++ b/packages/lumi-types/src/api.ts
@@ -288,6 +288,8 @@ export interface FeedbackStats {
 
   // Device & context stats
   byDevice: Record<string, { count: number; averageRating: number }>;
+  /** Coarse groups by the screen's longest edge. */
+  byScreenResolution: Record<string, number>;
   byPathname: Record<string, { count: number; averageRating: number }>;
   lowestRatingPaths: Record<string, { count: number; averageRating: number }>;
 

--- a/packages/lumi-types/src/schemas.ts
+++ b/packages/lumi-types/src/schemas.ts
@@ -1058,7 +1058,7 @@ export const FeedbackStatsSchema = z.object({
     z.string(),
     z.object({ count: z.number(), averageRating: z.number() }),
   ),
-  byScreenResolution: z.record(z.string(), z.number()),
+  byScreenResolution: z.record(z.string(), z.number()).default({}),
   byPathname: z.record(
     z.string(),
     z.object({ count: z.number(), averageRating: z.number() }),

--- a/packages/lumi-types/src/schemas.ts
+++ b/packages/lumi-types/src/schemas.ts
@@ -1058,6 +1058,7 @@ export const FeedbackStatsSchema = z.object({
     z.string(),
     z.object({ count: z.number(), averageRating: z.number() }),
   ),
+  byScreenResolution: z.record(z.string(), z.number()),
   byPathname: z.record(
     z.string(),
     z.object({ count: z.number(), averageRating: z.number() }),


### PR DESCRIPTION
## Hva

- parser `screenResolution` fra innsendingskontekst og viser eksakte mål i tilbakemeldingsdetaljer
- eksporterer `screenWidth` og `screenHeight` i CSV, JSON og XLSX
- aggregerer skjermstørrelser i fire grove grupper etter lengste skjermkant
- viser gruppene i survey-dashboardet, med antall, prosent og tilgjengelige etiketter
- oppdaterer mocks, delte API-kontrakter og dokumentasjon

## Hvorfor

Widgeten har samlet inn `screenResolution` siden #170, men API, statistikk, dashboard og eksport slapp dataene. Dette fullfører verdikjeden i #187.

## Funksjonell effekt

- eksakt skjermoppløsning er tilgjengelig per tilbakemelding og i eksport
- aggregert dashboard viser kun grove grupper for å unngå høy kardinalitet og unødvendig identifiserbarhet
- oversiktskortet beholder dagens kompakte høyde; skjermfordelingen vises på valgt survey
- eksisterende tilbakemeldinger uten skjermdata fungerer uendret
- ingen databasemigrering

## Verifisering

- `npm run lint`
- `npm run typecheck`
- `npm test` — 51 filer / 312 tester
- full API-suite med ren in-process Kotlin-kompilering
- målrettede API-tester for parsing, statistikk og eksport
- målrettede dashboardtester — 3 filer / 15 tester
- `npm run build`
- `npm run docs:build`
- `npm run e2e` — 34 bestått / 1 hoppet over
- visuelt kontrollert på desktop og mobil uten konsollfeil

Closes #187
