### PR TITLE
Add page-based survey authoring

### DIFF
--- a/apps/lumi-local-demo/src/scenarios.ts
+++ b/apps/lumi-local-demo/src/scenarios.ts
@@ -6,7 +6,7 @@ import {
   DEFAULT_SURVEY_RATING,
   DEFAULT_SURVEY_STARS,
   DEFAULT_SURVEY_THUMBS,
-  type LumiSurveyConfig,
+  type LumiSurveyDefinition,
 } from "@navikt/lumi-survey";
 
 export interface DemoScenario {
@@ -14,7 +14,7 @@ export interface DemoScenario {
   title: string;
   summary: string;
   coverage: string[];
-  survey: LumiSurveyConfig;
+  survey: LumiSurveyDefinition;
 }
 
 const tasks = [
@@ -135,6 +135,70 @@ export const demoScenarios: DemoScenario[] = [
             { value: "safe", label: "Trygg" },
           ],
           required: true,
+        },
+      ],
+    },
+  },
+  {
+    id: "pages-multi-question",
+    title: "Pages · flere spørsmål",
+    summary:
+      "To eksplisitte sider med samlet validering og betinget felt på siste side.",
+    coverage: ["SurveyDocumentV1", "pages", "multi-question", "visibleIf"],
+    survey: {
+      authoringSchemaVersion: 1,
+      type: "custom",
+      pages: [
+        {
+          id: "experience",
+          title: "Om opplevelsen",
+          description: "Begge spørsmålene valideres før du går videre.",
+          questions: [
+            {
+              id: "pageRating",
+              type: "rating",
+              variant: "stars",
+              prompt: "Hvor fornøyd er du med testflyten?",
+              required: true,
+            },
+            {
+              id: "pageReason",
+              type: "text",
+              prompt: "Hva la du særlig merke til?",
+              placeholder: "Skriv en kort testmerknad",
+              maxLength: 300,
+              required: true,
+            },
+          ],
+        },
+        {
+          id: "follow-up",
+          title: "Oppfølging",
+          description: "Det siste feltet vises bare når du velger ja.",
+          questions: [
+            {
+              id: "pageFollowUp",
+              type: "singleChoice",
+              prompt: "Vil du beskrive noe vi bør forbedre?",
+              options: [
+                { value: "yes", label: "Ja" },
+                { value: "no", label: "Nei" },
+              ],
+              required: true,
+            },
+            {
+              id: "pageImprovement",
+              type: "text",
+              prompt: "Hva bør vi forbedre?",
+              maxLength: 500,
+              required: true,
+              visibleIf: {
+                questionId: "pageFollowUp",
+                operator: "EQ",
+                value: "yes",
+              },
+            },
+          ],
         },
       ],
     },

--- a/docs/adr/0001-flytmodell-visibility-vs-logic.md
+++ b/docs/adr/0001-flytmodell-visibility-vs-logic.md
@@ -57,10 +57,10 @@ Konklusjon: vi kan ikke rive ut `logic`. Men vi kan slutte å behandle den som e
 
 2. **`visibleIf` er den kanoniske flytmodellen.** Den mentale modellen vi dokumenterer, anbefaler og bygger Survey Builder (#338) rundt er: *ordnet liste → filtrer på synlighet → gå gjennom de synlige i rekkefølge → send inn når ingen flere er synlige.* Builder-UI-en eksponerer dette som standard.
 
-3. **`logic` degraderes til en escape hatch for ekte ikke-lineær kontroll** (primært `JUMP_TO`). Den forblir støttet og fungerende (den har live konsumenter), men:
+3. **`logic` degraderes til en legacy escape hatch for ekte ikke-lineær kontroll** (primært `JUMP_TO`). Den forblir støttet og fungerende for eksisterende flat config (den har live konsumenter), men:
    - dokumenteres som «avansert», ikke som en sidestilt førstevalgs-modell,
    - utvides ikke med ny funksjonalitet utover det delte betingelseslaget,
-   - eksponeres i builder-UI-en (#338) kun bak en «avansert»-luke, ikke i hovedflyten.
+   - eksponeres ikke i den nye page-baserte authoringmodellen eller builder-UI-en (#338), se ADR 0003.
 
 4. **Migrer førstepartsbruk vekk fra `logic` der det er triviell-ekvivalent.**
    Levert i #359: `createTopTasksSurvey` uttrykker nå `otherTask` og `blocker`
@@ -95,7 +95,7 @@ Konklusjon: vi kan ikke rive ut `logic`. Men vi kan slutte å behandle den som e
   `visibleIf`; `logic` snevret til leaf. Evaluator-unifisering bevisst utsatt —
   operator-divergensen lever videre, men kun i den utfasede `logic`-mekanismen.)
 - [x] Oppdater `docs/guider/branching.md` (avansert-posisjonering + linje 64-klargjøring).
-- [ ] #338: bygg builder rundt synlighetsmodellen; `logic` bak «avansert»-luke.
+- [ ] #338: bygg builder rundt den page-baserte synlighetsmodellen i ADR 0003; ikke generer `logic`.
 - [x] #359: migrer `createTopTasksSurvey` `SKIP`/`SUBMIT` → `visibleIf`, og la
   verdi-baserte `visibleIf`-grener aktivere steg-modus under `"auto"`.
 - [ ] Etter #333+#338: revurder full deprecation av `logic`.

--- a/docs/adr/0003-pagebasert-authoringmodell.md
+++ b/docs/adr/0003-pagebasert-authoringmodell.md
@@ -1,0 +1,154 @@
+---
+title: "ADR 0003: Pagebasert authoringmodell for surveys"
+status: Akseptert
+date: 2026-08-15
+---
+
+# ADR 0003: Pagebasert authoringmodell for surveys
+
+- **Status:** Akseptert
+- **Dato:** 2026-08-15
+- **Berører:** #336 (flere spørsmål per steg), #338 (Survey Builder UI), ADR 0001
+
+## Kontekst
+
+`LumiSurveyConfig` er en flat, ordnet liste med spørsmål. I stegmodus er hvert
+spørsmål også en navigasjonsenhet. Det gjør det umulig å vise flere relaterte
+spørsmål sammen på ett steg uten å endre den offentlige kontrakten.
+
+En framtidig Survey Builder trenger en serialiserbar authoringmodell. Den må
+holdes adskilt fra dagens submission-`definition`, som er en strukturell guard
+for svarenes analytiske betydning og ikke et lager for presentasjon eller
+drafts.
+
+Vi vurderte også `sections`, inspirert av Oppfølgingsplanens versjonerte
+`FormSnapshot`. Der er sections semantiske dokumentkapitler som brukes i
+historisk visning og PDF. Lumi er en kort feedback-widget og har foreløpig ingen
+konsument av section-identitet eller flere navngitte grupper på samme steg.
+
+## Beslutning
+
+### Ny, versjonert dokumentform
+
+```ts
+export type SurveyQuestionV1 =
+  RemoveLegacyLogic<LumiSurveyQuestion>;
+
+export interface SurveyPageV1 {
+  id: string;
+  title?: string;
+  description?: string;
+  questions: [SurveyQuestionV1, ...SurveyQuestionV1[]];
+}
+
+export interface SurveyDocumentV1 {
+  authoringSchemaVersion: 1;
+  type?: SurveyType;
+  pages: [SurveyPageV1, ...SurveyPageV1[]];
+}
+```
+
+`RemoveLegacyLogic` er en privat hjelpe-type. Det offentlige navnet beskriver
+hva typen er, ikke hva som er fjernet.
+
+En authored page er en navigasjonsenhet. Et runtime-steg er en page som er
+synlig i den aktuelle svar- og metadatatilstanden.
+
+### Flyt og synlighet
+
+- `visibleIf` finnes bare på spørsmål i V1.
+- En page er synlig når minst ett av spørsmålene er synlig.
+- Pages uten synlige spørsmål hoppes over.
+- Svarbasert `visibleIf` kan bare referere til tidligere spørsmål i
+  dokumentrekkefølgen. Metadata-betingelser fungerer som før.
+- Den nye dokumentformen avviser `logic`, `JUMP_TO`, `SKIP` og tidlig
+  `SUBMIT`. Den kanoniske flyten er ordnet pages, filtrert av question-level
+  `visibleIf`.
+
+Dette innsnevrer builder-beslutningen i ADR 0001: en ny builder skal ikke
+generere `logic`. Legacy-støtten beholdes midlertidig for eksisterende
+konsumenter.
+
+### Layout
+
+- `steps` navigerer mellom synlige pages.
+- `singlePage` flater ut navigasjonen, men beholder page-tittel og description
+  som visuell og semantisk struktur.
+- `auto` bruker stegmodus for et V1-dokument med mer enn én authored page.
+  Valget er statisk og endres ikke når synlighet endres.
+- Flat legacy-config beholder dagens `auto`-policy, der branching eller
+  verdiavhengig synlighet aktiverer stegmodus.
+
+### Validering og tilgjengelighet
+
+- Alle synlige obligatoriske spørsmål på aktiv page valideres samlet.
+- Ved flere feil vises Aksel `ErrorSummary` med lenker til spørsmålene.
+- Etter eksplisitt page-navigasjon flyttes fokus til page-tittelen, eller det
+  første synlige spørsmålet dersom tittelen mangler.
+- Svarstyrte synlighetsendringer skal ikke stjele fokus.
+- Fremdrift, tilbakehistorikk og `onStepChange` er page-baserte for den nye
+  modellen. Intro og success teller ikke som pages.
+
+### Kompatibilitet og persistens
+
+- `LumiSurveyConfig` med flat `questions[]` beholdes som kompatibilitetsinput.
+- Canonicalizer markerer kilden og normaliserer legacy til én intern page per
+  spørsmål, uten å endre legacy-layout eller `logic`-semantikk.
+- Submission, answers og `definition.fields` forblir flate og question-baserte.
+- Page-ID, title og description sendes ikke i dagens payload og inngår ikke i
+  definition-hashen.
+- `authoringSchemaVersion` er versjonen av dokumentformatet, ikke
+  submission-`schemaVersion`.
+- En framtidig dashboard-store må lagre egne immutable authoring-revisjoner.
+  Dagens `survey_definitions` skal ikke gjenbrukes som configlager.
+
+## Konsekvenser
+
+### Positivt
+
+- Flere spørsmål kan valideres og vises som ett steg.
+- Den offentlige modellen er ren JSON og egner seg for framtidig builder/codegen.
+- Legacy-konsumenter trenger ingen migrering.
+- Presentasjonsendringer skaper ikke nye 409-konflikter i API-et.
+- `logic` utvides ikke inn i en ny og tvetydig page-semantikk.
+
+### Kostnad
+
+- Legacy- og dokumentflyt har ulik `auto`-policy og må bære kildeinformasjon i
+  den interne canonical-modellen.
+- Fremdriftsestimatet ved betingede pages er fortsatt et estimat, som ved annen
+  branching.
+- En senere serverstyrt builder trenger eksplisitt versjons- og
+  minimumsklienthåndtering.
+
+## Vurderte alternativer
+
+### Obligatoriske sections
+
+Forkastet i V1. Det gir et ekstra nivå og boilerplate uten en konkret
+Lumi-konsument.
+
+### Valgfrie sections
+
+Forkastet i V1. Det gir to permanente authoringgrammatikker på hver page og
+mer kompleks validering, rendering og builder-state. Dersom behovet oppstår,
+kan V1 migreres deterministisk til V2 ved å pakke hver page inn i én section.
+
+### Page-level `visibleIf`
+
+Forkastet i V1. Question-level synlighet er tilstrekkelig og holder ett
+betingelsesnivå. Feltet kan legges til additivt senere dersom repetisjon blir et
+dokumentert problem.
+
+### Pages i submission-definitionen
+
+Forkastet. Page-layout endrer ikke svarenes strukturelle betydning og skal ikke
+utløse 409 ved en ren presentasjonsendring.
+
+## Når `Section` skal revurderes
+
+`Section` innføres først når minst én reell survey trenger flere navngitte
+grupper på samme runtime-page, eller når builder, oppsummering, historikk eller
+PDF faktisk bruker gruppeidentiteten. Da skal en ny authoring-schema-versjon ha
+én entydig modell (`page → sections → questions`), ikke valgfrie sections ved
+siden av direkte spørsmål.

--- a/docs/kom-i-gang/konfigurer-survey.md
+++ b/docs/kom-i-gang/konfigurer-survey.md
@@ -8,7 +8,7 @@ Definer surveyen din som et TypeScript-objekt og send det til `LumiSurveyDock`. 
 
 ## Definer surveyen
 
-En survey er et objekt som tilfredsstiller `LumiSurveyConfig`. Her er et typisk oppsett med emoji-rating etterfulgt av et valgfritt fritekstfelt:
+En enkel, flat survey er et objekt som tilfredsstiller `LumiSurveyConfig`. Her er et typisk oppsett med emoji-rating etterfulgt av et valgfritt fritekstfelt:
 
 ```typescript
 import type { LumiSurveyConfig } from "@navikt/lumi-survey";
@@ -47,6 +47,10 @@ Tre ting å merke seg:
 ::: tip `satisfies` fremfor typeannotasjon
 `satisfies LumiSurveyConfig` gir deg typevalidering **og** bevarer den smale literal-typen, slik at `mySurvey.type` er `"rating"` — ikke `string`. Dette er idiomatisk TypeScript og gir bedre inferens nedover i appen.
 :::
+
+## Flere spørsmål på samme side
+
+Når flere spørsmål skal valideres og navigeres som én side, bruker du den versjonerte `SurveyDocumentV1`-modellen med `pages`. Den flate `LumiSurveyConfig`-varianten støttes fortsatt for enkle og eksisterende surveys. Se [props-referansen](/referanse/props-referanse) for kontrakt og eksempel.
 
 ## Tips for gode surveys
 

--- a/docs/referanse/events.md
+++ b/docs/referanse/events.md
@@ -97,7 +97,11 @@ onDismissalPersistFailed?: (cause: unknown) => void;
 
 ### `onStepChange`
 
-Fyres når brukeren navigerer mellom steg i step-modus. Indeksene reflekterer kun synlige spørsmål — skjulte spørsmål (via `visibleIf`) telles ikke med.
+Fyres når brukeren navigerer mellom steg i step-modus. For flat legacy-config
+er stegene spørsmål. For `SurveyDocumentV1` er stegene pages. Første argument er
+indeksen blant pages som er synlige i nåværende tilstand; totalen er et estimat
+over reachable pages og kan derfor inkludere en betinget page før svaret som
+avgjør synligheten finnes.
 
 ```ts
 onStepChange?: (visibleStepIndex: number, totalVisibleSteps: number) => void;

--- a/docs/referanse/props-referanse.md
+++ b/docs/referanse/props-referanse.md
@@ -11,7 +11,7 @@ Komplett oversikt over alle props for `LumiSurveyDock`-komponenten.
 | Prop | Type | Påkrevd | Beskrivelse |
 | :--- | :--- | :---: | :--- |
 | `surveyId` | `string` | ✅ | Unik identifikator for surveyen (f.eks. `"soknad-kvittering"`) |
-| `survey` | `LumiSurveyConfig` | ✅ | Konfigurasjonsobjekt med spørsmålene |
+| `survey` | `LumiSurveyDefinition` | ✅ | Flat legacy-config eller et versjonert dokument med pages |
 | `transport` | `LumiSurveyTransport` | ✅ | Objekt med `submit`-funksjon for innsending |
 | `context` | `LumiSurveyContext` | ❌ | Metadata/tags/debug for segmentering |
 | `behavior` | `LumiSurveyBehavior` | ❌ | Styrer åpning, lukking, cooldown og storage |
@@ -21,7 +21,10 @@ Komplett oversikt over alle props for `LumiSurveyDock`-komponenten.
 | `style` | `LumiSurveyStyle` | ❌ | Visuell styling (posisjon, farger, classNames) |
 | `intro` | `LumiSurveyIntroConfig` | ❌ | Intro-skjerm før første spørsmål |
 
-## `survey` — `LumiSurveyConfig`
+## `survey` — `LumiSurveyDefinition`
+
+`LumiSurveyDefinition` er en union av legacy-formatet under og
+`SurveyDocumentV1`.
 
 ```ts
 interface LumiSurveyConfig {
@@ -34,6 +37,65 @@ interface LumiSurveyConfig {
 ```
 
 Se [Spørsmålstyper](/guider/sporsmalstyper) for detaljer om spørsmål-objektene.
+
+### Flere spørsmål på samme page — `SurveyDocumentV1`
+
+Bruk det versjonerte dokumentformatet når flere spørsmål skal vises og
+valideres sammen på ett steg:
+
+```ts
+import type { SurveyDocumentV1 } from "@navikt/lumi-survey";
+
+const survey = {
+  authoringSchemaVersion: 1,
+  type: "custom",
+  pages: [
+    {
+      id: "opplevelse",
+      title: "Om opplevelsen",
+      description: "Svar på begge spørsmålene.",
+      questions: [
+        {
+          id: "oppgave",
+          type: "text",
+          prompt: "Hva prøvde du å gjøre?",
+          required: true,
+        },
+        {
+          id: "resultat",
+          type: "singleChoice",
+          prompt: "Fikk du gjort det?",
+          required: true,
+          options: [
+            { value: "ja", label: "Ja" },
+            { value: "nei", label: "Nei" },
+          ],
+        },
+      ],
+    },
+    {
+      id: "utdyping",
+      title: "Fortell mer",
+      questions: [
+        {
+          id: "kommentar",
+          type: "text",
+          prompt: "Hva kan vi forbedre?",
+          visibleIf: {
+            questionId: "resultat",
+            operator: "EQ",
+            value: "nei",
+          },
+        },
+      ],
+    },
+  ],
+} satisfies SurveyDocumentV1;
+```
+
+V1 bruker lineær page-navigasjon med `visibleIf` på spørsmål. `logic` støttes
+ikke i dokumentformatet. Svar og submission-definition forblir flate og basert
+på question-ID; page-metadata sendes ikke til API-et.
 
 ## `transport` — `LumiSurveyTransport`
 
@@ -65,9 +127,9 @@ Styrer åpning, lukking, lagring og layout.
 Intro og kvittering regnes ikke som steg. Ved branching viser den visuelle linjen det stabile estimatet, mens tilgjengelig stegtekst bare oppgir sikker informasjon som «Steg 2» uten estimert total.
 
 ::: details questionLayout-verdier
-- **`"auto"`** (default): Step-modus brukes automatisk når branching-logikk (`logic`) finnes. Ellers vises alle synlige spørsmål på én side.
-- **`"singlePage"`**: Alle synlige spørsmål vises alltid på én side.
-- **`"steps"`**: Alltid ett spørsmål om gangen med Neste/Tilbake-knapper.
+- **`"auto"`** (default): Legacy-config bruker dagens branching-regler. Et `SurveyDocumentV1` med flere authored pages bruker page-basert stegmodus.
+- **`"singlePage"`**: Alle synlige spørsmål vises på én side. Page-titler og beskrivelser beholdes som struktur.
+- **`"steps"`**: Navigerer mellom spørsmål for legacy-config og mellom pages for `SurveyDocumentV1`.
 :::
 
 ## `labels` — `LumiSurveyLabels`

--- a/packages/lumi-survey/CHANGELOG.md
+++ b/packages/lumi-survey/CHANGELOG.md
@@ -8,6 +8,7 @@ This project follows SemVer.
 
 ### Added
 
+- `SurveyDocumentV1`, `SurveyPageV1` and `SurveyQuestionV1` add a serializable page-based authoring format. A page can contain multiple questions that render and validate together; `singlePage` preserves page headings while step layout navigates pages. The new format uses question-level `visibleIf` and deliberately rejects legacy `logic`. Existing flat `LumiSurveyConfig` inputs remain supported unchanged. (#336)
 - `visibleIf` now supports `any` (OR) and `all` (AND) to combine multiple conditions. The wider condition type is exported as `VisibleIfCondition` (with `isConditionGroup`/`getLeafConditions`/`isLeafCondition` helpers); `LogicCondition` stays leaf-only so `LogicRule` consumers are unaffected. Note: `question.visibleIf` is now typed `VisibleIfCondition` (leaf | group), so code reading `visibleIf.operator` directly must first narrow with `isConditionGroup`/`isLeafCondition`. (#333)
 
 ### Changed

--- a/packages/lumi-survey/README.md
+++ b/packages/lumi-survey/README.md
@@ -52,9 +52,52 @@ const survey = {
 
 `visibleIf` gjør at tekstfeltet først vises etter at brukeren har valgt en emoji. Se [Progresjon](#progresjon-visibleif) for flere eksempler.
 
+### Flere spørsmål på samme page
+
+Bruk `SurveyDocumentV1` når flere spørsmål skal vises og valideres sammen:
+
+```tsx
+import type { SurveyDocumentV1 } from "@navikt/lumi-survey";
+
+const pagedSurvey = {
+  authoringSchemaVersion: 1,
+  type: "custom",
+  pages: [
+    {
+      id: "opplevelse",
+      title: "Om opplevelsen",
+      description: "Svar på begge spørsmålene.",
+      questions: [
+        {
+          id: "oppgave",
+          type: "text",
+          prompt: "Hva prøvde du å gjøre?",
+          required: true,
+        },
+        {
+          id: "resultat",
+          type: "singleChoice",
+          prompt: "Fikk du gjort det?",
+          required: true,
+          options: [
+            { value: "ja", label: "Ja" },
+            { value: "nei", label: "Nei" },
+          ],
+        },
+      ],
+    },
+  ],
+} satisfies SurveyDocumentV1;
+```
+
+Dokumentformatet bruker lineære pages og question-level `visibleIf`. Det
+støtter ikke legacy-`logic`. Flat `questions[]` støttes fortsatt uten
+migrering. Page-metadata inngår ikke i submission-payloaden.
+
 ## Spørsmålstyper
 
-En survey er et `LumiSurveyConfig`-objekt med spørsmål i rekkefølge.
+Spørsmålene under kan brukes både i flat `LumiSurveyConfig` og i pages i et
+`SurveyDocumentV1`.
 
 ### Rating
 
@@ -229,7 +272,7 @@ Anbefaling: Start med `rating` eller `discovery`, og gå videre til `topTasks`/`
 | Prop | Type | Påkrevd | Beskrivelse |
 | :--- | :--- | :---: | :--- |
 | `surveyId` | `string` | ✅ | Unik identifikator for surveyen (f.eks. `soknad-kvittering`) |
-| `survey` | `LumiSurveyConfig` | ✅ | Konfigurasjonsobjektet for spørsmålene |
+| `survey` | `LumiSurveyDefinition` | ✅ | Flat legacy-config eller versjonert page-dokument |
 | `transport` | `LumiSurveyTransport` | ✅ | Objekt med `submit`-funksjon for innsending |
 | `context` | `object` | ❌ | Metadata/tags/debug for segmentering |
 | `behavior` | `object` | ❌ | Styrer åpning, lukking, cooldown og storage-strategi |

--- a/packages/lumi-survey/src/components/LumiSurveyDock/LumiSurveyDock.tsx
+++ b/packages/lumi-survey/src/components/LumiSurveyDock/LumiSurveyDock.tsx
@@ -13,15 +13,17 @@ import {
   shouldShowSubmitButton,
   useLumiSurvey,
 } from "../../core";
+import { validateAnswers } from "../../core/validation.js";
 import { getVisibilityMetadata } from "../../core/visibilityMetadata.js";
 
 import { buildCanonicalSurvey } from "../shared/canonicalSurvey.js";
-import type { LumiSurveyConfig } from "../surveyTypes.js";
+import type { LumiSurveyDefinition } from "../surveyTypes.js";
 import { CLASS_NAMES, joinClassNames } from "./classNames.js";
 import { DockPanel } from "./components/DockPanel.js";
 import { MinimizedDock } from "./components/MinimizedDock.js";
 import { useAutoCloseOnSuccess } from "./hooks/useAutoCloseOnSuccess.js";
 import { useEnrichedContext } from "./hooks/useEnrichedContext.js";
+import { usePageNavigation } from "./hooks/usePageNavigation.js";
 import { usePersistedDismissal } from "./hooks/usePersistedDismissal.js";
 import { useStepNavigation } from "./hooks/useStepNavigation.js";
 import { resolveConfig } from "./resolveConfig.js";
@@ -58,10 +60,11 @@ export interface LumiSurveyDockProps {
   surveyId: string;
 
   /**
-   * Survey configuration defining the questions to display.
-   * Use presets like NAV_STANDARD_RATING or create custom with createRatingSurvey().
+   * Survey definition. Use a version 1 document with `pages` to group multiple
+   * questions into navigation units, or a legacy flat configuration for
+   * backwards compatibility.
    */
-  survey: LumiSurveyConfig;
+  survey: LumiSurveyDefinition;
 
   /**
    * Transport implementation for submitting feedback data.
@@ -142,30 +145,25 @@ export const LumiSurveyDock = ({
 
   // Track previous showIntro value to detect intro → question transition
   const prevShowIntroRef = useRef(showIntro);
-  const pendingStepFocusQuestionIdRef = useRef<string | null>(null);
+  const pendingStepFocusRef = useRef(false);
+  const [stepValidationMissing, setStepValidationMissing] = useState<string[]>(
+    [],
+  );
+  const [validationAttempt, setValidationAttempt] = useState(0);
 
   /*
    * Use the new flexible survey builder.
    * "questions" is the full list of questions in display order.
    */
   const canonicalSurvey = useMemo(() => buildCanonicalSurvey(survey), [survey]);
-  const { type: surveyType, questions } = canonicalSurvey;
+  const { type: surveyType, questions, pages, source } = canonicalSurvey;
 
   // The first question is used as the "prompt" question in the header
   const promptQuestion = questions[0];
 
-  const promptHeadingId = `${surveyId}-${promptQuestion.id}-dock-heading`;
   const successHeadingId = `${surveyId}-dock-success-heading`;
   const introHeadingId = `${surveyId}-dock-intro-heading`;
   const panelId = `${surveyId}-dock-panel`;
-
-  // Focus the question heading when transitioning from intro → questions
-  useEffect(() => {
-    if (prevShowIntroRef.current && !showIntro) {
-      document.getElementById(promptHeadingId)?.focus();
-    }
-    prevShowIntroRef.current = showIntro;
-  }, [showIntro, promptHeadingId]);
 
   // Auto-collect system context and merge with user-provided context
   const enrichedContext = useEnrichedContext(context, {
@@ -188,6 +186,34 @@ export const LumiSurveyDock = ({
   const forceStepMode = config.questionLayout === "steps";
   const forceSinglePage = config.questionLayout === "singlePage";
 
+  const legacyNavigation = useStepNavigation({
+    questions,
+    answers,
+    metadata: visibilityMetadata,
+    forceStepMode,
+    onStepChange:
+      source === "legacy" && !forceSinglePage
+        ? events?.onStepChange
+        : undefined,
+  });
+
+  const pageNavigation = usePageNavigation({
+    pages,
+    answers,
+    metadata: visibilityMetadata,
+    forceStepMode,
+    autoStepMode:
+      source === "document-v1" &&
+      config.questionLayout === "auto" &&
+      pages.length > 1,
+    onStepChange:
+      source === "document-v1" && !forceSinglePage
+        ? events?.onStepChange
+        : undefined,
+  });
+
+  const navigation =
+    source === "document-v1" ? pageNavigation : legacyNavigation;
   const {
     isStepMode: stepModeFromSurvey,
     currentQuestion: currentStepQuestion,
@@ -201,43 +227,97 @@ export const LumiSurveyDock = ({
     hasBranching,
     visibleStepIndex,
     totalVisibleSteps,
-  } = useStepNavigation({
-    questions,
-    answers,
-    metadata: visibilityMetadata,
-    forceStepMode,
-    onStepChange: forceSinglePage ? undefined : events?.onStepChange,
-  });
+  } = navigation;
+
+  const currentPage =
+    source === "document-v1"
+      ? pageNavigation.currentPage
+      : pages[navigation.currentStep];
+  const currentPageQuestions =
+    source === "document-v1"
+      ? pageNavigation.currentPageQuestions
+      : currentStepQuestion
+        ? [currentStepQuestion]
+        : [];
 
   // When the consumer explicitly requests "singlePage", always disable step
   // mode so that every question renders on one page — even for surveys that
   // contain branching logic.
   const isStepMode = forceSinglePage ? false : stepModeFromSurvey;
 
-  const activeDescriptionQuestion =
-    isStepMode && currentStepQuestion ? currentStepQuestion : promptQuestion;
-  const promptDescriptionId = activeDescriptionQuestion.description
-    ? `${surveyId}-${activeDescriptionQuestion.id}-dock-description`
+  const visiblePages = useMemo(
+    () =>
+      pages
+        .map((page) => ({
+          ...page,
+          questions: getVisibleQuestions(
+            page.questions,
+            answers,
+            visibilityMetadata,
+          ),
+        }))
+        .filter((page) => page.questions.length > 0),
+    [answers, pages, visibilityMetadata],
+  );
+
+  const headerPage =
+    source === "document-v1"
+      ? isStepMode
+        ? currentPage
+        : visiblePages[0]
+      : undefined;
+  const headerQuestion =
+    source === "document-v1"
+      ? ((isStepMode ? currentStepQuestion : visiblePages[0]?.questions[0]) ??
+        promptQuestion)
+      : isStepMode && currentStepQuestion
+        ? currentStepQuestion
+        : promptQuestion;
+  const headerUsesPageTitle = Boolean(headerPage?.title);
+  const promptHeadingId = headerUsesPageTitle
+    ? `${surveyId}-${headerPage?.id}-page-heading`
+    : `${surveyId}-${headerQuestion.id}-dock-heading`;
+  const promptDescription = headerUsesPageTitle
+    ? headerPage?.description
+    : (headerPage?.description ?? headerQuestion.description);
+  const promptDescriptionIsQuestionDescription = Boolean(
+    !headerUsesPageTitle &&
+      !headerPage?.description &&
+      headerQuestion.description,
+  );
+  const promptDescriptionId = promptDescription
+    ? `${promptHeadingId}-description`
     : undefined;
+  const promptQuestionId = headerUsesPageTitle ? undefined : headerQuestion.id;
+
+  // Focus the active page/question heading when leaving the intro.
+  useEffect(() => {
+    if (prevShowIntroRef.current && !showIntro) {
+      document.getElementById(promptHeadingId)?.focus();
+    }
+    prevShowIntroRef.current = showIntro;
+  }, [showIntro, promptHeadingId]);
 
   // Move focus only after an explicit step-navigation action has rendered its
   // target question. Answer-driven visibility updates must not steal focus.
   useEffect(() => {
-    if (
-      !currentStepQuestion ||
-      pendingStepFocusQuestionIdRef.current !== currentStepQuestion.id
-    ) {
-      return;
-    }
-
-    pendingStepFocusQuestionIdRef.current = null;
+    if (!pendingStepFocusRef.current) return;
+    pendingStepFocusRef.current = false;
     document.getElementById(promptHeadingId)?.focus();
-  }, [currentStepQuestion, promptHeadingId]);
+  }, [promptHeadingId]);
+
+  // Filter questions based on visibleIf conditions (progressive disclosure)
+  const visibleQuestions = useMemo(
+    () => getVisibleQuestions(questions, answers, visibilityMetadata),
+    [questions, answers, visibilityMetadata],
+  );
 
   // Combined reset: clears survey answers, resets step navigation, and restores intro screen
   const handleFullReset = useCallback(() => {
     reset();
     resetNavigation();
+    setStepValidationMissing([]);
+    setValidationAttempt(0);
     setShowIntro(config.hasIntro);
   }, [reset, resetNavigation, config.hasIntro]);
 
@@ -250,13 +330,9 @@ export const LumiSurveyDock = ({
       resetOnClose: config.resetOnClose,
       onReset: handleFullReset,
       storageStrategy: config.storageStrategy,
+      viewEnabled:
+        source === "legacy" || visibleQuestions.length > 0 || showIntro,
     });
-
-  // Filter questions based on visibleIf conditions (progressive disclosure)
-  const visibleQuestions = useMemo(
-    () => getVisibleQuestions(questions, answers, visibilityMetadata),
-    [questions, answers, visibilityMetadata],
-  );
 
   // Progressive submit: hide the button until a currently visible question has
   // at least one meaningful answer. Required-answer validation happens on submit.
@@ -271,9 +347,10 @@ export const LumiSurveyDock = ({
   const visitedQuestions = useMemo(() => {
     if (isStepMode) {
       const uniqueIndices = [...new Set(visitedSteps)];
-      const visited = uniqueIndices
-        .map((index) => questions[index])
-        .filter(Boolean);
+      const visited =
+        source === "document-v1"
+          ? uniqueIndices.flatMap((index) => pages[index]?.questions ?? [])
+          : uniqueIndices.map((index) => questions[index]).filter(Boolean);
       return getVisibleQuestions(visited, answers, visibilityMetadata);
     }
     // Non-step mode: only validate visible questions (hidden questions are
@@ -286,30 +363,40 @@ export const LumiSurveyDock = ({
     visibleQuestions,
     answers,
     visibilityMetadata,
+    source,
+    pages,
   ]);
 
   const showPersonalDataNotice = useMemo(() => {
     if (!config.showPersonalDataNotice) return false;
 
     if (isStepMode) {
-      return currentStepQuestion?.type === "text";
+      return currentPageQuestions.some((question) => question.type === "text");
     }
 
     return visibleQuestions.some((q) => q.type === "text");
   }, [
     config.showPersonalDataNotice,
-    currentStepQuestion?.type,
+    currentPageQuestions,
     isStepMode,
     visibleQuestions,
   ]);
 
   const handleNext = useCallback(async () => {
+    if (source === "document-v1") {
+      const missing = validateAnswers(currentPageQuestions, answers);
+      if (missing.length > 0) {
+        setStepValidationMissing(missing);
+        setValidationAttempt((attempt) => attempt + 1);
+        events?.onValidationFailed?.(missing);
+        return;
+      }
+      setStepValidationMissing([]);
+    }
+
     const result = goToNext();
     if (result?.nextIndex !== undefined && result.nextIndex !== -1) {
-      const targetQuestionId = questions[result.nextIndex]?.id;
-      if (targetQuestionId !== currentStepQuestion?.id) {
-        pendingStepFocusQuestionIdRef.current = targetQuestionId ?? null;
-      }
+      pendingStepFocusRef.current = true;
       return;
     }
 
@@ -322,24 +409,49 @@ export const LumiSurveyDock = ({
     } catch {
       // useLumiSurvey sets error state; avoid unhandled rejections
     }
-  }, [currentStepQuestion?.id, goToNext, questions, submit, visitedQuestions]);
+  }, [
+    answers,
+    currentPageQuestions,
+    events,
+    goToNext,
+    source,
+    submit,
+    visitedQuestions,
+  ]);
 
   const handleBack = useCallback(() => {
     const previousIndex = goToPrevious();
     if (previousIndex === null) return;
+    setStepValidationMissing([]);
+    pendingStepFocusRef.current = true;
+  }, [goToPrevious]);
 
-    const targetQuestionId = questions[previousIndex]?.id;
-    if (targetQuestionId !== currentStepQuestion?.id) {
-      pendingStepFocusQuestionIdRef.current = targetQuestionId ?? null;
-    }
-  }, [currentStepQuestion?.id, goToPrevious, questions]);
+  const handleQuestionChange = useCallback(
+    (questionId: string, value: Parameters<typeof setAnswer>[1]) => {
+      setAnswer(questionId, value);
+      setStepValidationMissing((missing) =>
+        missing.includes(questionId)
+          ? missing.filter((id) => id !== questionId)
+          : missing,
+      );
+    },
+    [setAnswer],
+  );
 
   const handleSubmit = useCallback(
     async (event: React.FormEvent<HTMLFormElement>) => {
       event.preventDefault();
+      const missing = validateAnswers(visitedQuestions, answers);
+      if (missing.length > 0) {
+        setStepValidationMissing(missing);
+        setValidationAttempt((attempt) => attempt + 1);
+        events?.onValidationFailed?.(missing);
+        return;
+      }
+      setStepValidationMissing([]);
       await submit(visitedQuestions);
     },
-    [submit, visitedQuestions],
+    [answers, events, submit, visitedQuestions],
   );
 
   const isSubmitting = status === "submitting";
@@ -359,7 +471,26 @@ export const LumiSurveyDock = ({
     delayMs: config.successCloseDelayMs,
     onClose: handleCloseDock,
   });
-  const validationMissing = error?.type === "validation" ? error.missing : [];
+  const validationMissing = useMemo(() => {
+    const storedMissing = new Set([
+      ...stepValidationMissing,
+      ...(error?.type === "validation" ? error.missing : []),
+    ]);
+    if (storedMissing.size === 0) return [];
+
+    const renderedQuestions = isStepMode
+      ? currentPageQuestions
+      : visibleQuestions;
+    const stillMissing = new Set(validateAnswers(renderedQuestions, answers));
+    return [...storedMissing].filter((id) => stillMissing.has(id));
+  }, [
+    answers,
+    currentPageQuestions,
+    error,
+    isStepMode,
+    stepValidationMissing,
+    visibleQuestions,
+  ]);
   const hasTransportError = error?.type === "transport";
 
   const baseContainerStyle: React.CSSProperties = {
@@ -371,8 +502,8 @@ export const LumiSurveyDock = ({
   };
 
   const isNpsDock =
-    promptQuestion.type === "rating" &&
-    (promptQuestion as RatingQuestion).variant === "nps";
+    headerQuestion.type === "rating" &&
+    (headerQuestion as RatingQuestion).variant === "nps";
 
   const openWidthRem = isNpsDock ? 32 : 24;
 
@@ -397,6 +528,15 @@ export const LumiSurveyDock = ({
 
   // Don't render anything when dismissed with hideCompletely flag
   if (dismissed && shouldHideCompletely) {
+    return null;
+  }
+
+  if (
+    source === "document-v1" &&
+    visibleQuestions.length === 0 &&
+    !showIntro &&
+    !isSuccess
+  ) {
     return null;
   }
 
@@ -426,14 +566,18 @@ export const LumiSurveyDock = ({
           panelStyle={panelStyle}
           panelBackground={config.panelBackground}
           panelBorderColor={config.panelBorderColor}
-          promptQuestion={promptQuestion}
+          promptQuestion={headerQuestion}
+          headerTitle={headerPage?.title}
+          headerDescription={promptDescription}
           successHeadingId={successHeadingId}
           introHeadingId={introHeadingId}
           onClose={handleCloseDock}
           onSubmit={handleSubmit}
           orderedQuestions={visibleQuestions}
+          orderedPages={source === "document-v1" ? visiblePages : undefined}
           answers={answers}
           validationMissing={validationMissing}
+          validationAttempt={validationAttempt}
           isSubmitting={isSubmitting}
           submitLabel={config.submitLabel}
           submitPendingLabel={config.submitPendingLabel}
@@ -443,14 +587,16 @@ export const LumiSurveyDock = ({
           isSubmitBlocked={isSubmitBlocked}
           hasTransportError={Boolean(hasTransportError)}
           transportErrorMessage={config.transportErrorMessage}
-          onQuestionChange={setAnswer}
+          onQuestionChange={handleQuestionChange}
           stepNavigation={{
             isStepMode,
             currentStep: visibleStepIndex,
             currentStepQuestion,
+            currentStepQuestions: currentPageQuestions,
             canGoBack,
             canGoNext,
             isLastStep,
+            disableWhenIncomplete: source === "legacy",
             onNext: handleNext,
             onBack: handleBack,
           }}
@@ -460,9 +606,11 @@ export const LumiSurveyDock = ({
             hasBranching,
           }}
           questionContext={{
-            promptQuestionId: promptQuestion.id,
+            promptQuestionId,
             promptHeadingId,
             promptDescriptionId,
+            promptDescriptionIsQuestionDescription,
+            questionAnchorPrefix: `${surveyId}-question`,
             validationErrorMessage: config.validationErrorMessage,
           }}
           intro={{

--- a/packages/lumi-survey/src/components/LumiSurveyDock/__tests__/LumiSurveyDock.test.tsx
+++ b/packages/lumi-survey/src/components/LumiSurveyDock/__tests__/LumiSurveyDock.test.tsx
@@ -9,7 +9,11 @@ import {
   createRatingSurvey,
   createTopTasksSurvey,
 } from "../../../presets/index.js";
-import type { LumiSurveyConfig } from "../../surveyTypes.js";
+import type {
+  LumiSurveyConfig,
+  LumiSurveyDefinition,
+  SurveyDocumentV1,
+} from "../../surveyTypes.js";
 import { LumiSurveyDock } from "../LumiSurveyDock.js";
 
 function createSurvey(): LumiSurveyConfig {
@@ -38,7 +42,7 @@ function createSurvey(): LumiSurveyConfig {
 function renderDock(options?: {
   transport?: LumiSurveyTransport;
   events?: LumiSurveyEvents;
-  survey?: LumiSurveyConfig;
+  survey?: LumiSurveyDefinition;
   context?: Record<string, unknown>;
   initialOpen?: boolean;
   behavior?: Record<string, unknown>;
@@ -65,6 +69,504 @@ function renderDock(options?: {
 describe("LumiSurveyDock", () => {
   beforeEach(() => {
     localStorage.clear();
+  });
+
+  it("renders and validates multiple questions on an authored page", async () => {
+    const user = userEvent.setup();
+    const onStepChange = vi.fn();
+    const survey: SurveyDocumentV1 = {
+      authoringSchemaVersion: 1,
+      type: "custom",
+      pages: [
+        {
+          id: "context",
+          title: "Om besøket",
+          description: "Svar på begge spørsmålene.",
+          questions: [
+            {
+              id: "task",
+              type: "text",
+              prompt: "Hva prøvde du å gjøre?",
+              required: true,
+            },
+            {
+              id: "outcome",
+              type: "text",
+              prompt: "Hvordan gikk det?",
+              required: true,
+            },
+          ],
+        },
+        {
+          id: "details",
+          title: "Fortell mer",
+          questions: [
+            {
+              id: "comment",
+              type: "text",
+              prompt: "Hva kan vi forbedre?",
+            },
+          ],
+        },
+      ],
+    };
+
+    renderDock({
+      survey,
+      events: { onStepChange },
+      behavior: { questionLayout: "auto", showProgress: true },
+    });
+
+    expect(
+      await screen.findByRole("heading", { name: "Om besøket" }),
+    ).toBeInTheDocument();
+    expect(screen.getByText("Svar på begge spørsmålene.")).toBeInTheDocument();
+    expect(
+      screen.getByRole("textbox", { name: "Hva prøvde du å gjøre?" }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("textbox", { name: "Hvordan gikk det?" }),
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByRole("textbox", { name: "Hva kan vi forbedre?" }),
+    ).not.toBeInTheDocument();
+    expect(onStepChange).toHaveBeenLastCalledWith(0, 2);
+
+    await user.click(screen.getByRole("button", { name: "Neste" }));
+
+    const errorSummary = await screen.findByText(
+      "Du må svare på disse spørsmålene før du kan fortsette:",
+    );
+    expect(errorSummary).toHaveFocus();
+    expect(
+      screen.getByRole("link", { name: "Hva prøvde du å gjøre?" }),
+    ).toHaveAttribute("href", "#dock-feedback-question-task");
+    await user.click(screen.getByRole("button", { name: "Neste" }));
+    expect(errorSummary).toHaveFocus();
+    await user.click(
+      screen.getByRole("link", { name: "Hva prøvde du å gjøre?" }),
+    );
+    expect(
+      screen.getByRole("textbox", { name: "Hva prøvde du å gjøre?" }),
+    ).toHaveFocus();
+
+    await user.type(
+      screen.getByRole("textbox", { name: "Hva prøvde du å gjøre?" }),
+      "Finne informasjon",
+    );
+    expect(
+      screen.getByRole("textbox", { name: "Hva prøvde du å gjøre?" }),
+    ).toHaveFocus();
+    await user.type(
+      screen.getByRole("textbox", { name: "Hvordan gikk det?" }),
+      "Bra",
+    );
+    await user.click(screen.getByRole("button", { name: "Neste" }));
+
+    const secondHeading = await screen.findByRole("heading", {
+      name: "Fortell mer",
+    });
+    expect(secondHeading).toHaveFocus();
+    expect(onStepChange).toHaveBeenLastCalledWith(1, 2);
+  });
+
+  it("skips authored pages that have no visible questions", async () => {
+    const user = userEvent.setup();
+    const survey: SurveyDocumentV1 = {
+      authoringSchemaVersion: 1,
+      pages: [
+        {
+          id: "decision",
+          questions: [
+            {
+              id: "decision-question",
+              type: "singleChoice",
+              prompt: "Vil du utdype?",
+              required: true,
+              options: [
+                { value: "yes", label: "Ja" },
+                { value: "no", label: "Nei" },
+              ],
+            },
+          ],
+        },
+        {
+          id: "conditional",
+          title: "Utdyping",
+          questions: [
+            {
+              id: "conditional-comment",
+              type: "text",
+              prompt: "Fortell mer",
+              visibleIf: {
+                questionId: "decision-question",
+                operator: "EQ",
+                value: "yes",
+              },
+            },
+          ],
+        },
+        {
+          id: "final",
+          title: "Til slutt",
+          questions: [
+            {
+              id: "final-comment",
+              type: "text",
+              prompt: "Andre kommentarer?",
+            },
+          ],
+        },
+      ],
+    };
+
+    renderDock({ survey });
+    await user.click(await screen.findByRole("radio", { name: "Nei" }));
+    await user.click(screen.getByRole("button", { name: "Neste" }));
+
+    expect(
+      await screen.findByRole("heading", { name: "Til slutt" }),
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByRole("heading", { name: "Utdyping" }),
+    ).not.toBeInTheDocument();
+  });
+
+  it("flattens authored pages in single-page layout and keeps page headings", async () => {
+    const survey: SurveyDocumentV1 = {
+      authoringSchemaVersion: 1,
+      pages: [
+        {
+          id: "first",
+          title: "Første del",
+          questions: [{ id: "q1", type: "text", prompt: "Spørsmål én" }],
+        },
+        {
+          id: "second",
+          title: "Andre del",
+          description: "Felles kontekst.",
+          questions: [{ id: "q2", type: "text", prompt: "Spørsmål to" }],
+        },
+      ],
+    };
+
+    renderDock({ survey, behavior: { questionLayout: "singlePage" } });
+
+    expect(
+      await screen.findByRole("heading", { name: "Første del" }),
+    ).toBeInTheDocument();
+    expect(screen.getByRole("heading", { name: "Andre del" }).tagName).toBe(
+      "H2",
+    );
+    expect(screen.getByText("Felles kontekst.")).toBeInTheDocument();
+    expect(
+      screen.getByRole("textbox", { name: /Spørsmål én/ }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("textbox", { name: /Spørsmål to/ }),
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: "Neste" }),
+    ).not.toBeInTheDocument();
+  });
+
+  it("uses the first visible question as the header when a document page has no title", async () => {
+    const survey: SurveyDocumentV1 = {
+      authoringSchemaVersion: 1,
+      pages: [
+        {
+          id: "untitled",
+          questions: [
+            {
+              id: "hidden",
+              type: "text",
+              prompt: "Skjult spørsmål",
+              visibleIf: {
+                field: "METADATA",
+                key: "showHidden",
+                operator: "EQ",
+                value: true,
+              },
+            },
+            {
+              id: "visible",
+              type: "text",
+              prompt: "Synlig spørsmål",
+            },
+          ],
+        },
+      ],
+    };
+
+    renderDock({ survey, behavior: { questionLayout: "singlePage" } });
+
+    expect(
+      await screen.findByRole("heading", { name: /Synlig spørsmål/ }),
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByRole("heading", { name: "Skjult spørsmål" }),
+    ).not.toBeInTheDocument();
+  });
+
+  it("clears page validation errors when the dock resets on close", async () => {
+    const user = userEvent.setup();
+    const survey: SurveyDocumentV1 = {
+      authoringSchemaVersion: 1,
+      pages: [
+        {
+          id: "required",
+          questions: [
+            { id: "first", type: "text", prompt: "Første", required: true },
+            { id: "second", type: "text", prompt: "Andre", required: true },
+          ],
+        },
+        {
+          id: "last",
+          questions: [{ id: "last", type: "text", prompt: "Siste" }],
+        },
+      ],
+    };
+
+    renderDock({ survey, behavior: { storageStrategy: "none" } });
+    await user.click(await screen.findByRole("button", { name: "Neste" }));
+    expect(
+      screen.getByText(
+        "Du må svare på disse spørsmålene før du kan fortsette:",
+      ),
+    ).toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: "Lukk" }));
+    await user.click(screen.getByRole("button", { name: "Gi tilbakemelding" }));
+
+    expect(
+      screen.queryByText(
+        "Du må svare på disse spørsmålene før du kan fortsette:",
+      ),
+    ).not.toBeInTheDocument();
+  });
+
+  it("does not render a document while every page is hidden", async () => {
+    const onViewDock = vi.fn();
+    const survey: SurveyDocumentV1 = {
+      authoringSchemaVersion: 1,
+      pages: [
+        {
+          id: "hidden",
+          questions: [
+            {
+              id: "hidden-question",
+              type: "text",
+              prompt: "Skjult spørsmål",
+              visibleIf: {
+                field: "METADATA",
+                key: "ready",
+                operator: "EQ",
+                value: true,
+              },
+            },
+          ],
+        },
+      ],
+    };
+
+    renderDock({ survey, events: { onViewDock } });
+
+    await waitFor(() => {
+      expect(
+        screen.queryByRole("complementary", {
+          name: "Tilbakemeldingspanel",
+        }),
+      ).not.toBeInTheDocument();
+    });
+    expect(onViewDock).not.toHaveBeenCalled();
+  });
+
+  it("keeps page and rating descriptions visible and associated", async () => {
+    const survey: SurveyDocumentV1 = {
+      authoringSchemaVersion: 1,
+      pages: [
+        {
+          id: "rating-page",
+          description: "Dette gjelder besøket ditt.",
+          questions: [
+            {
+              id: "rating",
+              type: "rating",
+              prompt: "Hvordan gikk det?",
+              description: "Velg det alternativet som passer best.",
+            },
+          ],
+        },
+      ],
+    };
+
+    const { container } = renderDock({ survey });
+
+    expect(
+      await screen.findByText("Dette gjelder besøket ditt."),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText("Velg det alternativet som passer best."),
+    ).toBeInTheDocument();
+    expect(container.querySelector("fieldset")).toHaveAttribute(
+      "aria-describedby",
+      expect.stringContaining("rating-description"),
+    );
+    expect(container.querySelector("fieldset")).toHaveAttribute(
+      "aria-describedby",
+      expect.stringContaining("dock-feedback-rating-dock-heading-description"),
+    );
+  });
+
+  it("does not repeat a question description in a titled page header", async () => {
+    const survey: SurveyDocumentV1 = {
+      authoringSchemaVersion: 1,
+      pages: [
+        {
+          id: "titled",
+          title: "Om opplevelsen",
+          questions: [
+            {
+              id: "comment",
+              type: "text",
+              prompt: "Fortell mer",
+              description: "Du kan skrive kort.",
+            },
+          ],
+        },
+      ],
+    };
+
+    renderDock({ survey });
+
+    expect(
+      await screen.findByRole("heading", { name: "Om opplevelsen" }),
+    ).toBeInTheDocument();
+    expect(screen.getAllByText("Du kan skrive kort.")).toHaveLength(1);
+  });
+
+  it("removes errors for questions hidden by a new answer without stealing focus", async () => {
+    const user = userEvent.setup();
+    const visibleWhenYes = {
+      questionId: "controller",
+      operator: "EQ" as const,
+      value: "yes",
+    };
+    const survey: SurveyDocumentV1 = {
+      authoringSchemaVersion: 1,
+      pages: [
+        {
+          id: "conditional-fields",
+          questions: [
+            {
+              id: "controller",
+              type: "singleChoice",
+              prompt: "Vil du utdype?",
+              required: true,
+              options: [
+                { value: "yes", label: "Ja" },
+                { value: "no", label: "Nei" },
+              ],
+            },
+            {
+              id: "detail-one",
+              type: "text",
+              prompt: "Detalj én",
+              required: true,
+              visibleIf: visibleWhenYes,
+            },
+            {
+              id: "detail-two",
+              type: "text",
+              prompt: "Detalj to",
+              required: true,
+              visibleIf: visibleWhenYes,
+            },
+          ],
+        },
+        {
+          id: "last",
+          questions: [{ id: "last", type: "text", prompt: "Siste" }],
+        },
+      ],
+    };
+
+    renderDock({ survey });
+    await user.click(await screen.findByRole("radio", { name: "Ja" }));
+    await user.click(screen.getByRole("button", { name: "Neste" }));
+    expect(
+      screen.getByText(
+        "Du må svare på disse spørsmålene før du kan fortsette:",
+      ),
+    ).toBeInTheDocument();
+
+    const noOption = screen.getByRole("radio", { name: "Nei" });
+    await user.click(noOption);
+
+    expect(
+      screen.queryByText(
+        "Du må svare på disse spørsmålene før du kan fortsette:",
+      ),
+    ).not.toBeInTheDocument();
+    expect(noOption).toHaveFocus();
+  });
+
+  it("keeps authored page metadata out of the flat submission contract", async () => {
+    const user = userEvent.setup();
+    const transport: LumiSurveyTransport = {
+      submit: vi.fn().mockResolvedValue(undefined),
+    };
+    const survey: SurveyDocumentV1 = {
+      authoringSchemaVersion: 1,
+      type: "custom",
+      pages: [
+        {
+          id: "page-identity-must-not-leak",
+          title: "Tilbakemelding",
+          description: "Denne teksten er bare presentasjon.",
+          questions: [
+            {
+              id: "answer",
+              type: "text",
+              prompt: "Hva synes du?",
+              required: true,
+            },
+            {
+              id: "hidden-detail",
+              type: "text",
+              prompt: "Skjult detalj",
+              visibleIf: {
+                questionId: "answer",
+                operator: "EQ",
+                value: "vis",
+              },
+            },
+          ],
+        },
+      ],
+    };
+
+    renderDock({ survey, transport });
+    await user.type(
+      await screen.findByRole("textbox", { name: "Hva synes du?" }),
+      "bra",
+    );
+    await user.click(screen.getByRole("button", { name: "Send" }));
+
+    await waitFor(() => expect(transport.submit).toHaveBeenCalledOnce());
+    const submission = vi.mocked(transport.submit).mock.calls[0]?.[0];
+    expect(submission?.answers).toEqual({ answer: "bra" });
+    expect(
+      submission?.transportPayload.definition.fields.map(
+        (field) => field.fieldId,
+      ),
+    ).toEqual(["answer", "hidden-detail"]);
+    expect(JSON.stringify(submission)).not.toContain(
+      "page-identity-must-not-leak",
+    );
+    expect(JSON.stringify(submission)).not.toContain(
+      "Denne teksten er bare presentasjon.",
+    );
   });
 
   it("uses the same typography scale for every question on a single page", async () => {
@@ -502,6 +1004,7 @@ describe("LumiSurveyDock", () => {
     expect(events.onValidationFailed).toHaveBeenCalledWith(
       expect.arrayContaining(["feedback"]),
     );
+    expect(screen.getByLabelText(/hva kan vi forbedre/i)).toHaveFocus();
   });
 
   it("calls onViewDock when the dock mounts", () => {

--- a/packages/lumi-survey/src/components/LumiSurveyDock/__tests__/accessibility.test.tsx
+++ b/packages/lumi-survey/src/components/LumiSurveyDock/__tests__/accessibility.test.tsx
@@ -3,6 +3,7 @@ import userEvent from "@testing-library/user-event";
 import axe from "axe-core";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { createRatingSurvey } from "../../../presets";
+import type { SurveyDocumentV1 } from "../../surveyTypes.js";
 import { LumiSurveyDock } from "../LumiSurveyDock.js";
 
 const survey = createRatingSurvey({
@@ -281,5 +282,54 @@ describe("LumiSurveyDock Accessibility", () => {
     expect(
       screen.getByRole("heading", { name: /hvor fornøyd er du/i }),
     ).not.toHaveFocus();
+  });
+
+  it("has no axe violations with multiple questions and an error summary", async () => {
+    const user = userEvent.setup();
+    const pageSurvey: SurveyDocumentV1 = {
+      authoringSchemaVersion: 1,
+      pages: [
+        {
+          id: "page-one",
+          title: "Om opplevelsen",
+          questions: [
+            {
+              id: "first",
+              type: "text",
+              prompt: "Første spørsmål",
+              required: true,
+            },
+            {
+              id: "second",
+              type: "text",
+              prompt: "Andre spørsmål",
+              required: true,
+            },
+          ],
+        },
+        {
+          id: "page-two",
+          title: "Til slutt",
+          questions: [{ id: "last", type: "text", prompt: "Siste spørsmål" }],
+        },
+      ],
+    };
+    const { container } = render(
+      <LumiSurveyDock
+        surveyId="page-a11y-test"
+        survey={pageSurvey}
+        transport={mockTransport}
+      />,
+    );
+
+    await user.click(await screen.findByRole("button", { name: "Neste" }));
+    expect(
+      await screen.findByText(
+        "Du må svare på disse spørsmålene før du kan fortsette:",
+      ),
+    ).toHaveFocus();
+
+    const results = await axe.run(container);
+    expect(results.violations).toEqual([]);
   });
 });

--- a/packages/lumi-survey/src/components/LumiSurveyDock/components/DockPanel.tsx
+++ b/packages/lumi-survey/src/components/LumiSurveyDock/components/DockPanel.tsx
@@ -10,6 +10,7 @@ import type React from "react";
 import type { ComponentProps } from "react";
 import type { LumiSurveyAnswerValue, LumiSurveyQuestion } from "../../../core";
 import { formatQuestionPrompt } from "../../questions/utils/formatQuestionPrompt.js";
+import type { CanonicalSurveyPage } from "../../shared/canonicalSurvey.js";
 import { CLASS_NAMES, joinClassNames } from "../classNames.js";
 import type {
   IntroProps,
@@ -35,13 +36,17 @@ interface DockPanelProps {
   panelBackground: BoxProps["background"];
   panelBorderColor?: BoxProps["borderColor"];
   promptQuestion: LumiSurveyQuestion;
+  headerTitle?: string;
+  headerDescription?: string;
   successHeadingId: string;
   introHeadingId: string;
   onClose: () => void;
   onSubmit: (event: React.FormEvent<HTMLFormElement>) => Promise<void>;
   orderedQuestions: LumiSurveyQuestion[];
+  orderedPages?: CanonicalSurveyPage[];
   answers: Record<string, LumiSurveyAnswerValue>;
   validationMissing: string[];
+  validationAttempt: number;
   isSubmitting: boolean;
   submitLabel: string;
   submitPendingLabel: string;
@@ -71,13 +76,17 @@ export const DockPanel = ({
   panelBackground,
   panelBorderColor,
   promptQuestion,
+  headerTitle,
+  headerDescription,
   successHeadingId,
   introHeadingId,
   onClose,
   onSubmit,
   orderedQuestions,
+  orderedPages,
   answers,
   validationMissing,
+  validationAttempt,
   isSubmitting,
   submitLabel,
   submitPendingLabel,
@@ -116,6 +125,10 @@ export const DockPanel = ({
   const activeQuestion =
     isStepMode && currentStepQuestion ? currentStepQuestion : promptQuestion;
   const usesFieldTypography = !isStepMode && orderedQuestions.length > 1;
+  const activeHeading = headerTitle ?? formatQuestionPrompt(activeQuestion);
+  const activeDescription = headerTitle
+    ? headerDescription
+    : (headerDescription ?? activeQuestion.description);
 
   return (
     <div style={{ position: "relative" }}>
@@ -203,15 +216,15 @@ export const DockPanel = ({
                       id={promptHeadingId}
                       tabIndex={-1}
                     >
-                      {formatQuestionPrompt(activeQuestion)}
+                      {activeHeading}
                     </Heading>
-                    {activeQuestion.description && (
+                    {activeDescription && (
                       <BodyShort
                         size={usesFieldTypography ? "medium" : "small"}
                         className={CLASS_NAMES.ratingDescription}
                         id={promptDescriptionId}
                       >
-                        {activeQuestion.description}
+                        {activeDescription}
                       </BodyShort>
                     )}
                   </>
@@ -239,9 +252,11 @@ export const DockPanel = ({
                 submitLabel={submitLabel}
                 submitPendingLabel={submitPendingLabel}
                 orderedQuestions={orderedQuestions}
+                orderedPages={orderedPages}
                 answers={answers}
                 onQuestionChange={onQuestionChange}
                 validationMissing={validationMissing}
+                validationAttempt={validationAttempt}
                 stepNavigation={stepNavigation}
                 progress={progress}
                 questionContext={questionContext}

--- a/packages/lumi-survey/src/components/LumiSurveyDock/components/DockQuestionRenderer.tsx
+++ b/packages/lumi-survey/src/components/LumiSurveyDock/components/DockQuestionRenderer.tsx
@@ -5,9 +5,10 @@ import { DefaultQuestionRenderer, RatingQuestionField } from "../../questions";
 import { CLASS_NAMES } from "../classNames.js";
 
 interface DockQuestionRendererProps extends LumiSurveyRenderQuestionProps {
-  promptQuestionId: string;
+  promptQuestionId?: string;
   promptHeadingId: string;
   promptDescriptionId?: string;
+  promptDescriptionIsQuestionDescription?: boolean;
   validationErrorMessage: string;
 }
 
@@ -22,6 +23,7 @@ export const DockQuestionRenderer = React.memo(
     promptQuestionId,
     promptHeadingId,
     promptDescriptionId,
+    promptDescriptionIsQuestionDescription = true,
     validationErrorMessage,
   }: DockQuestionRendererProps) => {
     if (question.type === "rating") {
@@ -41,7 +43,10 @@ export const DockQuestionRenderer = React.memo(
               disabled={disabled}
               fieldsetClassName={CLASS_NAMES.ratingFieldset}
               hidePrompt={shouldHideInternalHeading}
-              hideDescription={shouldHideInternalHeading}
+              hideDescription={
+                shouldHideInternalHeading &&
+                promptDescriptionIsQuestionDescription
+              }
               hideValueLabels
               wrap={false}
               ariaLabelledBy={

--- a/packages/lumi-survey/src/components/LumiSurveyDock/components/SurveyFormContent.tsx
+++ b/packages/lumi-survey/src/components/LumiSurveyDock/components/SurveyFormContent.tsx
@@ -2,12 +2,16 @@ import {
   Alert,
   BodyShort,
   Button,
+  ErrorSummary,
+  Heading,
   HStack,
   ProgressBar,
   VStack,
 } from "@navikt/ds-react";
-import React, { useCallback, useRef } from "react";
+import React, { useCallback, useEffect, useRef } from "react";
 import type { LumiSurveyAnswerValue, LumiSurveyQuestion } from "../../../core";
+import { formatQuestionPrompt } from "../../questions/utils/formatQuestionPrompt.js";
+import type { CanonicalSurveyPage } from "../../shared/canonicalSurvey.js";
 import { CLASS_NAMES } from "../classNames.js";
 import type {
   ProgressProps,
@@ -26,12 +30,14 @@ interface SurveyFormContentProps {
 
   // Questions
   orderedQuestions: LumiSurveyQuestion[];
+  orderedPages?: CanonicalSurveyPage[];
   answers: Record<string, LumiSurveyAnswerValue>;
   onQuestionChange: (
     questionId: string,
     value: LumiSurveyAnswerValue | null | undefined,
   ) => void;
   validationMissing: string[];
+  validationAttempt?: number;
 
   // Grouped props
   stepNavigation: StepNavigationProps;
@@ -48,6 +54,14 @@ interface SurveyFormContentProps {
   disabled: boolean;
 }
 
+function focusQuestionField(anchorPrefix: string, questionId: string) {
+  const question = document.getElementById(`${anchorPrefix}-${questionId}`);
+  const field = question?.querySelector<HTMLElement>(
+    "input, textarea, select, button",
+  );
+  (field ?? question)?.focus();
+}
+
 export const SurveyFormContent = React.memo(
   ({
     onSubmit,
@@ -56,9 +70,11 @@ export const SurveyFormContent = React.memo(
     submitLabel,
     submitPendingLabel,
     orderedQuestions,
+    orderedPages,
     answers,
     onQuestionChange,
     validationMissing,
+    validationAttempt = 0,
     stepNavigation,
     progress,
     questionContext,
@@ -73,9 +89,11 @@ export const SurveyFormContent = React.memo(
       isStepMode = false,
       currentStep = 0,
       currentStepQuestion,
+      currentStepQuestions,
       canGoBack = false,
       canGoNext = true,
       isLastStep = false,
+      disableWhenIncomplete = true,
       onNext,
       onBack,
       nextLabel = "Neste",
@@ -92,6 +110,8 @@ export const SurveyFormContent = React.memo(
       promptQuestionId,
       promptHeadingId,
       promptDescriptionId,
+      promptDescriptionIsQuestionDescription,
+      questionAnchorPrefix,
       validationErrorMessage,
     } = questionContext;
     const currentStepNumber = currentStep + 1;
@@ -120,6 +140,88 @@ export const SurveyFormContent = React.memo(
       }
       return handler;
     }, []);
+
+    const errorSummaryRef = useRef<HTMLDivElement>(null);
+    const validationMissingRef = useRef(validationMissing);
+    validationMissingRef.current = validationMissing;
+    const questionAnchorPrefixRef = useRef(questionAnchorPrefix);
+    questionAnchorPrefixRef.current = questionAnchorPrefix;
+    const previousValidationAttemptRef = useRef(validationAttempt);
+    useEffect(() => {
+      if (
+        validationAttempt === 0 ||
+        previousValidationAttemptRef.current === validationAttempt
+      ) {
+        return;
+      }
+      previousValidationAttemptRef.current = validationAttempt;
+      const missing = validationMissingRef.current;
+      if (missing.length > 1) {
+        errorSummaryRef.current?.focus();
+        return;
+      }
+      if (missing.length === 0) return;
+      focusQuestionField(questionAnchorPrefixRef.current, missing[0]);
+    }, [validationAttempt]);
+
+    const renderQuestion = (
+      question: LumiSurveyQuestion,
+      hideLabel: boolean,
+    ) => {
+      const isMissing = validationMissing.includes(question.id);
+      return (
+        <div
+          key={question.id}
+          id={`${questionAnchorPrefix}-${question.id}`}
+          className={CLASS_NAMES.question}
+          tabIndex={-1}
+        >
+          <DockQuestionRenderer
+            question={question}
+            value={answers[question.id]}
+            onChange={getChangeHandler(question.id)}
+            isMissing={isMissing}
+            disabled={disabled}
+            hideLabel={hideLabel}
+            promptQuestionId={promptQuestionId}
+            promptHeadingId={promptHeadingId}
+            promptDescriptionId={promptDescriptionId}
+            promptDescriptionIsQuestionDescription={
+              promptDescriptionIsQuestionDescription
+            }
+            validationErrorMessage={validationErrorMessage}
+          />
+        </div>
+      );
+    };
+
+    const errorSummary = validationMissing.length > 1 && (
+      <ErrorSummary
+        ref={errorSummaryRef}
+        size="small"
+        heading="Du må svare på disse spørsmålene før du kan fortsette:"
+      >
+        {validationMissing.map((questionId) => {
+          const question = orderedQuestions.find(
+            (candidate) => candidate.id === questionId,
+          );
+          return (
+            <ErrorSummary.Item
+              key={questionId}
+              href={`#${questionAnchorPrefix}-${questionId}`}
+              onClick={(event) => {
+                event.preventDefault();
+                focusQuestionField(questionAnchorPrefix, questionId);
+              }}
+            >
+              {question
+                ? formatQuestionPrompt(question)
+                : validationErrorMessage}
+            </ErrorSummary.Item>
+          );
+        })}
+      </ErrorSummary>
+    );
 
     return (
       <>
@@ -155,24 +257,13 @@ export const SurveyFormContent = React.memo(
         <form onSubmit={onSubmit} noValidate>
           <VStack gap="space-16">
             {isStepMode && currentStepQuestion ? (
-              // Step mode: Show only the current question
+              // Step mode: Show all visible questions on the current page.
               <>
-                <div className={CLASS_NAMES.question}>
-                  <DockQuestionRenderer
-                    question={currentStepQuestion}
-                    value={answers[currentStepQuestion.id]}
-                    onChange={getChangeHandler(currentStepQuestion.id)}
-                    isMissing={validationMissing.includes(
-                      currentStepQuestion.id,
-                    )}
-                    disabled={disabled}
-                    hideLabel
-                    promptQuestionId={promptQuestionId}
-                    promptHeadingId={promptHeadingId}
-                    promptDescriptionId={promptDescriptionId}
-                    validationErrorMessage={validationErrorMessage}
-                  />
-                </div>
+                {errorSummary}
+                {(currentStepQuestions ?? [currentStepQuestion]).map(
+                  (question) =>
+                    renderQuestion(question, question.id === promptQuestionId),
+                )}
 
                 {/* Show privacy notice when a text field is visible */}
                 {showPersonalDataNotice && (
@@ -203,7 +294,9 @@ export const SurveyFormContent = React.memo(
                       key="submit-btn"
                       type="submit"
                       loading={isSubmitting}
-                      disabled={isSubmitting || !canGoNext}
+                      disabled={
+                        isSubmitting || (disableWhenIncomplete && !canGoNext)
+                      }
                     >
                       {isSubmitting ? submitPendingLabel : submitLabel}
                     </Button>
@@ -212,7 +305,9 @@ export const SurveyFormContent = React.memo(
                       key="next-btn"
                       type="button"
                       onClick={onNext}
-                      disabled={isSubmitting || !canGoNext}
+                      disabled={
+                        isSubmitting || (disableWhenIncomplete && !canGoNext)
+                      }
                     >
                       {nextLabel}
                     </Button>
@@ -222,27 +317,36 @@ export const SurveyFormContent = React.memo(
             ) : (
               // All visible questions mode
               <>
-                {orderedQuestions.map((question) => {
-                  const value = answers[question.id];
-                  const isMissing = validationMissing.includes(question.id);
-
-                  return (
-                    <div key={question.id} className={CLASS_NAMES.question}>
-                      <DockQuestionRenderer
-                        question={question}
-                        value={value}
-                        onChange={getChangeHandler(question.id)}
-                        isMissing={isMissing}
-                        disabled={disabled}
-                        hideLabel={question.id === promptQuestionId}
-                        promptQuestionId={promptQuestionId}
-                        promptHeadingId={promptHeadingId}
-                        promptDescriptionId={promptDescriptionId}
-                        validationErrorMessage={validationErrorMessage}
-                      />
-                    </div>
-                  );
-                })}
+                {errorSummary}
+                {orderedPages
+                  ? orderedPages.map((page, pageIndex) => (
+                      <VStack key={page.id} gap="space-12">
+                        {pageIndex > 0 && (page.title || page.description) && (
+                          <div>
+                            {page.title && (
+                              <Heading level="2" size="xsmall">
+                                {page.title}
+                              </Heading>
+                            )}
+                            {page.description && (
+                              <BodyShort>{page.description}</BodyShort>
+                            )}
+                          </div>
+                        )}
+                        {page.questions.map((question) =>
+                          renderQuestion(
+                            question,
+                            question.id === promptQuestionId,
+                          ),
+                        )}
+                      </VStack>
+                    ))
+                  : orderedQuestions.map((question) =>
+                      renderQuestion(
+                        question,
+                        question.id === promptQuestionId,
+                      ),
+                    )}
 
                 {showPersonalDataNotice && (
                   <Alert variant="warning" role="status">

--- a/packages/lumi-survey/src/components/LumiSurveyDock/components/__tests__/SurveyFormContent.test.tsx
+++ b/packages/lumi-survey/src/components/LumiSurveyDock/components/__tests__/SurveyFormContent.test.tsx
@@ -80,6 +80,7 @@ function defaultProps(
     questionContext: {
       promptQuestionId: "rating",
       promptHeadingId: "heading-id",
+      questionAnchorPrefix: "survey-question",
       validationErrorMessage: "Feltet er påkrevd",
     },
 

--- a/packages/lumi-survey/src/components/LumiSurveyDock/dockTypes.ts
+++ b/packages/lumi-survey/src/components/LumiSurveyDock/dockTypes.ts
@@ -5,9 +5,12 @@ export interface StepNavigationProps {
   isStepMode?: boolean;
   currentStep?: number;
   currentStepQuestion?: LumiSurveyQuestion;
+  currentStepQuestions?: LumiSurveyQuestion[];
   canGoBack?: boolean;
   canGoNext?: boolean;
   isLastStep?: boolean;
+  /** Legacy steps keep the historical disabled-button behavior. */
+  disableWhenIncomplete?: boolean;
   onNext?: () => void;
   onBack?: () => void;
   nextLabel?: string;
@@ -21,9 +24,11 @@ export interface ProgressProps {
 }
 
 export interface QuestionContextProps {
-  promptQuestionId: string;
+  promptQuestionId?: string;
   promptHeadingId: string;
   promptDescriptionId?: string;
+  promptDescriptionIsQuestionDescription?: boolean;
+  questionAnchorPrefix: string;
   validationErrorMessage: string;
 }
 

--- a/packages/lumi-survey/src/components/LumiSurveyDock/hooks/__tests__/usePageNavigation.test.ts
+++ b/packages/lumi-survey/src/components/LumiSurveyDock/hooks/__tests__/usePageNavigation.test.ts
@@ -1,0 +1,200 @@
+import { act, renderHook, waitFor } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import type { CanonicalSurveyPage } from "../../../shared/canonicalSurvey.js";
+import { usePageNavigation } from "../usePageNavigation.js";
+
+const PAGES: CanonicalSurveyPage[] = [
+  {
+    id: "first",
+    questions: [
+      {
+        id: "choice",
+        type: "singleChoice",
+        prompt: "Velg",
+        required: true,
+        options: [
+          { value: "yes", label: "Ja" },
+          { value: "no", label: "Nei" },
+        ],
+      },
+      {
+        id: "reason",
+        type: "text",
+        prompt: "Begrunn",
+        required: true,
+      },
+    ],
+  },
+  {
+    id: "conditional",
+    questions: [
+      {
+        id: "details",
+        type: "text",
+        prompt: "Fortell mer",
+        visibleIf: {
+          questionId: "choice",
+          operator: "EQ",
+          value: "yes",
+        },
+      },
+    ],
+  },
+  {
+    id: "last",
+    questions: [
+      {
+        id: "comment",
+        type: "text",
+        prompt: "Kommentar",
+      },
+    ],
+  },
+];
+
+describe("usePageNavigation", () => {
+  it("validates every visible question on the current page", () => {
+    const { result, rerender } = renderHook(
+      ({ answers }) =>
+        usePageNavigation({
+          pages: PAGES,
+          answers,
+          autoStepMode: true,
+        }),
+      { initialProps: { answers: {} } },
+    );
+
+    expect(result.current.currentPage?.id).toBe("first");
+    expect(result.current.currentPageQuestions.map(({ id }) => id)).toEqual([
+      "choice",
+      "reason",
+    ]);
+    expect(result.current.canGoNext).toBe(false);
+
+    rerender({ answers: { choice: "yes", reason: "Fordi" } });
+    expect(result.current.canGoNext).toBe(true);
+  });
+
+  it("skips hidden pages and returns through the visited page history", () => {
+    const answers = { choice: "no", reason: "Fordi" };
+    const { result } = renderHook(() =>
+      usePageNavigation({ pages: PAGES, answers, autoStepMode: true }),
+    );
+
+    act(() => {
+      result.current.goToNext();
+    });
+    expect(result.current.currentPage?.id).toBe("last");
+    expect(result.current.visitedSteps).toEqual([0, 2]);
+
+    act(() => {
+      result.current.goToPrevious();
+    });
+    expect(result.current.currentPage?.id).toBe("first");
+    expect(result.current.visitedSteps).toEqual([0]);
+  });
+
+  it("treats only conditionally visible pages as uncertain progress", () => {
+    const pageWithConditionalExtra: CanonicalSurveyPage = {
+      id: "stable",
+      questions: [
+        PAGES[2].questions[0],
+        {
+          ...PAGES[1].questions[0],
+          id: "conditional-extra",
+        },
+      ],
+    };
+
+    const { result } = renderHook(() =>
+      usePageNavigation({
+        pages: [PAGES[0], pageWithConditionalExtra],
+        answers: {},
+        autoStepMode: true,
+      }),
+    );
+
+    expect(result.current.hasBranching).toBe(false);
+  });
+
+  it("uses the current visible path to choose the submit button", () => {
+    const pages = PAGES.slice(0, 2);
+    const { result, rerender } = renderHook(
+      ({ answers }) =>
+        usePageNavigation({ pages, answers, autoStepMode: true }),
+      {
+        initialProps: {
+          answers: {} as Record<string, string>,
+        },
+      },
+    );
+
+    expect(result.current.isLastStep).toBe(true);
+
+    rerender({ answers: { choice: "yes", reason: "Fordi" } });
+    expect(result.current.isLastStep).toBe(false);
+
+    rerender({ answers: { choice: "no", reason: "Fordi" } });
+    expect(result.current.isLastStep).toBe(true);
+  });
+
+  it("recovers when metadata makes the first page visible", async () => {
+    const pages: CanonicalSurveyPage[] = [
+      {
+        id: "metadata-page",
+        questions: [
+          {
+            id: "metadata-question",
+            type: "text",
+            prompt: "Metadata question",
+            visibleIf: {
+              field: "METADATA",
+              key: "ready",
+              operator: "EQ",
+              value: true,
+            },
+          },
+        ],
+      },
+    ];
+    const onStepChange = vi.fn();
+    const { result, rerender } = renderHook(
+      ({ metadata }) =>
+        usePageNavigation({
+          pages,
+          answers: {},
+          metadata,
+          autoStepMode: true,
+          onStepChange,
+        }),
+      { initialProps: { metadata: {} as Record<string, unknown> } },
+    );
+
+    expect(result.current.currentStep).toBe(-1);
+    expect(result.current.currentPage).toBeUndefined();
+    expect(onStepChange).not.toHaveBeenCalled();
+
+    rerender({ metadata: { ready: true } });
+
+    await waitFor(() => expect(result.current.currentStep).toBe(0));
+    expect(result.current.currentPage?.id).toBe("metadata-page");
+    expect(onStepChange).toHaveBeenCalledWith(0, 1);
+  });
+
+  it("does not reset navigation for a structurally identical pages prop", () => {
+    const answers = { choice: "no", reason: "Fordi" };
+    const { result, rerender } = renderHook(
+      ({ pages }) => usePageNavigation({ pages, answers, autoStepMode: true }),
+      { initialProps: { pages: PAGES } },
+    );
+
+    act(() => {
+      result.current.goToNext();
+    });
+    expect(result.current.currentPage?.id).toBe("last");
+
+    rerender({ pages: JSON.parse(JSON.stringify(PAGES)) });
+    expect(result.current.currentPage?.id).toBe("last");
+    expect(result.current.visitedSteps).toEqual([0, 2]);
+  });
+});

--- a/packages/lumi-survey/src/components/LumiSurveyDock/hooks/pageNavigationUtils.ts
+++ b/packages/lumi-survey/src/components/LumiSurveyDock/hooks/pageNavigationUtils.ts
@@ -1,0 +1,124 @@
+import {
+  getLeafConditions,
+  isLeafCondition,
+} from "../../../core/conditionUtils.js";
+import { evaluateVisibility } from "../../../core/evaluateVisibility.js";
+import type {
+  LumiSurveyAnswerValue,
+  LumiSurveyQuestion,
+} from "../../../core/types.js";
+import type { CanonicalSurveyPage } from "../../shared/canonicalSurvey.js";
+
+/** Whether page visibility can change and therefore the total is conditional. */
+export function surveyHasConditionalPages(
+  pages: CanonicalSurveyPage[],
+): boolean {
+  return pages.some(
+    (page) =>
+      page.questions.length > 0 &&
+      page.questions.every((question) => question.visibleIf !== undefined),
+  );
+}
+
+export function getVisiblePageQuestions(
+  page: CanonicalSurveyPage | undefined,
+  answers: Record<string, LumiSurveyAnswerValue>,
+  metadata?: Record<string, unknown>,
+): LumiSurveyQuestion[] {
+  if (!page) return [];
+  return page.questions.filter((question) =>
+    evaluateVisibility(question.visibleIf, answers, metadata),
+  );
+}
+
+export function isPageVisible(
+  page: CanonicalSurveyPage | undefined,
+  answers: Record<string, LumiSurveyAnswerValue>,
+  metadata?: Record<string, unknown>,
+): boolean {
+  return getVisiblePageQuestions(page, answers, metadata).length > 0;
+}
+
+export function findNextVisiblePageIndex(
+  pages: CanonicalSurveyPage[],
+  answers: Record<string, LumiSurveyAnswerValue>,
+  metadata: Record<string, unknown> | undefined,
+  startIndex: number,
+): number {
+  for (let index = Math.max(0, startIndex); index < pages.length; index++) {
+    if (isPageVisible(pages[index], answers, metadata)) return index;
+  }
+  return -1;
+}
+
+export function findLastVisiblePageInHistory(
+  history: number[],
+  pages: CanonicalSurveyPage[],
+  answers: Record<string, LumiSurveyAnswerValue>,
+  metadata?: Record<string, unknown>,
+): { step: number; history: number[] } | null {
+  for (let index = history.length - 1; index >= 0; index--) {
+    const step = history[index];
+    if (isPageVisible(pages[step], answers, metadata)) {
+      return { step, history: history.slice(0, index + 1) };
+    }
+  }
+  return null;
+}
+
+export function findPageRedirectTarget(
+  pages: CanonicalSurveyPage[],
+  answers: Record<string, LumiSurveyAnswerValue>,
+  metadata: Record<string, unknown> | undefined,
+  currentStep: number,
+  visitedSteps: number[],
+): number {
+  const forward = findNextVisiblePageIndex(
+    pages,
+    answers,
+    metadata,
+    currentStep + 1,
+  );
+  if (forward !== -1) return forward;
+
+  const history = findLastVisiblePageInHistory(
+    visitedSteps.slice(0, -1),
+    pages,
+    answers,
+    metadata,
+  );
+  if (history) return history.step;
+
+  return findNextVisiblePageIndex(pages, answers, metadata, 0);
+}
+
+export function estimateReachablePages(
+  pages: CanonicalSurveyPage[],
+  answers: Record<string, LumiSurveyAnswerValue>,
+  metadata?: Record<string, unknown>,
+): number {
+  const questionOrder = new Map<string, number>();
+  pages
+    .flatMap((page) => page.questions)
+    .forEach((question, index) => {
+      questionOrder.set(question.id, index);
+    });
+
+  return pages.filter((page) =>
+    page.questions.some((question) => {
+      if (evaluateVisibility(question.visibleIf, answers, metadata))
+        return true;
+      if (!question.visibleIf) return true;
+
+      return getLeafConditions(question.visibleIf).some((leaf) => {
+        if (!isLeafCondition(leaf)) return false;
+        if (leaf.field === "METADATA" || !leaf.questionId) return true;
+        if (answers[leaf.questionId] !== undefined) return false;
+        return (
+          (questionOrder.get(leaf.questionId) ?? Number.POSITIVE_INFINITY) <
+          (questionOrder.get(question.id) ?? -1)
+        );
+      });
+    }),
+  ).length;
+}

--- a/packages/lumi-survey/src/components/LumiSurveyDock/hooks/usePageNavigation.ts
+++ b/packages/lumi-survey/src/components/LumiSurveyDock/hooks/usePageNavigation.ts
@@ -1,0 +1,209 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import type {
+  LumiSurveyAnswerValue,
+  LumiSurveyQuestion,
+} from "../../../core/types.js";
+import { validateAnswers } from "../../../core/validation.js";
+import type { CanonicalSurveyPage } from "../../shared/canonicalSurvey.js";
+import {
+  estimateReachablePages,
+  findLastVisiblePageInHistory,
+  findNextVisiblePageIndex,
+  findPageRedirectTarget,
+  getVisiblePageQuestions,
+  isPageVisible,
+  surveyHasConditionalPages,
+} from "./pageNavigationUtils.js";
+
+interface UsePageNavigationOptions {
+  pages: CanonicalSurveyPage[];
+  answers: Record<string, LumiSurveyAnswerValue>;
+  metadata?: Record<string, unknown>;
+  forceStepMode?: boolean;
+  autoStepMode?: boolean;
+  onStepChange?: (visibleStepIndex: number, totalVisibleSteps: number) => void;
+}
+
+export interface UsePageNavigationReturn {
+  isStepMode: boolean;
+  currentStep: number;
+  currentPage: CanonicalSurveyPage | undefined;
+  currentPageQuestions: LumiSurveyQuestion[];
+  currentQuestion: LumiSurveyQuestion | undefined;
+  canGoBack: boolean;
+  canGoNext: boolean;
+  isLastStep: boolean;
+  goToNext: () => { nextIndex: number } | null;
+  goToPrevious: () => number | null;
+  resetNavigation: () => void;
+  hasBranching: boolean;
+  visitedSteps: number[];
+  visibleStepIndex: number;
+  totalVisibleSteps: number;
+}
+
+export function usePageNavigation({
+  pages,
+  answers,
+  metadata,
+  forceStepMode = false,
+  autoStepMode = false,
+  onStepChange,
+}: UsePageNavigationOptions): UsePageNavigationReturn {
+  const hasBranching = useMemo(() => surveyHasConditionalPages(pages), [pages]);
+  const isStepMode = forceStepMode || autoStepMode;
+  const firstVisiblePage = useCallback(
+    () => findNextVisiblePageIndex(pages, answers, metadata, 0),
+    [answers, metadata, pages],
+  );
+
+  const [currentStep, setCurrentStep] = useState(firstVisiblePage);
+  const [visitedSteps, setVisitedSteps] = useState<number[]>(() => {
+    const first = firstVisiblePage();
+    return first === -1 ? [] : [first];
+  });
+
+  const currentPage = pages[currentStep];
+  const currentPageQuestions = useMemo(
+    () => getVisiblePageQuestions(currentPage, answers, metadata),
+    [currentPage, answers, metadata],
+  );
+  const currentQuestion = currentPageQuestions[0];
+  const canGoBack = visitedSteps.length > 1;
+  const canGoNext =
+    currentPageQuestions.length > 0 &&
+    validateAnswers(currentPageQuestions, answers).length === 0;
+  const isLastStep =
+    currentStep >= 0 &&
+    findNextVisiblePageIndex(pages, answers, metadata, currentStep + 1) === -1;
+
+  const reachablePages = useMemo(
+    () => estimateReachablePages(pages, answers, metadata),
+    [pages, answers, metadata],
+  );
+  const reachablePagesRef = useRef(reachablePages);
+  reachablePagesRef.current = reachablePages;
+  const [displayedTotal, setDisplayedTotal] = useState(reachablePages);
+
+  const visibleStepIndex = useMemo(() => {
+    if (currentStep < 0) return -1;
+    let visibleBefore = 0;
+    for (let index = 0; index < currentStep; index++) {
+      if (isPageVisible(pages[index], answers, metadata)) visibleBefore++;
+    }
+    return visibleBefore;
+  }, [answers, currentStep, metadata, pages]);
+
+  const pageDefinitionKey = useMemo(() => JSON.stringify(pages), [pages]);
+  const previousPageDefinitionKeyRef = useRef(pageDefinitionKey);
+  const previousStepRef = useRef<number | null>(null);
+  useEffect(() => {
+    if (previousPageDefinitionKeyRef.current === pageDefinitionKey) return;
+    previousPageDefinitionKeyRef.current = pageDefinitionKey;
+    previousStepRef.current = null;
+    const first = firstVisiblePage();
+    setCurrentStep(first);
+    setVisitedSteps(first === -1 ? [] : [first]);
+    setDisplayedTotal(reachablePages);
+  }, [firstVisiblePage, pageDefinitionKey, reachablePages]);
+
+  const onStepChangeRef = useRef(onStepChange);
+  onStepChangeRef.current = onStepChange;
+  useEffect(() => {
+    if (!isStepMode || currentStep < 0) return;
+    if (previousStepRef.current === currentStep) return;
+    previousStepRef.current = currentStep;
+    onStepChangeRef.current?.(visibleStepIndex, displayedTotal);
+  }, [currentStep, displayedTotal, isStepMode, visibleStepIndex]);
+
+  const goToNext = useCallback(() => {
+    if (!currentPage || !canGoNext) return null;
+    const next = findNextVisiblePageIndex(
+      pages,
+      answers,
+      metadata,
+      currentStep + 1,
+    );
+    if (next === -1) return { nextIndex: -1 };
+
+    setCurrentStep(next);
+    setVisitedSteps((previous) => [...previous, next]);
+    setDisplayedTotal(reachablePagesRef.current);
+    return { nextIndex: next };
+  }, [answers, canGoNext, currentPage, currentStep, metadata, pages]);
+
+  const goToPrevious = useCallback(() => {
+    if (visitedSteps.length <= 1) return null;
+    const result = findLastVisiblePageInHistory(
+      visitedSteps.slice(0, -1),
+      pages,
+      answers,
+      metadata,
+    );
+    if (!result) return null;
+    setVisitedSteps(result.history);
+    setCurrentStep(result.step);
+    setDisplayedTotal(reachablePagesRef.current);
+    return result.step;
+  }, [answers, metadata, pages, visitedSteps]);
+
+  const resetNavigation = useCallback(() => {
+    const first = findNextVisiblePageIndex(pages, answers, metadata, 0);
+    setCurrentStep(first);
+    setVisitedSteps(first === -1 ? [] : [first]);
+    setDisplayedTotal(reachablePagesRef.current);
+  }, [answers, metadata, pages]);
+
+  useEffect(() => {
+    if (!isStepMode) return;
+    if (isPageVisible(currentPage, answers, metadata)) return;
+
+    const target = findPageRedirectTarget(
+      pages,
+      answers,
+      metadata,
+      currentStep,
+      visitedSteps,
+    );
+    if (target === -1) {
+      if (currentStep !== -1) setCurrentStep(-1);
+      if (visitedSteps.length > 0) setVisitedSteps([]);
+      return;
+    }
+    if (target === currentStep) return;
+    setCurrentStep(target);
+    setVisitedSteps((previous) => {
+      const existing = previous.indexOf(target);
+      return existing === -1
+        ? [...previous, target]
+        : previous.slice(0, existing + 1);
+    });
+    setDisplayedTotal(reachablePagesRef.current);
+  }, [
+    answers,
+    currentPage,
+    currentStep,
+    isStepMode,
+    metadata,
+    pages,
+    visitedSteps,
+  ]);
+
+  return {
+    isStepMode,
+    currentStep,
+    currentPage,
+    currentPageQuestions,
+    currentQuestion,
+    canGoBack,
+    canGoNext,
+    isLastStep,
+    goToNext,
+    goToPrevious,
+    resetNavigation,
+    hasBranching,
+    visitedSteps,
+    visibleStepIndex,
+    totalVisibleSteps: displayedTotal,
+  };
+}

--- a/packages/lumi-survey/src/components/LumiSurveyDock/hooks/usePersistedDismissal.ts
+++ b/packages/lumi-survey/src/components/LumiSurveyDock/hooks/usePersistedDismissal.ts
@@ -44,6 +44,8 @@ export interface UsePersistedDismissalOptions {
   resetOnClose: boolean;
   onReset: () => void;
   storageStrategy: StorageStrategy;
+  /** Whether the open dock currently has renderable content. */
+  viewEnabled?: boolean;
 }
 
 export interface UsePersistedDismissalReturn {
@@ -65,6 +67,7 @@ export const usePersistedDismissal = (
     resetOnClose,
     onReset,
     storageStrategy,
+    viewEnabled = true,
   } = options;
 
   const storageKey = useMemo(() => `lumi-dismissed-${surveyId}`, [surveyId]);
@@ -137,10 +140,10 @@ export const usePersistedDismissal = (
   }, [initialOpen, storageKey, storageAdapter]);
 
   useEffect(() => {
-    if (!dismissed) {
+    if (!dismissed && viewEnabled) {
       events?.onViewDock?.(surveyId);
     }
-  }, [dismissed, events, surveyId]);
+  }, [dismissed, events, surveyId, viewEnabled]);
 
   const persistDismissedState = useCallback(
     async (nextDismissed: boolean, hideCompletely?: boolean) => {

--- a/packages/lumi-survey/src/components/LumiSurveyDock/propTypes.ts
+++ b/packages/lumi-survey/src/components/LumiSurveyDock/propTypes.ts
@@ -64,9 +64,11 @@ export type StorageStrategy = "consent" | "localStorage" | "none";
 
 /**
  * Controls how questions are presented.
- * - "auto": step mode only when branching logic exists (default)
- * - "singlePage": always show all visible questions on one page
- * - "steps": always show one question at a time with Next/Back
+ * - "auto": authored pages become steps; legacy surveys use step mode only
+ *   when branching logic exists (default)
+ * - "singlePage": show all visible authored pages/questions on one surface
+ * - "steps": authored pages become steps; legacy surveys show one question
+ *   per step
  */
 export type QuestionLayout = "auto" | "singlePage" | "steps";
 

--- a/packages/lumi-survey/src/components/questions/rating/NpsRating.tsx
+++ b/packages/lumi-survey/src/components/questions/rating/NpsRating.tsx
@@ -66,6 +66,16 @@ export function NpsRating({
   const fallbackHeadingId = `${question.id}-heading`;
   const fallbackDescriptionId = `${question.id}-description`;
   const errorId = `${question.id}-error`;
+  const describedBy =
+    [
+      ariaDescribedBy,
+      !hideDescription && question.description
+        ? fallbackDescriptionId
+        : undefined,
+      isMissing ? errorId : undefined,
+    ]
+      .filter(Boolean)
+      .join(" ") || undefined;
 
   const lowLabel = question.lowLabel ?? "Lite sannsynlig";
   const highLabel = question.highLabel ?? "Svært sannsynlig";
@@ -114,9 +124,7 @@ export function NpsRating({
         </Heading>
       )}
       {question.description && !hideDescription && (
-        <BodyShort id={ariaDescribedBy ? undefined : fallbackDescriptionId}>
-          {question.description}
-        </BodyShort>
+        <BodyShort id={fallbackDescriptionId}>{question.description}</BodyShort>
       )}
       <Box
         as="fieldset"
@@ -124,12 +132,7 @@ export function NpsRating({
         aria-labelledby={
           ariaLabelledBy ?? (!hidePrompt ? fallbackHeadingId : undefined)
         }
-        aria-describedby={
-          ariaDescribedBy ??
-          (!hideDescription && question.description
-            ? fallbackDescriptionId
-            : undefined)
-        }
+        aria-describedby={describedBy}
         paddingBlock={fieldsetPaddingBlock ?? "space-8"}
         paddingInline={fieldsetPaddingInline ?? "space-12"}
       >

--- a/packages/lumi-survey/src/components/questions/rating/RatingQuestionField.tsx
+++ b/packages/lumi-survey/src/components/questions/rating/RatingQuestionField.tsx
@@ -32,7 +32,7 @@ interface RatingQuestionFieldProps {
   buttonClassName?: string;
   /** Provide external aria-labelledby id; skip internal heading when set */
   ariaLabelledBy?: string;
-  /** Provide external aria-describedby id; skip internal description when set */
+  /** Provide an additional external aria-describedby id. */
   ariaDescribedBy?: string;
   /** Hide the prompt heading inside the component */
   hidePrompt?: boolean;
@@ -194,13 +194,12 @@ export const RatingQuestionField = ({
   const headingId =
     ariaLabelledBy ?? (!hidePrompt ? fallbackHeadingId : undefined);
   const descriptionId =
-    ariaDescribedBy ??
-    (!hideDescription && question.description
+    !hideDescription && question.description
       ? fallbackDescriptionId
-      : undefined);
+      : undefined;
   const errorId = `${question.id}-error`;
   const describedBy =
-    [descriptionId, isMissing ? errorId : undefined]
+    [ariaDescribedBy, descriptionId, isMissing ? errorId : undefined]
       .filter(Boolean)
       .join(" ") || undefined;
 
@@ -242,9 +241,7 @@ export const RatingQuestionField = ({
         </Heading>
       )}
       {question.description && !hideDescription && (
-        <BodyShort id={ariaDescribedBy ? undefined : fallbackDescriptionId}>
-          {question.description}
-        </BodyShort>
+        <BodyShort id={fallbackDescriptionId}>{question.description}</BodyShort>
       )}
       <Box
         as="fieldset"

--- a/packages/lumi-survey/src/components/questions/rating/StarRating.tsx
+++ b/packages/lumi-survey/src/components/questions/rating/StarRating.tsx
@@ -65,6 +65,16 @@ export function StarRating({
   const fallbackHeadingId = `${question.id}-heading`;
   const fallbackDescriptionId = `${question.id}-description`;
   const errorId = `${question.id}-error`;
+  const describedBy =
+    [
+      ariaDescribedBy,
+      !hideDescription && question.description
+        ? fallbackDescriptionId
+        : undefined,
+      isMissing ? errorId : undefined,
+    ]
+      .filter(Boolean)
+      .join(" ") || undefined;
 
   const labels = question.labels
     ? question.labels.reduce<Record<number, string>>((acc, label) => {
@@ -120,9 +130,7 @@ export function StarRating({
         </Heading>
       )}
       {question.description && !hideDescription && (
-        <BodyShort id={ariaDescribedBy ? undefined : fallbackDescriptionId}>
-          {question.description}
-        </BodyShort>
+        <BodyShort id={fallbackDescriptionId}>{question.description}</BodyShort>
       )}
       <Box
         as="fieldset"
@@ -130,12 +138,7 @@ export function StarRating({
         aria-labelledby={
           ariaLabelledBy ?? (!hidePrompt ? fallbackHeadingId : undefined)
         }
-        aria-describedby={
-          ariaDescribedBy ??
-          (!hideDescription && question.description
-            ? fallbackDescriptionId
-            : undefined)
-        }
+        aria-describedby={describedBy}
         paddingBlock={fieldsetPaddingBlock ?? "space-12"}
         paddingInline={fieldsetPaddingInline ?? "space-16"}
       >

--- a/packages/lumi-survey/src/components/questions/rating/ThumbsRating.tsx
+++ b/packages/lumi-survey/src/components/questions/rating/ThumbsRating.tsx
@@ -57,6 +57,16 @@ export function ThumbsRating({
   const fallbackHeadingId = `${question.id}-heading`;
   const fallbackDescriptionId = `${question.id}-description`;
   const errorId = `${question.id}-error`;
+  const describedBy =
+    [
+      ariaDescribedBy,
+      !hideDescription && question.description
+        ? fallbackDescriptionId
+        : undefined,
+      isMissing ? errorId : undefined,
+    ]
+      .filter(Boolean)
+      .join(" ") || undefined;
 
   const handleSelect = useCallback(
     (nextValue: number) => {
@@ -79,9 +89,7 @@ export function ThumbsRating({
         </Heading>
       )}
       {question.description && !hideDescription && (
-        <BodyShort id={ariaDescribedBy ? undefined : fallbackDescriptionId}>
-          {question.description}
-        </BodyShort>
+        <BodyShort id={fallbackDescriptionId}>{question.description}</BodyShort>
       )}
       <Box
         as="fieldset"
@@ -89,12 +97,7 @@ export function ThumbsRating({
         aria-labelledby={
           ariaLabelledBy ?? (!hidePrompt ? fallbackHeadingId : undefined)
         }
-        aria-describedby={
-          ariaDescribedBy ??
-          (!hideDescription && question.description
-            ? fallbackDescriptionId
-            : undefined)
-        }
+        aria-describedby={describedBy}
         paddingBlock={fieldsetPaddingBlock ?? "space-12"}
         paddingInline={fieldsetPaddingInline ?? "space-16"}
       >

--- a/packages/lumi-survey/src/components/shared/__tests__/canonicalSurvey.test.ts
+++ b/packages/lumi-survey/src/components/shared/__tests__/canonicalSurvey.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import type { LumiSurveyConfig } from "../../surveyTypes.js";
+import type { LumiSurveyConfig, SurveyDocumentV1 } from "../../surveyTypes.js";
 import { buildCanonicalSurvey } from "../canonicalSurvey.js";
 
 const validQuestions = [
@@ -16,6 +16,252 @@ describe("buildCanonicalSurvey", () => {
     const canonical = buildCanonicalSurvey(survey);
     expect(canonical.questions).toEqual(validQuestions);
     expect(canonical.type).toBe("custom");
+    expect(canonical.source).toBe("legacy");
+    expect(canonical.pages.map((page) => page.questions)).toEqual([
+      [validQuestions[0]],
+      [validQuestions[1]],
+    ]);
+  });
+
+  it("normalizes an explicit page document without changing flat question order", () => {
+    const survey: SurveyDocumentV1 = {
+      authoringSchemaVersion: 1,
+      type: "custom",
+      pages: [
+        {
+          id: "first-page",
+          title: "Første side",
+          description: "Svar på begge spørsmålene.",
+          questions: [
+            { id: "q1", type: "rating", prompt: "Rating" },
+            { id: "q2", type: "text", prompt: "Text" },
+          ],
+        },
+        {
+          id: "second-page",
+          questions: [{ id: "q3", type: "text", prompt: "More text" }],
+        },
+      ],
+    };
+
+    const canonical = buildCanonicalSurvey(survey);
+
+    expect(canonical.source).toBe("document-v1");
+    expect(canonical.questions.map((question) => question.id)).toEqual([
+      "q1",
+      "q2",
+      "q3",
+    ]);
+    expect(canonical.pages).toMatchObject([
+      {
+        id: "first-page",
+        title: "Første side",
+        description: "Svar på begge spørsmålene.",
+        questions: [{ id: "q1" }, { id: "q2" }],
+      },
+      { id: "second-page", questions: [{ id: "q3" }] },
+    ]);
+  });
+
+  it("rejects duplicate and empty pages in document input", () => {
+    expect(() =>
+      buildCanonicalSurvey({
+        authoringSchemaVersion: 1,
+        pages: [
+          {
+            id: "same",
+            questions: [{ id: "q1", type: "text", prompt: "Q1" }],
+          },
+          {
+            id: "same",
+            questions: [{ id: "q2", type: "text", prompt: "Q2" }],
+          },
+        ],
+      }),
+    ).toThrowError(/duplicate page id/i);
+
+    expect(() =>
+      buildCanonicalSurvey({
+        authoringSchemaVersion: 1,
+        pages: [{ id: "empty", questions: [] }],
+      } as unknown as SurveyDocumentV1),
+    ).toThrowError(/at least one question/i);
+  });
+
+  it("rejects logic and forward visibleIf references in document input", () => {
+    expect(() =>
+      buildCanonicalSurvey({
+        authoringSchemaVersion: 1,
+        pages: [
+          {
+            id: "page",
+            questions: [
+              {
+                id: "q1",
+                type: "text",
+                prompt: "Q1",
+                logic: [
+                  {
+                    condition: { operator: "EXISTS" },
+                    action: { type: "SUBMIT" },
+                  },
+                ],
+              },
+            ],
+          },
+        ],
+      } as unknown as SurveyDocumentV1),
+    ).toThrowError(/version 1.*visibleIf/i);
+
+    expect(() =>
+      buildCanonicalSurvey({
+        authoringSchemaVersion: 1,
+        pages: [
+          {
+            id: "page",
+            questions: [
+              {
+                id: "q1",
+                type: "text",
+                prompt: "Q1",
+                visibleIf: { operator: "EXISTS", questionId: "q2" },
+              },
+              { id: "q2", type: "text", prompt: "Q2" },
+            ],
+          },
+        ],
+      }),
+    ).toThrowError(/only reference earlier questions/i);
+  });
+
+  it("rejects unknown authoring schema versions", () => {
+    expect(() =>
+      buildCanonicalSurvey({
+        authoringSchemaVersion: 2,
+        pages: [],
+      } as unknown as SurveyDocumentV1),
+    ).toThrowError(/unsupported authoringSchemaVersion/i);
+  });
+
+  it("requires answer conditions in documents to reference a question", () => {
+    expect(() =>
+      buildCanonicalSurvey({
+        authoringSchemaVersion: 1,
+        pages: [
+          {
+            id: "page",
+            questions: [
+              {
+                id: "q1",
+                type: "text",
+                prompt: "Q1",
+                visibleIf: { operator: "EXISTS" },
+              },
+            ],
+          },
+        ],
+      } as unknown as SurveyDocumentV1),
+    ).toThrowError(/without a questionId/i);
+
+    expect(() =>
+      buildCanonicalSurvey({
+        questions: [
+          {
+            id: "legacy",
+            type: "text",
+            prompt: "Legacy",
+            visibleIf: { operator: "EXISTS" },
+          },
+        ],
+      }),
+    ).not.toThrow();
+  });
+
+  it("requires comparison values in document visibility conditions", () => {
+    expect(() =>
+      buildCanonicalSurvey({
+        authoringSchemaVersion: 1,
+        pages: [
+          {
+            id: "page",
+            questions: [
+              { id: "q1", type: "text", prompt: "Q1" },
+              {
+                id: "q2",
+                type: "text",
+                prompt: "Q2",
+                visibleIf: { questionId: "q1", operator: "EQ" },
+              },
+            ],
+          },
+        ],
+      } as unknown as SurveyDocumentV1),
+    ).toThrowError(/without a value/i);
+  });
+
+  it("rejects malformed document pages and question payloads cleanly", () => {
+    const buildRaw = (page: unknown) =>
+      buildCanonicalSurvey({
+        authoringSchemaVersion: 1,
+        pages: [page],
+      } as unknown as SurveyDocumentV1);
+
+    expect(() =>
+      buildRaw({ id: "page", title: {}, questions: [validQuestions[1]] }),
+    ).toThrowError(/non-string title/i);
+    expect(() => buildRaw({ id: "page", questions: [null] })).toThrowError(
+      /not a question object/i,
+    );
+    expect(() =>
+      buildRaw({
+        id: "page",
+        questions: [{ id: "choice", type: "singleChoice", prompt: "Choice" }],
+      }),
+    ).toThrowError(/valid options/i);
+    expect(() =>
+      buildRaw({
+        id: "page",
+        questions: [
+          { id: "rating", type: "rating", prompt: "Rating", variant: "ten" },
+        ],
+      }),
+    ).toThrowError(/unsupported variant/i);
+    expect(() =>
+      buildRaw({
+        id: "page",
+        questions: [
+          {
+            id: "nps",
+            type: "rating",
+            variant: "nps",
+            prompt: "NPS",
+            lowLabel: {},
+          },
+        ],
+      }),
+    ).toThrowError(/non-string lowLabel/i);
+    expect(() =>
+      buildRaw({
+        id: "page",
+        questions: [
+          { id: "text", type: "text", prompt: "Text", maxLength: "100" },
+        ],
+      }),
+    ).toThrowError(/invalid maxLength/i);
+    expect(() =>
+      buildRaw({
+        id: "page",
+        questions: [
+          {
+            id: "choice",
+            type: "multiChoice",
+            prompt: "Choice",
+            options: [{ value: "yes", label: "Yes" }],
+            maxSelections: 0,
+          },
+        ],
+      }),
+    ).toThrowError(/invalid maxSelections/i);
   });
 
   it("sets survey type if provided", () => {

--- a/packages/lumi-survey/src/components/shared/canonicalSurvey.ts
+++ b/packages/lumi-survey/src/components/shared/canonicalSurvey.ts
@@ -4,24 +4,60 @@ import {
   isLeafCondition,
 } from "../../core/conditionUtils.js";
 import type { LumiSurveyQuestion } from "../../core/types.js";
-import type { LumiSurveyConfig, SurveyType } from "../surveyTypes.js";
+import type {
+  LumiSurveyDefinition,
+  SurveyPageV1,
+  SurveyType,
+} from "../surveyTypes.js";
 
 export const RATING_ANSWER_KEY = "svar";
 export const MAIN_ANSWER_KEY = "feedback";
 
 export interface CanonicalSurvey {
+  source: "legacy" | "document-v1";
   type: SurveyType;
+  questions: LumiSurveyQuestion[];
+  pages: CanonicalSurveyPage[];
+}
+
+export interface CanonicalSurveyPage {
+  id: string;
+  title?: string;
+  description?: string;
   questions: LumiSurveyQuestion[];
 }
 
 export function buildCanonicalSurvey(
-  survey: LumiSurveyConfig,
+  survey: LumiSurveyDefinition,
 ): CanonicalSurvey {
-  if (!survey.questions || survey.questions.length === 0) {
-    throw new Error("Lumi survey must have at least one question");
+  const isDocument = "authoringSchemaVersion" in survey;
+
+  if (isDocument && survey.authoringSchemaVersion !== 1) {
+    throw new Error(
+      `Lumi: Unsupported authoringSchemaVersion "${String(survey.authoringSchemaVersion)}"`,
+    );
   }
 
+  const inputPages: Array<{
+    id: string;
+    title?: string;
+    description?: string;
+    questions: readonly LumiSurveyQuestion[];
+  }> = isDocument
+    ? validateDocumentPages(survey.pages)
+    : validateLegacyQuestions(survey.questions);
+
+  const inputQuestions = inputPages.flatMap((page) => page.questions);
+
   const surveyType = survey.type ?? "custom";
+  if (
+    isDocument &&
+    !["rating", "topTasks", "discovery", "taskPriority", "custom"].includes(
+      surveyType,
+    )
+  ) {
+    throw new Error(`Lumi: Unsupported survey type "${String(surveyType)}"`);
+  }
 
   // Apply small UX-safe defaults at build time (without changing the external API shape).
   // For rating surveys, the first rating question is the main interaction and should be
@@ -29,19 +65,35 @@ export function buildCanonicalSurvey(
   const questions: LumiSurveyQuestion[] = (() => {
     if (
       surveyType === "rating" &&
-      survey.questions[0]?.type === "rating" &&
-      survey.questions[0]?.required === undefined
+      inputQuestions[0]?.type === "rating" &&
+      inputQuestions[0]?.required === undefined
     ) {
-      const next = [...survey.questions];
+      const next = [...inputQuestions];
       next[0] = { ...next[0], required: true } as LumiSurveyQuestion;
       return next as LumiSurveyQuestion[];
     }
 
-    return survey.questions;
+    return [...inputQuestions];
   })();
+
+  let questionOffset = 0;
+  const pages: CanonicalSurveyPage[] = inputPages.map((page) => {
+    const pageQuestions = questions.slice(
+      questionOffset,
+      questionOffset + page.questions.length,
+    );
+    questionOffset += page.questions.length;
+    return {
+      id: page.id,
+      title: page.title,
+      description: page.description,
+      questions: pageQuestions,
+    };
+  });
 
   // Validate all questions have IDs
   const ids = new Set<string>();
+  const previousIds = new Set<string>();
   for (const question of questions) {
     if (!question.id) {
       throw new Error("Lumi: All questions must have an id");
@@ -93,6 +145,52 @@ export function buildCanonicalSurvey(
           );
         }
         if (
+          isDocument &&
+          leaf.field !== undefined &&
+          leaf.field !== "ANSWER" &&
+          leaf.field !== "METADATA"
+        ) {
+          throw new Error(
+            `Lumi: Question "${question.id}" has an unsupported visibleIf field`,
+          );
+        }
+        if (
+          isDocument &&
+          leaf.field === "METADATA" &&
+          (typeof leaf.key !== "string" || leaf.key.trim().length === 0)
+        ) {
+          throw new Error(
+            `Lumi: Question "${question.id}" has a METADATA visibleIf without a key`,
+          );
+        }
+        if (
+          isDocument &&
+          leaf.operator !== "EXISTS" &&
+          !["string", "number", "boolean"].includes(typeof leaf.value)
+        ) {
+          throw new Error(
+            `Lumi: Question "${question.id}" has a ${leaf.operator} visibleIf without a value`,
+          );
+        }
+        if (
+          isDocument &&
+          leaf.operator === "EXISTS" &&
+          leaf.value !== undefined
+        ) {
+          throw new Error(
+            `Lumi: Question "${question.id}" has an EXISTS visibleIf with an unused value`,
+          );
+        }
+        if (
+          isDocument &&
+          leaf.field !== "METADATA" &&
+          (!leaf.questionId || leaf.questionId.trim().length === 0)
+        ) {
+          throw new Error(
+            `Lumi: Question "${question.id}" has an ANSWER visibleIf without a questionId`,
+          );
+        }
+        if (
           leaf.field !== "METADATA" &&
           leaf.questionId &&
           !ids.has(leaf.questionId)
@@ -101,10 +199,29 @@ export function buildCanonicalSurvey(
             `Lumi: Question "${question.id}" has visibleIf.questionId "${leaf.questionId}", but no such question exists`,
           );
         }
+        if (
+          isDocument &&
+          leaf.field !== "METADATA" &&
+          leaf.questionId &&
+          !previousIds.has(leaf.questionId)
+        ) {
+          throw new Error(
+            `Lumi: Question "${question.id}" has visibleIf.questionId "${leaf.questionId}", but version 1 survey documents may only reference earlier questions`,
+          );
+        }
       }
     }
 
-    if (!question.logic) continue;
+    if (isDocument && question.logic !== undefined) {
+      throw new Error(
+        `Lumi: Question "${question.id}" uses logic, but version 1 survey documents only support visibleIf`,
+      );
+    }
+
+    if (!question.logic) {
+      previousIds.add(question.id);
+      continue;
+    }
     for (const rule of question.logic) {
       const condition = rule.condition;
       if (isConditionGroup(condition)) {
@@ -132,10 +249,247 @@ export function buildCanonicalSurvey(
         );
       }
     }
+    previousIds.add(question.id);
   }
 
   return {
+    source: isDocument ? "document-v1" : "legacy",
     type: surveyType,
     questions,
+    pages,
   };
+}
+
+function validateLegacyQuestions(
+  questions: LumiSurveyQuestion[] | undefined,
+): CanonicalSurveyPage[] {
+  if (!questions || questions.length === 0) {
+    throw new Error("Lumi survey must have at least one question");
+  }
+
+  return questions.map((question) => ({
+    id: `legacy-page:${question.id}`,
+    questions: [question],
+  }));
+}
+
+function validateDocumentPages(
+  pages: readonly SurveyPageV1[] | undefined,
+): CanonicalSurveyPage[] {
+  if (!pages || pages.length === 0) {
+    throw new Error("Lumi: Survey document must have at least one page");
+  }
+
+  const pageIds = new Set<string>();
+  return pages.map((page, index) => {
+    if (!page || typeof page !== "object" || Array.isArray(page)) {
+      throw new Error(`Lumi: Page at index ${index} is not a page object`);
+    }
+    if (typeof page.id !== "string" || page.id.trim().length === 0) {
+      throw new Error("Lumi: All pages must have an id");
+    }
+    if (page.title !== undefined && typeof page.title !== "string") {
+      throw new Error(`Lumi: Page "${page.id}" has a non-string title`);
+    }
+    if (
+      page.description !== undefined &&
+      typeof page.description !== "string"
+    ) {
+      throw new Error(`Lumi: Page "${page.id}" has a non-string description`);
+    }
+    if (pageIds.has(page.id)) {
+      throw new Error(`Lumi: Duplicate page id "${page.id}"`);
+    }
+    if (!Array.isArray(page.questions) || page.questions.length === 0) {
+      throw new Error(
+        `Lumi: Page "${page.id}" must have at least one question`,
+      );
+    }
+    const questions = (page.questions as readonly unknown[]).map(
+      (question, questionIndex) =>
+        validateDocumentQuestion(question, page.id, questionIndex),
+    );
+    pageIds.add(page.id);
+    return {
+      id: page.id,
+      title: page.title,
+      description: page.description,
+      questions,
+    };
+  });
+}
+
+function validateDocumentQuestion(
+  question: unknown,
+  pageId: string,
+  questionIndex: number,
+): LumiSurveyQuestion {
+  if (!question || typeof question !== "object" || Array.isArray(question)) {
+    throw new Error(
+      `Lumi: Question at index ${questionIndex} on page "${pageId}" is not a question object`,
+    );
+  }
+
+  const candidate = question as Record<string, unknown>;
+  if (typeof candidate.id !== "string" || candidate.id.trim().length === 0) {
+    throw new Error(`Lumi: All questions on page "${pageId}" need an id`);
+  }
+  if (typeof candidate.prompt !== "string") {
+    throw new Error(
+      `Lumi: Question "${candidate.id}" on page "${pageId}" has a non-string prompt`,
+    );
+  }
+  if (
+    candidate.description !== undefined &&
+    typeof candidate.description !== "string"
+  ) {
+    throw new Error(
+      `Lumi: Question "${candidate.id}" on page "${pageId}" has a non-string description`,
+    );
+  }
+  if (
+    candidate.required !== undefined &&
+    typeof candidate.required !== "boolean"
+  ) {
+    throw new Error(
+      `Lumi: Question "${candidate.id}" on page "${pageId}" has a non-boolean required value`,
+    );
+  }
+  if (
+    candidate.analyticsId !== undefined &&
+    typeof candidate.analyticsId !== "string"
+  ) {
+    throw new Error(
+      `Lumi: Question "${candidate.id}" on page "${pageId}" has a non-string analyticsId`,
+    );
+  }
+  if (
+    !["rating", "text", "singleChoice", "multiChoice"].includes(
+      String(candidate.type),
+    )
+  ) {
+    throw new Error(
+      `Lumi: Question "${candidate.id}" on page "${pageId}" has an unsupported type`,
+    );
+  }
+
+  if (candidate.type === "rating") {
+    const variant = candidate.variant ?? "emoji";
+    if (!["emoji", "thumbs", "stars", "nps"].includes(String(variant))) {
+      throw new Error(
+        `Lumi: Rating question "${candidate.id}" has an unsupported variant`,
+      );
+    }
+    if (
+      candidate.labels !== undefined &&
+      (!Array.isArray(candidate.labels) ||
+        candidate.labels.some(
+          (label) =>
+            !label ||
+            typeof label !== "object" ||
+            typeof (label as Record<string, unknown>).value !== "number" ||
+            !Number.isFinite(
+              (label as Record<string, unknown>).value as number,
+            ) ||
+            typeof (label as Record<string, unknown>).label !== "string",
+        ))
+    ) {
+      throw new Error(
+        `Lumi: Rating question "${candidate.id}" has invalid labels`,
+      );
+    }
+    for (const labelKey of ["lowLabel", "highLabel"] as const) {
+      if (
+        candidate[labelKey] !== undefined &&
+        typeof candidate[labelKey] !== "string"
+      ) {
+        throw new Error(
+          `Lumi: Rating question "${candidate.id}" has a non-string ${labelKey}`,
+        );
+      }
+    }
+  }
+
+  if (candidate.type === "text") {
+    for (const numberKey of ["maxLength", "minRows"] as const) {
+      const value = candidate[numberKey];
+      if (
+        value !== undefined &&
+        (typeof value !== "number" || !Number.isFinite(value) || value <= 0)
+      ) {
+        throw new Error(
+          `Lumi: Text question "${candidate.id}" has an invalid ${numberKey}`,
+        );
+      }
+    }
+    for (const stringKey of ["placeholder", "autoComplete"] as const) {
+      if (
+        candidate[stringKey] !== undefined &&
+        typeof candidate[stringKey] !== "string"
+      ) {
+        throw new Error(
+          `Lumi: Text question "${candidate.id}" has a non-string ${stringKey}`,
+        );
+      }
+    }
+  }
+
+  if (candidate.type === "singleChoice" || candidate.type === "multiChoice") {
+    if (
+      !Array.isArray(candidate.options) ||
+      candidate.options.length === 0 ||
+      candidate.options.some(
+        (option) =>
+          !option ||
+          typeof option !== "object" ||
+          typeof (option as Record<string, unknown>).value !== "string" ||
+          typeof (option as Record<string, unknown>).label !== "string" ||
+          ((option as Record<string, unknown>).description !== undefined &&
+            typeof (option as Record<string, unknown>).description !==
+              "string"),
+      )
+    ) {
+      throw new Error(
+        `Lumi: Choice question "${candidate.id}" must have valid options`,
+      );
+    }
+    const optionIds = new Set(
+      candidate.options.map(
+        (option) => (option as Record<string, unknown>).value,
+      ),
+    );
+    if (optionIds.size !== candidate.options.length) {
+      throw new Error(
+        `Lumi: Choice question "${candidate.id}" has duplicate option values`,
+      );
+    }
+    if (
+      candidate.randomize !== undefined &&
+      typeof candidate.randomize !== "boolean"
+    ) {
+      throw new Error(
+        `Lumi: Choice question "${candidate.id}" has a non-boolean randomize value`,
+      );
+    }
+    if (
+      candidate.variant !== undefined &&
+      !["checkbox", "combobox"].includes(String(candidate.variant))
+    ) {
+      throw new Error(
+        `Lumi: Choice question "${candidate.id}" has an unsupported variant`,
+      );
+    }
+    if (
+      candidate.maxSelections !== undefined &&
+      (typeof candidate.maxSelections !== "number" ||
+        !Number.isInteger(candidate.maxSelections) ||
+        candidate.maxSelections <= 0)
+    ) {
+      throw new Error(
+        `Lumi: Choice question "${candidate.id}" has an invalid maxSelections`,
+      );
+    }
+  }
+
+  return question as LumiSurveyQuestion;
 }

--- a/packages/lumi-survey/src/components/surveyTypes.ts
+++ b/packages/lumi-survey/src/components/surveyTypes.ts
@@ -1,4 +1,8 @@
-import type { LumiSurveyQuestion, SurveyType } from "../core/types.js";
+import type {
+  LogicOperator,
+  LumiSurveyQuestion,
+  SurveyType,
+} from "../core/types.js";
 
 export type { SurveyType };
 
@@ -8,6 +12,10 @@ export type { SurveyType };
  * Use `visibleIf` on individual questions for progressive disclosure.
  */
 export interface LumiSurveyConfig {
+  /** Versioned documents use `SurveyDocumentV1` instead. */
+  authoringSchemaVersion?: never;
+  /** Versioned documents use `pages` instead. */
+  pages?: never;
   /**
    * Survey type for analytics categorization.
    * Determines how the dashboard displays and aggregates results.
@@ -22,3 +30,68 @@ export interface LumiSurveyConfig {
    */
   questions: LumiSurveyQuestion[];
 }
+
+type SurveyConditionTargetV1 =
+  | {
+      field?: "ANSWER";
+      questionId: string;
+    }
+  | {
+      field: "METADATA";
+      key: string;
+    };
+
+type SurveyConditionOperatorV1 =
+  | {
+      operator: "EXISTS";
+      value?: never;
+    }
+  | {
+      operator: Exclude<LogicOperator, "EXISTS">;
+      value: string | number | boolean;
+    };
+
+type SurveyConditionLeafV1 = SurveyConditionTargetV1 &
+  SurveyConditionOperatorV1;
+
+type SurveyVisibleIfV1 =
+  | SurveyConditionLeafV1
+  | { any: SurveyConditionLeafV1[] }
+  | { all: SurveyConditionLeafV1[] };
+
+type RemoveLegacyLogic<T> = T extends unknown
+  ? Omit<T, "logic" | "visibleIf"> & {
+      readonly logic?: never;
+      visibleIf?: SurveyVisibleIfV1;
+    }
+  : never;
+
+/** A question authored in the version 1 survey document format. */
+export type SurveyQuestionV1 = RemoveLegacyLogic<LumiSurveyQuestion>;
+
+/** An authored page. Visible questions on the page are rendered together. */
+export interface SurveyPageV1 {
+  /** Stable identifier within the authoring document. */
+  id: string;
+  /** Optional page heading. */
+  title?: string;
+  /** Optional shared context shown below the page heading. */
+  description?: string;
+  /** Ordered, non-empty question list. Runtime validation also enforces this. */
+  questions: [SurveyQuestionV1, ...SurveyQuestionV1[]];
+}
+
+/**
+ * Serializable authoring format for surveys with explicit pages.
+ * This version is separate from the submission payload schema version.
+ */
+export interface SurveyDocumentV1 {
+  authoringSchemaVersion: 1;
+  type?: SurveyType;
+  pages: [SurveyPageV1, ...SurveyPageV1[]];
+  /** Legacy flat configurations use `questions` instead. */
+  questions?: never;
+}
+
+/** Public survey input: legacy flat configuration or an explicit page document. */
+export type LumiSurveyDefinition = LumiSurveyConfig | SurveyDocumentV1;

--- a/packages/lumi-survey/src/core/types.ts
+++ b/packages/lumi-survey/src/core/types.ts
@@ -427,7 +427,9 @@ export interface LumiSurveyEvents {
   /**
    * Fired when the current step changes in step mode.
    * Also fires on initial render when step mode is active.
-   * Receives 0-based visible step index and estimated total reachable steps.
+   * A step is an authored page for version 1 documents and a question for
+   * legacy flat surveys. Receives the 0-based visible step index and estimated
+   * total reachable steps.
    */
   onStepChange?: (visibleStepIndex: number, totalVisibleSteps: number) => void;
 }

--- a/packages/lumi-survey/src/index.ts
+++ b/packages/lumi-survey/src/index.ts
@@ -13,6 +13,10 @@ export type {
 export * from "./components/questions/index.js";
 export type {
   LumiSurveyConfig,
+  LumiSurveyDefinition,
+  SurveyDocumentV1,
+  SurveyPageV1,
+  SurveyQuestionV1,
   SurveyType,
 } from "./components/surveyTypes.js";
 export * from "./core/index.js";

--- a/packages/lumi-survey/src/stories/LumiSurveyDock.custom.stories.tsx
+++ b/packages/lumi-survey/src/stories/LumiSurveyDock.custom.stories.tsx
@@ -1,6 +1,9 @@
 import type { Meta, StoryObj } from "@storybook/react-vite";
 import { LumiSurveyDock } from "../components/LumiSurveyDock";
-import type { LumiSurveyConfig } from "../components/surveyTypes.js";
+import type {
+  LumiSurveyConfig,
+  SurveyDocumentV1,
+} from "../components/surveyTypes.js";
 import { ExamplePage, SUCCESS_TRANSPORT } from "./LumiSurveyDockExamplePage";
 
 const CUSTOM_SURVEY: LumiSurveyConfig = {
@@ -155,6 +158,48 @@ const LINEAR_PROGRESS_SURVEY: LumiSurveyConfig = {
   questions: CUSTOM_SURVEY.questions.slice(0, 3),
 };
 
+const PAGED_SURVEY: SurveyDocumentV1 = {
+  authoringSchemaVersion: 1,
+  type: "custom",
+  pages: [
+    {
+      id: "opplevelse",
+      title: "Din opplevelse",
+      description: "Svarene gjelder denne siden i tjenesten.",
+      questions: [
+        {
+          id: "vurdering",
+          type: "rating",
+          prompt: "Hvor fornøyd er du?",
+          variant: "emoji",
+          required: true,
+        },
+        {
+          id: "begrunnelse",
+          type: "text",
+          prompt: "Hva er den viktigste grunnen til vurderingen din?",
+          required: true,
+          maxLength: 500,
+          minRows: 3,
+        },
+      ],
+    },
+    {
+      id: "forbedring",
+      title: "Hva kan bli bedre?",
+      questions: [
+        {
+          id: "forslag",
+          type: "text",
+          prompt: "Har du et konkret forslag?",
+          maxLength: 500,
+          minRows: 3,
+        },
+      ],
+    },
+  ],
+};
+
 const meta: Meta<typeof LumiSurveyDock> = {
   title: "Components/LumiSurveyDock/Custom",
   component: LumiSurveyDock,
@@ -183,6 +228,28 @@ const meta: Meta<typeof LumiSurveyDock> = {
 export default meta;
 
 type Story = StoryObj<typeof LumiSurveyDock>;
+
+export const FlereSporsmalPerSide: Story = {
+  name: "Flere spørsmål per side",
+  render: (args) => <ExamplePage {...args} />,
+  args: {
+    surveyId: "storybook-dock-pages",
+    survey: PAGED_SURVEY,
+    behavior: {
+      questionLayout: "auto",
+      storageStrategy: "consent",
+      showProgress: true,
+    },
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "Et versjonert survey-dokument der to relaterte spørsmål valideres og vises sammen på første side.",
+      },
+    },
+  },
+};
 
 export const LinearProgress: Story = {
   name: "Lineær fremdrift",

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -56,6 +56,7 @@ definisjonskontroll også testes. Testbenken dekker:
 | Task Priority · avkryssing | `taskPriority` | `multiChoice/checkbox` |
 | Task Priority · komboboks | `taskPriority` | `multiChoice/combobox` |
 | Custom · feltmatrise | `custom` | `text`, `singleChoice`, `multiChoice` |
+| Pages · flere spørsmål | `custom` | `SurveyDocumentV1`, `pages`, samlet validering, `visibleIf` |
 
 ### Lokal auth
 


### PR DESCRIPTION
## Summary

- add the versioned SurveyDocumentV1 authoring model with pages containing one or more questions
- preserve flat LumiSurveyConfig as an unchanged compatibility input while keeping logic out of the new model
- add page navigation, validation, focus handling, accessible descriptions, runtime guards, docs, ADR, and Storybook coverage
- add a permanent SurveyDocumentV1 scenario to the local full-chain demo
- keep submission payloads, analytics definitions, backend storage, and database schema unchanged

## Validation

- npm run lint
- npm run typecheck
- npm test — 51 files / 313 dashboard tests
- cd packages/lumi-survey && npm test — 27 files / 358 survey tests
- npm run verify:lumi-survey
- local full-chain: browser → widget → proxy → API → Postgres → dashboard
- verified shared page validation, error focus/links, back navigation, visibleIf reveal/hide, and Yes/No submission paths
- verified 4-answer and 3-answer rows share one immutable definition hash; hidden answer is omitted
- no browser console errors or runtime container errors
- two independent subagent reviews with no remaining P0–P3 findings

Closes #336.