### PR TITLE
Fix clean dashboard production build

### DIFF
--- a/apps/lumi-dashboard/package.json
+++ b/apps/lumi-dashboard/package.json
@@ -6,6 +6,7 @@
   "scripts": {
     "predev": "pnpm --filter @navikt/lumi-survey run build",
     "dev": "vite dev",
+    "prebuild": "pnpm --filter @navikt/lumi-survey run build",
     "build": "vite build && tsc -p tsconfig.typecheck.json --noEmit",
     "start": "node .output/server/index.mjs",
     "lint": "biome check .",


### PR DESCRIPTION
## Hva

- bygger `@navikt/lumi-survey` automatisk før en direkte dashboard-build
- gjør dashboardets produksjonsbuild selvforsynt med widgetens JavaScript, typer og CSS

## Hvorfor

Deploy-workflowen bygger dashboard-pakken direkte etter `lumi-types`. Surveyverkstedet importerer nå `@navikt/lumi-survey/styles.css`, men `dist/index.css` fantes ikke i et rent checkout. Root-CI skjulte avhengigheten fordi et tidligere typecheck-steg bygget survey-pakken.

## Verifisering

- flyttet eksisterende `packages/lumi-survey/dist` ut av worktree
- kjørte `npm run build` direkte i `apps/lumi-dashboard`
- `prebuild` bygget survey-pakken, og dashboardets klient-, SSR- og Nitro-build fullførte
- `npm run lint`

Oppfølging etter #428.