### PR TITLE
Surveyverksted: persistent draft og ekte preview

### DIFF
--- a/apps/lumi-api/src/main/kotlin/no/nav/lumi/config/Routing.kt
+++ b/apps/lumi-api/src/main/kotlin/no/nav/lumi/config/Routing.kt
@@ -12,6 +12,7 @@ import no.nav.lumi.routes.exportRoutes
 import no.nav.lumi.routes.filterRoutes
 import no.nav.lumi.routes.markerRoutes
 import no.nav.lumi.routes.surveyArchiveRoutes
+import no.nav.lumi.routes.surveyAuthoringRoutes
 import no.nav.lumi.routes.surveyFacetRoutes
 import no.nav.lumi.routes.statsRoutes
 import no.nav.lumi.routes.internalRoutes
@@ -45,6 +46,7 @@ fun Application.configureRouting() {
                     feedbackRoutes()
                     surveyFacetRoutes()
                     surveyArchiveRoutes()
+                    surveyAuthoringRoutes()
                     markerRoutes()
                     statsRoutes()
                     discoveryRoutes()

--- a/apps/lumi-api/src/main/kotlin/no/nav/lumi/domain/SurveyAuthoringProject.kt
+++ b/apps/lumi-api/src/main/kotlin/no/nav/lumi/domain/SurveyAuthoringProject.kt
@@ -1,0 +1,42 @@
+package no.nav.lumi.domain
+
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.JsonObject
+
+@Serializable
+data class CreateSurveyAuthoringProjectRequest(
+    val name: String,
+    val surveyId: String,
+    val document: JsonObject,
+)
+
+@Serializable
+data class UpdateSurveyAuthoringDraftRequest(
+    val expectedVersion: Long,
+    val name: String,
+    val surveyId: String,
+    val document: JsonObject,
+)
+
+@Serializable
+data class SurveyAuthoringProject(
+    val id: String,
+    val team: String,
+    val name: String,
+    val surveyId: String,
+    val document: JsonObject,
+    val draftVersion: Long,
+    val createdAt: String,
+    val updatedAt: String,
+)
+
+@Serializable
+data class SurveyAuthoringProjectSummary(
+    val id: String,
+    val team: String,
+    val name: String,
+    val surveyId: String,
+    val draftVersion: Long,
+    val createdAt: String,
+    val updatedAt: String,
+)

--- a/apps/lumi-api/src/main/kotlin/no/nav/lumi/repository/SurveyAuthoringProjectRepository.kt
+++ b/apps/lumi-api/src/main/kotlin/no/nav/lumi/repository/SurveyAuthoringProjectRepository.kt
@@ -1,0 +1,124 @@
+package no.nav.lumi.repository
+
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonObject
+import no.nav.lumi.domain.SurveyAuthoringProject
+import no.nav.lumi.domain.SurveyAuthoringProjectSummary
+import org.jetbrains.exposed.v1.core.ResultRow
+import org.jetbrains.exposed.v1.core.SortOrder
+import org.jetbrains.exposed.v1.core.and
+import org.jetbrains.exposed.v1.core.eq
+import org.jetbrains.exposed.v1.jdbc.selectAll
+import org.jetbrains.exposed.v1.jdbc.transactions.TransactionManager
+import org.jetbrains.exposed.v1.jdbc.update
+import java.sql.Connection
+import java.time.OffsetDateTime
+import java.util.UUID
+
+class SurveyAuthoringProjectRepository {
+    private val json = Json
+
+    suspend fun create(
+        team: String,
+        name: String,
+        surveyId: String,
+        document: JsonObject,
+        principalIdentity: String,
+        maxProjects: Int,
+    ): SurveyAuthoringProject? = dbQuery {
+        val connection = TransactionManager.current().connection.connection as Connection
+        connection.prepareStatement("SELECT pg_advisory_xact_lock(hashtext(?))").use { lock ->
+            lock.setString(1, "survey-authoring:$team")
+            lock.execute()
+        }
+
+        val sql = """
+            INSERT INTO survey_authoring_projects
+                (team, name, survey_id, draft, created_by, updated_by)
+            SELECT ?, ?, ?, ?::jsonb, ?, ?
+            WHERE (SELECT count(*) FROM survey_authoring_projects WHERE team = ?) < ?
+            RETURNING id
+        """.trimIndent()
+        val id = connection.prepareStatement(sql).use { statement ->
+            statement.setString(1, team)
+            statement.setString(2, name)
+            statement.setString(3, surveyId)
+            statement.setString(4, document.toString())
+            statement.setString(5, principalIdentity)
+            statement.setString(6, principalIdentity)
+            statement.setString(7, team)
+            statement.setInt(8, maxProjects)
+            statement.executeQuery().use { result ->
+                if (result.next()) result.getObject("id", UUID::class.java) else null
+            }
+        }
+
+        id?.let { findByIdInCurrentTransaction(team, it) }
+    }
+
+    suspend fun findByTeam(team: String): List<SurveyAuthoringProjectSummary> = dbQuery {
+        SurveyAuthoringProjectTable.selectAll()
+            .where { SurveyAuthoringProjectTable.team eq team }
+            .orderBy(SurveyAuthoringProjectTable.updatedAt to SortOrder.DESC)
+            .map(::toSummary)
+    }
+
+    suspend fun findById(team: String, id: UUID): SurveyAuthoringProject? = dbQuery {
+        findByIdInCurrentTransaction(team, id)
+    }
+
+    suspend fun updateDraft(
+        team: String,
+        id: UUID,
+        expectedVersion: Long,
+        name: String,
+        surveyId: String,
+        document: JsonObject,
+        principalIdentity: String,
+    ): SurveyAuthoringProject? = dbQuery {
+        val updated = SurveyAuthoringProjectTable.update({
+            (SurveyAuthoringProjectTable.id eq id) and
+                (SurveyAuthoringProjectTable.team eq team) and
+                (SurveyAuthoringProjectTable.draftVersion eq expectedVersion)
+        }) {
+            it[SurveyAuthoringProjectTable.name] = name
+            it[SurveyAuthoringProjectTable.surveyId] = surveyId
+            it[draft] = document.toString()
+            it[draftVersion] = expectedVersion + 1
+            it[updatedBy] = principalIdentity
+            it[updatedAt] = OffsetDateTime.now()
+        }
+
+        if (updated == 0) null else findByIdInCurrentTransaction(team, id)
+    }
+
+    private fun findByIdInCurrentTransaction(team: String, id: UUID): SurveyAuthoringProject? =
+        SurveyAuthoringProjectTable.selectAll()
+            .where {
+                (SurveyAuthoringProjectTable.id eq id) and
+                    (SurveyAuthoringProjectTable.team eq team)
+            }
+            .singleOrNull()
+            ?.let(::toProject)
+
+    private fun toProject(row: ResultRow) = SurveyAuthoringProject(
+        id = row[SurveyAuthoringProjectTable.id].toString(),
+        team = row[SurveyAuthoringProjectTable.team],
+        name = row[SurveyAuthoringProjectTable.name],
+        surveyId = row[SurveyAuthoringProjectTable.surveyId],
+        document = json.parseToJsonElement(row[SurveyAuthoringProjectTable.draft]) as JsonObject,
+        draftVersion = row[SurveyAuthoringProjectTable.draftVersion],
+        createdAt = row[SurveyAuthoringProjectTable.createdAt].toString(),
+        updatedAt = row[SurveyAuthoringProjectTable.updatedAt].toString(),
+    )
+
+    private fun toSummary(row: ResultRow) = SurveyAuthoringProjectSummary(
+        id = row[SurveyAuthoringProjectTable.id].toString(),
+        team = row[SurveyAuthoringProjectTable.team],
+        name = row[SurveyAuthoringProjectTable.name],
+        surveyId = row[SurveyAuthoringProjectTable.surveyId],
+        draftVersion = row[SurveyAuthoringProjectTable.draftVersion],
+        createdAt = row[SurveyAuthoringProjectTable.createdAt].toString(),
+        updatedAt = row[SurveyAuthoringProjectTable.updatedAt].toString(),
+    )
+}

--- a/apps/lumi-api/src/main/kotlin/no/nav/lumi/repository/SurveyAuthoringProjectTable.kt
+++ b/apps/lumi-api/src/main/kotlin/no/nav/lumi/repository/SurveyAuthoringProjectTable.kt
@@ -1,0 +1,20 @@
+package no.nav.lumi.repository
+
+import org.jetbrains.exposed.v1.core.Table
+import org.jetbrains.exposed.v1.core.java.javaUUID
+import org.jetbrains.exposed.v1.javatime.timestampWithTimeZone
+
+object SurveyAuthoringProjectTable : Table("survey_authoring_projects") {
+    val id = javaUUID("id").autoGenerate()
+    val team = varchar("team", 255)
+    val name = varchar("name", 120)
+    val surveyId = varchar("survey_id", 200)
+    val draft = registerColumn<String>("draft", JsonbColumnType())
+    val draftVersion = long("draft_version")
+    val createdBy = text("created_by")
+    val updatedBy = text("updated_by")
+    val createdAt = timestampWithTimeZone("created_at")
+    val updatedAt = timestampWithTimeZone("updated_at")
+
+    override val primaryKey = PrimaryKey(id)
+}

--- a/apps/lumi-api/src/main/kotlin/no/nav/lumi/routes/Resources.kt
+++ b/apps/lumi-api/src/main/kotlin/no/nav/lumi/routes/Resources.kt
@@ -275,4 +275,27 @@ class ApiV1Intern {
         val choiceFieldId: String? = null,
         val choiceValue: String? = null,
     )
+
+    @Resource("authoring")
+    @Serializable
+    class Authoring(val parent: ApiV1Intern = ApiV1Intern()) {
+        @Resource("projects")
+        @Serializable
+        class Projects(
+            val parent: Authoring = Authoring(),
+            /** Optional team scope. If omitted, the backend selects a default authorized team. */
+            val team: String? = null,
+        ) {
+            @Resource("{projectId}")
+            @Serializable
+            class Id(
+                val parent: Projects = Projects(),
+                val projectId: String,
+            ) {
+                @Resource("draft")
+                @Serializable
+                class Draft(val parent: Id)
+            }
+        }
+    }
 }

--- a/apps/lumi-api/src/main/kotlin/no/nav/lumi/routes/SurveyAuthoringRoutes.kt
+++ b/apps/lumi-api/src/main/kotlin/no/nav/lumi/routes/SurveyAuthoringRoutes.kt
@@ -1,0 +1,143 @@
+package no.nav.lumi.routes
+
+import io.ktor.http.HttpStatusCode
+import io.ktor.http.HttpHeaders
+import io.ktor.server.request.receive
+import io.ktor.server.resources.get
+import io.ktor.server.resources.post
+import io.ktor.server.resources.put
+import io.ktor.server.response.respond
+import io.ktor.server.routing.Route
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.intOrNull
+import no.nav.lumi.config.auth.authorizedPrincipal
+import no.nav.lumi.config.auth.authorizedTeam
+import no.nav.lumi.config.exception.ApiErrorException
+import no.nav.lumi.domain.CreateSurveyAuthoringProjectRequest
+import no.nav.lumi.domain.UpdateSurveyAuthoringDraftRequest
+import no.nav.lumi.repository.SurveyAuthoringProjectRepository
+import java.util.UUID
+
+private val defaultSurveyAuthoringProjectRepository = SurveyAuthoringProjectRepository()
+private const val MAX_PROJECT_NAME_LENGTH = 120
+private const val MAX_SURVEY_ID_LENGTH = 200
+private const val MAX_DRAFT_BYTES = 256 * 1024
+private const val MAX_REQUEST_BYTES = MAX_DRAFT_BYTES + 16 * 1024
+private const val MAX_PROJECTS_PER_TEAM = 100
+
+fun Route.surveyAuthoringRoutes(
+    repository: SurveyAuthoringProjectRepository = defaultSurveyAuthoringProjectRepository,
+) {
+    get<ApiV1Intern.Authoring.Projects> {
+        call.respond(repository.findByTeam(call.authorizedTeam))
+    }
+
+    post<ApiV1Intern.Authoring.Projects> {
+        validateRequestSize(call.request.headers[HttpHeaders.ContentLength]?.toLongOrNull())
+        val request = call.receive<CreateSurveyAuthoringProjectRequest>()
+        val validated = validateProjectInput(request.name, request.surveyId, request.document)
+        val principalIdentity = stablePrincipalIdentity(call.authorizedPrincipal)
+            ?: throw ApiErrorException.BadRequestException("Authenticated user needs a stable identity")
+
+        val project = repository.create(
+            team = call.authorizedTeam,
+            name = validated.name,
+            surveyId = validated.surveyId,
+            document = request.document,
+            principalIdentity = principalIdentity,
+            maxProjects = MAX_PROJECTS_PER_TEAM,
+        ) ?: throw ApiErrorException.TooManyRequestsException(
+            "Team has reached the limit of $MAX_PROJECTS_PER_TEAM survey drafts",
+        )
+        call.respond(HttpStatusCode.Created, project)
+    }
+
+    get<ApiV1Intern.Authoring.Projects.Id> { params ->
+        val project = repository.findById(
+            team = call.authorizedTeam,
+            id = parseProjectId(params.projectId),
+        ) ?: throw ApiErrorException.NotFoundException("Survey project not found")
+
+        call.respond(project)
+    }
+
+    put<ApiV1Intern.Authoring.Projects.Id.Draft> { params ->
+        validateRequestSize(call.request.headers[HttpHeaders.ContentLength]?.toLongOrNull())
+        val request = call.receive<UpdateSurveyAuthoringDraftRequest>()
+        if (request.expectedVersion < 1) {
+            throw ApiErrorException.BadRequestException("expectedVersion must be positive")
+        }
+        val validated = validateProjectInput(request.name, request.surveyId, request.document)
+        val team = call.authorizedTeam
+        val projectId = parseProjectId(params.parent.projectId)
+        val principalIdentity = stablePrincipalIdentity(call.authorizedPrincipal)
+            ?: throw ApiErrorException.BadRequestException("Authenticated user needs a stable identity")
+
+        if (repository.findById(team, projectId) == null) {
+            throw ApiErrorException.NotFoundException("Survey project not found")
+        }
+
+        val project = repository.updateDraft(
+            team = team,
+            id = projectId,
+            expectedVersion = request.expectedVersion,
+            name = validated.name,
+            surveyId = validated.surveyId,
+            document = request.document,
+            principalIdentity = principalIdentity,
+        ) ?: throw ApiErrorException.ConflictException(
+            "Draft changed since it was loaded. Reload before saving again.",
+        )
+
+        call.respond(project)
+    }
+}
+
+private data class ValidatedProjectInput(val name: String, val surveyId: String)
+
+private fun validateRequestSize(contentLength: Long?) {
+    if (contentLength != null && contentLength > MAX_REQUEST_BYTES) {
+        throw ApiErrorException.PayloadTooLargeException(
+            "Survey draft request must be at most $MAX_REQUEST_BYTES bytes",
+        )
+    }
+}
+
+private fun validateProjectInput(
+    rawName: String,
+    rawSurveyId: String,
+    document: JsonObject,
+): ValidatedProjectInput {
+    val name = rawName.trim()
+    val surveyId = rawSurveyId.trim()
+
+    if (name.isEmpty() || name.length > MAX_PROJECT_NAME_LENGTH) {
+        throw ApiErrorException.BadRequestException(
+            "name must contain 1-$MAX_PROJECT_NAME_LENGTH characters",
+        )
+    }
+    if (surveyId.isEmpty() || surveyId.length > MAX_SURVEY_ID_LENGTH) {
+        throw ApiErrorException.BadRequestException(
+            "surveyId must contain 1-$MAX_SURVEY_ID_LENGTH characters",
+        )
+    }
+    if (document.toString().toByteArray(Charsets.UTF_8).size > MAX_DRAFT_BYTES) {
+        throw ApiErrorException.PayloadTooLargeException(
+            "Survey draft must be at most $MAX_DRAFT_BYTES bytes",
+        )
+    }
+    if ((document["authoringSchemaVersion"] as? JsonPrimitive)?.intOrNull != 1) {
+        throw ApiErrorException.BadRequestException(
+            "Only authoringSchemaVersion 1 is supported",
+        )
+    }
+
+    return ValidatedProjectInput(name, surveyId)
+}
+
+private fun parseProjectId(value: String): UUID = try {
+    UUID.fromString(value)
+} catch (_: IllegalArgumentException) {
+    throw ApiErrorException.BadRequestException("Invalid survey project ID")
+}

--- a/apps/lumi-api/src/main/kotlin/no/nav/lumi/routes/SurveyAuthoringRoutes.kt
+++ b/apps/lumi-api/src/main/kotlin/no/nav/lumi/routes/SurveyAuthoringRoutes.kt
@@ -2,12 +2,17 @@ package no.nav.lumi.routes
 
 import io.ktor.http.HttpStatusCode
 import io.ktor.http.HttpHeaders
-import io.ktor.server.request.receive
+import io.ktor.server.application.ApplicationCall
+import io.ktor.server.request.receiveChannel
 import io.ktor.server.resources.get
 import io.ktor.server.resources.post
 import io.ktor.server.resources.put
 import io.ktor.server.response.respond
 import io.ktor.server.routing.Route
+import io.ktor.utils.io.core.readText
+import io.ktor.utils.io.readRemaining
+import kotlinx.serialization.SerializationException
+import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.JsonPrimitive
 import kotlinx.serialization.json.intOrNull
@@ -34,8 +39,7 @@ fun Route.surveyAuthoringRoutes(
     }
 
     post<ApiV1Intern.Authoring.Projects> {
-        validateRequestSize(call.request.headers[HttpHeaders.ContentLength]?.toLongOrNull())
-        val request = call.receive<CreateSurveyAuthoringProjectRequest>()
+        val request = receiveAuthoringRequest<CreateSurveyAuthoringProjectRequest>(call)
         val validated = validateProjectInput(request.name, request.surveyId, request.document)
         val principalIdentity = stablePrincipalIdentity(call.authorizedPrincipal)
             ?: throw ApiErrorException.BadRequestException("Authenticated user needs a stable identity")
@@ -63,8 +67,7 @@ fun Route.surveyAuthoringRoutes(
     }
 
     put<ApiV1Intern.Authoring.Projects.Id.Draft> { params ->
-        validateRequestSize(call.request.headers[HttpHeaders.ContentLength]?.toLongOrNull())
-        val request = call.receive<UpdateSurveyAuthoringDraftRequest>()
+        val request = receiveAuthoringRequest<UpdateSurveyAuthoringDraftRequest>(call)
         if (request.expectedVersion < 1) {
             throw ApiErrorException.BadRequestException("expectedVersion must be positive")
         }
@@ -96,11 +99,32 @@ fun Route.surveyAuthoringRoutes(
 
 private data class ValidatedProjectInput(val name: String, val surveyId: String)
 
-private fun validateRequestSize(contentLength: Long?) {
+private val authoringJson = Json {
+    ignoreUnknownKeys = true
+    isLenient = false
+    encodeDefaults = true
+}
+
+private suspend inline fun <reified T> receiveAuthoringRequest(call: ApplicationCall): T {
+    val contentLength = call.request.headers[HttpHeaders.ContentLength]?.toLongOrNull()
     if (contentLength != null && contentLength > MAX_REQUEST_BYTES) {
         throw ApiErrorException.PayloadTooLargeException(
             "Survey draft request must be at most $MAX_REQUEST_BYTES bytes",
         )
+    }
+
+    val packet = call.receiveChannel().readRemaining(MAX_REQUEST_BYTES.toLong() + 1)
+    val text = packet.readText()
+    if (text.toByteArray(Charsets.UTF_8).size > MAX_REQUEST_BYTES) {
+        throw ApiErrorException.PayloadTooLargeException(
+            "Survey draft request must be at most $MAX_REQUEST_BYTES bytes",
+        )
+    }
+
+    return try {
+        authoringJson.decodeFromString<T>(text)
+    } catch (_: SerializationException) {
+        throw ApiErrorException.BadRequestException("Invalid survey draft request")
     }
 }
 

--- a/apps/lumi-api/src/main/resources/db/migration/V14__survey_authoring_projects.sql
+++ b/apps/lumi-api/src/main/resources/db/migration/V14__survey_authoring_projects.sql
@@ -1,0 +1,23 @@
+-- Mutable, team-scoped working copies for Surveyverkstedet.
+-- Kept deliberately separate from survey_definitions: authoring drafts are not
+-- production configuration and must never affect submission compatibility.
+
+CREATE TABLE survey_authoring_projects (
+    id            UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    team          VARCHAR(255) NOT NULL,
+    name          VARCHAR(120) NOT NULL,
+    survey_id     VARCHAR(200) NOT NULL,
+    draft         JSONB NOT NULL,
+    draft_version BIGINT NOT NULL DEFAULT 1 CHECK (draft_version > 0),
+    created_by    TEXT NOT NULL,
+    updated_by    TEXT NOT NULL,
+    created_at    TIMESTAMPTZ NOT NULL DEFAULT now(),
+    updated_at    TIMESTAMPTZ NOT NULL DEFAULT now(),
+    CONSTRAINT chk_survey_authoring_draft_object
+        CHECK (jsonb_typeof(draft) = 'object'),
+    CONSTRAINT chk_survey_authoring_schema_v1
+        CHECK (draft ->> 'authoringSchemaVersion' = '1')
+);
+
+CREATE INDEX idx_survey_authoring_projects_team_updated
+    ON survey_authoring_projects(team, updated_at DESC);

--- a/apps/lumi-api/src/test/kotlin/no/nav/lumi/TestDatabase.kt
+++ b/apps/lumi-api/src/test/kotlin/no/nav/lumi/TestDatabase.kt
@@ -80,7 +80,10 @@ object TestDatabase {
     fun clearAllData() {
         dataSource.connection.use { conn ->
             conn.createStatement().use { stmt ->
-                stmt.execute("TRUNCATE TABLE rating_marker, feedback, survey_definitions, survey_metadata CASCADE")
+                stmt.execute(
+                    "TRUNCATE TABLE rating_marker, feedback, survey_definitions, survey_metadata, " +
+                        "survey_authoring_projects CASCADE"
+                )
             }
             conn.commit()
         }

--- a/apps/lumi-api/src/test/kotlin/no/nav/lumi/TestUtils.kt
+++ b/apps/lumi-api/src/test/kotlin/no/nav/lumi/TestUtils.kt
@@ -28,6 +28,7 @@ import no.nav.lumi.routes.exportRoutes
 import no.nav.lumi.routes.markerRoutes
 import no.nav.lumi.routes.filterRoutes
 import no.nav.lumi.routes.surveyArchiveRoutes
+import no.nav.lumi.routes.surveyAuthoringRoutes
 import no.nav.lumi.routes.surveyFacetRoutes
 import no.nav.lumi.routes.submissionRoutes
 import no.nav.lumi.routes.discoveryRoutes
@@ -309,6 +310,7 @@ fun Application.testModule(
                 bootstrapCache = bootstrapCache,
                 statsCacheInvalidator = statsCacheInvalidator,
             )
+            surveyAuthoringRoutes()
             filterRoutes(bootstrapCache = bootstrapCache)
             markerRoutes()
             statsRoutes(statsService)

--- a/apps/lumi-api/src/test/kotlin/no/nav/lumi/repository/SurveyAuthoringProjectRepositoryTest.kt
+++ b/apps/lumi-api/src/test/kotlin/no/nav/lumi/repository/SurveyAuthoringProjectRepositoryTest.kt
@@ -1,0 +1,47 @@
+package no.nav.lumi.repository
+
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.put
+import no.nav.lumi.TestDatabase
+
+class SurveyAuthoringProjectRepositoryTest : FunSpec({
+    beforeSpec { TestDatabase.initialize() }
+    beforeTest { TestDatabase.clearAllData() }
+
+    test("project limit is enforced per team") {
+        val repository = SurveyAuthoringProjectRepository()
+        val document = buildJsonObject {
+            put("authoringSchemaVersion", 1)
+            put("pages", kotlinx.serialization.json.buildJsonArray {})
+        }
+
+        repository.create(
+            team = "team-a",
+            name = "First",
+            surveyId = "survey-1",
+            document = document,
+            principalIdentity = "A123456",
+            maxProjects = 1,
+        )?.draftVersion shouldBe 1
+
+        repository.create(
+            team = "team-a",
+            name = "Second",
+            surveyId = "survey-2",
+            document = document,
+            principalIdentity = "A123456",
+            maxProjects = 1,
+        ) shouldBe null
+
+        repository.create(
+            team = "team-b",
+            name = "Other team",
+            surveyId = "survey-1",
+            document = document,
+            principalIdentity = "B123456",
+            maxProjects = 1,
+        )?.team shouldBe "team-b"
+    }
+})

--- a/apps/lumi-api/src/test/kotlin/no/nav/lumi/routes/SurveyAuthoringRoutesTest.kt
+++ b/apps/lumi-api/src/test/kotlin/no/nav/lumi/routes/SurveyAuthoringRoutesTest.kt
@@ -174,6 +174,22 @@ class SurveyAuthoringRoutesTest : FunSpec({
             response.status shouldBe HttpStatusCode.BadRequest
         }
     }
+
+    test("draft requests reject oversized bodies before deserialization") {
+        testApplication {
+            application { testModule() }
+
+            val response = createTestClient().post(
+                "/api/v1/intern/authoring/projects?team=team-test",
+            ) {
+                header(HttpHeaders.Authorization, "Bearer test-token")
+                contentType(ContentType.Application.Json)
+                setBody("x".repeat(300_000))
+            }
+
+            response.status shouldBe HttpStatusCode.PayloadTooLarge
+        }
+    }
 })
 
 private fun createBody() = """

--- a/apps/lumi-api/src/test/kotlin/no/nav/lumi/routes/SurveyAuthoringRoutesTest.kt
+++ b/apps/lumi-api/src/test/kotlin/no/nav/lumi/routes/SurveyAuthoringRoutesTest.kt
@@ -1,0 +1,218 @@
+package no.nav.lumi.routes
+
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import io.ktor.client.request.get
+import io.ktor.client.request.header
+import io.ktor.client.request.post
+import io.ktor.client.request.put
+import io.ktor.client.request.setBody
+import io.ktor.client.statement.bodyAsText
+import io.ktor.http.ContentType
+import io.ktor.http.HttpHeaders
+import io.ktor.http.HttpStatusCode
+import io.ktor.http.contentType
+import io.ktor.server.testing.testApplication
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.jsonArray
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
+import no.nav.lumi.TestDatabase
+import no.nav.lumi.createTestClient
+import no.nav.lumi.testModule
+
+class SurveyAuthoringRoutesTest : FunSpec({
+    beforeSpec { TestDatabase.initialize() }
+    beforeTest { TestDatabase.clearAllData() }
+
+    test("authoring projects require authentication") {
+        testApplication {
+            application { testModule() }
+
+            client.get("/api/v1/intern/authoring/projects?team=team-test").status shouldBe
+                HttpStatusCode.Unauthorized
+        }
+    }
+
+    test("create, list and reopen a team-scoped draft") {
+        testApplication {
+            application { testModule() }
+            val client = createTestClient()
+
+            val created = client.post("/api/v1/intern/authoring/projects?team=team-test") {
+                header(HttpHeaders.Authorization, "Bearer test-token")
+                contentType(ContentType.Application.Json)
+                setBody(createBody())
+            }
+
+            created.status shouldBe HttpStatusCode.Created
+            val createdJson = Json.parseToJsonElement(created.bodyAsText()).jsonObject
+            val projectId = createdJson.getValue("id").jsonPrimitive.content
+            createdJson.getValue("team").jsonPrimitive.content shouldBe "team-test"
+            createdJson.getValue("name").jsonPrimitive.content shouldBe "Første utkast"
+            createdJson.getValue("draftVersion").jsonPrimitive.content shouldBe "1"
+
+            val listed = client.get("/api/v1/intern/authoring/projects?team=team-test") {
+                header(HttpHeaders.Authorization, "Bearer test-token")
+            }
+            listed.status shouldBe HttpStatusCode.OK
+            Json.parseToJsonElement(listed.bodyAsText()).jsonArray.single()
+                .jsonObject.getValue("id").jsonPrimitive.content shouldBe projectId
+
+            val reopened = client.get(
+                "/api/v1/intern/authoring/projects/$projectId?team=team-test",
+            ) {
+                header(HttpHeaders.Authorization, "Bearer test-token")
+            }
+            reopened.status shouldBe HttpStatusCode.OK
+            Json.parseToJsonElement(reopened.bodyAsText()).jsonObject
+                .getValue("document").jsonObject
+                .getValue("authoringSchemaVersion").jsonPrimitive.content shouldBe "1"
+        }
+    }
+
+    test("draft update uses optimistic versioning") {
+        testApplication {
+            application { testModule() }
+            val client = createTestClient()
+            val created = client.post("/api/v1/intern/authoring/projects?team=team-test") {
+                header(HttpHeaders.Authorization, "Bearer test-token")
+                contentType(ContentType.Application.Json)
+                setBody(createBody())
+            }
+            val projectId = Json.parseToJsonElement(created.bodyAsText()).jsonObject
+                .getValue("id").jsonPrimitive.content
+
+            val firstUpdate = client.put(
+                "/api/v1/intern/authoring/projects/$projectId/draft?team=team-test",
+            ) {
+                header(HttpHeaders.Authorization, "Bearer test-token")
+                contentType(ContentType.Application.Json)
+                setBody(updateBody(expectedVersion = 1, name = "Finjustert"))
+            }
+            firstUpdate.status shouldBe HttpStatusCode.OK
+            Json.parseToJsonElement(firstUpdate.bodyAsText()).jsonObject
+                .getValue("draftVersion").jsonPrimitive.content shouldBe "2"
+
+            val staleUpdate = client.put(
+                "/api/v1/intern/authoring/projects/$projectId/draft?team=team-test",
+            ) {
+                header(HttpHeaders.Authorization, "Bearer test-token")
+                contentType(ContentType.Application.Json)
+                setBody(updateBody(expectedVersion = 1, name = "Overskriver"))
+            }
+            staleUpdate.status shouldBe HttpStatusCode.Conflict
+        }
+    }
+
+    test("projects cannot be read through another team scope") {
+        testApplication {
+            application { testModule() }
+            val client = createTestClient()
+            val created = client.post("/api/v1/intern/authoring/projects?team=team-test") {
+                header(HttpHeaders.Authorization, "Bearer test-token")
+                contentType(ContentType.Application.Json)
+                setBody(createBody())
+            }
+            val projectId = Json.parseToJsonElement(created.bodyAsText()).jsonObject
+                .getValue("id").jsonPrimitive.content
+
+            val response = client.get(
+                "/api/v1/intern/authoring/projects/$projectId?team=flex",
+            ) {
+                header(HttpHeaders.Authorization, "Bearer test-token")
+            }
+
+            response.status shouldBe HttpStatusCode.NotFound
+        }
+    }
+
+    test("drafts reject unsupported schema versions") {
+        testApplication {
+            application { testModule() }
+
+            val response = createTestClient().post(
+                "/api/v1/intern/authoring/projects?team=team-test",
+            ) {
+                header(HttpHeaders.Authorization, "Bearer test-token")
+                contentType(ContentType.Application.Json)
+                setBody(
+                    """
+                    {
+                      "name": "Ugyldig",
+                      "surveyId": "ugyldig",
+                      "document": {"authoringSchemaVersion": 2, "pages": []}
+                    }
+                    """.trimIndent(),
+                )
+            }
+
+            response.status shouldBe HttpStatusCode.BadRequest
+        }
+    }
+
+    test("drafts reject malformed schema versions without an internal error") {
+        testApplication {
+            application { testModule() }
+
+            val response = createTestClient().post(
+                "/api/v1/intern/authoring/projects?team=team-test",
+            ) {
+                header(HttpHeaders.Authorization, "Bearer test-token")
+                contentType(ContentType.Application.Json)
+                setBody(
+                    """
+                    {
+                      "name": "Ugyldig",
+                      "surveyId": "ugyldig",
+                      "document": {"authoringSchemaVersion": {}, "pages": []}
+                    }
+                    """.trimIndent(),
+                )
+            }
+
+            response.status shouldBe HttpStatusCode.BadRequest
+        }
+    }
+})
+
+private fun createBody() = """
+    {
+      "name": " Første utkast ",
+      "surveyId": " verksted-test ",
+      "document": {
+        "authoringSchemaVersion": 1,
+        "type": "rating",
+        "pages": [{
+          "id": "opplevelse",
+          "title": "Fortell om opplevelsen",
+          "questions": [{
+            "id": "rating",
+            "type": "rating",
+            "prompt": "Hvordan gikk det?",
+            "required": true
+          }]
+        }]
+      }
+    }
+""".trimIndent()
+
+private fun updateBody(expectedVersion: Long, name: String) = """
+    {
+      "expectedVersion": $expectedVersion,
+      "name": "$name",
+      "surveyId": "verksted-test",
+      "document": {
+        "authoringSchemaVersion": 1,
+        "type": "rating",
+        "pages": [{
+          "id": "opplevelse",
+          "questions": [{
+            "id": "rating",
+            "type": "rating",
+            "prompt": "Hvordan gikk det?"
+          }]
+        }]
+      }
+    }
+""".trimIndent()

--- a/apps/lumi-dashboard/app/components/shared/Header/index.tsx
+++ b/apps/lumi-dashboard/app/components/shared/Header/index.tsx
@@ -1,4 +1,9 @@
-import { BarChartIcon, DownloadIcon, TableIcon } from "@navikt/aksel-icons";
+import {
+  BarChartIcon,
+  DownloadIcon,
+  PencilWritingIcon,
+  TableIcon,
+} from "@navikt/aksel-icons";
 import { Box, Button, Hide, HStack } from "@navikt/ds-react";
 import { Link, useLocation } from "@tanstack/react-router";
 import lumiLogo from "~/assets/lumi.png";
@@ -92,6 +97,17 @@ export function Header() {
             >
               <Hide below="md" asChild>
                 <span>Eksporter</span>
+              </Hide>
+            </Button>
+          </Link>
+          <Link to="/surveyverksted" search={{}}>
+            <Button
+              variant={getVariant("/surveyverksted")}
+              size="small"
+              icon={<PencilWritingIcon aria-hidden />}
+            >
+              <Hide below="md" asChild>
+                <span>Surveyverksted</span>
               </Hide>
             </Button>
           </Link>

--- a/apps/lumi-dashboard/app/mock/__tests__/surveyAuthoring.test.ts
+++ b/apps/lumi-dashboard/app/mock/__tests__/surveyAuthoring.test.ts
@@ -1,0 +1,66 @@
+import type { SurveyDocumentV1 } from "@navikt/lumi-survey";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const document: SurveyDocumentV1 = {
+  authoringSchemaVersion: 1,
+  pages: [
+    {
+      id: "page-1",
+      questions: [
+        { id: "rating", type: "rating", prompt: "Hvordan gikk det?" },
+      ],
+    },
+  ],
+};
+
+describe("mock survey authoring store", () => {
+  beforeEach(() => {
+    vi.resetModules();
+  });
+
+  it("persists a draft and reopens it for the same team", async () => {
+    const store = await import("../surveyAuthoring");
+    const created = store.createMockSurveyProject({
+      team: "team-a",
+      name: "Utkast",
+      surveyId: "survey-1",
+      document,
+    });
+
+    expect(store.listMockSurveyProjects("team-a")).toHaveLength(1);
+    expect(store.getMockSurveyProject("team-a", created.id)).toEqual(created);
+    expect(store.getMockSurveyProject("team-b", created.id)).toBeUndefined();
+  });
+
+  it("increments the version and rejects a stale autosave", async () => {
+    const store = await import("../surveyAuthoring");
+    const created = store.createMockSurveyProject({
+      team: "team-a",
+      name: "Utkast",
+      surveyId: "survey-1",
+      document,
+    });
+
+    const saved = store.saveMockSurveyProject({
+      team: "team-a",
+      projectId: created.id,
+      expectedVersion: 1,
+      name: "Finjustert",
+      surveyId: "survey-1",
+      document,
+    });
+
+    expect(saved.draftVersion).toBe(2);
+    expect(saved.name).toBe("Finjustert");
+    expect(() =>
+      store.saveMockSurveyProject({
+        team: "team-a",
+        projectId: created.id,
+        expectedVersion: 1,
+        name: "Stale",
+        surveyId: "survey-1",
+        document,
+      }),
+    ).toThrow("Draft changed since it was loaded");
+  });
+});

--- a/apps/lumi-dashboard/app/mock/surveyAuthoring.ts
+++ b/apps/lumi-dashboard/app/mock/surveyAuthoring.ts
@@ -1,0 +1,73 @@
+import type { SurveyDocumentV1 } from "@navikt/lumi-survey";
+import type {
+  SurveyAuthoringProject,
+  SurveyAuthoringProjectSummary,
+} from "~/types/surveyAuthoring";
+
+const projects = new Map<string, SurveyAuthoringProject>();
+
+export function listMockSurveyProjects(
+  team: string,
+): SurveyAuthoringProjectSummary[] {
+  return [...projects.values()]
+    .filter((project) => project.team === team)
+    .sort((a, b) => b.updatedAt.localeCompare(a.updatedAt))
+    .map(({ document: _document, ...summary }) => summary);
+}
+
+export function getMockSurveyProject(
+  team: string,
+  projectId: string,
+): SurveyAuthoringProject | undefined {
+  const project = projects.get(projectId);
+  return project?.team === team ? structuredClone(project) : undefined;
+}
+
+export function createMockSurveyProject(input: {
+  team: string;
+  name: string;
+  surveyId: string;
+  document: SurveyDocumentV1;
+}): SurveyAuthoringProject {
+  const now = new Date().toISOString();
+  const project: SurveyAuthoringProject = {
+    id: crypto.randomUUID(),
+    team: input.team,
+    name: input.name.trim(),
+    surveyId: input.surveyId.trim(),
+    document: structuredClone(input.document),
+    draftVersion: 1,
+    createdAt: now,
+    updatedAt: now,
+  };
+  projects.set(project.id, project);
+  return structuredClone(project);
+}
+
+export function saveMockSurveyProject(input: {
+  team: string;
+  projectId: string;
+  expectedVersion: number;
+  name: string;
+  surveyId: string;
+  document: SurveyDocumentV1;
+}): SurveyAuthoringProject {
+  const current = projects.get(input.projectId);
+  if (!current || current.team !== input.team) {
+    throw new Error("Survey project not found");
+  }
+  if (current.draftVersion !== input.expectedVersion) {
+    throw new Error("Draft changed since it was loaded");
+  }
+
+  const updated: SurveyAuthoringProject = {
+    ...current,
+    name: input.name.trim(),
+    surveyId: input.surveyId.trim(),
+    document: structuredClone(input.document),
+    draftVersion: current.draftVersion + 1,
+    updatedAt: new Date().toISOString(),
+  };
+  projects.set(updated.id, updated);
+  return structuredClone(updated);
+}

--- a/apps/lumi-dashboard/app/routeTree.gen.ts
+++ b/apps/lumi-dashboard/app/routeTree.gen.ts
@@ -9,13 +9,27 @@
 // Additionally, you should also exclude this file from your linter and/or formatter to prevent it from being checked or modified.
 
 import { Route as rootRouteImport } from './routes/__root'
+import { Route as SurveyverkstedRouteImport } from './routes/surveyverksted'
+import { Route as SurveyPreviewRouteImport } from './routes/survey-preview'
 import { Route as FeedbackRouteImport } from './routes/feedback'
 import { Route as ExportRouteImport } from './routes/export'
 import { Route as IndexRouteImport } from './routes/index'
+import { Route as SurveyverkstedIndexRouteImport } from './routes/surveyverksted.index'
+import { Route as SurveyverkstedProjectIdRouteImport } from './routes/surveyverksted.$projectId'
 import { Route as ApiInternalMetricsRouteImport } from './routes/api/internal/metrics'
 import { Route as ApiInternalIsReadyRouteImport } from './routes/api/internal/isReady'
 import { Route as ApiInternalIsAliveRouteImport } from './routes/api/internal/isAlive'
 
+const SurveyverkstedRoute = SurveyverkstedRouteImport.update({
+  id: '/surveyverksted',
+  path: '/surveyverksted',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const SurveyPreviewRoute = SurveyPreviewRouteImport.update({
+  id: '/survey-preview',
+  path: '/survey-preview',
+  getParentRoute: () => rootRouteImport,
+} as any)
 const FeedbackRoute = FeedbackRouteImport.update({
   id: '/feedback',
   path: '/feedback',
@@ -30,6 +44,16 @@ const IndexRoute = IndexRouteImport.update({
   id: '/',
   path: '/',
   getParentRoute: () => rootRouteImport,
+} as any)
+const SurveyverkstedIndexRoute = SurveyverkstedIndexRouteImport.update({
+  id: '/',
+  path: '/',
+  getParentRoute: () => SurveyverkstedRoute,
+} as any)
+const SurveyverkstedProjectIdRoute = SurveyverkstedProjectIdRouteImport.update({
+  id: '/$projectId',
+  path: '/$projectId',
+  getParentRoute: () => SurveyverkstedRoute,
 } as any)
 const ApiInternalMetricsRoute = ApiInternalMetricsRouteImport.update({
   id: '/api/internal/metrics',
@@ -51,6 +75,10 @@ export interface FileRoutesByFullPath {
   '/': typeof IndexRoute
   '/export': typeof ExportRoute
   '/feedback': typeof FeedbackRoute
+  '/survey-preview': typeof SurveyPreviewRoute
+  '/surveyverksted': typeof SurveyverkstedRouteWithChildren
+  '/surveyverksted/$projectId': typeof SurveyverkstedProjectIdRoute
+  '/surveyverksted/': typeof SurveyverkstedIndexRoute
   '/api/internal/isAlive': typeof ApiInternalIsAliveRoute
   '/api/internal/isReady': typeof ApiInternalIsReadyRoute
   '/api/internal/metrics': typeof ApiInternalMetricsRoute
@@ -59,6 +87,9 @@ export interface FileRoutesByTo {
   '/': typeof IndexRoute
   '/export': typeof ExportRoute
   '/feedback': typeof FeedbackRoute
+  '/survey-preview': typeof SurveyPreviewRoute
+  '/surveyverksted/$projectId': typeof SurveyverkstedProjectIdRoute
+  '/surveyverksted': typeof SurveyverkstedIndexRoute
   '/api/internal/isAlive': typeof ApiInternalIsAliveRoute
   '/api/internal/isReady': typeof ApiInternalIsReadyRoute
   '/api/internal/metrics': typeof ApiInternalMetricsRoute
@@ -68,6 +99,10 @@ export interface FileRoutesById {
   '/': typeof IndexRoute
   '/export': typeof ExportRoute
   '/feedback': typeof FeedbackRoute
+  '/survey-preview': typeof SurveyPreviewRoute
+  '/surveyverksted': typeof SurveyverkstedRouteWithChildren
+  '/surveyverksted/$projectId': typeof SurveyverkstedProjectIdRoute
+  '/surveyverksted/': typeof SurveyverkstedIndexRoute
   '/api/internal/isAlive': typeof ApiInternalIsAliveRoute
   '/api/internal/isReady': typeof ApiInternalIsReadyRoute
   '/api/internal/metrics': typeof ApiInternalMetricsRoute
@@ -78,6 +113,10 @@ export interface FileRouteTypes {
     | '/'
     | '/export'
     | '/feedback'
+    | '/survey-preview'
+    | '/surveyverksted'
+    | '/surveyverksted/$projectId'
+    | '/surveyverksted/'
     | '/api/internal/isAlive'
     | '/api/internal/isReady'
     | '/api/internal/metrics'
@@ -86,6 +125,9 @@ export interface FileRouteTypes {
     | '/'
     | '/export'
     | '/feedback'
+    | '/survey-preview'
+    | '/surveyverksted/$projectId'
+    | '/surveyverksted'
     | '/api/internal/isAlive'
     | '/api/internal/isReady'
     | '/api/internal/metrics'
@@ -94,6 +136,10 @@ export interface FileRouteTypes {
     | '/'
     | '/export'
     | '/feedback'
+    | '/survey-preview'
+    | '/surveyverksted'
+    | '/surveyverksted/$projectId'
+    | '/surveyverksted/'
     | '/api/internal/isAlive'
     | '/api/internal/isReady'
     | '/api/internal/metrics'
@@ -103,6 +149,8 @@ export interface RootRouteChildren {
   IndexRoute: typeof IndexRoute
   ExportRoute: typeof ExportRoute
   FeedbackRoute: typeof FeedbackRoute
+  SurveyPreviewRoute: typeof SurveyPreviewRoute
+  SurveyverkstedRoute: typeof SurveyverkstedRouteWithChildren
   ApiInternalIsAliveRoute: typeof ApiInternalIsAliveRoute
   ApiInternalIsReadyRoute: typeof ApiInternalIsReadyRoute
   ApiInternalMetricsRoute: typeof ApiInternalMetricsRoute
@@ -110,6 +158,20 @@ export interface RootRouteChildren {
 
 declare module '@tanstack/react-router' {
   interface FileRoutesByPath {
+    '/surveyverksted': {
+      id: '/surveyverksted'
+      path: '/surveyverksted'
+      fullPath: '/surveyverksted'
+      preLoaderRoute: typeof SurveyverkstedRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/survey-preview': {
+      id: '/survey-preview'
+      path: '/survey-preview'
+      fullPath: '/survey-preview'
+      preLoaderRoute: typeof SurveyPreviewRouteImport
+      parentRoute: typeof rootRouteImport
+    }
     '/feedback': {
       id: '/feedback'
       path: '/feedback'
@@ -130,6 +192,20 @@ declare module '@tanstack/react-router' {
       fullPath: '/'
       preLoaderRoute: typeof IndexRouteImport
       parentRoute: typeof rootRouteImport
+    }
+    '/surveyverksted/': {
+      id: '/surveyverksted/'
+      path: '/'
+      fullPath: '/surveyverksted/'
+      preLoaderRoute: typeof SurveyverkstedIndexRouteImport
+      parentRoute: typeof SurveyverkstedRoute
+    }
+    '/surveyverksted/$projectId': {
+      id: '/surveyverksted/$projectId'
+      path: '/$projectId'
+      fullPath: '/surveyverksted/$projectId'
+      preLoaderRoute: typeof SurveyverkstedProjectIdRouteImport
+      parentRoute: typeof SurveyverkstedRoute
     }
     '/api/internal/metrics': {
       id: '/api/internal/metrics'
@@ -155,10 +231,26 @@ declare module '@tanstack/react-router' {
   }
 }
 
+interface SurveyverkstedRouteChildren {
+  SurveyverkstedProjectIdRoute: typeof SurveyverkstedProjectIdRoute
+  SurveyverkstedIndexRoute: typeof SurveyverkstedIndexRoute
+}
+
+const SurveyverkstedRouteChildren: SurveyverkstedRouteChildren = {
+  SurveyverkstedProjectIdRoute: SurveyverkstedProjectIdRoute,
+  SurveyverkstedIndexRoute: SurveyverkstedIndexRoute,
+}
+
+const SurveyverkstedRouteWithChildren = SurveyverkstedRoute._addFileChildren(
+  SurveyverkstedRouteChildren,
+)
+
 const rootRouteChildren: RootRouteChildren = {
   IndexRoute: IndexRoute,
   ExportRoute: ExportRoute,
   FeedbackRoute: FeedbackRoute,
+  SurveyPreviewRoute: SurveyPreviewRoute,
+  SurveyverkstedRoute: SurveyverkstedRouteWithChildren,
   ApiInternalIsAliveRoute: ApiInternalIsAliveRoute,
   ApiInternalIsReadyRoute: ApiInternalIsReadyRoute,
   ApiInternalMetricsRoute: ApiInternalMetricsRoute,

--- a/apps/lumi-dashboard/app/routes/__root.tsx
+++ b/apps/lumi-dashboard/app/routes/__root.tsx
@@ -1,5 +1,6 @@
 // Import Aksel and global styles as regular CSS so they are emitted as manifest assets.
 import "@navikt/ds-css";
+import "@navikt/lumi-survey/styles.css";
 import { Alert, BodyShort, Heading } from "@navikt/ds-react";
 import { Theme } from "@navikt/ds-react/Theme";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";

--- a/apps/lumi-dashboard/app/routes/survey-preview.module.css
+++ b/apps/lumi-dashboard/app/routes/survey-preview.module.css
@@ -1,0 +1,34 @@
+.previewSurface {
+  position: relative;
+  min-height: 100vh;
+  overflow: hidden;
+  background:
+    linear-gradient(var(--ax-border-neutral-subtle) 1px, transparent 1px),
+    linear-gradient(90deg, var(--ax-border-neutral-subtle) 1px, transparent 1px),
+    var(--ax-bg-neutral-soft);
+  background-size: 24px 24px;
+}
+
+.previewMeta {
+  position: absolute;
+  top: var(--ax-space-16);
+  left: var(--ax-space-16);
+  display: flex;
+  align-items: center;
+  gap: var(--ax-space-8);
+  padding: var(--ax-space-8) var(--ax-space-12);
+  background: var(--ax-bg-raised);
+  border: 1px solid var(--ax-border-neutral-subtle);
+  border-radius: var(--ax-radius-8);
+}
+
+.centered {
+  min-height: 100vh;
+  display: grid;
+  place-content: center;
+}
+
+.previewAlert {
+  max-width: 34rem;
+  margin: 6rem auto;
+}

--- a/apps/lumi-dashboard/app/routes/survey-preview.tsx
+++ b/apps/lumi-dashboard/app/routes/survey-preview.tsx
@@ -1,0 +1,96 @@
+import { Alert, BodyShort, Box, Loader, Tag } from "@navikt/ds-react";
+import {
+  LumiSurveyDock,
+  type LumiSurveyTransport,
+  validateSurveyDocumentV1,
+} from "@navikt/lumi-survey";
+import { useQuery } from "@tanstack/react-query";
+import { createFileRoute } from "@tanstack/react-router";
+import { zodValidator } from "@tanstack/zod-adapter";
+import { useMemo } from "react";
+import { z } from "zod";
+import { fetchSurveyAuthoringProjectServerFn } from "~/server/actions";
+import styles from "./survey-preview.module.css";
+
+const searchSchema = z.object({
+  team: z.string().min(1),
+  projectId: z.string().uuid(),
+  version: z.coerce.number().int().positive().optional(),
+});
+
+const previewTransport: LumiSurveyTransport = {
+  submit: async () => undefined,
+};
+
+export const Route = createFileRoute("/survey-preview")({
+  validateSearch: zodValidator(searchSchema),
+  component: SurveyPreview,
+});
+
+function SurveyPreview() {
+  const { team, projectId, version } = Route.useSearch();
+  const projectQuery = useQuery({
+    queryKey: ["survey-authoring-preview", team, projectId, version],
+    queryFn: () =>
+      fetchSurveyAuthoringProjectServerFn({ data: { team, projectId } }),
+  });
+
+  const validation = useMemo(() => {
+    if (!projectQuery.data) return null;
+    try {
+      return {
+        document: validateSurveyDocumentV1(projectQuery.data.document),
+        error: null,
+      };
+    } catch (error) {
+      return {
+        document: null,
+        error: error instanceof Error ? error.message : "Ugyldig dokument",
+      };
+    }
+  }, [projectQuery.data]);
+
+  return (
+    <Box as="main" className={styles.previewSurface}>
+      <div className={styles.previewMeta}>
+        <Tag variant="warning" size="small">
+          Forhåndsvisning
+        </Tag>
+        <BodyShort size="small">Svar sendes ikke eller lagres.</BodyShort>
+      </div>
+
+      {projectQuery.isPending ? (
+        <div className={styles.centered}>
+          <Loader title="Laster forhåndsvisning" size="large" />
+        </div>
+      ) : projectQuery.isError ? (
+        <Alert variant="error" className={styles.previewAlert}>
+          Kunne ikke hente det lagrede utkastet.
+        </Alert>
+      ) : validation?.error ? (
+        <Alert variant="warning" className={styles.previewAlert}>
+          Widgeten kan ikke vises ennå: {validation.error}
+        </Alert>
+      ) : validation?.document ? (
+        <LumiSurveyDock
+          key={`${projectId}:${projectQuery.data.draftVersion}`}
+          surveyId={`preview-${projectQuery.data.surveyId}`}
+          survey={validation.document}
+          transport={previewTransport}
+          context={{ tags: { environment: "survey-workshop-preview" } }}
+          behavior={{
+            initialOpen: true,
+            hideAfterSubmit: false,
+            questionLayout: "auto",
+            showProgress: true,
+            storageStrategy: "none",
+          }}
+          success={{
+            title: "Slik ser kvitteringen ut",
+            body: "Dette var bare en forhåndsvisning. Ingenting ble sendt inn.",
+          }}
+        />
+      ) : null}
+    </Box>
+  );
+}

--- a/apps/lumi-dashboard/app/routes/surveyverksted-editor.module.css
+++ b/apps/lumi-dashboard/app/routes/surveyverksted-editor.module.css
@@ -1,0 +1,194 @@
+.loading {
+  min-height: 50vh;
+  display: grid;
+  place-content: center;
+}
+
+.editorShell {
+  min-height: calc(100vh - 64px);
+  background: var(--ax-bg-neutral-soft);
+}
+
+.editorTopbar {
+  position: sticky;
+  top: 0;
+  z-index: 5;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: var(--ax-space-16);
+  min-height: 72px;
+  padding: var(--ax-space-12) var(--ax-space-20);
+  background: color-mix(in srgb, var(--ax-bg-default) 94%, transparent);
+  border-bottom: 1px solid var(--ax-border-neutral-subtle);
+  backdrop-filter: blur(12px);
+}
+
+.saveAlert {
+  margin: var(--ax-space-12) var(--ax-space-20) 0;
+}
+
+.editorGrid {
+  display: grid;
+  grid-template-columns: minmax(15rem, 0.65fr) minmax(25rem, 1.35fr) minmax(
+      21rem,
+      1fr
+    );
+  min-height: calc(100vh - 136px);
+}
+
+.outline,
+.canvas,
+.preview {
+  padding: var(--ax-space-20);
+}
+
+.outline {
+  border-right: 1px solid var(--ax-border-neutral-subtle);
+  background: var(--ax-bg-default);
+}
+
+.canvas {
+  min-width: 0;
+}
+
+.preview {
+  position: sticky;
+  top: 72px;
+  align-self: start;
+  min-height: calc(100vh - 72px);
+  display: flex;
+  flex-direction: column;
+  gap: var(--ax-space-12);
+  background: var(--ax-bg-raised);
+  border-left: 1px solid var(--ax-border-neutral-subtle);
+}
+
+.previewCard {
+  margin-block: auto;
+  padding: var(--ax-space-24);
+  border: 1px solid var(--ax-border-neutral-subtle);
+  border-radius: var(--ax-radius-8);
+  background: var(--ax-bg-default);
+}
+
+.previewStats {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: var(--ax-space-8);
+}
+
+.previewStats div {
+  display: flex;
+  flex-direction: column;
+  gap: var(--ax-space-2);
+  padding: var(--ax-space-12);
+  background: var(--ax-bg-neutral-soft);
+  border-radius: var(--ax-radius-8);
+}
+
+.previewStats strong {
+  font-size: var(--ax-font-size-heading-medium);
+  font-variant-numeric: tabular-nums;
+}
+
+.previewStats span {
+  color: var(--ax-text-neutral-subtle);
+  font-size: var(--ax-font-size-small);
+}
+
+.previewButton {
+  width: 100%;
+}
+
+.pageList {
+  display: flex;
+  flex-direction: column;
+  gap: var(--ax-space-6);
+  padding: 0;
+  margin: var(--ax-space-12) 0 0;
+  list-style: none;
+}
+
+.pageButton {
+  width: 100%;
+  display: grid;
+  grid-template-columns: 2rem 1fr;
+  gap: var(--ax-space-4) var(--ax-space-8);
+  padding: var(--ax-space-12);
+  color: var(--ax-text-neutral);
+  text-align: left;
+  background: transparent;
+  border: 1px solid transparent;
+  border-radius: var(--ax-radius-8);
+  cursor: pointer;
+}
+
+.pageButton span:first-child {
+  grid-row: 1 / 3;
+  color: var(--ax-text-neutral-subtle);
+  font-variant-numeric: tabular-nums;
+}
+
+.pageButton small {
+  color: var(--ax-text-neutral-subtle);
+}
+
+.pageButton:hover {
+  background: var(--ax-bg-neutral-soft);
+}
+
+.pageButton[data-selected="true"] {
+  background: var(--ax-bg-accent-soft);
+  border-color: var(--ax-border-accent-subtle);
+}
+
+.pageButton:focus-visible {
+  outline: 3px solid var(--ax-border-focus);
+  outline-offset: 2px;
+}
+
+.questionNumber {
+  width: 1.75rem;
+  height: 1.75rem;
+  display: inline-grid;
+  place-content: center;
+  font-size: var(--ax-font-size-small);
+  font-weight: 700;
+  color: var(--ax-text-accent);
+  background: var(--ax-bg-accent-soft);
+  border-radius: 50%;
+}
+
+@media (max-width: 75rem) {
+  .editorGrid {
+    grid-template-columns: minmax(14rem, 0.55fr) minmax(24rem, 1.45fr);
+  }
+
+  .preview {
+    position: static;
+    grid-column: 1 / -1;
+    min-height: auto;
+    border-top: 1px solid var(--ax-border-neutral-subtle);
+    border-left: 0;
+  }
+}
+
+@media (max-width: 48rem) {
+  .editorTopbar {
+    position: static;
+    align-items: flex-start;
+    flex-direction: column;
+  }
+
+  .editorGrid {
+    display: block;
+  }
+
+  .outline,
+  .canvas,
+  .preview {
+    border: 0;
+    border-bottom: 1px solid var(--ax-border-neutral-subtle);
+  }
+}

--- a/apps/lumi-dashboard/app/routes/surveyverksted.$projectId.tsx
+++ b/apps/lumi-dashboard/app/routes/surveyverksted.$projectId.tsx
@@ -18,7 +18,7 @@ import type {
   SurveyQuestionV1,
 } from "@navikt/lumi-survey";
 import { useMutation, useQuery } from "@tanstack/react-query";
-import { createFileRoute, Link } from "@tanstack/react-router";
+import { createFileRoute } from "@tanstack/react-router";
 import { zodValidator } from "@tanstack/zod-adapter";
 import { useEffect, useMemo, useState } from "react";
 import { z } from "zod";
@@ -80,6 +80,7 @@ function SurveyWorkshopEditor({
 }: {
   project: SurveyAuthoringProject;
 }) {
+  const navigate = Route.useNavigate();
   const [draft, setDraft] = useState<EditableDraft>(() => ({
     name: project.name,
     surveyId: project.surveyId,
@@ -227,11 +228,19 @@ function SurveyWorkshopEditor({
     <main className={styles.editorShell}>
       <div className={styles.editorTopbar}>
         <HStack gap="space-12" align="center" wrap>
-          <Link to="/surveyverksted" search={{ team: project.team }}>
-            <Button data-color="neutral" variant="tertiary" size="small">
-              Til utkast
-            </Button>
-          </Link>
+          <Button
+            data-color="neutral"
+            variant="tertiary"
+            size="small"
+            onClick={() =>
+              navigate({
+                to: "/surveyverksted",
+                search: { team: project.team },
+              })
+            }
+          >
+            Til utkast
+          </Button>
           <div>
             <Heading size="medium" level="1">
               {draft.name || "Uten navn"}
@@ -310,6 +319,7 @@ function SurveyWorkshopEditor({
                       type="button"
                       className={styles.pageButton}
                       data-selected={page.id === selectedPage.id}
+                      aria-pressed={page.id === selectedPage.id}
                       onClick={() => setSelectedPageId(page.id)}
                     >
                       <span>{String(index + 1).padStart(2, "0")}</span>
@@ -441,16 +451,27 @@ function SurveyWorkshopEditor({
                   <span>lagret</span>
                 </div>
               </div>
-              <Button
-                as="a"
-                href={previewHref}
-                target="_blank"
-                rel="noreferrer"
-                variant="primary"
-                className={styles.previewButton}
-              >
-                Åpne forhåndsvisning
-              </Button>
+              {isDirty || saveMutation.isPending ? (
+                <Button
+                  type="button"
+                  variant="primary"
+                  className={styles.previewButton}
+                  disabled
+                >
+                  Åpne forhåndsvisning
+                </Button>
+              ) : (
+                <Button
+                  as="a"
+                  href={previewHref}
+                  target="_blank"
+                  rel="noreferrer"
+                  variant="primary"
+                  className={styles.previewButton}
+                >
+                  Åpne forhåndsvisning
+                </Button>
+              )}
               {isDirty ? (
                 <BodyShort size="small" textColor="subtle">
                   Vent til utkastet er lagret for å se de siste endringene.

--- a/apps/lumi-dashboard/app/routes/surveyverksted.$projectId.tsx
+++ b/apps/lumi-dashboard/app/routes/surveyverksted.$projectId.tsx
@@ -1,0 +1,621 @@
+import {
+  Alert,
+  BodyShort,
+  Box,
+  Button,
+  Checkbox,
+  Heading,
+  HStack,
+  Loader,
+  Select,
+  Tag,
+  TextField,
+  VStack,
+} from "@navikt/ds-react";
+import type {
+  SurveyDocumentV1,
+  SurveyPageV1,
+  SurveyQuestionV1,
+} from "@navikt/lumi-survey";
+import { useMutation, useQuery } from "@tanstack/react-query";
+import { createFileRoute, Link } from "@tanstack/react-router";
+import { zodValidator } from "@tanstack/zod-adapter";
+import { useEffect, useMemo, useState } from "react";
+import { z } from "zod";
+import {
+  fetchSurveyAuthoringProjectServerFn,
+  saveSurveyAuthoringDraftServerFn,
+} from "~/server/actions";
+import type { SurveyAuthoringProject } from "~/types/surveyAuthoring";
+import styles from "./surveyverksted-editor.module.css";
+
+const searchSchema = z.object({ team: z.string().min(1) });
+
+interface EditableDraft {
+  name: string;
+  surveyId: string;
+  document: SurveyDocumentV1;
+}
+
+export const Route = createFileRoute("/surveyverksted/$projectId")({
+  validateSearch: zodValidator(searchSchema),
+  component: SurveyWorkshopEditorRoute,
+});
+
+function SurveyWorkshopEditorRoute() {
+  const { projectId } = Route.useParams();
+  const { team } = Route.useSearch();
+  const projectQuery = useQuery({
+    queryKey: ["survey-authoring-project", team, projectId],
+    queryFn: () =>
+      fetchSurveyAuthoringProjectServerFn({ data: { team, projectId } }),
+  });
+
+  if (projectQuery.isPending) {
+    return (
+      <Box as="main" padding="space-32" className={styles.loading}>
+        <Loader size="large" title="Åpner utkast" />
+      </Box>
+    );
+  }
+
+  if (projectQuery.isError) {
+    return (
+      <Box as="main" padding="space-32" className="main-container">
+        <Alert variant="error">Utkastet kunne ikke åpnes.</Alert>
+      </Box>
+    );
+  }
+
+  return (
+    <SurveyWorkshopEditor
+      key={`${projectQuery.data.id}:${projectQuery.data.draftVersion}`}
+      project={projectQuery.data}
+    />
+  );
+}
+
+function SurveyWorkshopEditor({
+  project,
+}: {
+  project: SurveyAuthoringProject;
+}) {
+  const [draft, setDraft] = useState<EditableDraft>(() => ({
+    name: project.name,
+    surveyId: project.surveyId,
+    document: project.document,
+  }));
+  const [draftVersion, setDraftVersion] = useState(project.draftVersion);
+  const [savedFingerprint, setSavedFingerprint] = useState(() =>
+    JSON.stringify({
+      name: project.name,
+      surveyId: project.surveyId,
+      document: project.document,
+    }),
+  );
+  const [selectedPageId, setSelectedPageId] = useState(
+    project.document.pages[0].id,
+  );
+
+  const fingerprint = useMemo(() => JSON.stringify(draft), [draft]);
+  const hasRequiredMetadata = Boolean(
+    draft.name.trim() && draft.surveyId.trim(),
+  );
+
+  const saveMutation = useMutation({
+    mutationFn: (variables: EditableDraft & { expectedVersion: number }) =>
+      saveSurveyAuthoringDraftServerFn({
+        data: {
+          team: project.team,
+          projectId: project.id,
+          expectedVersion: variables.expectedVersion,
+          name: variables.name,
+          surveyId: variables.surveyId,
+          document: variables.document,
+        },
+      }),
+    onSuccess: (saved, variables) => {
+      setDraftVersion(saved.draftVersion);
+      setSavedFingerprint(
+        JSON.stringify({
+          name: variables.name,
+          surveyId: variables.surveyId,
+          document: variables.document,
+        }),
+      );
+    },
+  });
+
+  useEffect(() => {
+    if (
+      fingerprint === savedFingerprint ||
+      !hasRequiredMetadata ||
+      saveMutation.isPending ||
+      saveMutation.isError
+    ) {
+      return;
+    }
+
+    const timeout = window.setTimeout(() => {
+      saveMutation.mutate({ ...draft, expectedVersion: draftVersion });
+    }, 800);
+    return () => window.clearTimeout(timeout);
+  }, [
+    draft,
+    draftVersion,
+    fingerprint,
+    hasRequiredMetadata,
+    saveMutation,
+    savedFingerprint,
+  ]);
+
+  const selectedPage =
+    draft.document.pages.find((page) => page.id === selectedPageId) ??
+    draft.document.pages[0];
+  const isDirty = fingerprint !== savedFingerprint;
+
+  const updateDocument = (document: SurveyDocumentV1) =>
+    setDraft((current) => ({ ...current, document }));
+
+  const updatePage = (
+    pageId: string,
+    updater: (page: SurveyPageV1) => SurveyPageV1,
+  ) => {
+    updateDocument({
+      ...draft.document,
+      pages: draft.document.pages.map((page) =>
+        page.id === pageId ? updater(page) : page,
+      ) as SurveyDocumentV1["pages"],
+    });
+  };
+
+  const addPage = () => {
+    const id = `side-${crypto.randomUUID().slice(0, 8)}`;
+    const page: SurveyPageV1 = {
+      id,
+      title: "Ny side",
+      questions: [createQuestion("rating")],
+    };
+    updateDocument({
+      ...draft.document,
+      pages: [...draft.document.pages, page],
+    });
+    setSelectedPageId(id);
+  };
+
+  const removePage = (pageId: string) => {
+    if (draft.document.pages.length === 1) return;
+    const remaining = draft.document.pages.filter((page) => page.id !== pageId);
+    updateDocument({
+      ...draft.document,
+      pages: remaining as SurveyDocumentV1["pages"],
+    });
+    if (selectedPageId === pageId) setSelectedPageId(remaining[0].id);
+  };
+
+  const updateQuestion = (
+    pageId: string,
+    questionId: string,
+    updater: (question: SurveyQuestionV1) => SurveyQuestionV1,
+  ) =>
+    updatePage(pageId, (page) => ({
+      ...page,
+      questions: page.questions.map((question) =>
+        question.id === questionId ? updater(question) : question,
+      ) as SurveyPageV1["questions"],
+    }));
+
+  const addQuestion = (type: "rating" | "text") =>
+    updatePage(selectedPage.id, (page) => ({
+      ...page,
+      questions: [...page.questions, createQuestion(type)],
+    }));
+
+  const removeQuestion = (questionId: string) => {
+    if (selectedPage.questions.length === 1) return;
+    updatePage(selectedPage.id, (page) => ({
+      ...page,
+      questions: page.questions.filter(
+        (question) => question.id !== questionId,
+      ) as SurveyPageV1["questions"],
+    }));
+  };
+
+  const previewHref = `/survey-preview?team=${encodeURIComponent(project.team)}&projectId=${encodeURIComponent(project.id)}&version=${draftVersion}`;
+
+  return (
+    <main className={styles.editorShell}>
+      <div className={styles.editorTopbar}>
+        <HStack gap="space-12" align="center" wrap>
+          <Link to="/surveyverksted" search={{ team: project.team }}>
+            <Button data-color="neutral" variant="tertiary" size="small">
+              Til utkast
+            </Button>
+          </Link>
+          <div>
+            <Heading size="medium" level="1">
+              {draft.name || "Uten navn"}
+            </Heading>
+            <BodyShort size="small" textColor="subtle">
+              {project.team} · {draft.surveyId || "Mangler survey-ID"}
+            </BodyShort>
+          </div>
+        </HStack>
+        <SaveStatus
+          isDirty={isDirty}
+          isPending={saveMutation.isPending}
+          isError={saveMutation.isError}
+          hasRequiredMetadata={hasRequiredMetadata}
+          version={draftVersion}
+        />
+      </div>
+
+      {saveMutation.isError ? (
+        <Alert variant="error" className={styles.saveAlert}>
+          Utkastet ble ikke lagret. Det kan ha blitt endret i en annen fane.
+          Last siden på nytt før du fortsetter.
+        </Alert>
+      ) : null}
+
+      <div className={styles.editorGrid}>
+        <aside className={styles.outline} aria-label="Struktur">
+          <VStack gap="space-20">
+            <div>
+              <Heading size="small" level="2" spacing>
+                Dokument
+              </Heading>
+              <VStack gap="space-12">
+                <TextField
+                  label="Navn på utkastet"
+                  size="small"
+                  value={draft.name}
+                  error={!draft.name.trim() ? "Navn er påkrevd" : undefined}
+                  onChange={(event) =>
+                    setDraft((current) => ({
+                      ...current,
+                      name: event.target.value,
+                    }))
+                  }
+                />
+                <TextField
+                  label="Foreslått survey-ID"
+                  size="small"
+                  value={draft.surveyId}
+                  error={
+                    !draft.surveyId.trim() ? "Survey-ID er påkrevd" : undefined
+                  }
+                  onChange={(event) =>
+                    setDraft((current) => ({
+                      ...current,
+                      surveyId: event.target.value,
+                    }))
+                  }
+                />
+              </VStack>
+            </div>
+
+            <div>
+              <HStack justify="space-between" align="center" gap="space-8">
+                <Heading size="small" level="2">
+                  Sider
+                </Heading>
+                <Button size="xsmall" variant="tertiary" onClick={addPage}>
+                  Ny side
+                </Button>
+              </HStack>
+              <ol className={styles.pageList}>
+                {draft.document.pages.map((page, index) => (
+                  <li key={page.id}>
+                    <button
+                      type="button"
+                      className={styles.pageButton}
+                      data-selected={page.id === selectedPage.id}
+                      onClick={() => setSelectedPageId(page.id)}
+                    >
+                      <span>{String(index + 1).padStart(2, "0")}</span>
+                      <span>{page.title?.trim() || "Side uten tittel"}</span>
+                      <small>{page.questions.length} spørsmål</small>
+                    </button>
+                  </li>
+                ))}
+              </ol>
+            </div>
+          </VStack>
+        </aside>
+
+        <section
+          className={styles.canvas}
+          aria-labelledby="page-editor-heading"
+        >
+          <VStack gap="space-24">
+            <HStack justify="space-between" align="start" gap="space-16">
+              <div>
+                <BodyShort size="small" textColor="subtle">
+                  Side {draft.document.pages.indexOf(selectedPage) + 1}
+                </BodyShort>
+                <Heading id="page-editor-heading" size="large" level="2">
+                  Innhold
+                </Heading>
+              </div>
+              <Button
+                size="small"
+                variant="tertiary"
+                data-color="danger"
+                disabled={draft.document.pages.length === 1}
+                onClick={() => removePage(selectedPage.id)}
+              >
+                Slett side
+              </Button>
+            </HStack>
+
+            <Box
+              background="raised"
+              borderRadius="12"
+              borderWidth="1"
+              borderColor="neutral-subtle"
+              padding={{ xs: "space-16", md: "space-24" }}
+            >
+              <VStack gap="space-16">
+                <TextField
+                  label="Sidetittel"
+                  value={selectedPage.title ?? ""}
+                  onChange={(event) =>
+                    updatePage(selectedPage.id, (page) => ({
+                      ...page,
+                      title: event.target.value || undefined,
+                    }))
+                  }
+                />
+                <TextField
+                  label="Beskrivelse"
+                  value={selectedPage.description ?? ""}
+                  onChange={(event) =>
+                    updatePage(selectedPage.id, (page) => ({
+                      ...page,
+                      description: event.target.value || undefined,
+                    }))
+                  }
+                />
+              </VStack>
+            </Box>
+
+            <VStack gap="space-12">
+              {selectedPage.questions.map((question, index) => (
+                <QuestionEditor
+                  key={question.id}
+                  index={index}
+                  question={question}
+                  canDelete={selectedPage.questions.length > 1}
+                  onChange={(updater) =>
+                    updateQuestion(selectedPage.id, question.id, updater)
+                  }
+                  onDelete={() => removeQuestion(question.id)}
+                />
+              ))}
+            </VStack>
+
+            <HStack gap="space-8" wrap>
+              <Button variant="secondary" onClick={() => addQuestion("rating")}>
+                Legg til vurdering
+              </Button>
+              <Button variant="secondary" onClick={() => addQuestion("text")}>
+                Legg til tekstfelt
+              </Button>
+            </HStack>
+          </VStack>
+        </section>
+
+        <aside className={styles.preview} aria-labelledby="preview-heading">
+          <div className={styles.previewCard}>
+            <VStack gap="space-20">
+              <div>
+                <Tag variant="warning" size="small">
+                  Ingen innsending
+                </Tag>
+              </div>
+              <div>
+                <Heading id="preview-heading" size="medium" level="2" spacing>
+                  Prøv den ekte widgeten
+                </Heading>
+                <BodyShort textColor="subtle">
+                  Forhåndsvisningen åpnes separat, slik at docken får en ekte
+                  viewport og dashboardets sikkerhetsgrenser beholdes.
+                </BodyShort>
+              </div>
+              <div className={styles.previewStats}>
+                <div>
+                  <strong>{draft.document.pages.length}</strong>
+                  <span>sider</span>
+                </div>
+                <div>
+                  <strong>
+                    {draft.document.pages.reduce(
+                      (sum, page) => sum + page.questions.length,
+                      0,
+                    )}
+                  </strong>
+                  <span>spørsmål</span>
+                </div>
+                <div>
+                  <strong>v{draftVersion}</strong>
+                  <span>lagret</span>
+                </div>
+              </div>
+              <Button
+                as="a"
+                href={previewHref}
+                target="_blank"
+                rel="noreferrer"
+                variant="primary"
+                className={styles.previewButton}
+              >
+                Åpne forhåndsvisning
+              </Button>
+              {isDirty ? (
+                <BodyShort size="small" textColor="subtle">
+                  Vent til utkastet er lagret for å se de siste endringene.
+                </BodyShort>
+              ) : null}
+            </VStack>
+          </div>
+        </aside>
+      </div>
+    </main>
+  );
+}
+
+function QuestionEditor({
+  question,
+  index,
+  canDelete,
+  onChange,
+  onDelete,
+}: {
+  question: SurveyQuestionV1;
+  index: number;
+  canDelete: boolean;
+  onChange: (updater: (question: SurveyQuestionV1) => SurveyQuestionV1) => void;
+  onDelete: () => void;
+}) {
+  return (
+    <Box
+      background="raised"
+      borderRadius="12"
+      borderWidth="1"
+      borderColor="neutral-subtle"
+      padding={{ xs: "space-16", md: "space-24" }}
+    >
+      <VStack gap="space-16">
+        <HStack justify="space-between" align="center" gap="space-12">
+          <HStack gap="space-8" align="center">
+            <span className={styles.questionNumber}>{index + 1}</span>
+            <Heading size="small" level="3">
+              Spørsmål
+            </Heading>
+          </HStack>
+          <Button
+            size="xsmall"
+            variant="tertiary"
+            data-color="danger"
+            disabled={!canDelete}
+            onClick={onDelete}
+          >
+            Fjern
+          </Button>
+        </HStack>
+        <Select
+          label="Type"
+          value={question.type}
+          onChange={(event) => {
+            const type = event.target.value as "rating" | "text";
+            onChange(() => ({
+              ...createQuestion(type),
+              id: question.id,
+              prompt: question.prompt,
+              description: question.description,
+              required: question.required,
+            }));
+          }}
+        >
+          <option value="rating">Vurdering</option>
+          <option value="text">Tekst</option>
+        </Select>
+        <TextField
+          label="Spørsmålstekst"
+          value={question.prompt}
+          onChange={(event) =>
+            onChange((current) => ({
+              ...current,
+              prompt: event.target.value,
+            }))
+          }
+        />
+        <TextField
+          label="Hjelpetekst"
+          value={question.description ?? ""}
+          onChange={(event) =>
+            onChange((current) => ({
+              ...current,
+              description: event.target.value || undefined,
+            }))
+          }
+        />
+        {question.type === "rating" ? (
+          <Select
+            label="Visning"
+            value={question.variant ?? "emoji"}
+            onChange={(event) =>
+              onChange((current) => {
+                if (current.type !== "rating") return current;
+                return {
+                  ...current,
+                  variant: event.target.value as
+                    | "emoji"
+                    | "thumbs"
+                    | "stars"
+                    | "nps",
+                };
+              })
+            }
+          >
+            <option value="emoji">Emoji (5)</option>
+            <option value="thumbs">Tommel opp/ned</option>
+            <option value="stars">Stjerner (5)</option>
+            <option value="nps">NPS (0–10)</option>
+          </Select>
+        ) : null}
+        <Checkbox
+          checked={question.required ?? false}
+          onChange={(event) =>
+            onChange((current) => ({
+              ...current,
+              required: event.target.checked,
+            }))
+          }
+        >
+          Må besvares
+        </Checkbox>
+      </VStack>
+    </Box>
+  );
+}
+
+function SaveStatus({
+  isDirty,
+  isPending,
+  isError,
+  hasRequiredMetadata,
+  version,
+}: {
+  isDirty: boolean;
+  isPending: boolean;
+  isError: boolean;
+  hasRequiredMetadata: boolean;
+  version: number;
+}) {
+  if (isError) return <Tag variant="error">Ikke lagret</Tag>;
+  if (!hasRequiredMetadata) return <Tag variant="warning">Mangler felter</Tag>;
+  if (isPending) return <Tag variant="info">Lagrer …</Tag>;
+  if (isDirty) return <Tag variant="neutral">Venter på autosave</Tag>;
+  return <Tag variant="success">Lagret · v{version}</Tag>;
+}
+
+function createQuestion(type: "rating" | "text"): SurveyQuestionV1 {
+  const id = `${type}-${crypto.randomUUID().slice(0, 8)}`;
+  if (type === "text") {
+    return {
+      id,
+      type: "text",
+      prompt: "Hva vil du fortelle oss?",
+      maxLength: 1000,
+      minRows: 4,
+    };
+  }
+  return {
+    id,
+    type: "rating",
+    prompt: "Hvordan opplevde du tjenesten?",
+    variant: "emoji",
+    required: true,
+  };
+}

--- a/apps/lumi-dashboard/app/routes/surveyverksted.index.tsx
+++ b/apps/lumi-dashboard/app/routes/surveyverksted.index.tsx
@@ -1,0 +1,290 @@
+import {
+  Alert,
+  BodyLong,
+  BodyShort,
+  Box,
+  Button,
+  Heading,
+  HStack,
+  Loader,
+  Select,
+  Tag,
+  TextField,
+  VStack,
+} from "@navikt/ds-react";
+import type { SurveyDocumentV1 } from "@navikt/lumi-survey";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { createFileRoute, Link } from "@tanstack/react-router";
+import { zodValidator } from "@tanstack/zod-adapter";
+import { useMemo, useState } from "react";
+import { z } from "zod";
+import {
+  createSurveyAuthoringProjectServerFn,
+  fetchSurveyAuthoringProjectsServerFn,
+  fetchTeamsServerFn,
+} from "~/server/actions";
+import styles from "./surveyverksted.module.css";
+
+const searchSchema = z.object({ team: z.string().optional() });
+
+const initialDocument: SurveyDocumentV1 = {
+  authoringSchemaVersion: 1,
+  type: "rating",
+  pages: [
+    {
+      id: "opplevelse",
+      title: "Fortell om opplevelsen",
+      questions: [
+        {
+          id: "rating",
+          type: "rating",
+          prompt: "Hvordan opplevde du tjenesten?",
+          required: true,
+        },
+        {
+          id: "kommentar",
+          type: "text",
+          prompt: "Hva kan vi gjøre bedre?",
+          required: false,
+          maxLength: 1000,
+          minRows: 4,
+        },
+      ],
+    },
+  ],
+};
+
+export const Route = createFileRoute("/surveyverksted/")({
+  validateSearch: zodValidator(searchSchema),
+  component: SurveyWorkshopIndex,
+});
+
+function SurveyWorkshopIndex() {
+  const search = Route.useSearch();
+  const navigate = Route.useNavigate();
+  const queryClient = useQueryClient();
+  const [name, setName] = useState("");
+  const [surveyId, setSurveyId] = useState("");
+
+  const teamsQuery = useQuery({
+    queryKey: ["teams"],
+    queryFn: () => fetchTeamsServerFn(),
+  });
+  const availableTeams = useMemo(
+    () => Object.keys(teamsQuery.data?.teams ?? {}).sort(),
+    [teamsQuery.data],
+  );
+  const selectedTeam =
+    search.team && availableTeams.includes(search.team)
+      ? search.team
+      : availableTeams[0];
+
+  const projectsQuery = useQuery({
+    queryKey: ["survey-authoring-projects", selectedTeam],
+    queryFn: () => {
+      if (!selectedTeam) throw new Error("No authorized team selected");
+      return fetchSurveyAuthoringProjectsServerFn({
+        data: { team: selectedTeam },
+      });
+    },
+    enabled: Boolean(selectedTeam),
+  });
+
+  const createMutation = useMutation({
+    mutationFn: () => {
+      if (!selectedTeam) throw new Error("No authorized team selected");
+      return createSurveyAuthoringProjectServerFn({
+        data: {
+          team: selectedTeam,
+          name,
+          surveyId,
+          document: initialDocument,
+        },
+      });
+    },
+    onSuccess: async (project) => {
+      await queryClient.invalidateQueries({
+        queryKey: ["survey-authoring-projects", selectedTeam],
+      });
+      await navigate({
+        to: "/surveyverksted/$projectId",
+        params: { projectId: project.id },
+        search: { team: selectedTeam },
+      });
+    },
+  });
+
+  const canCreate = Boolean(selectedTeam && name.trim() && surveyId.trim());
+
+  return (
+    <Box
+      as="main"
+      paddingInline={{ xs: "space-12", sm: "space-16" }}
+      paddingBlock={{ xs: "space-24", md: "space-40" }}
+      className="main-container"
+    >
+      <VStack gap="space-32">
+        <div className={styles.masthead}>
+          <VStack gap="space-8" className={styles.mastheadText}>
+            <div>
+              <Tag variant="info" size="small">
+                Survey as code
+              </Tag>
+            </div>
+            <Heading size="xlarge" level="1">
+              Surveyverksted
+            </Heading>
+            <BodyLong size="large">
+              Formuler og prøv ut en survey sammen. Utkastet lagres for teamet,
+              men blir ikke produksjonskonfigurasjon før koden senere tas inn i
+              en app.
+            </BodyLong>
+          </VStack>
+          <div aria-hidden className={styles.mastheadMark}>
+            01
+          </div>
+        </div>
+
+        {teamsQuery.isPending ? (
+          <HStack gap="space-8" align="center">
+            <Loader size="small" title="Henter team" />
+            <BodyShort>Henter team …</BodyShort>
+          </HStack>
+        ) : teamsQuery.isError || availableTeams.length === 0 ? (
+          <Alert variant="error">
+            Fant ingen team du kan opprette utkast for.
+          </Alert>
+        ) : (
+          <div className={styles.workshopGrid}>
+            <Box
+              background="raised"
+              borderRadius="12"
+              borderWidth="1"
+              borderColor="neutral-subtle"
+              padding={{ xs: "space-16", md: "space-24" }}
+            >
+              <VStack gap="space-20">
+                <div>
+                  <Heading size="medium" level="2" spacing>
+                    Start et utkast
+                  </Heading>
+                  <BodyShort textColor="subtle">
+                    Du starter med én side, et vurderingsspørsmål og et åpent
+                    oppfølgingsspørsmål.
+                  </BodyShort>
+                </div>
+                <Select
+                  label="Team"
+                  value={selectedTeam}
+                  onChange={(event) =>
+                    navigate({
+                      search: { team: event.target.value },
+                      replace: true,
+                    })
+                  }
+                >
+                  {availableTeams.map((team) => (
+                    <option key={team} value={team}>
+                      {team}
+                    </option>
+                  ))}
+                </Select>
+                <TextField
+                  label="Navn på utkastet"
+                  value={name}
+                  maxLength={120}
+                  onChange={(event) => setName(event.target.value)}
+                  placeholder="For eksempel: Kvitteringsside høst 2026"
+                />
+                <TextField
+                  label="Foreslått survey-ID"
+                  description="Dette er identiteten utvikleren senere tar stilling til i kode."
+                  value={surveyId}
+                  maxLength={200}
+                  onChange={(event) => setSurveyId(event.target.value)}
+                  placeholder="min-app-kvittering-v1"
+                />
+                {createMutation.isError ? (
+                  <Alert variant="error">
+                    Utkastet kunne ikke opprettes. Prøv igjen.
+                  </Alert>
+                ) : null}
+                <Button
+                  type="button"
+                  disabled={!canCreate}
+                  loading={createMutation.isPending}
+                  onClick={() => createMutation.mutate()}
+                >
+                  Opprett utkast
+                </Button>
+              </VStack>
+            </Box>
+
+            <VStack gap="space-16">
+              <HStack justify="space-between" align="end" gap="space-8">
+                <div>
+                  <Heading size="medium" level="2">
+                    Teamets utkast
+                  </Heading>
+                  <BodyShort textColor="subtle">{selectedTeam}</BodyShort>
+                </div>
+                <Tag variant="neutral" size="small">
+                  {projectsQuery.data?.length ?? 0} utkast
+                </Tag>
+              </HStack>
+
+              {projectsQuery.isPending ? (
+                <Box padding="space-24" className={styles.emptyState}>
+                  <Loader title="Henter utkast" />
+                </Box>
+              ) : projectsQuery.isError ? (
+                <Alert variant="error">Utkastene kunne ikke hentes.</Alert>
+              ) : projectsQuery.data?.length ? (
+                <VStack gap="space-8" as="ul" className={styles.projectList}>
+                  {projectsQuery.data.map((project) => (
+                    <li key={project.id}>
+                      <Link
+                        to="/surveyverksted/$projectId"
+                        params={{ projectId: project.id }}
+                        search={{ team: selectedTeam }}
+                        className={styles.projectLink}
+                      >
+                        <div>
+                          <Heading size="small" level="3">
+                            {project.name}
+                          </Heading>
+                          <BodyShort size="small" textColor="subtle">
+                            {project.surveyId}
+                          </BodyShort>
+                        </div>
+                        <VStack gap="space-2" align="end">
+                          <BodyShort size="small">Åpne</BodyShort>
+                          <BodyShort size="small" textColor="subtle">
+                            v{project.draftVersion}
+                          </BodyShort>
+                        </VStack>
+                      </Link>
+                    </li>
+                  ))}
+                </VStack>
+              ) : (
+                <Box
+                  padding={{ xs: "space-24", md: "space-32" }}
+                  className={styles.emptyState}
+                >
+                  <Heading size="small" level="3" spacing>
+                    Ingen utkast ennå
+                  </Heading>
+                  <BodyShort textColor="subtle">
+                    Opprett det første til venstre. Det blir tilgjengelig for
+                    teamet også neste gang dere fortsetter.
+                  </BodyShort>
+                </Box>
+              )}
+            </VStack>
+          </div>
+        )}
+      </VStack>
+    </Box>
+  );
+}

--- a/apps/lumi-dashboard/app/routes/surveyverksted.module.css
+++ b/apps/lumi-dashboard/app/routes/surveyverksted.module.css
@@ -1,0 +1,78 @@
+.masthead {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-end;
+  gap: var(--ax-space-24);
+  padding-block-end: var(--ax-space-24);
+  border-bottom: 1px solid var(--ax-border-neutral-subtle);
+}
+
+.mastheadText {
+  max-width: 46rem;
+}
+
+.mastheadMark {
+  color: var(--ax-text-neutral-subtle);
+  font-size: clamp(3rem, 9vw, 7rem);
+  font-weight: 700;
+  line-height: 0.8;
+  letter-spacing: -0.08em;
+  opacity: 0.25;
+}
+
+.workshopGrid {
+  display: grid;
+  grid-template-columns: minmax(17rem, 0.8fr) minmax(20rem, 1.2fr);
+  gap: var(--ax-space-32);
+  align-items: start;
+}
+
+.projectList {
+  padding: 0;
+  margin: 0;
+  list-style: none;
+}
+
+.projectLink {
+  display: flex;
+  justify-content: space-between;
+  gap: var(--ax-space-16);
+  padding: var(--ax-space-16);
+  color: inherit;
+  text-decoration: none;
+  background: var(--ax-bg-raised);
+  border: 1px solid var(--ax-border-neutral-subtle);
+  border-radius: var(--ax-radius-8);
+  transition:
+    border-color 120ms ease,
+    transform 120ms ease;
+}
+
+.projectLink:hover {
+  border-color: var(--ax-border-accent);
+  transform: translateX(2px);
+}
+
+.projectLink:focus-visible {
+  outline: 3px solid var(--ax-border-focus);
+  outline-offset: 2px;
+}
+
+.emptyState {
+  min-height: 10rem;
+  display: grid;
+  place-content: center;
+  text-align: center;
+  border: 1px dashed var(--ax-border-neutral-subtle);
+  border-radius: var(--ax-radius-8);
+}
+
+@media (max-width: 48rem) {
+  .workshopGrid {
+    grid-template-columns: 1fr;
+  }
+
+  .mastheadMark {
+    display: none;
+  }
+}

--- a/apps/lumi-dashboard/app/routes/surveyverksted.tsx
+++ b/apps/lumi-dashboard/app/routes/surveyverksted.tsx
@@ -1,0 +1,15 @@
+import { createFileRoute, Outlet } from "@tanstack/react-router";
+import { Header } from "~/components/shared/Header";
+
+export const Route = createFileRoute("/surveyverksted")({
+  component: SurveyWorkshopLayout,
+});
+
+function SurveyWorkshopLayout() {
+  return (
+    <>
+      <Header />
+      <Outlet />
+    </>
+  );
+}

--- a/apps/lumi-dashboard/app/server/actions/index.ts
+++ b/apps/lumi-dashboard/app/server/actions/index.ts
@@ -29,6 +29,8 @@ export { fetchStatsServerFn } from "./fetchStats";
 export { fetchSurveysByAppServerFn } from "./fetchSurveys";
 // Task Priority
 export { fetchTaskPriorityServerFn } from "./fetchTaskPriority";
+// Teams
+export { fetchTeamsServerFn } from "./fetchTeams";
 // Top Tasks
 export { fetchTopTasksServerFn } from "./fetchTopTasks";
 // Markers
@@ -38,5 +40,12 @@ export {
   fetchMarkersServerFn,
   updateMarkerServerFn,
 } from "./markers";
+// Survey authoring
+export {
+  createSurveyAuthoringProjectServerFn,
+  fetchSurveyAuthoringProjectServerFn,
+  fetchSurveyAuthoringProjectsServerFn,
+  saveSurveyAuthoringDraftServerFn,
+} from "./surveyAuthoring";
 // Tags
 export { addTagServerFn, fetchTagsServerFn, removeTagServerFn } from "./tags";

--- a/apps/lumi-dashboard/app/server/actions/surveyAuthoring.ts
+++ b/apps/lumi-dashboard/app/server/actions/surveyAuthoring.ts
@@ -1,0 +1,146 @@
+import { createServerFn } from "@tanstack/react-start";
+import { zodValidator } from "@tanstack/zod-adapter";
+import { authMiddleware } from "~/server/middleware/auth";
+import {
+  type AuthContext,
+  buildUrl,
+  getHeaders,
+  isMockMode,
+  mockDelay,
+} from "~/server/utils";
+import type {
+  SurveyAuthoringProject,
+  SurveyAuthoringProjectSummary,
+} from "~/types/surveyAuthoring";
+import {
+  CreateSurveyAuthoringProjectSchema,
+  SaveSurveyAuthoringDraftSchema,
+  SurveyAuthoringProjectIdSchema,
+  SurveyAuthoringTeamSchema,
+} from "~/types/surveyAuthoring";
+import { handleApiResponse } from "../fetchUtils";
+
+export const fetchSurveyAuthoringProjectsServerFn = createServerFn({
+  method: "GET",
+})
+  .middleware([authMiddleware])
+  .inputValidator(zodValidator(SurveyAuthoringTeamSchema))
+  .handler(
+    async ({ data, context }): Promise<SurveyAuthoringProjectSummary[]> => {
+      if (isMockMode()) {
+        const { listMockSurveyProjects } = await import(
+          "~/mock/surveyAuthoring"
+        );
+        await mockDelay();
+        return listMockSurveyProjects(data.team);
+      }
+
+      const { backendUrl, oboToken } = context as AuthContext;
+      const response = await fetch(
+        buildUrl(backendUrl, "/api/v1/intern/authoring/projects", {
+          team: data.team,
+        }),
+        { headers: getHeaders(oboToken) },
+      );
+      await handleApiResponse(response);
+      return response.json() as Promise<SurveyAuthoringProjectSummary[]>;
+    },
+  );
+
+export const fetchSurveyAuthoringProjectServerFn = createServerFn({
+  method: "GET",
+})
+  .middleware([authMiddleware])
+  .inputValidator(zodValidator(SurveyAuthoringProjectIdSchema))
+  .handler(async ({ data, context }): Promise<SurveyAuthoringProject> => {
+    if (isMockMode()) {
+      const { getMockSurveyProject } = await import("~/mock/surveyAuthoring");
+      await mockDelay();
+      const project = getMockSurveyProject(data.team, data.projectId);
+      if (!project) throw new Error("Survey project not found");
+      return project;
+    }
+
+    const { backendUrl, oboToken } = context as AuthContext;
+    const response = await fetch(
+      buildUrl(
+        backendUrl,
+        `/api/v1/intern/authoring/projects/${encodeURIComponent(data.projectId)}`,
+        { team: data.team },
+      ),
+      { headers: getHeaders(oboToken) },
+    );
+    await handleApiResponse(response);
+    return response.json() as Promise<SurveyAuthoringProject>;
+  });
+
+export const createSurveyAuthoringProjectServerFn = createServerFn({
+  method: "POST",
+})
+  .middleware([authMiddleware])
+  .inputValidator(zodValidator(CreateSurveyAuthoringProjectSchema))
+  .handler(async ({ data, context }): Promise<SurveyAuthoringProject> => {
+    if (isMockMode()) {
+      const { createMockSurveyProject } = await import(
+        "~/mock/surveyAuthoring"
+      );
+      await mockDelay();
+      return createMockSurveyProject(
+        data as Parameters<typeof createMockSurveyProject>[0],
+      );
+    }
+
+    const { backendUrl, oboToken } = context as AuthContext;
+    const response = await fetch(
+      buildUrl(backendUrl, "/api/v1/intern/authoring/projects", {
+        team: data.team,
+      }),
+      {
+        method: "POST",
+        headers: getHeaders(oboToken),
+        body: JSON.stringify({
+          name: data.name,
+          surveyId: data.surveyId,
+          document: data.document,
+        }),
+      },
+    );
+    await handleApiResponse(response);
+    return response.json() as Promise<SurveyAuthoringProject>;
+  });
+
+export const saveSurveyAuthoringDraftServerFn = createServerFn({
+  method: "POST",
+})
+  .middleware([authMiddleware])
+  .inputValidator(zodValidator(SaveSurveyAuthoringDraftSchema))
+  .handler(async ({ data, context }): Promise<SurveyAuthoringProject> => {
+    if (isMockMode()) {
+      const { saveMockSurveyProject } = await import("~/mock/surveyAuthoring");
+      await mockDelay();
+      return saveMockSurveyProject(
+        data as Parameters<typeof saveMockSurveyProject>[0],
+      );
+    }
+
+    const { backendUrl, oboToken } = context as AuthContext;
+    const response = await fetch(
+      buildUrl(
+        backendUrl,
+        `/api/v1/intern/authoring/projects/${encodeURIComponent(data.projectId)}/draft`,
+        { team: data.team },
+      ),
+      {
+        method: "PUT",
+        headers: getHeaders(oboToken),
+        body: JSON.stringify({
+          expectedVersion: data.expectedVersion,
+          name: data.name,
+          surveyId: data.surveyId,
+          document: data.document,
+        }),
+      },
+    );
+    await handleApiResponse(response);
+    return response.json() as Promise<SurveyAuthoringProject>;
+  });

--- a/apps/lumi-dashboard/app/types/__tests__/surveyAuthoring.test.ts
+++ b/apps/lumi-dashboard/app/types/__tests__/surveyAuthoring.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from "vitest";
+import {
+  CreateSurveyAuthoringProjectSchema,
+  SaveSurveyAuthoringDraftSchema,
+} from "../surveyAuthoring";
+
+describe("survey authoring input contracts", () => {
+  const document = {
+    authoringSchemaVersion: 1,
+    pages: [
+      {
+        id: "page-1",
+        questions: [
+          { id: "rating", type: "rating", prompt: "Hvordan gikk det?" },
+        ],
+      },
+    ],
+  };
+
+  it("accepts a V1 authoring document", () => {
+    expect(
+      CreateSurveyAuthoringProjectSchema.parse({
+        team: "team-a",
+        name: "Utkast",
+        surveyId: "survey-1",
+        document,
+      }).document,
+    ).toEqual(document);
+  });
+
+  it("rejects unsupported authoring versions and invalid locks", () => {
+    expect(() =>
+      CreateSurveyAuthoringProjectSchema.parse({
+        team: "team-a",
+        name: "Utkast",
+        surveyId: "survey-1",
+        document: { authoringSchemaVersion: 2 },
+      }),
+    ).toThrow();
+
+    expect(() =>
+      SaveSurveyAuthoringDraftSchema.parse({
+        team: "team-a",
+        projectId: crypto.randomUUID(),
+        expectedVersion: 0,
+        name: "Utkast",
+        surveyId: "survey-1",
+        document,
+      }),
+    ).toThrow();
+  });
+});

--- a/apps/lumi-dashboard/app/types/surveyAuthoring.ts
+++ b/apps/lumi-dashboard/app/types/surveyAuthoring.ts
@@ -1,0 +1,50 @@
+import type { SurveyDocumentV1 } from "@navikt/lumi-survey";
+import { z } from "zod";
+
+export interface SurveyAuthoringProject {
+  id: string;
+  team: string;
+  name: string;
+  surveyId: string;
+  document: SurveyDocumentV1;
+  draftVersion: number;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export type SurveyAuthoringProjectSummary = Omit<
+  SurveyAuthoringProject,
+  "document"
+>;
+
+const documentSchema = z.custom<SurveyDocumentV1>(
+  (value) =>
+    Boolean(
+      value &&
+        typeof value === "object" &&
+        "authoringSchemaVersion" in value &&
+        value.authoringSchemaVersion === 1,
+    ),
+  "Only authoringSchemaVersion 1 is supported",
+);
+
+export const SurveyAuthoringTeamSchema = z.object({
+  team: z.string().trim().min(1).max(255),
+});
+
+export const SurveyAuthoringProjectIdSchema = SurveyAuthoringTeamSchema.extend({
+  projectId: z.string().uuid(),
+});
+
+export const CreateSurveyAuthoringProjectSchema =
+  SurveyAuthoringTeamSchema.extend({
+    name: z.string().trim().min(1).max(120),
+    surveyId: z.string().trim().min(1).max(200),
+    document: documentSchema,
+  });
+
+export const SaveSurveyAuthoringDraftSchema =
+  CreateSurveyAuthoringProjectSchema.extend({
+    projectId: z.string().uuid(),
+    expectedVersion: z.number().int().positive(),
+  });

--- a/apps/lumi-dashboard/e2e/survey-workshop.spec.ts
+++ b/apps/lumi-dashboard/e2e/survey-workshop.spec.ts
@@ -1,0 +1,43 @@
+import { expect, test } from "@playwright/test";
+
+test("creates, saves, reopens and previews a survey draft", async ({
+  page,
+}) => {
+  await page.goto("/surveyverksted");
+
+  await page.getByLabel("Navn på utkastet").fill("E2E surveyutkast");
+  await page.getByLabel("Foreslått survey-ID").fill("e2e-survey-v1");
+  await page.getByRole("button", { name: "Opprett utkast" }).click();
+
+  await expect(page).toHaveURL(/\/surveyverksted\/[0-9a-f-]+\?team=team-esyfo/);
+  await expect(
+    page.getByRole("heading", { name: "E2E surveyutkast" }),
+  ).toBeVisible();
+
+  const pageTitle = page.getByLabel("Sidetittel");
+  await pageTitle.fill("Detaljer om opplevelsen");
+  await expect(page.getByText("Lagret · v2")).toBeVisible();
+
+  await page.reload();
+  await expect(pageTitle).toHaveValue("Detaljer om opplevelsen");
+
+  await page.getByRole("button", { name: "Ny side" }).click();
+  await expect(page.getByText("2", { exact: true }).last()).toBeVisible();
+  await expect(page.getByText("Lagret · v3")).toBeVisible();
+
+  const previewPromise = page.waitForEvent("popup");
+  await page.getByRole("button", { name: "Åpne forhåndsvisning" }).click();
+  const preview = await previewPromise;
+
+  await expect(
+    preview.getByText("Svar sendes ikke eller lagres."),
+  ).toBeVisible();
+  await expect(
+    preview.getByRole("heading", { name: "Detaljer om opplevelsen" }),
+  ).toBeVisible();
+  const progress = preview.getByRole("progressbar", {
+    name: "Fremdrift i undersøkelsen",
+  });
+  await expect(progress).toBeVisible();
+  await expect(progress).toHaveAttribute("aria-valuetext", "Steg 1 av 2");
+});

--- a/apps/lumi-dashboard/e2e/survey-workshop.spec.ts
+++ b/apps/lumi-dashboard/e2e/survey-workshop.spec.ts
@@ -22,6 +22,12 @@ test("creates, saves, reopens and previews a survey draft", async ({
   await expect(pageTitle).toHaveValue("Detaljer om opplevelsen");
 
   await page.getByRole("button", { name: "Ny side" }).click();
+  await expect(
+    page.getByRole("button", { name: /02 Ny side 1 spørsmål/ }),
+  ).toHaveAttribute("aria-pressed", "true");
+  await expect(
+    page.getByRole("button", { name: "Åpne forhåndsvisning" }),
+  ).toBeDisabled();
   await expect(page.getByText("2", { exact: true }).last()).toBeVisible();
   await expect(page.getByText("Lagret · v3")).toBeVisible();
 

--- a/apps/lumi-dashboard/package.json
+++ b/apps/lumi-dashboard/package.json
@@ -4,6 +4,7 @@
   "private": true,
   "type": "module",
   "scripts": {
+    "predev": "pnpm --filter @navikt/lumi-survey run build",
     "dev": "vite dev",
     "build": "vite build && tsc -p tsconfig.typecheck.json --noEmit",
     "start": "node .output/server/index.mjs",

--- a/apps/lumi-dashboard/package.json
+++ b/apps/lumi-dashboard/package.json
@@ -21,6 +21,7 @@
     "@navikt/ds-css": "^8.7.0",
     "@navikt/ds-react": "^8.7.0",
     "@navikt/lumi-types": "workspace:*",
+    "@navikt/lumi-survey": "workspace:*",
     "@navikt/oasis": "^4.1.4",
     "@navikt/pino-logger": "^4.5.1",
     "@tanstack/react-query": "^5.96.1",

--- a/apps/lumi-dashboard/tsconfig.json
+++ b/apps/lumi-dashboard/tsconfig.json
@@ -16,7 +16,12 @@
     "isolatedModules": true,
     "noEmit": true,
     "paths": {
-      "~/*": ["./app/*"]
+      "~/*": ["./app/*"],
+      "@navikt/lumi-survey": ["../../packages/lumi-survey/src/index.ts"],
+      "@navikt/lumi-survey/styles.css": [
+        "../../packages/lumi-survey/dist/index.css"
+      ],
+      "@navikt/lumi-survey/*": ["../../packages/lumi-survey/dist/*"]
     }
   },
   "include": ["app/**/*", "*.config.ts"]

--- a/apps/lumi-dashboard/tsconfig.json
+++ b/apps/lumi-dashboard/tsconfig.json
@@ -17,6 +17,12 @@
     "noEmit": true,
     "paths": {
       "~/*": ["./app/*"],
+      "@navikt/lumi-types": ["../../packages/lumi-types/src/index.ts"],
+      "@navikt/lumi-types/api": ["../../packages/lumi-types/src/api.ts"],
+      "@navikt/lumi-types/errors": ["../../packages/lumi-types/src/errors.ts"],
+      "@navikt/lumi-types/schemas": [
+        "../../packages/lumi-types/src/schemas.ts"
+      ],
       "@navikt/lumi-survey": ["../../packages/lumi-survey/src/index.ts"],
       "@navikt/lumi-survey/styles.css": [
         "../../packages/lumi-survey/dist/index.css"

--- a/apps/lumi-dashboard/tsconfig.typecheck.json
+++ b/apps/lumi-dashboard/tsconfig.typecheck.json
@@ -6,7 +6,14 @@
       "@navikt/lumi-types": ["../../packages/lumi-types/src/index.ts"],
       "@navikt/lumi-types/api": ["../../packages/lumi-types/src/api.ts"],
       "@navikt/lumi-types/errors": ["../../packages/lumi-types/src/errors.ts"],
-      "@navikt/lumi-types/schemas": ["../../packages/lumi-types/src/schemas.ts"]
+      "@navikt/lumi-types/schemas": [
+        "../../packages/lumi-types/src/schemas.ts"
+      ],
+      "@navikt/lumi-survey": ["../../packages/lumi-survey/dist/index.d.ts"],
+      "@navikt/lumi-survey/styles.css": [
+        "../../packages/lumi-survey/dist/index.css"
+      ],
+      "@navikt/lumi-survey/*": ["../../packages/lumi-survey/dist/*"]
     }
   }
 }

--- a/apps/lumi-dashboard/vite.config.ts
+++ b/apps/lumi-dashboard/vite.config.ts
@@ -43,7 +43,7 @@ export default defineConfig(({ command, mode }) => {
       // Custom plugin to stub server-only modules in client builds
       serverOnlyPlugin(serverOnlyModules),
       tsconfigPaths({
-        projects: ["./tsconfig.typecheck.json"],
+        projects: ["./tsconfig.json"],
       }),
       tanstackStart({
         // Use app directory as source (non-standard but keeps our structure)

--- a/docs/adr/0002-arkivering-er-visningsmetadata.md
+++ b/docs/adr/0002-arkivering-er-visningsmetadata.md
@@ -29,7 +29,7 @@ Uten intake-kontroll er faren at arkivering *misforstås* som stopp: en PO arkiv
 
 3. **Dashboard-styrt intake-kontroll utsettes bevisst.** Vi bygger den ikke nå, og vi lover den ikke. Kostnaden (punkt 1 i kontekst: widget-kapabilitet + publikt endepunkt + endring i hver konsuments backend) står ikke i forhold til gevinsten så lenge det reelle behovet er *oversikt*, ikke *fjernstyring*. Beslutningen revurderes hvis konsumentteam faktisk etterspør fjernstopp — ikke før.
 
-4. **Døra holdes åpen strukturelt.** `survey_definitions.source` har allerede enum-verdiene `'dashboard'` og `'import'` reservert, og `survey_metadata`-tabellen er frøet til survey-registeret som Survey Builder (#338) uansett trenger. Skulle intake-kontroll bli aktuelt, bygges det på dette registeret — det krever ingen riving av arkiveringsløsningen.
+4. **Døra holdes åpen strukturelt.** `survey_definitions.source` har allerede enum-verdiene `'dashboard'` og `'import'` reservert. Skulle intake-kontroll bli aktuelt, må den bygges som et eksplisitt produksjonsregister — ikke ved å gi authoring-drafts runtime-semantikk. Surveyverkstedets separate modell er besluttet i ADR 0004.
 
 ## Konsekvenser
 
@@ -37,7 +37,7 @@ Uten intake-kontroll er faren at arkivering *misforstås* som stopp: en PO arkiv
 
 - Arkivering leveres som to små slices (#394, #395) uten å røre widget, datakontrakt eller konsumentteam.
 - «Arkiverte»-bryteren styrer faktisk datagrunnlaget i liste, statistikk og eksport, ikke bare hvilke valg som vises i filteret.
-- Survey-metadata får endelig et hjem på dashboard-siden — det delte åpne spørsmålet fra #338/#339 om hvor survey-identitet bor, er besvart.
+- Survey-metadata får et hjem på dashboard-siden uten å blande visning, authoring og produksjonskontroll.
 - Ingen falske løfter: UI-et sier eksplisitt hva arkivering *ikke* gjør.
 
 **Negativt / kostnad**
@@ -45,7 +45,7 @@ Uten intake-kontroll er faren at arkivering *misforstås* som stopp: en PO arkiv
 - Lumi kan fortsatt ikke stoppe en survey sentralt — avvikling krever fortsatt endring i konsumentens frontend. Dette er en reell begrensning vi aksepterer og dokumenterer.
 - Nye innsendinger til en arkivert survey lagres fortsatt, men er skjult fra standardvisningen frem til arkivvisningen slås på eller surveyen gjenopprettes.
 - «Mottar fortsatt innsendinger»-badgen er et symptomvarsel, ikke en løsning; oppfølgingen (be teamet fjerne widgeten) er manuell.
-- To «survey finnes»-begreper består (avledet liste + definisjonstabell), nå med en tredje tabell ved siden av. Konsolidering til ett register er bevisst skjøvet til #338.
+- To «survey finnes»-begreper består (avledet liste + definisjonstabell). Surveyverkstedet tilfører et separat authoring-begrep, ikke et tredje produksjonsregister; se ADR 0004.
 
 ## Vurderte alternativer
 

--- a/docs/adr/0004-surveyverksted-er-authoring-ikke-runtime.md
+++ b/docs/adr/0004-surveyverksted-er-authoring-ikke-runtime.md
@@ -1,0 +1,100 @@
+---
+title: "ADR 0004: Surveyverkstedet lagrer authoring-revisjoner, ikke runtime-konfigurasjon"
+status: Akseptert
+date: 2026-08-16
+---
+
+# ADR 0004: Surveyverkstedet lagrer authoring-revisjoner, ikke runtime-konfigurasjon
+
+- **Status:** Akseptert
+- **Dato:** 2026-08-16
+- **Berører:** #338 (Surveyverksted), ADR 0002, ADR 0003
+
+## Kontekst
+
+Designere og produktfolk trenger å kunne arbeide med en survey over flere
+økter, prøve den i den ekte widgeten og dele et stabilt resultat med en
+utvikler. En ren kodegenerator uten lagring mister arbeidet mellom økter.
+
+Samtidig er Lumi i dag survey-as-code: konsumentappen eier
+produksjonskonfigurasjonen, widgeten gjør ingen config-henting, og
+`survey_definitions` er en immutable kompatibilitetsguard for innsendinger.
+Hvis dashboardet blir runtime-kilde, innfører vi ny tilgjengelighet, caching,
+signering, rollback, klientversjonering og zero-trust-proxying hos alle
+konsumenter.
+
+## Beslutning
+
+1. **Surveyverkstedet er et team-scopet authoring-domene.** En
+   `AuthoringProject` har én muterbar draft med optimistic locking. Draften
+   lagres separat fra `survey_definitions` og `survey_metadata`.
+2. **Draften er ikke en statusmaskin.** Den kan være under arbeid og autosaves.
+   UI-et bruker ikke «publisert», «live» eller «overlevert», fordi ingen av
+   disse tilstandene kan håndheves av Lumi.
+3. **En eksplisitt authoring-revisjon blir immutable.** Senere slices oppretter
+   revisjoner fra en gyldig draft. En revisjonslenke kan deles i GitHub,
+   Trello eller Jira og viser preview, diff og deterministisk kodeeksport.
+4. **Produksjon forblir survey-as-code.** Utvikleren tar den eksporterte
+   `SurveyDocumentV1` inn i konsumentappen og deployer på vanlig måte. Widgeten
+   får ingen nye nettverkskall.
+5. **Preview bruker ekte widget med inert transport.** Preview kan aldri sende
+   data. Lokal full-chain-demo er fortsatt stedet for å teste faktisk
+   innsending og dashboardkjeden.
+6. **Miljøene synkroniseres ikke.** Produksjon er kanonisk authoring-store;
+   utviklingsmiljøets drafts er disposable. Delbare produksjonsrevisjoner er
+   teamautoriserte.
+7. **Authoring og analytics har ulike hasher.** En framtidig
+   `authoringDocumentHash` identifiserer hele authoring-revisjonen. Dagens
+   `definitionHash` beskriver bare svarenes analytiske struktur og endres ikke
+   av page-titler eller layout.
+
+## Første vertikale snitt
+
+- opprette og liste team-scopede prosjekter
+- redigere et `SurveyDocumentV1` med pages og spørsmål
+- autosave med versjonskonfliktvern og gjenåpning
+- validere gjennom widgetens offentlige `validateSurveyDocumentV1`
+- åpne en separat, inert forhåndsvisning i den ekte `LumiSurveyDock`
+
+Immutable revisjoner, delbar revisjonslenke, diff og kodeeksport følger som
+egne vertikale slices. Begrensningen er bevisst; første snitt etablerer
+lagrings- og sikkerhetsgrensen de bygger på.
+
+## Konsekvenser
+
+### Positivt
+
+- Arbeid kan fortsette over flere økter uten at draften blir produksjonssannhet.
+- En designer kan samarbeide før en utvikler tar eierskap til deployen.
+- Widget- og submission-arkitekturen er uendret.
+- En senere full runtime-tjeneste kan vurderes separat hvis det oppstår et
+  dokumentert behov for deploy-uavhengig publisering, kill-switch eller
+  målretting.
+
+### Kostnad
+
+- «Eksportert» betyr ikke «deployet»; handoff må fortsatt følges opp i teamets
+  valgte oppgaveverktøy.
+- Draft, authoring-revisjon og analytics-definisjon er tre bevisst forskjellige
+  begreper som må navngis presist.
+- Produksjonsauthoring krever egen lagring, teamautorisasjon, audit og
+  revisjonshåndtering selv om runtime forblir statisk.
+
+## Forkastede alternativer
+
+### Bruk-og-kast-playground
+
+Forkastet fordi reelt designarbeid skjer i flere korte økter og ofte
+finjusteres sammen med produktleder senere.
+
+### Dashboardet som runtime-kilde fra dag én
+
+Forkastet fordi det snur eierskapsmodellen og krever et distribuert
+kontrollplan med vesentlig større sikkerhets- og driftskostnad. Det behovet er
+ikke dokumentert nå.
+
+### Egen «overlevert»-status
+
+Forkastet fordi Lumi ikke kjenner tilstanden i GitHub, Trello, Jira eller
+konsumentens deploy. Den delbare immutable revisjonen er artefaktet; statusen
+bor i teamets faktiske arbeidsflyt.

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "build-storybook:survey": "pnpm --filter @navikt/lumi-survey run build-storybook",
     "lint": "biome check .",
     "lint:fix": "biome check --write .",
-    "typecheck": "pnpm --filter @navikt/lumi-types run typecheck && pnpm --filter @navikt/lumi-survey run typecheck && pnpm --filter lumi-dashboard run typecheck && pnpm --filter @navikt/lumi-survey run build && pnpm --filter lumi-local-demo run typecheck",
+    "typecheck": "pnpm --filter @navikt/lumi-types run typecheck && pnpm --filter @navikt/lumi-survey run typecheck && pnpm --filter @navikt/lumi-survey run build && pnpm --filter lumi-dashboard run typecheck && pnpm --filter lumi-local-demo run typecheck",
     "verify:lumi-survey": "pnpm --filter @navikt/lumi-survey run build && node scripts/verify-lumi-survey-package.mjs",
     "test": "pnpm --filter lumi-dashboard run test",
     "e2e": "pnpm --filter lumi-dashboard run e2e",

--- a/packages/lumi-survey/CHANGELOG.md
+++ b/packages/lumi-survey/CHANGELOG.md
@@ -8,6 +8,7 @@ This project follows SemVer.
 
 ### Added
 
+- `validateSurveyDocumentV1` exposes the widget's runtime document validation as a pure public seam for authoring tools before preview or export. (#338)
 - `SurveyDocumentV1`, `SurveyPageV1` and `SurveyQuestionV1` add a serializable page-based authoring format. A page can contain multiple questions that render and validate together; `singlePage` preserves page headings while step layout navigates pages. The new format uses question-level `visibleIf` and deliberately rejects legacy `logic`. Existing flat `LumiSurveyConfig` inputs remain supported unchanged. (#336)
 - `visibleIf` now supports `any` (OR) and `all` (AND) to combine multiple conditions. The wider condition type is exported as `VisibleIfCondition` (with `isConditionGroup`/`getLeafConditions`/`isLeafCondition` helpers); `LogicCondition` stays leaf-only so `LogicRule` consumers are unaffected. Note: `question.visibleIf` is now typed `VisibleIfCondition` (leaf | group), so code reading `visibleIf.operator` directly must first narrow with `isConditionGroup`/`isLeafCondition`. (#333)
 

--- a/packages/lumi-survey/src/components/shared/__tests__/canonicalSurvey.test.ts
+++ b/packages/lumi-survey/src/components/shared/__tests__/canonicalSurvey.test.ts
@@ -1,6 +1,9 @@
 import { describe, expect, it } from "vitest";
 import type { LumiSurveyConfig, SurveyDocumentV1 } from "../../surveyTypes.js";
-import { buildCanonicalSurvey } from "../canonicalSurvey.js";
+import {
+  buildCanonicalSurvey,
+  validateSurveyDocumentV1,
+} from "../canonicalSurvey.js";
 
 const validQuestions = [
   { id: "q1", type: "rating", prompt: "Rating" },
@@ -519,5 +522,33 @@ describe("buildCanonicalSurvey", () => {
     expect(() => make({ operator: "BOGUS", questionId: "q1" })).toThrowError(
       /invalid visibleIf condition/i,
     );
+  });
+});
+
+describe("validateSurveyDocumentV1", () => {
+  it("returns a valid V1 document unchanged", () => {
+    const document = {
+      authoringSchemaVersion: 1 as const,
+      pages: [
+        {
+          id: "page-1",
+          questions: [
+            {
+              id: "rating",
+              type: "rating" as const,
+              prompt: "Hvordan gikk det?",
+            },
+          ],
+        },
+      ],
+    };
+
+    expect(validateSurveyDocumentV1(document)).toBe(document);
+  });
+
+  it("rejects unknown authoring payloads before preview", () => {
+    expect(() =>
+      validateSurveyDocumentV1({ authoringSchemaVersion: 1, pages: [] }),
+    ).toThrow("at least one page");
   });
 });

--- a/packages/lumi-survey/src/components/shared/canonicalSurvey.ts
+++ b/packages/lumi-survey/src/components/shared/canonicalSurvey.ts
@@ -6,6 +6,7 @@ import {
 import type { LumiSurveyQuestion } from "../../core/types.js";
 import type {
   LumiSurveyDefinition,
+  SurveyDocumentV1,
   SurveyPageV1,
   SurveyType,
 } from "../surveyTypes.js";
@@ -258,6 +259,27 @@ export function buildCanonicalSurvey(
     questions,
     pages,
   };
+}
+
+/**
+ * Validate an unknown authoring payload against the public V1 document
+ * contract. Returns the original JSON-compatible document when valid.
+ *
+ * Authoring tools can use this before preview/export without duplicating the
+ * widget's runtime validation rules.
+ */
+export function validateSurveyDocumentV1(input: unknown): SurveyDocumentV1 {
+  if (!input || typeof input !== "object" || Array.isArray(input)) {
+    throw new Error("Lumi: Survey document must be an object");
+  }
+
+  const document = input as Record<string, unknown>;
+  if (document.authoringSchemaVersion !== 1) {
+    throw new Error("Lumi: Survey document must use authoringSchemaVersion 1");
+  }
+
+  buildCanonicalSurvey(input as SurveyDocumentV1);
+  return input as SurveyDocumentV1;
 }
 
 function validateLegacyQuestions(

--- a/packages/lumi-survey/src/index.ts
+++ b/packages/lumi-survey/src/index.ts
@@ -11,6 +11,7 @@ export type {
   StorageStrategy,
 } from "./components/LumiSurveyDock/propTypes.js";
 export * from "./components/questions/index.js";
+export { validateSurveyDocumentV1 } from "./components/shared/canonicalSurvey.js";
 export type {
   LumiSurveyConfig,
   LumiSurveyDefinition,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -38,6 +38,9 @@ importers:
       '@navikt/lumi-types':
         specifier: workspace:*
         version: link:../../packages/lumi-types
+      '@navikt/lumi-survey':
+        specifier: workspace:*
+        version: link:../../packages/lumi-survey
       '@navikt/oasis':
         specifier: ^4.1.4
         version: 4.1.4


### PR DESCRIPTION
## Hva

Første vertikale snitt av #338 etablerer et persistent, team-scopet Surveyverksted uten å endre Lumi sin survey-as-code-runtime:

- legger til en separat authoring-store og API for muterbare drafts
- bruker optimistic locking, teamautorisasjon, størrelsesgrenser og prosjektkvote
- bygger editor for `SurveyDocumentV1` med pages, rating-/tekstspørsmål, autosave og gjenåpning
- rendrer forhåndsvisning i den ekte `LumiSurveyDock` med inert transport
- eksponerer widgetens validering som offentlig authoring-seam
- dokumenterer grensen mellom authoring, runtime og analytics-definisjoner i ADR 0004

## Hvorfor

Designarbeid skjer over flere økter, så en ren bruk-og-kast-kodegenerator er ikke nok. Samtidig skal dashboardet ikke bli runtime-kilde. Drafts lagres derfor separat fra `survey_definitions`, mens konsumentappen fortsatt eier produksjonskonfigurasjonen og vanlig Git/deploy.

Dette er bevisst bare første tracer bullet. Immutable revisjoner, delbar revisjonslenke, diff og deterministisk JSON/TypeScript-eksport følger i neste vertikale snitt. PR-en lukker derfor ikke #338.

## Funksjonell effekt

- Ny navigasjon til Surveyverksted i dashboardet.
- Teammedlemmer kan opprette et utkast, redigere det, vente på autosave og åpne det igjen senere.
- Parallelle/stale lagringer blir avvist med versjonskonflikt i stedet for stille overskriving.
- Preview åpnes separat og kan ikke sende eller lagre feedback.
- Widget-, submission- og konsumentruntime får ingen nye nettverkskall eller konfigurasjonsavhengigheter.

## Verifisering

- `npm run lint`
- `npm run typecheck`
- `npm run build`
- `npm run docs:build`
- dashboard: 53 filer / 317 tester
- lumi-survey: 27 filer / 360 tester
- API: full Gradle-test suite
- Playwright: 35 bestått / 1 eksisterende skipped, inkludert ny opprett → autosave → reload → ekte preview-regresjon
- manuell browsergjennomgang av liste, editor og widget-preview
