### PR TITLE
Add immutable Surveyverksted revisions

### DIFF
--- a/apps/lumi-api/src/main/kotlin/no/nav/lumi/domain/SurveyAuthoringProject.kt
+++ b/apps/lumi-api/src/main/kotlin/no/nav/lumi/domain/SurveyAuthoringProject.kt
@@ -19,6 +19,11 @@ data class UpdateSurveyAuthoringDraftRequest(
 )
 
 @Serializable
+data class CreateSurveyAuthoringRevisionRequest(
+    val expectedDraftVersion: Long,
+)
+
+@Serializable
 data class SurveyAuthoringProject(
     val id: String,
     val team: String,
@@ -39,4 +44,39 @@ data class SurveyAuthoringProjectSummary(
     val draftVersion: Long,
     val createdAt: String,
     val updatedAt: String,
+)
+
+@Serializable
+data class SurveyAuthoringRevision(
+    val id: String,
+    val projectId: String,
+    val revisionNumber: Long,
+    val draftVersion: Long,
+    val name: String,
+    val surveyId: String,
+    val document: JsonObject,
+    val documentHash: String,
+    val definitionHash: String,
+    val createdBy: String,
+    val createdAt: String,
+)
+
+@Serializable
+data class SurveyAuthoringRevisionSummary(
+    val id: String,
+    val projectId: String,
+    val revisionNumber: Long,
+    val draftVersion: Long,
+    val name: String,
+    val surveyId: String,
+    val documentHash: String,
+    val definitionHash: String,
+    val createdBy: String,
+    val createdAt: String,
+)
+
+@Serializable
+data class SurveyAuthoringRevisionDetail(
+    val revision: SurveyAuthoringRevision,
+    val previousRevision: SurveyAuthoringRevision? = null,
 )

--- a/apps/lumi-api/src/main/kotlin/no/nav/lumi/repository/SurveyAuthoringRevisionRepository.kt
+++ b/apps/lumi-api/src/main/kotlin/no/nav/lumi/repository/SurveyAuthoringRevisionRepository.kt
@@ -1,0 +1,179 @@
+package no.nav.lumi.repository
+
+import kotlinx.serialization.encodeToString
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonObject
+import no.nav.lumi.domain.SurveyAuthoringRevision
+import no.nav.lumi.domain.SurveyAuthoringRevisionDetail
+import no.nav.lumi.domain.SurveyAuthoringRevisionSummary
+import no.nav.lumi.domain.computeHash
+import no.nav.lumi.validation.SurveyAuthoringDocumentValidator
+import org.jetbrains.exposed.v1.core.ResultRow
+import org.jetbrains.exposed.v1.core.SortOrder
+import org.jetbrains.exposed.v1.core.and
+import org.jetbrains.exposed.v1.core.eq
+import org.jetbrains.exposed.v1.core.less
+import org.jetbrains.exposed.v1.jdbc.insert
+import org.jetbrains.exposed.v1.jdbc.selectAll
+import org.jetbrains.exposed.v1.jdbc.transactions.TransactionManager
+import java.sql.Connection
+import java.util.UUID
+
+sealed interface CreateSurveyAuthoringRevisionResult {
+    data class Created(val revision: SurveyAuthoringRevision) : CreateSurveyAuthoringRevisionResult
+    data object NotFound : CreateSurveyAuthoringRevisionResult
+    data object DraftChanged : CreateSurveyAuthoringRevisionResult
+    data object LimitReached : CreateSurveyAuthoringRevisionResult
+    data class DefinitionConflict(val previousRevisionNumber: Long) : CreateSurveyAuthoringRevisionResult
+}
+
+class SurveyAuthoringRevisionRepository {
+    private val json = Json
+
+    suspend fun createFromDraft(
+        team: String,
+        projectId: UUID,
+        expectedDraftVersion: Long,
+        principalIdentity: String,
+        maxRevisions: Long,
+    ): CreateSurveyAuthoringRevisionResult = dbQuery {
+        val connection = TransactionManager.current().connection.connection as Connection
+        connection.prepareStatement("SELECT pg_advisory_xact_lock(hashtext(?))").use { lock ->
+            lock.setString(1, "survey-authoring-revision:$projectId")
+            lock.execute()
+        }
+
+        val projectRow = SurveyAuthoringProjectTable.selectAll()
+            .where {
+                (SurveyAuthoringProjectTable.id eq projectId) and
+                    (SurveyAuthoringProjectTable.team eq team)
+            }
+            .singleOrNull()
+            ?: return@dbQuery CreateSurveyAuthoringRevisionResult.NotFound
+
+        val draftVersion = projectRow[SurveyAuthoringProjectTable.draftVersion]
+        if (draftVersion != expectedDraftVersion) {
+            return@dbQuery CreateSurveyAuthoringRevisionResult.DraftChanged
+        }
+
+        val document = json.parseToJsonElement(projectRow[SurveyAuthoringProjectTable.draft]) as JsonObject
+        val surveyId = projectRow[SurveyAuthoringProjectTable.surveyId]
+        val validated = SurveyAuthoringDocumentValidator.validate(document, surveyId)
+        val definitionHash = validated.definition.computeHash()
+
+        val previousRevisionNumber = SurveyAuthoringRevisionTable.selectAll()
+            .where { SurveyAuthoringRevisionTable.projectId eq projectId }
+            .orderBy(SurveyAuthoringRevisionTable.revisionNumber to SortOrder.DESC)
+            .limit(1)
+            .singleOrNull()
+            ?.get(SurveyAuthoringRevisionTable.revisionNumber)
+            ?: 0L
+        if (previousRevisionNumber >= maxRevisions) {
+            return@dbQuery CreateSurveyAuthoringRevisionResult.LimitReached
+        }
+
+        val previousForSurvey = SurveyAuthoringRevisionTable.selectAll()
+            .where {
+                (SurveyAuthoringRevisionTable.projectId eq projectId) and
+                    (SurveyAuthoringRevisionTable.surveyId eq surveyId)
+            }
+            .orderBy(SurveyAuthoringRevisionTable.revisionNumber to SortOrder.DESC)
+            .limit(1)
+            .singleOrNull()
+        if (
+            previousForSurvey != null &&
+            previousForSurvey[SurveyAuthoringRevisionTable.definitionHash] != definitionHash
+        ) {
+            return@dbQuery CreateSurveyAuthoringRevisionResult.DefinitionConflict(
+                previousForSurvey[SurveyAuthoringRevisionTable.revisionNumber],
+            )
+        }
+
+        val inserted = SurveyAuthoringRevisionTable.insert {
+            it[SurveyAuthoringRevisionTable.projectId] = projectId
+            it[revisionNumber] = previousRevisionNumber + 1
+            it[SurveyAuthoringRevisionTable.draftVersion] = draftVersion
+            it[name] = projectRow[SurveyAuthoringProjectTable.name]
+            it[SurveyAuthoringRevisionTable.surveyId] = surveyId
+            it[SurveyAuthoringRevisionTable.document] = document.toString()
+            it[documentHash] = validated.documentHash
+            it[definition] = json.encodeToString(validated.definition)
+            it[SurveyAuthoringRevisionTable.definitionHash] = definitionHash
+            it[createdBy] = principalIdentity
+        }
+
+        CreateSurveyAuthoringRevisionResult.Created(
+            findByIdInCurrentTransaction(team, inserted[SurveyAuthoringRevisionTable.id])!!,
+        )
+    }
+
+    suspend fun findByProject(
+        team: String,
+        projectId: UUID,
+    ): List<SurveyAuthoringRevisionSummary>? = dbQuery {
+        val projectExists = SurveyAuthoringProjectTable.selectAll()
+            .where {
+                (SurveyAuthoringProjectTable.id eq projectId) and
+                    (SurveyAuthoringProjectTable.team eq team)
+            }
+            .limit(1)
+            .any()
+        if (!projectExists) return@dbQuery null
+
+        SurveyAuthoringRevisionTable.selectAll()
+            .where { SurveyAuthoringRevisionTable.projectId eq projectId }
+            .orderBy(SurveyAuthoringRevisionTable.revisionNumber to SortOrder.DESC)
+            .map(::toSummary)
+    }
+
+    suspend fun findDetailById(team: String, revisionId: UUID): SurveyAuthoringRevisionDetail? = dbQuery {
+        val revision = findByIdInCurrentTransaction(team, revisionId) ?: return@dbQuery null
+        val previous = SurveyAuthoringRevisionTable.selectAll()
+            .where {
+                (SurveyAuthoringRevisionTable.projectId eq UUID.fromString(revision.projectId)) and
+                    (SurveyAuthoringRevisionTable.revisionNumber less revision.revisionNumber)
+            }
+            .orderBy(SurveyAuthoringRevisionTable.revisionNumber to SortOrder.DESC)
+            .limit(1)
+            .singleOrNull()
+            ?.let(::toRevision)
+        SurveyAuthoringRevisionDetail(revision = revision, previousRevision = previous)
+    }
+
+    private fun findByIdInCurrentTransaction(team: String, revisionId: UUID): SurveyAuthoringRevision? =
+        (SurveyAuthoringRevisionTable innerJoin SurveyAuthoringProjectTable)
+            .selectAll()
+            .where {
+                (SurveyAuthoringRevisionTable.id eq revisionId) and
+                    (SurveyAuthoringProjectTable.team eq team)
+            }
+            .singleOrNull()
+            ?.let(::toRevision)
+
+    private fun toRevision(row: ResultRow) = SurveyAuthoringRevision(
+        id = row[SurveyAuthoringRevisionTable.id].toString(),
+        projectId = row[SurveyAuthoringRevisionTable.projectId].toString(),
+        revisionNumber = row[SurveyAuthoringRevisionTable.revisionNumber],
+        draftVersion = row[SurveyAuthoringRevisionTable.draftVersion],
+        name = row[SurveyAuthoringRevisionTable.name],
+        surveyId = row[SurveyAuthoringRevisionTable.surveyId],
+        document = json.parseToJsonElement(row[SurveyAuthoringRevisionTable.document]) as JsonObject,
+        documentHash = row[SurveyAuthoringRevisionTable.documentHash],
+        definitionHash = row[SurveyAuthoringRevisionTable.definitionHash],
+        createdBy = row[SurveyAuthoringRevisionTable.createdBy],
+        createdAt = row[SurveyAuthoringRevisionTable.createdAt].toString(),
+    )
+
+    private fun toSummary(row: ResultRow) = SurveyAuthoringRevisionSummary(
+        id = row[SurveyAuthoringRevisionTable.id].toString(),
+        projectId = row[SurveyAuthoringRevisionTable.projectId].toString(),
+        revisionNumber = row[SurveyAuthoringRevisionTable.revisionNumber],
+        draftVersion = row[SurveyAuthoringRevisionTable.draftVersion],
+        name = row[SurveyAuthoringRevisionTable.name],
+        surveyId = row[SurveyAuthoringRevisionTable.surveyId],
+        documentHash = row[SurveyAuthoringRevisionTable.documentHash],
+        definitionHash = row[SurveyAuthoringRevisionTable.definitionHash],
+        createdBy = row[SurveyAuthoringRevisionTable.createdBy],
+        createdAt = row[SurveyAuthoringRevisionTable.createdAt].toString(),
+    )
+}

--- a/apps/lumi-api/src/main/kotlin/no/nav/lumi/repository/SurveyAuthoringRevisionTable.kt
+++ b/apps/lumi-api/src/main/kotlin/no/nav/lumi/repository/SurveyAuthoringRevisionTable.kt
@@ -1,0 +1,22 @@
+package no.nav.lumi.repository
+
+import org.jetbrains.exposed.v1.core.Table
+import org.jetbrains.exposed.v1.core.java.javaUUID
+import org.jetbrains.exposed.v1.javatime.timestampWithTimeZone
+
+object SurveyAuthoringRevisionTable : Table("survey_authoring_revisions") {
+    val id = javaUUID("id").autoGenerate()
+    val projectId = reference("project_id", SurveyAuthoringProjectTable.id)
+    val revisionNumber = long("revision_number")
+    val draftVersion = long("draft_version")
+    val name = varchar("name", 120)
+    val surveyId = varchar("survey_id", 200)
+    val document = registerColumn<String>("document", JsonbColumnType())
+    val documentHash = varchar("document_hash", 64)
+    val definition = registerColumn<String>("definition", JsonbColumnType())
+    val definitionHash = varchar("definition_hash", 64)
+    val createdBy = text("created_by")
+    val createdAt = timestampWithTimeZone("created_at")
+
+    override val primaryKey = PrimaryKey(id)
+}

--- a/apps/lumi-api/src/main/kotlin/no/nav/lumi/routes/Resources.kt
+++ b/apps/lumi-api/src/main/kotlin/no/nav/lumi/routes/Resources.kt
@@ -295,7 +295,22 @@ class ApiV1Intern {
                 @Resource("draft")
                 @Serializable
                 class Draft(val parent: Id)
+
+                @Resource("revisions")
+                @Serializable
+                class ProjectRevisions(val parent: Id)
             }
+        }
+
+        @Resource("revisions")
+        @Serializable
+        class Revisions(val parent: Authoring = Authoring()) {
+            @Resource("{revisionId}")
+            @Serializable
+            class Id(
+                val parent: Revisions = Revisions(),
+                val revisionId: String,
+            )
         }
     }
 }

--- a/apps/lumi-api/src/main/kotlin/no/nav/lumi/routes/SurveyAuthoringRoutes.kt
+++ b/apps/lumi-api/src/main/kotlin/no/nav/lumi/routes/SurveyAuthoringRoutes.kt
@@ -20,19 +20,25 @@ import no.nav.lumi.config.auth.authorizedPrincipal
 import no.nav.lumi.config.auth.authorizedTeam
 import no.nav.lumi.config.exception.ApiErrorException
 import no.nav.lumi.domain.CreateSurveyAuthoringProjectRequest
+import no.nav.lumi.domain.CreateSurveyAuthoringRevisionRequest
 import no.nav.lumi.domain.UpdateSurveyAuthoringDraftRequest
+import no.nav.lumi.repository.CreateSurveyAuthoringRevisionResult
 import no.nav.lumi.repository.SurveyAuthoringProjectRepository
+import no.nav.lumi.repository.SurveyAuthoringRevisionRepository
 import java.util.UUID
 
 private val defaultSurveyAuthoringProjectRepository = SurveyAuthoringProjectRepository()
+private val defaultSurveyAuthoringRevisionRepository = SurveyAuthoringRevisionRepository()
 private const val MAX_PROJECT_NAME_LENGTH = 120
 private const val MAX_SURVEY_ID_LENGTH = 200
 private const val MAX_DRAFT_BYTES = 256 * 1024
 private const val MAX_REQUEST_BYTES = MAX_DRAFT_BYTES + 16 * 1024
 private const val MAX_PROJECTS_PER_TEAM = 100
+private const val MAX_REVISIONS_PER_PROJECT = 500L
 
 fun Route.surveyAuthoringRoutes(
     repository: SurveyAuthoringProjectRepository = defaultSurveyAuthoringProjectRepository,
+    revisionRepository: SurveyAuthoringRevisionRepository = defaultSurveyAuthoringRevisionRepository,
 ) {
     get<ApiV1Intern.Authoring.Projects> {
         call.respond(repository.findByTeam(call.authorizedTeam))
@@ -94,6 +100,59 @@ fun Route.surveyAuthoringRoutes(
         )
 
         call.respond(project)
+    }
+
+    get<ApiV1Intern.Authoring.Projects.Id.ProjectRevisions> { params ->
+        val revisions = revisionRepository.findByProject(
+            team = call.authorizedTeam,
+            projectId = parseProjectId(params.parent.projectId),
+        ) ?: throw ApiErrorException.NotFoundException("Survey project not found")
+        call.respond(revisions)
+    }
+
+    post<ApiV1Intern.Authoring.Projects.Id.ProjectRevisions> { params ->
+        val request = receiveAuthoringRequest<CreateSurveyAuthoringRevisionRequest>(call)
+        if (request.expectedDraftVersion < 1) {
+            throw ApiErrorException.BadRequestException("expectedDraftVersion must be positive")
+        }
+        val principalIdentity = stablePrincipalIdentity(call.authorizedPrincipal)
+            ?: throw ApiErrorException.BadRequestException("Authenticated user needs a stable identity")
+
+        when (
+            val result = revisionRepository.createFromDraft(
+                team = call.authorizedTeam,
+                projectId = parseProjectId(params.parent.projectId),
+                expectedDraftVersion = request.expectedDraftVersion,
+                principalIdentity = principalIdentity,
+                maxRevisions = MAX_REVISIONS_PER_PROJECT,
+            )
+        ) {
+            is CreateSurveyAuthoringRevisionResult.Created ->
+                call.respond(HttpStatusCode.Created, result.revision)
+            CreateSurveyAuthoringRevisionResult.NotFound ->
+                throw ApiErrorException.NotFoundException("Survey project not found")
+            CreateSurveyAuthoringRevisionResult.DraftChanged ->
+                throw ApiErrorException.ConflictException(
+                    "Draft changed since it was validated. Wait for save and try again.",
+                )
+            CreateSurveyAuthoringRevisionResult.LimitReached ->
+                throw ApiErrorException.TooManyRequestsException(
+                    "Survey project has reached the limit of $MAX_REVISIONS_PER_PROJECT revisions",
+                )
+            is CreateSurveyAuthoringRevisionResult.DefinitionConflict ->
+                throw ApiErrorException.ConflictException(
+                    "Survey structure differs from revision ${result.previousRevisionNumber}. " +
+                        "Use a new surveyId before creating a shared revision.",
+                )
+        }
+    }
+
+    get<ApiV1Intern.Authoring.Revisions.Id> { params ->
+        val detail = revisionRepository.findDetailById(
+            team = call.authorizedTeam,
+            revisionId = parseRevisionId(params.revisionId),
+        ) ?: throw ApiErrorException.NotFoundException("Survey revision not found")
+        call.respond(detail)
     }
 }
 
@@ -164,4 +223,10 @@ private fun parseProjectId(value: String): UUID = try {
     UUID.fromString(value)
 } catch (_: IllegalArgumentException) {
     throw ApiErrorException.BadRequestException("Invalid survey project ID")
+}
+
+private fun parseRevisionId(value: String): UUID = try {
+    UUID.fromString(value)
+} catch (_: IllegalArgumentException) {
+    throw ApiErrorException.BadRequestException("Invalid survey revision ID")
 }

--- a/apps/lumi-api/src/main/kotlin/no/nav/lumi/validation/SurveyAuthoringDocumentValidator.kt
+++ b/apps/lumi-api/src/main/kotlin/no/nav/lumi/validation/SurveyAuthoringDocumentValidator.kt
@@ -1,0 +1,292 @@
+package no.nav.lumi.validation
+
+import kotlinx.serialization.json.JsonArray
+import kotlinx.serialization.json.JsonElement
+import kotlinx.serialization.json.JsonNull
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.booleanOrNull
+import kotlinx.serialization.json.contentOrNull
+import kotlinx.serialization.json.doubleOrNull
+import kotlinx.serialization.json.intOrNull
+import no.nav.lumi.config.exception.ApiErrorException
+import no.nav.lumi.domain.FieldDefinition
+import no.nav.lumi.domain.FieldType
+import no.nav.lumi.domain.RatingVariant
+import no.nav.lumi.domain.SurveyDefinition
+import no.nav.lumi.domain.SurveyType
+import java.security.MessageDigest
+
+data class ValidatedSurveyAuthoringDocument(
+    val documentHash: String,
+    val definition: SurveyDefinition,
+)
+
+object SurveyAuthoringDocumentValidator {
+    private val surveyTypes = mapOf(
+        "rating" to SurveyType.RATING,
+        "topTasks" to SurveyType.TOP_TASKS,
+        "discovery" to SurveyType.DISCOVERY,
+        "taskPriority" to SurveyType.TASK_PRIORITY,
+        "custom" to SurveyType.CUSTOM,
+    )
+    private val ratingVariants = mapOf(
+        "emoji" to RatingVariant.EMOJI,
+        "thumbs" to RatingVariant.THUMBS,
+        "stars" to RatingVariant.STARS,
+        "nps" to RatingVariant.NPS,
+    )
+    private val conditionOperators = setOf("EQ", "NEQ", "GT", "LT", "CONTAINS", "EXISTS")
+
+    fun validate(document: JsonObject, surveyId: String): ValidatedSurveyAuthoringDocument {
+        requireInt(document, "authoringSchemaVersion", "Document")
+            .takeIf { it == 1 }
+            ?: invalid("Only authoringSchemaVersion 1 is supported")
+        if (document.containsKey("questions")) {
+            invalid("Version 1 survey documents use pages, not legacy questions")
+        }
+
+        val surveyTypeName = optionalString(document, "type", "Document") ?: "custom"
+        val surveyType = surveyTypes[surveyTypeName]
+            ?: invalid("Unsupported survey type '$surveyTypeName'")
+        val pages = document["pages"] as? JsonArray
+            ?: invalid("Survey document must contain pages")
+        if (pages.isEmpty()) invalid("Survey document must have at least one page")
+
+        val pageIds = mutableSetOf<String>()
+        val questionIds = mutableSetOf<String>()
+        val previousQuestionIds = mutableSetOf<String>()
+        val fields = mutableListOf<FieldDefinition>()
+
+        pages.forEachIndexed { pageIndex, pageElement ->
+            val page = pageElement as? JsonObject
+                ?: invalid("Page at index $pageIndex is not an object")
+            val pageId = requireNonBlankString(page, "id", "Page at index $pageIndex")
+            if (!pageIds.add(pageId)) invalid("Duplicate page id '$pageId'")
+            optionalString(page, "title", "Page '$pageId'")
+            optionalString(page, "description", "Page '$pageId'")
+            val questions = page["questions"] as? JsonArray
+                ?: invalid("Page '$pageId' must contain questions")
+            if (questions.isEmpty()) invalid("Page '$pageId' must have at least one question")
+
+            questions.forEachIndexed { questionIndex, questionElement ->
+                val question = questionElement as? JsonObject
+                    ?: invalid("Question at index $questionIndex on page '$pageId' is not an object")
+                val questionId = requireNonBlankString(question, "id", "Question on page '$pageId'")
+                if (!questionIds.add(questionId)) invalid("Duplicate question id '$questionId'")
+                requireString(question, "prompt", "Question '$questionId'")
+                optionalString(question, "description", "Question '$questionId'")
+                optionalString(question, "analyticsId", "Question '$questionId'")
+                optionalBoolean(question, "required", "Question '$questionId'")
+                if (question.containsKey("logic")) {
+                    invalid("Question '$questionId' uses legacy logic")
+                }
+                question["visibleIf"]?.let {
+                    validateVisibleIf(it, questionId, previousQuestionIds)
+                }
+
+                val type = requireString(question, "type", "Question '$questionId'")
+                fields += when (type) {
+                    "rating" -> validateRating(question, questionId)
+                    "text" -> validateText(question, questionId)
+                    "singleChoice" -> validateChoice(question, questionId, FieldType.SINGLE_CHOICE)
+                    "multiChoice" -> validateChoice(question, questionId, FieldType.MULTI_CHOICE)
+                    else -> invalid("Question '$questionId' has unsupported type '$type'")
+                }
+                previousQuestionIds += questionId
+            }
+        }
+
+        val definition = SurveyDefinition(surveyId = surveyId, surveyType = surveyType, fields = fields)
+        SurveyDefinitionValidator.validateDefinition(definition)
+        return ValidatedSurveyAuthoringDocument(
+            documentHash = sha256(canonicalJson(document)),
+            definition = definition,
+        )
+    }
+
+    private fun validateRating(question: JsonObject, questionId: String): FieldDefinition {
+        val variantName = optionalString(question, "variant", "Rating question '$questionId'") ?: "emoji"
+        val variant = ratingVariants[variantName]
+            ?: invalid("Rating question '$questionId' has unsupported variant '$variantName'")
+        for (labelKey in listOf("lowLabel", "highLabel")) {
+            optionalString(question, labelKey, "Rating question '$questionId'")
+        }
+        question["labels"]?.let { labelsElement ->
+            val labels = labelsElement as? JsonArray
+                ?: invalid("Rating question '$questionId' has invalid labels")
+            labels.forEach { labelElement ->
+                val label = labelElement as? JsonObject
+                    ?: invalid("Rating question '$questionId' has invalid labels")
+                requireFiniteNumber(label, "value", "Rating question '$questionId' label")
+                requireString(label, "label", "Rating question '$questionId' label")
+            }
+        }
+        return FieldDefinition(
+            fieldId = questionId,
+            fieldType = FieldType.RATING,
+            ratingVariant = variant,
+            ratingScale = RatingVariant.getScale(variant),
+            optionIds = null,
+        )
+    }
+
+    private fun validateText(question: JsonObject, questionId: String): FieldDefinition {
+        for (key in listOf("maxLength", "minRows")) {
+            question[key]?.let { value ->
+                val number = (value as? JsonPrimitive)?.doubleOrNull
+                if (number == null || !number.isFinite() || number <= 0) {
+                    invalid("Text question '$questionId' has invalid $key")
+                }
+            }
+        }
+        for (key in listOf("placeholder", "autoComplete")) {
+            optionalString(question, key, "Text question '$questionId'")
+        }
+        return FieldDefinition(questionId, FieldType.TEXT, null, null, null)
+    }
+
+    private fun validateChoice(
+        question: JsonObject,
+        questionId: String,
+        fieldType: FieldType,
+    ): FieldDefinition {
+        val options = question["options"] as? JsonArray
+            ?: invalid("Choice question '$questionId' must have options")
+        if (options.isEmpty()) invalid("Choice question '$questionId' must have at least one option")
+        val optionIds = options.mapIndexed { index, optionElement ->
+            val option = optionElement as? JsonObject
+                ?: invalid("Option $index on question '$questionId' is not an object")
+            val value = requireString(option, "value", "Option $index on question '$questionId'")
+            requireString(option, "label", "Option '$value' on question '$questionId'")
+            optionalString(option, "description", "Option '$value' on question '$questionId'")
+            value
+        }
+        if (optionIds.distinct().size != optionIds.size) {
+            invalid("Choice question '$questionId' has duplicate option values")
+        }
+        optionalBoolean(question, "randomize", "Choice question '$questionId'")
+        question["variant"]?.let {
+            val variant = requireString(question, "variant", "Choice question '$questionId'")
+            if (variant !in setOf("checkbox", "combobox")) {
+                invalid("Choice question '$questionId' has unsupported variant '$variant'")
+            }
+        }
+        question["maxSelections"]?.let {
+            val maxSelections = (it as? JsonPrimitive)?.intOrNull
+            if (maxSelections == null || maxSelections <= 0) {
+                invalid("Choice question '$questionId' has invalid maxSelections")
+            }
+        }
+        return FieldDefinition(questionId, fieldType, null, null, optionIds)
+    }
+
+    private fun validateVisibleIf(
+        element: JsonElement,
+        questionId: String,
+        previousQuestionIds: Set<String>,
+    ) {
+        val condition = element as? JsonObject
+            ?: invalid("Question '$questionId' has an invalid visibleIf")
+        val groupKeys = listOf("any", "all").filter(condition::containsKey)
+        if (groupKeys.size > 1) invalid("Question '$questionId' visibleIf must use exactly one group")
+        if (groupKeys.isEmpty()) {
+            validateConditionLeaf(condition, questionId, previousQuestionIds)
+            return
+        }
+        val conditions = condition[groupKeys.single()] as? JsonArray
+            ?: invalid("Question '$questionId' visibleIf group must be a list")
+        if (conditions.isEmpty()) invalid("Question '$questionId' visibleIf group cannot be empty")
+        conditions.forEach { leafElement ->
+            val leaf = leafElement as? JsonObject
+                ?: invalid("Question '$questionId' has an invalid visibleIf condition")
+            if (leaf.containsKey("any") || leaf.containsKey("all")) {
+                invalid("Question '$questionId' has a nested visibleIf group")
+            }
+            validateConditionLeaf(leaf, questionId, previousQuestionIds)
+        }
+    }
+
+    private fun validateConditionLeaf(
+        leaf: JsonObject,
+        questionId: String,
+        previousQuestionIds: Set<String>,
+    ) {
+        val field = optionalString(leaf, "field", "Question '$questionId' visibleIf") ?: "ANSWER"
+        if (field !in setOf("ANSWER", "METADATA")) {
+            invalid("Question '$questionId' has unsupported visibleIf field '$field'")
+        }
+        val operator = requireString(leaf, "operator", "Question '$questionId' visibleIf")
+        if (operator !in conditionOperators) {
+            invalid("Question '$questionId' has unsupported visibleIf operator '$operator'")
+        }
+        if (operator == "EXISTS") {
+            if (leaf.containsKey("value")) invalid("Question '$questionId' EXISTS visibleIf must not have a value")
+        } else {
+            val value = leaf["value"] ?: invalid("Question '$questionId' $operator visibleIf needs a value")
+            if (value !is JsonPrimitive || value is JsonNull || (!value.isString && value.booleanOrNull == null && value.doubleOrNull == null)) {
+                invalid("Question '$questionId' $operator visibleIf has an invalid value")
+            }
+        }
+        if (field == "METADATA") {
+            requireNonBlankString(leaf, "key", "Question '$questionId' METADATA visibleIf")
+        } else {
+            val referencedId = requireNonBlankString(leaf, "questionId", "Question '$questionId' ANSWER visibleIf")
+            if (referencedId !in previousQuestionIds) {
+                invalid("Question '$questionId' visibleIf may only reference an earlier question")
+            }
+        }
+    }
+
+    private fun requireString(value: JsonObject, key: String, context: String): String {
+        return optionalString(value, key, context) ?: invalid("$context needs a string $key")
+    }
+
+    private fun requireNonBlankString(value: JsonObject, key: String, context: String): String {
+        val result = requireString(value, key, context)
+        if (result.isBlank()) invalid("$context needs a non-blank $key")
+        return result
+    }
+
+    private fun optionalString(value: JsonObject, key: String, context: String): String? {
+        val element = value[key] ?: return null
+        val primitive = element as? JsonPrimitive
+            ?: invalid("$context has a non-string $key")
+        return primitive.contentOrNull?.takeIf { primitive.isString }
+            ?: invalid("$context has a non-string $key")
+    }
+
+    private fun optionalBoolean(value: JsonObject, key: String, context: String): Boolean? {
+        val element = value[key] ?: return null
+        return (element as? JsonPrimitive)?.booleanOrNull
+            ?: invalid("$context has a non-boolean $key")
+    }
+
+    private fun requireInt(value: JsonObject, key: String, context: String): Int {
+        return (value[key] as? JsonPrimitive)?.intOrNull
+            ?: invalid("$context needs an integer $key")
+    }
+
+    private fun requireFiniteNumber(value: JsonObject, key: String, context: String): Double {
+        val number = (value[key] as? JsonPrimitive)?.doubleOrNull
+            ?: invalid("$context needs a number $key")
+        if (!number.isFinite()) invalid("$context has an invalid $key")
+        return number
+    }
+
+    private fun canonicalJson(element: JsonElement): String = when (element) {
+        is JsonObject -> element.entries.sortedBy { it.key }.joinToString(
+            prefix = "{",
+            postfix = "}",
+            separator = ",",
+        ) { (key, value) -> "${JsonPrimitive(key)}:${canonicalJson(value)}" }
+        is JsonArray -> element.joinToString(prefix = "[", postfix = "]", separator = ",", transform = ::canonicalJson)
+        else -> element.toString()
+    }
+
+    private fun sha256(value: String): String = MessageDigest.getInstance("SHA-256")
+        .digest(value.toByteArray(Charsets.UTF_8))
+        .joinToString("") { "%02x".format(it) }
+
+    private fun invalid(message: String): Nothing = throw ApiErrorException.BadRequestException(message)
+}

--- a/apps/lumi-api/src/main/resources/db/migration/V15__survey_authoring_revisions.sql
+++ b/apps/lumi-api/src/main/resources/db/migration/V15__survey_authoring_revisions.sql
@@ -1,0 +1,35 @@
+-- Immutable handoff snapshots from Surveyverkstedet. Revisions are authoring
+-- artifacts only and remain separate from production survey_definitions.
+
+CREATE TABLE survey_authoring_revisions (
+    id                UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    project_id        UUID NOT NULL REFERENCES survey_authoring_projects(id) ON DELETE CASCADE,
+    revision_number   BIGINT NOT NULL CHECK (revision_number > 0),
+    draft_version     BIGINT NOT NULL CHECK (draft_version > 0),
+    name              VARCHAR(120) NOT NULL,
+    survey_id         VARCHAR(200) NOT NULL,
+    document          JSONB NOT NULL,
+    document_hash     VARCHAR(64) NOT NULL,
+    definition        JSONB NOT NULL,
+    definition_hash   VARCHAR(64) NOT NULL,
+    created_by        TEXT NOT NULL,
+    created_at        TIMESTAMPTZ NOT NULL DEFAULT now(),
+    CONSTRAINT uq_survey_authoring_revision_number
+        UNIQUE (project_id, revision_number),
+    CONSTRAINT chk_survey_authoring_revision_document_object
+        CHECK (jsonb_typeof(document) = 'object'),
+    CONSTRAINT chk_survey_authoring_revision_schema_v1
+        CHECK (document ->> 'authoringSchemaVersion' = '1'),
+    CONSTRAINT chk_survey_authoring_revision_definition_object
+        CHECK (jsonb_typeof(definition) = 'object'),
+    CONSTRAINT chk_survey_authoring_revision_document_hash
+        CHECK (document_hash ~ '^[0-9a-f]{64}$'),
+    CONSTRAINT chk_survey_authoring_revision_definition_hash
+        CHECK (definition_hash ~ '^[0-9a-f]{64}$')
+);
+
+CREATE INDEX idx_survey_authoring_revisions_project_created
+    ON survey_authoring_revisions(project_id, revision_number DESC);
+
+CREATE INDEX idx_survey_authoring_revisions_project_survey
+    ON survey_authoring_revisions(project_id, survey_id, revision_number DESC);

--- a/apps/lumi-api/src/test/kotlin/no/nav/lumi/TestDatabase.kt
+++ b/apps/lumi-api/src/test/kotlin/no/nav/lumi/TestDatabase.kt
@@ -82,7 +82,7 @@ object TestDatabase {
             conn.createStatement().use { stmt ->
                 stmt.execute(
                     "TRUNCATE TABLE rating_marker, feedback, survey_definitions, survey_metadata, " +
-                        "survey_authoring_projects CASCADE"
+                        "survey_authoring_revisions, survey_authoring_projects CASCADE"
                 )
             }
             conn.commit()

--- a/apps/lumi-api/src/test/kotlin/no/nav/lumi/routes/SurveyAuthoringRoutesTest.kt
+++ b/apps/lumi-api/src/test/kotlin/no/nav/lumi/routes/SurveyAuthoringRoutesTest.kt
@@ -190,6 +190,199 @@ class SurveyAuthoringRoutesTest : FunSpec({
             response.status shouldBe HttpStatusCode.PayloadTooLarge
         }
     }
+
+    test("creates immutable revisions and exposes the previous snapshot") {
+        testApplication {
+            application { testModule() }
+            val client = createTestClient()
+            val created = client.post("/api/v1/intern/authoring/projects?team=team-test") {
+                header(HttpHeaders.Authorization, "Bearer test-token")
+                contentType(ContentType.Application.Json)
+                setBody(createBody())
+            }
+            val projectId = Json.parseToJsonElement(created.bodyAsText()).jsonObject
+                .getValue("id").jsonPrimitive.content
+
+            val firstRevision = client.post(
+                "/api/v1/intern/authoring/projects/$projectId/revisions?team=team-test",
+            ) {
+                header(HttpHeaders.Authorization, "Bearer test-token")
+                contentType(ContentType.Application.Json)
+                setBody("""{"expectedDraftVersion":1}""")
+            }
+            firstRevision.status shouldBe HttpStatusCode.Created
+            val firstJson = Json.parseToJsonElement(firstRevision.bodyAsText()).jsonObject
+            val firstRevisionId = firstJson.getValue("id").jsonPrimitive.content
+            val firstDefinitionHash = firstJson.getValue("definitionHash").jsonPrimitive.content
+            firstJson.getValue("revisionNumber").jsonPrimitive.content shouldBe "1"
+            firstJson.getValue("documentHash").jsonPrimitive.content.length shouldBe 64
+
+            val updated = client.put(
+                "/api/v1/intern/authoring/projects/$projectId/draft?team=team-test",
+            ) {
+                header(HttpHeaders.Authorization, "Bearer test-token")
+                contentType(ContentType.Application.Json)
+                setBody(updateBody(expectedVersion = 1, name = "Ny tekst"))
+            }
+            updated.status shouldBe HttpStatusCode.OK
+
+            val secondRevision = client.post(
+                "/api/v1/intern/authoring/projects/$projectId/revisions?team=team-test",
+            ) {
+                header(HttpHeaders.Authorization, "Bearer test-token")
+                contentType(ContentType.Application.Json)
+                setBody("""{"expectedDraftVersion":2}""")
+            }
+            secondRevision.status shouldBe HttpStatusCode.Created
+            val secondJson = Json.parseToJsonElement(secondRevision.bodyAsText()).jsonObject
+            val secondRevisionId = secondJson.getValue("id").jsonPrimitive.content
+            secondJson.getValue("revisionNumber").jsonPrimitive.content shouldBe "2"
+            secondJson.getValue("definitionHash").jsonPrimitive.content shouldBe firstDefinitionHash
+
+            val listed = client.get(
+                "/api/v1/intern/authoring/projects/$projectId/revisions?team=team-test",
+            ) {
+                header(HttpHeaders.Authorization, "Bearer test-token")
+            }
+            listed.status shouldBe HttpStatusCode.OK
+            val listedJson = Json.parseToJsonElement(listed.bodyAsText()).jsonArray
+            listedJson.size shouldBe 2
+            listedJson.first().jsonObject
+                .getValue("id").jsonPrimitive.content shouldBe secondRevisionId
+
+            val detail = client.get(
+                "/api/v1/intern/authoring/revisions/$secondRevisionId?team=team-test",
+            ) {
+                header(HttpHeaders.Authorization, "Bearer test-token")
+            }
+            detail.status shouldBe HttpStatusCode.OK
+            val detailJson = Json.parseToJsonElement(detail.bodyAsText()).jsonObject
+            detailJson.getValue("previousRevision").jsonObject
+                .getValue("id").jsonPrimitive.content shouldBe firstRevisionId
+            detailJson.getValue("revision").jsonObject
+                .getValue("name").jsonPrimitive.content shouldBe "Ny tekst"
+
+            val firstAfterDraftChange = client.get(
+                "/api/v1/intern/authoring/revisions/$firstRevisionId?team=team-test",
+            ) {
+                header(HttpHeaders.Authorization, "Bearer test-token")
+            }
+            firstAfterDraftChange.status shouldBe HttpStatusCode.OK
+            Json.parseToJsonElement(firstAfterDraftChange.bodyAsText()).jsonObject
+                .getValue("revision").jsonObject
+                .getValue("name").jsonPrimitive.content shouldBe "Første utkast"
+        }
+    }
+
+    test("revision creation rejects invalid drafts and stale versions") {
+        testApplication {
+            application { testModule() }
+            val client = createTestClient()
+            val created = client.post("/api/v1/intern/authoring/projects?team=team-test") {
+                header(HttpHeaders.Authorization, "Bearer test-token")
+                contentType(ContentType.Application.Json)
+                setBody(
+                    """
+                    {
+                      "name": "Påbegynt",
+                      "surveyId": "invalid-draft",
+                      "document": {"authoringSchemaVersion": 1, "pages": []}
+                    }
+                    """.trimIndent(),
+                )
+            }
+            val projectId = Json.parseToJsonElement(created.bodyAsText()).jsonObject
+                .getValue("id").jsonPrimitive.content
+
+            val invalid = client.post(
+                "/api/v1/intern/authoring/projects/$projectId/revisions?team=team-test",
+            ) {
+                header(HttpHeaders.Authorization, "Bearer test-token")
+                contentType(ContentType.Application.Json)
+                setBody("""{"expectedDraftVersion":1}""")
+            }
+            invalid.status shouldBe HttpStatusCode.BadRequest
+
+            val stale = client.post(
+                "/api/v1/intern/authoring/projects/$projectId/revisions?team=team-test",
+            ) {
+                header(HttpHeaders.Authorization, "Bearer test-token")
+                contentType(ContentType.Application.Json)
+                setBody("""{"expectedDraftVersion":2}""")
+            }
+            stale.status shouldBe HttpStatusCode.Conflict
+        }
+    }
+
+    test("structural changes require a new survey id before a new revision") {
+        testApplication {
+            application { testModule() }
+            val client = createTestClient()
+            val created = client.post("/api/v1/intern/authoring/projects?team=team-test") {
+                header(HttpHeaders.Authorization, "Bearer test-token")
+                contentType(ContentType.Application.Json)
+                setBody(createBody())
+            }
+            val projectId = Json.parseToJsonElement(created.bodyAsText()).jsonObject
+                .getValue("id").jsonPrimitive.content
+            client.post("/api/v1/intern/authoring/projects/$projectId/revisions?team=team-test") {
+                header(HttpHeaders.Authorization, "Bearer test-token")
+                contentType(ContentType.Application.Json)
+                setBody("""{"expectedDraftVersion":1}""")
+            }.status shouldBe HttpStatusCode.Created
+
+            client.put("/api/v1/intern/authoring/projects/$projectId/draft?team=team-test") {
+                header(HttpHeaders.Authorization, "Bearer test-token")
+                contentType(ContentType.Application.Json)
+                setBody(structuralUpdateBody(expectedVersion = 1, surveyId = "verksted-test"))
+            }.status shouldBe HttpStatusCode.OK
+
+            client.post("/api/v1/intern/authoring/projects/$projectId/revisions?team=team-test") {
+                header(HttpHeaders.Authorization, "Bearer test-token")
+                contentType(ContentType.Application.Json)
+                setBody("""{"expectedDraftVersion":2}""")
+            }.status shouldBe HttpStatusCode.Conflict
+
+            client.put("/api/v1/intern/authoring/projects/$projectId/draft?team=team-test") {
+                header(HttpHeaders.Authorization, "Bearer test-token")
+                contentType(ContentType.Application.Json)
+                setBody(structuralUpdateBody(expectedVersion = 2, surveyId = "verksted-test-v2"))
+            }.status shouldBe HttpStatusCode.OK
+
+            client.post("/api/v1/intern/authoring/projects/$projectId/revisions?team=team-test") {
+                header(HttpHeaders.Authorization, "Bearer test-token")
+                contentType(ContentType.Application.Json)
+                setBody("""{"expectedDraftVersion":3}""")
+            }.status shouldBe HttpStatusCode.Created
+        }
+    }
+
+    test("revision links are team scoped") {
+        testApplication {
+            application { testModule() }
+            val client = createTestClient()
+            val created = client.post("/api/v1/intern/authoring/projects?team=team-test") {
+                header(HttpHeaders.Authorization, "Bearer test-token")
+                contentType(ContentType.Application.Json)
+                setBody(createBody())
+            }
+            val projectId = Json.parseToJsonElement(created.bodyAsText()).jsonObject
+                .getValue("id").jsonPrimitive.content
+            val revision = client.post(
+                "/api/v1/intern/authoring/projects/$projectId/revisions?team=team-test",
+            ) {
+                header(HttpHeaders.Authorization, "Bearer test-token")
+                contentType(ContentType.Application.Json)
+                setBody("""{"expectedDraftVersion":1}""")
+            }
+            val revisionId = Json.parseToJsonElement(revision.bodyAsText()).jsonObject
+                .getValue("id").jsonPrimitive.content
+
+            client.get("/api/v1/intern/authoring/revisions/$revisionId?team=flex") {
+                header(HttpHeaders.Authorization, "Bearer test-token")
+            }.status shouldBe HttpStatusCode.NotFound
+        }
+    }
 })
 
 private fun createBody() = """
@@ -227,6 +420,26 @@ private fun updateBody(expectedVersion: Long, name: String) = """
             "id": "rating",
             "type": "rating",
             "prompt": "Hvordan gikk det?"
+          }]
+        }]
+      }
+    }
+""".trimIndent()
+
+private fun structuralUpdateBody(expectedVersion: Long, surveyId: String) = """
+    {
+      "expectedVersion": $expectedVersion,
+      "name": "Endret struktur",
+      "surveyId": "$surveyId",
+      "document": {
+        "authoringSchemaVersion": 1,
+        "type": "rating",
+        "pages": [{
+          "id": "opplevelse",
+          "questions": [{
+            "id": "rating",
+            "type": "text",
+            "prompt": "Beskriv opplevelsen"
           }]
         }]
       }

--- a/apps/lumi-api/src/test/kotlin/no/nav/lumi/validation/SurveyAuthoringDocumentValidatorTest.kt
+++ b/apps/lumi-api/src/test/kotlin/no/nav/lumi/validation/SurveyAuthoringDocumentValidatorTest.kt
@@ -1,0 +1,164 @@
+package no.nav.lumi.validation
+
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.collections.shouldContainExactly
+import io.kotest.matchers.shouldBe
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.jsonObject
+import no.nav.lumi.config.exception.ApiErrorException
+import no.nav.lumi.domain.FieldType
+import no.nav.lumi.domain.computeHash
+
+class SurveyAuthoringDocumentValidatorTest : FunSpec({
+    test("validates the full V1 question surface and derives the analytics definition") {
+        val validated = SurveyAuthoringDocumentValidator.validate(validDocument(), "survey-v1")
+
+        validated.documentHash.length shouldBe 64
+        validated.definition.surveyId shouldBe "survey-v1"
+        validated.definition.fields.map { it.fieldType } shouldContainExactly listOf(
+            FieldType.RATING,
+            FieldType.SINGLE_CHOICE,
+            FieldType.MULTI_CHOICE,
+            FieldType.TEXT,
+        )
+        validated.definition.fields[1].optionIds shouldContainExactly listOf("yes", "no")
+    }
+
+    test("text changes alter document hash without altering definition hash") {
+        val original = SurveyAuthoringDocumentValidator.validate(validDocument(), "survey-v1")
+        val changed = SurveyAuthoringDocumentValidator.validate(
+            validDocument().let { document ->
+                Json.parseToJsonElement(
+                    document.toString().replace("Hvordan gikk det?", "Hvordan var opplevelsen?"),
+                ).jsonObject
+            },
+            "survey-v1",
+        )
+
+        (changed.documentHash == original.documentHash) shouldBe false
+        changed.definition.computeHash() shouldBe original.definition.computeHash()
+    }
+
+    test("document hash is independent of object key order") {
+        val original = SurveyAuthoringDocumentValidator.validate(validDocument(), "survey-v1")
+        val reordered = Json.parseToJsonElement(
+            """
+            {
+              "pages": ${validDocument().getValue("pages")},
+              "type": "rating",
+              "authoringSchemaVersion": 1
+            }
+            """.trimIndent(),
+        ).jsonObject
+
+        SurveyAuthoringDocumentValidator.validate(reordered, "survey-v1").documentHash shouldBe
+            original.documentHash
+    }
+
+    test("rejects forward visibleIf references") {
+        val invalid = Json.parseToJsonElement(
+            """
+            {
+              "authoringSchemaVersion": 1,
+              "pages": [{
+                "id": "page",
+                "questions": [
+                  {
+                    "id": "first",
+                    "type": "text",
+                    "prompt": "First",
+                    "visibleIf": {"questionId": "later", "operator": "EXISTS"}
+                  },
+                  {"id": "later", "type": "text", "prompt": "Later"}
+                ]
+              }]
+            }
+            """.trimIndent(),
+        ).jsonObject
+
+        shouldThrow<ApiErrorException.BadRequestException> {
+            SurveyAuthoringDocumentValidator.validate(invalid, "survey-v1")
+        }.errorMessage shouldBe "Question 'first' visibleIf may only reference an earlier question"
+    }
+
+    test("rejects malformed variant-specific fields") {
+        val invalid = Json.parseToJsonElement(
+            """
+            {
+              "authoringSchemaVersion": 1,
+              "pages": [{
+                "id": "page",
+                "questions": [{
+                  "id": "rating",
+                  "type": "rating",
+                  "prompt": "Rating",
+                  "lowLabel": {}
+                }]
+              }]
+            }
+            """.trimIndent(),
+        ).jsonObject
+
+        shouldThrow<ApiErrorException.BadRequestException> {
+            SurveyAuthoringDocumentValidator.validate(invalid, "survey-v1")
+        }.errorMessage shouldBe "Rating question 'rating' has a non-string lowLabel"
+    }
+})
+
+private fun validDocument(): JsonObject = Json.parseToJsonElement(
+    """
+    {
+      "authoringSchemaVersion": 1,
+      "type": "rating",
+      "pages": [
+        {
+          "id": "rating-page",
+          "title": "Opplevelsen",
+          "questions": [
+            {
+              "id": "rating",
+              "type": "rating",
+              "prompt": "Hvordan gikk det?",
+              "variant": "nps",
+              "lowLabel": "Dårlig",
+              "highLabel": "Bra",
+              "labels": [{"value": 0, "label": "Ikke sannsynlig"}]
+            },
+            {
+              "id": "choice",
+              "type": "singleChoice",
+              "prompt": "Vil du svare?",
+              "options": [
+                {"value": "yes", "label": "Ja"},
+                {"value": "no", "label": "Nei"}
+              ],
+              "visibleIf": {"questionId": "rating", "operator": "GT", "value": 3}
+            },
+            {
+              "id": "topics",
+              "type": "multiChoice",
+              "prompt": "Tema",
+              "options": [
+                {"value": "speed", "label": "Fart"},
+                {"value": "content", "label": "Innhold"}
+              ],
+              "variant": "combobox",
+              "maxSelections": 2,
+              "randomize": false
+            },
+            {
+              "id": "comment",
+              "type": "text",
+              "prompt": "Kommentar",
+              "maxLength": 1000,
+              "minRows": 4,
+              "visibleIf": {"field": "METADATA", "key": "country", "operator": "EXISTS"}
+            }
+          ]
+        }
+      ]
+    }
+    """.trimIndent(),
+).jsonObject

--- a/apps/lumi-dashboard/app/mock/surveyAuthoring.ts
+++ b/apps/lumi-dashboard/app/mock/surveyAuthoring.ts
@@ -1,10 +1,21 @@
-import type { SurveyDocumentV1 } from "@navikt/lumi-survey";
+import {
+  type SurveyDocumentV1,
+  validateSurveyDocumentV1,
+} from "@navikt/lumi-survey";
 import type {
   SurveyAuthoringProject,
   SurveyAuthoringProjectSummary,
+  SurveyAuthoringRevision,
+  SurveyAuthoringRevisionDetail,
+  SurveyAuthoringRevisionSummary,
 } from "~/types/surveyAuthoring";
+import {
+  analyticalStructure,
+  serializeSurveyDocumentJson,
+} from "~/utils/surveyRevision";
 
 const projects = new Map<string, SurveyAuthoringProject>();
+const revisions = new Map<string, SurveyAuthoringRevision>();
 
 export function listMockSurveyProjects(
   team: string,
@@ -70,4 +81,92 @@ export function saveMockSurveyProject(input: {
   };
   projects.set(updated.id, updated);
   return structuredClone(updated);
+}
+
+export function listMockSurveyRevisions(
+  team: string,
+  projectId: string,
+): SurveyAuthoringRevisionSummary[] {
+  const project = projects.get(projectId);
+  if (!project || project.team !== team)
+    throw new Error("Survey project not found");
+  return [...revisions.values()]
+    .filter((revision) => revision.projectId === projectId)
+    .sort((a, b) => b.revisionNumber - a.revisionNumber)
+    .map(({ document: _document, ...summary }) => structuredClone(summary));
+}
+
+export async function createMockSurveyRevision(input: {
+  team: string;
+  projectId: string;
+  expectedDraftVersion: number;
+}): Promise<SurveyAuthoringRevision> {
+  const project = projects.get(input.projectId);
+  if (!project || project.team !== input.team)
+    throw new Error("Survey project not found");
+  if (project.draftVersion !== input.expectedDraftVersion) {
+    throw new Error("Draft changed since it was validated");
+  }
+  const document = validateSurveyDocumentV1(structuredClone(project.document));
+  const projectRevisions = [...revisions.values()]
+    .filter((revision) => revision.projectId === project.id)
+    .sort((a, b) => b.revisionNumber - a.revisionNumber);
+  const previousForSurvey = projectRevisions.find(
+    (revision) => revision.surveyId === project.surveyId,
+  );
+  if (
+    previousForSurvey &&
+    analyticalStructure(previousForSurvey.document) !==
+      analyticalStructure(document)
+  ) {
+    throw new Error("Survey structure differs from the previous revision");
+  }
+
+  const documentHash = await sha256(serializeSurveyDocumentJson(document));
+  const definitionHash = await sha256(analyticalStructure(document));
+  const revision: SurveyAuthoringRevision = {
+    id: crypto.randomUUID(),
+    projectId: project.id,
+    revisionNumber: (projectRevisions[0]?.revisionNumber ?? 0) + 1,
+    draftVersion: project.draftVersion,
+    name: project.name,
+    surveyId: project.surveyId,
+    document: structuredClone(document),
+    documentHash,
+    definitionHash,
+    createdBy: "A123456",
+    createdAt: new Date().toISOString(),
+  };
+  revisions.set(revision.id, revision);
+  return structuredClone(revision);
+}
+
+export function getMockSurveyRevisionDetail(
+  team: string,
+  revisionId: string,
+): SurveyAuthoringRevisionDetail | undefined {
+  const revision = revisions.get(revisionId);
+  const project = revision ? projects.get(revision.projectId) : undefined;
+  if (!revision || !project || project.team !== team) return undefined;
+  const previousRevision = [...revisions.values()]
+    .filter(
+      (candidate) =>
+        candidate.projectId === revision.projectId &&
+        candidate.revisionNumber < revision.revisionNumber,
+    )
+    .sort((a, b) => b.revisionNumber - a.revisionNumber)[0];
+  return structuredClone({
+    revision,
+    previousRevision: previousRevision ?? null,
+  });
+}
+
+async function sha256(value: string): Promise<string> {
+  const digest = await crypto.subtle.digest(
+    "SHA-256",
+    new TextEncoder().encode(value),
+  );
+  return [...new Uint8Array(digest)]
+    .map((byte) => byte.toString(16).padStart(2, "0"))
+    .join("");
 }

--- a/apps/lumi-dashboard/app/routeTree.gen.ts
+++ b/apps/lumi-dashboard/app/routeTree.gen.ts
@@ -16,6 +16,7 @@ import { Route as ExportRouteImport } from './routes/export'
 import { Route as IndexRouteImport } from './routes/index'
 import { Route as SurveyverkstedIndexRouteImport } from './routes/surveyverksted.index'
 import { Route as SurveyverkstedProjectIdRouteImport } from './routes/surveyverksted.$projectId'
+import { Route as SurveyverkstedRevisionsRevisionIdRouteImport } from './routes/surveyverksted.revisions.$revisionId'
 import { Route as ApiInternalMetricsRouteImport } from './routes/api/internal/metrics'
 import { Route as ApiInternalIsReadyRouteImport } from './routes/api/internal/isReady'
 import { Route as ApiInternalIsAliveRouteImport } from './routes/api/internal/isAlive'
@@ -55,6 +56,12 @@ const SurveyverkstedProjectIdRoute = SurveyverkstedProjectIdRouteImport.update({
   path: '/$projectId',
   getParentRoute: () => SurveyverkstedRoute,
 } as any)
+const SurveyverkstedRevisionsRevisionIdRoute =
+  SurveyverkstedRevisionsRevisionIdRouteImport.update({
+    id: '/revisions/$revisionId',
+    path: '/revisions/$revisionId',
+    getParentRoute: () => SurveyverkstedRoute,
+  } as any)
 const ApiInternalMetricsRoute = ApiInternalMetricsRouteImport.update({
   id: '/api/internal/metrics',
   path: '/api/internal/metrics',
@@ -82,6 +89,7 @@ export interface FileRoutesByFullPath {
   '/api/internal/isAlive': typeof ApiInternalIsAliveRoute
   '/api/internal/isReady': typeof ApiInternalIsReadyRoute
   '/api/internal/metrics': typeof ApiInternalMetricsRoute
+  '/surveyverksted/revisions/$revisionId': typeof SurveyverkstedRevisionsRevisionIdRoute
 }
 export interface FileRoutesByTo {
   '/': typeof IndexRoute
@@ -93,6 +101,7 @@ export interface FileRoutesByTo {
   '/api/internal/isAlive': typeof ApiInternalIsAliveRoute
   '/api/internal/isReady': typeof ApiInternalIsReadyRoute
   '/api/internal/metrics': typeof ApiInternalMetricsRoute
+  '/surveyverksted/revisions/$revisionId': typeof SurveyverkstedRevisionsRevisionIdRoute
 }
 export interface FileRoutesById {
   __root__: typeof rootRouteImport
@@ -106,6 +115,7 @@ export interface FileRoutesById {
   '/api/internal/isAlive': typeof ApiInternalIsAliveRoute
   '/api/internal/isReady': typeof ApiInternalIsReadyRoute
   '/api/internal/metrics': typeof ApiInternalMetricsRoute
+  '/surveyverksted/revisions/$revisionId': typeof SurveyverkstedRevisionsRevisionIdRoute
 }
 export interface FileRouteTypes {
   fileRoutesByFullPath: FileRoutesByFullPath
@@ -120,6 +130,7 @@ export interface FileRouteTypes {
     | '/api/internal/isAlive'
     | '/api/internal/isReady'
     | '/api/internal/metrics'
+    | '/surveyverksted/revisions/$revisionId'
   fileRoutesByTo: FileRoutesByTo
   to:
     | '/'
@@ -131,6 +142,7 @@ export interface FileRouteTypes {
     | '/api/internal/isAlive'
     | '/api/internal/isReady'
     | '/api/internal/metrics'
+    | '/surveyverksted/revisions/$revisionId'
   id:
     | '__root__'
     | '/'
@@ -143,6 +155,7 @@ export interface FileRouteTypes {
     | '/api/internal/isAlive'
     | '/api/internal/isReady'
     | '/api/internal/metrics'
+    | '/surveyverksted/revisions/$revisionId'
   fileRoutesById: FileRoutesById
 }
 export interface RootRouteChildren {
@@ -207,6 +220,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof SurveyverkstedProjectIdRouteImport
       parentRoute: typeof SurveyverkstedRoute
     }
+    '/surveyverksted/revisions/$revisionId': {
+      id: '/surveyverksted/revisions/$revisionId'
+      path: '/revisions/$revisionId'
+      fullPath: '/surveyverksted/revisions/$revisionId'
+      preLoaderRoute: typeof SurveyverkstedRevisionsRevisionIdRouteImport
+      parentRoute: typeof SurveyverkstedRoute
+    }
     '/api/internal/metrics': {
       id: '/api/internal/metrics'
       path: '/api/internal/metrics'
@@ -234,11 +254,14 @@ declare module '@tanstack/react-router' {
 interface SurveyverkstedRouteChildren {
   SurveyverkstedProjectIdRoute: typeof SurveyverkstedProjectIdRoute
   SurveyverkstedIndexRoute: typeof SurveyverkstedIndexRoute
+  SurveyverkstedRevisionsRevisionIdRoute: typeof SurveyverkstedRevisionsRevisionIdRoute
 }
 
 const SurveyverkstedRouteChildren: SurveyverkstedRouteChildren = {
   SurveyverkstedProjectIdRoute: SurveyverkstedProjectIdRoute,
   SurveyverkstedIndexRoute: SurveyverkstedIndexRoute,
+  SurveyverkstedRevisionsRevisionIdRoute:
+    SurveyverkstedRevisionsRevisionIdRoute,
 }
 
 const SurveyverkstedRouteWithChildren = SurveyverkstedRoute._addFileChildren(

--- a/apps/lumi-dashboard/app/routes/surveyverksted-editor.module.css
+++ b/apps/lumi-dashboard/app/routes/surveyverksted-editor.module.css
@@ -101,6 +101,34 @@
   width: 100%;
 }
 
+.revisionDivider {
+  height: 1px;
+  background: var(--ax-border-neutral-subtle);
+}
+
+.revisionList {
+  display: flex;
+  flex-direction: column;
+  gap: var(--ax-space-8);
+  padding: 0;
+  margin: 0;
+  list-style: none;
+}
+
+.revisionList li {
+  display: flex;
+  justify-content: space-between;
+  gap: var(--ax-space-8);
+  font-size: var(--ax-font-size-small);
+}
+
+.revisionList span {
+  overflow: hidden;
+  color: var(--ax-text-neutral-subtle);
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
 .pageList {
   display: flex;
   flex-direction: column;

--- a/apps/lumi-dashboard/app/routes/surveyverksted-revision.module.css
+++ b/apps/lumi-dashboard/app/routes/surveyverksted-revision.module.css
@@ -1,0 +1,218 @@
+.centered {
+  min-height: 50vh;
+  display: grid;
+  place-content: center;
+}
+
+.revisionSurface {
+  --revision-rule: 3px solid var(--ax-border-neutral-strong);
+  min-height: calc(100vh - 64px);
+  padding: var(--ax-space-24) max(var(--ax-space-16), calc((100vw - 76rem) / 2));
+  background: var(--ax-bg-neutral-soft);
+}
+
+.topline {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: var(--ax-space-16);
+  padding-block-end: var(--ax-space-16);
+  border-bottom: 1px solid var(--ax-border-neutral-subtle);
+}
+
+.backLink {
+  color: var(--ax-text-accent);
+  font-weight: 600;
+}
+
+.backLink:focus-visible {
+  outline: 3px solid var(--ax-border-focus);
+  outline-offset: 3px;
+}
+
+.hero {
+  display: grid;
+  grid-template-columns: minmax(7rem, 0.35fr) minmax(20rem, 1.65fr);
+  gap: var(--ax-space-24);
+  align-items: end;
+  padding-block: var(--ax-space-48);
+  border-bottom: var(--revision-rule);
+}
+
+.revisionMark {
+  color: var(--ax-text-neutral-subtle);
+  font-size: clamp(5rem, 13vw, 10rem);
+  font-weight: 700;
+  line-height: 0.72;
+  letter-spacing: -0.1em;
+  font-variant-numeric: tabular-nums;
+}
+
+.heroCopy {
+  max-width: 48rem;
+}
+
+.contentGrid {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) minmax(18rem, 22rem);
+  gap: var(--ax-space-48);
+  align-items: start;
+  padding-block: var(--ax-space-40) var(--ax-space-64);
+}
+
+.mainColumn > section {
+  padding-block-end: var(--ax-space-32);
+  border-bottom: 1px solid var(--ax-border-neutral-subtle);
+}
+
+.previewStage {
+  position: relative;
+  min-height: 14rem;
+  display: grid;
+  place-content: center;
+  margin-block-start: var(--ax-space-16);
+  padding: var(--ax-space-32);
+  text-align: center;
+  background:
+    linear-gradient(var(--ax-border-neutral-subtle) 1px, transparent 1px),
+    linear-gradient(90deg, var(--ax-border-neutral-subtle) 1px, transparent 1px),
+    var(--ax-bg-default);
+  background-size: 24px 24px;
+  border: 1px solid var(--ax-border-neutral-subtle);
+  border-radius: var(--ax-radius-8);
+}
+
+.previewEyebrow {
+  position: absolute;
+  top: var(--ax-space-12);
+  left: var(--ax-space-12);
+  padding: var(--ax-space-4) var(--ax-space-8);
+  color: var(--ax-text-neutral);
+  font-family: monospace;
+  font-size: var(--ax-font-size-small);
+  font-weight: 700;
+  background: var(--ax-bg-warning-soft);
+}
+
+.changeList {
+  display: grid;
+  gap: var(--ax-space-12);
+  padding: 0;
+  margin: 0;
+  list-style: none;
+}
+
+.changeList li {
+  position: relative;
+  padding-inline-start: var(--ax-space-24);
+}
+
+.changeList li::before {
+  position: absolute;
+  left: 0;
+  content: "→";
+  color: var(--ax-text-accent);
+  font-weight: 700;
+}
+
+.exportActions {
+  margin-block: var(--ax-space-16);
+}
+
+.codeDisclosure {
+  overflow: hidden;
+  background: var(--ax-bg-default);
+  border: 1px solid var(--ax-border-neutral-subtle);
+  border-radius: var(--ax-radius-8);
+}
+
+.codeDisclosure summary {
+  padding: var(--ax-space-12) var(--ax-space-16);
+  font-weight: 600;
+  cursor: pointer;
+}
+
+.codeDisclosure summary:focus-visible {
+  outline: 3px solid var(--ax-border-focus);
+  outline-offset: -3px;
+}
+
+.codeScroller {
+  background: var(--ax-bg-neutral-moderate);
+}
+
+.codeScroller pre {
+  padding: var(--ax-space-16);
+  margin: 0;
+  font-size: var(--ax-font-size-small);
+  overflow-wrap: anywhere;
+  white-space: pre-wrap;
+}
+
+.metadata {
+  position: sticky;
+  top: var(--ax-space-16);
+  padding: var(--ax-space-20);
+  background: var(--ax-bg-raised);
+  border-top: var(--revision-rule);
+  box-shadow: var(--ax-shadow-dialog);
+}
+
+.metadata dl {
+  display: grid;
+  gap: var(--ax-space-12);
+  margin-block: 0 var(--ax-space-20);
+}
+
+.metadata dl div {
+  display: grid;
+  grid-template-columns: 7rem 1fr;
+  gap: var(--ax-space-12);
+  padding-block-end: var(--ax-space-8);
+  border-bottom: 1px solid var(--ax-border-neutral-subtle);
+}
+
+.metadata dt {
+  color: var(--ax-text-neutral-subtle);
+  font-size: var(--ax-font-size-small);
+}
+
+.metadata dd {
+  overflow-wrap: anywhere;
+  margin: 0;
+  font-weight: 600;
+}
+
+.hashBlock {
+  margin-block: var(--ax-space-16);
+}
+
+.hashBlock code {
+  display: block;
+  margin-block-start: var(--ax-space-4);
+  overflow-wrap: anywhere;
+  color: var(--ax-text-neutral-subtle);
+  font-size: var(--ax-font-size-small);
+}
+
+@media (max-width: 48rem) {
+  .revisionSurface {
+    padding-inline: var(--ax-space-12);
+  }
+
+  .hero {
+    grid-template-columns: 1fr;
+  }
+
+  .revisionMark {
+    font-size: 5rem;
+  }
+
+  .contentGrid {
+    grid-template-columns: 1fr;
+  }
+
+  .metadata {
+    position: static;
+  }
+}

--- a/apps/lumi-dashboard/app/routes/surveyverksted.$projectId.tsx
+++ b/apps/lumi-dashboard/app/routes/surveyverksted.$projectId.tsx
@@ -17,13 +17,16 @@ import type {
   SurveyPageV1,
   SurveyQuestionV1,
 } from "@navikt/lumi-survey";
-import { useMutation, useQuery } from "@tanstack/react-query";
-import { createFileRoute } from "@tanstack/react-router";
+import { validateSurveyDocumentV1 } from "@navikt/lumi-survey";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { createFileRoute, Link } from "@tanstack/react-router";
 import { zodValidator } from "@tanstack/zod-adapter";
 import { useEffect, useMemo, useState } from "react";
 import { z } from "zod";
 import {
+  createSurveyAuthoringRevisionServerFn,
   fetchSurveyAuthoringProjectServerFn,
+  fetchSurveyAuthoringRevisionsServerFn,
   saveSurveyAuthoringDraftServerFn,
 } from "~/server/actions";
 import type { SurveyAuthoringProject } from "~/types/surveyAuthoring";
@@ -81,6 +84,7 @@ function SurveyWorkshopEditor({
   project: SurveyAuthoringProject;
 }) {
   const navigate = Route.useNavigate();
+  const queryClient = useQueryClient();
   const [draft, setDraft] = useState<EditableDraft>(() => ({
     name: project.name,
     surveyId: project.surveyId,
@@ -97,6 +101,14 @@ function SurveyWorkshopEditor({
   const [selectedPageId, setSelectedPageId] = useState(
     project.document.pages[0].id,
   );
+
+  const revisionsQuery = useQuery({
+    queryKey: ["survey-authoring-revisions", project.team, project.id],
+    queryFn: () =>
+      fetchSurveyAuthoringRevisionsServerFn({
+        data: { team: project.team, projectId: project.id },
+      }),
+  });
 
   const fingerprint = useMemo(() => JSON.stringify(draft), [draft]);
   const hasRequiredMetadata = Boolean(
@@ -154,6 +166,37 @@ function SurveyWorkshopEditor({
     draft.document.pages.find((page) => page.id === selectedPageId) ??
     draft.document.pages[0];
   const isDirty = fingerprint !== savedFingerprint;
+  const validationError = useMemo(() => {
+    try {
+      validateSurveyDocumentV1(draft.document);
+      return null;
+    } catch (error) {
+      return error instanceof Error ? error.message : "Dokumentet er ugyldig";
+    }
+  }, [draft.document]);
+
+  const revisionMutation = useMutation({
+    mutationFn: () => {
+      validateSurveyDocumentV1(draft.document);
+      return createSurveyAuthoringRevisionServerFn({
+        data: {
+          team: project.team,
+          projectId: project.id,
+          expectedDraftVersion: draftVersion,
+        },
+      });
+    },
+    onSuccess: async (revision) => {
+      await queryClient.invalidateQueries({
+        queryKey: ["survey-authoring-revisions", project.team, project.id],
+      });
+      await navigate({
+        to: "/surveyverksted/revisions/$revisionId",
+        params: { revisionId: revision.id },
+        search: { team: project.team },
+      });
+    },
+  });
 
   const updateDocument = (document: SurveyDocumentV1) =>
     setDraft((current) => ({ ...current, document }));
@@ -476,6 +519,69 @@ function SurveyWorkshopEditor({
                 <BodyShort size="small" textColor="subtle">
                   Vent til utkastet er lagret for å se de siste endringene.
                 </BodyShort>
+              ) : null}
+
+              <div className={styles.revisionDivider} />
+              <div>
+                <Heading size="small" level="3" spacing>
+                  Delbar revisjon
+                </Heading>
+                <BodyShort size="small" textColor="subtle">
+                  Fryser den lagrede versjonen til en teamautorisert lenke.
+                  Dette publiserer ikke surveyen.
+                </BodyShort>
+              </div>
+              {validationError ? (
+                <Alert variant="warning" size="small">
+                  Kan ikke opprette revisjon: {validationError}
+                </Alert>
+              ) : (
+                <Alert variant="success" size="small">
+                  Dokumentet er gyldig og klart for handoff.
+                </Alert>
+              )}
+              {revisionMutation.isError ? (
+                <Alert variant="error" size="small">
+                  {revisionMutation.error instanceof Error
+                    ? revisionMutation.error.message
+                    : "Revisjonen kunne ikke opprettes."}
+                </Alert>
+              ) : null}
+              <Button
+                type="button"
+                variant="secondary"
+                className={styles.previewButton}
+                disabled={Boolean(
+                  isDirty ||
+                    saveMutation.isPending ||
+                    validationError ||
+                    !hasRequiredMetadata,
+                )}
+                loading={revisionMutation.isPending}
+                onClick={() => revisionMutation.mutate()}
+              >
+                Opprett delbar revisjon
+              </Button>
+              {revisionsQuery.data?.length ? (
+                <div>
+                  <BodyShort size="small" weight="semibold" spacing>
+                    Tidligere revisjoner
+                  </BodyShort>
+                  <ul className={styles.revisionList}>
+                    {revisionsQuery.data.slice(0, 3).map((revision) => (
+                      <li key={revision.id}>
+                        <Link
+                          to="/surveyverksted/revisions/$revisionId"
+                          params={{ revisionId: revision.id }}
+                          search={{ team: project.team }}
+                        >
+                          Revisjon {revision.revisionNumber}
+                        </Link>
+                        <span>{revision.surveyId}</span>
+                      </li>
+                    ))}
+                  </ul>
+                </div>
               ) : null}
             </VStack>
           </div>

--- a/apps/lumi-dashboard/app/routes/surveyverksted.revisions.$revisionId.tsx
+++ b/apps/lumi-dashboard/app/routes/surveyverksted.revisions.$revisionId.tsx
@@ -1,0 +1,338 @@
+import {
+  Alert,
+  BodyLong,
+  BodyShort,
+  Box,
+  Button,
+  CopyButton,
+  Heading,
+  HStack,
+  Loader,
+  Tag,
+  VStack,
+} from "@navikt/ds-react";
+import {
+  LumiSurveyDock,
+  type LumiSurveyTransport,
+  validateSurveyDocumentV1,
+} from "@navikt/lumi-survey";
+import { useQuery } from "@tanstack/react-query";
+import { createFileRoute, Link } from "@tanstack/react-router";
+import { zodValidator } from "@tanstack/zod-adapter";
+import { useEffect, useMemo, useState } from "react";
+import { z } from "zod";
+import { fetchSurveyAuthoringRevisionServerFn } from "~/server/actions";
+import type { SurveyAuthoringRevisionDetail } from "~/types/surveyAuthoring";
+import {
+  createRevisionMarkdown,
+  describeRevisionChanges,
+  serializeSurveyDocumentJson,
+  serializeSurveyDocumentTypeScript,
+} from "~/utils/surveyRevision";
+import styles from "./surveyverksted-revision.module.css";
+
+const searchSchema = z.object({ team: z.string().min(1) });
+
+const previewTransport: LumiSurveyTransport = {
+  submit: async () => undefined,
+};
+
+export const Route = createFileRoute("/surveyverksted/revisions/$revisionId")({
+  validateSearch: zodValidator(searchSchema),
+  component: SurveyRevisionRoute,
+});
+
+function SurveyRevisionRoute() {
+  const { revisionId } = Route.useParams();
+  const { team } = Route.useSearch();
+  const revisionQuery = useQuery({
+    queryKey: ["survey-authoring-revision", team, revisionId],
+    queryFn: () =>
+      fetchSurveyAuthoringRevisionServerFn({ data: { team, revisionId } }),
+  });
+
+  if (revisionQuery.isPending) {
+    return (
+      <Box as="main" padding="space-32" className={styles.centered}>
+        <Loader size="large" title="Åpner revisjon" />
+      </Box>
+    );
+  }
+
+  if (revisionQuery.isError) {
+    return (
+      <Box as="main" padding="space-32" className="main-container">
+        <Alert variant="error">
+          Revisjonen finnes ikke, eller du har ikke tilgang til teamet.
+        </Alert>
+      </Box>
+    );
+  }
+
+  return <SurveyRevision detail={revisionQuery.data} team={team} />;
+}
+
+function SurveyRevision({
+  detail,
+  team,
+}: {
+  detail: SurveyAuthoringRevisionDetail;
+  team: string;
+}) {
+  const { revision, previousRevision } = detail;
+  const [previewOpen, setPreviewOpen] = useState(false);
+  const [revisionUrl, setRevisionUrl] = useState("");
+
+  useEffect(() => setRevisionUrl(window.location.href), []);
+
+  const validation = useMemo(() => {
+    try {
+      return {
+        document: validateSurveyDocumentV1(revision.document),
+        error: null,
+      };
+    } catch (error) {
+      return {
+        document: null,
+        error: error instanceof Error ? error.message : "Ugyldig dokument",
+      };
+    }
+  }, [revision.document]);
+  const jsonExport = useMemo(
+    () => serializeSurveyDocumentJson(revision.document),
+    [revision.document],
+  );
+  const typeScriptExport = useMemo(
+    () => serializeSurveyDocumentTypeScript(revision.document),
+    [revision.document],
+  );
+  const diff = useMemo(
+    () =>
+      describeRevisionChanges(revision.document, previousRevision?.document),
+    [previousRevision?.document, revision.document],
+  );
+  const markdown = revisionUrl
+    ? createRevisionMarkdown(revision, revisionUrl)
+    : "";
+
+  const downloadJson = () => {
+    const blob = new Blob([jsonExport], { type: "application/json" });
+    const href = URL.createObjectURL(blob);
+    const link = document.createElement("a");
+    link.href = href;
+    link.download = `${safeFilename(revision.surveyId)}-revision-${revision.revisionNumber}.json`;
+    link.click();
+    URL.revokeObjectURL(href);
+  };
+
+  return (
+    <main className={styles.revisionSurface}>
+      <div className={styles.topline}>
+        <Link
+          to="/surveyverksted/$projectId"
+          params={{ projectId: revision.projectId }}
+          search={{ team }}
+          className={styles.backLink}
+        >
+          Tilbake til redigerbart utkast
+        </Link>
+        <Tag variant="success" size="small">
+          Frosset revisjon
+        </Tag>
+      </div>
+
+      <header className={styles.hero}>
+        <div className={styles.revisionMark} aria-hidden>
+          {String(revision.revisionNumber).padStart(2, "0")}
+        </div>
+        <div className={styles.heroCopy}>
+          <BodyShort size="small" textColor="subtle">
+            Delbart authoring-artefakt
+          </BodyShort>
+          <Heading size="xlarge" level="1" spacing>
+            {revision.name}
+          </Heading>
+          <BodyLong size="large">
+            Denne lenken viser nøyaktig innhold fra revisjon{" "}
+            {revision.revisionNumber}. Senere endringer i utkastet påvirker den
+            ikke.
+          </BodyLong>
+        </div>
+      </header>
+
+      <div className={styles.contentGrid}>
+        <VStack gap="space-32" className={styles.mainColumn}>
+          <section aria-labelledby="validation-heading">
+            <Heading id="validation-heading" size="medium" level="2" spacing>
+              Validering
+            </Heading>
+            {validation.error ? (
+              <Alert variant="error">
+                Revisjonen kan ikke brukes av widgeten: {validation.error}
+              </Alert>
+            ) : (
+              <Alert variant="success">
+                Gyldig SurveyDocumentV1. Preview og eksport bruker det frosne
+                dokumentet under.
+              </Alert>
+            )}
+          </section>
+
+          <section aria-labelledby="preview-heading">
+            <HStack justify="space-between" align="end" gap="space-16" wrap>
+              <div>
+                <Heading id="preview-heading" size="medium" level="2" spacing>
+                  Interaktiv preview
+                </Heading>
+                <BodyShort textColor="subtle">
+                  Den ekte widgeten brukes med inert transport. Ingen svar
+                  sendes.
+                </BodyShort>
+              </div>
+              <Button
+                type="button"
+                variant={previewOpen ? "secondary" : "primary"}
+                disabled={!validation.document}
+                onClick={() => setPreviewOpen((open) => !open)}
+              >
+                {previewOpen ? "Avslutt preview" : "Start preview"}
+              </Button>
+            </HStack>
+            <div className={styles.previewStage} aria-live="polite">
+              <span className={styles.previewEyebrow}>
+                INERT / INGEN INNSENDING
+              </span>
+              <BodyLong>
+                {previewOpen
+                  ? "Widgeten er åpnet nederst i vinduet. Prøv hele flyten, og avslutt preview når du er ferdig."
+                  : "Start preview for å prøve det frosne dokumentet i en ekte viewport."}
+              </BodyLong>
+            </div>
+          </section>
+
+          <section aria-labelledby="changes-heading">
+            <Heading id="changes-heading" size="medium" level="2" spacing>
+              Endringer fra forrige revisjon
+            </Heading>
+            <ul className={styles.changeList}>
+              {diff.map((change) => (
+                <li key={change}>{change}</li>
+              ))}
+            </ul>
+          </section>
+
+          <section aria-labelledby="export-heading">
+            <Heading id="export-heading" size="medium" level="2" spacing>
+              Handoff til utvikler
+            </Heading>
+            <BodyShort textColor="subtle" spacing>
+              JSON er round-trip-formatet. TypeScript er en deterministisk
+              presentasjon klar for kodebasen.
+            </BodyShort>
+            <HStack gap="space-8" wrap className={styles.exportActions}>
+              <CopyButton
+                copyText={typeScriptExport}
+                text="Kopier TypeScript"
+                activeText="TypeScript kopiert"
+              />
+              <Button type="button" variant="secondary" onClick={downloadJson}>
+                Last ned JSON
+              </Button>
+              <CopyButton
+                copyText={markdown}
+                text="Kopier som Markdown"
+                activeText="Markdown kopiert"
+                disabled={!revisionUrl}
+              />
+            </HStack>
+            <details className={styles.codeDisclosure}>
+              <summary>Vis TypeScript</summary>
+              <div className={styles.codeScroller}>
+                <pre>
+                  <code>{typeScriptExport}</code>
+                </pre>
+              </div>
+            </details>
+          </section>
+        </VStack>
+
+        <aside className={styles.metadata} aria-labelledby="metadata-heading">
+          <Heading id="metadata-heading" size="small" level="2" spacing>
+            Revisjonsbevis
+          </Heading>
+          <dl>
+            <div>
+              <dt>Revisjon</dt>
+              <dd>{revision.revisionNumber}</dd>
+            </div>
+            <div>
+              <dt>Survey-ID</dt>
+              <dd>{revision.surveyId}</dd>
+            </div>
+            <div>
+              <dt>Opprettet av</dt>
+              <dd>{revision.createdBy}</dd>
+            </div>
+            <div>
+              <dt>Opprettet</dt>
+              <dd>{formatTimestamp(revision.createdAt)}</dd>
+            </div>
+            <div>
+              <dt>Draft-versjon</dt>
+              <dd>{revision.draftVersion}</dd>
+            </div>
+          </dl>
+          <div className={styles.hashBlock}>
+            <BodyShort size="small" weight="semibold">
+              documentHash
+            </BodyShort>
+            <code>{revision.documentHash}</code>
+          </div>
+          <div className={styles.hashBlock}>
+            <BodyShort size="small" weight="semibold">
+              definitionHash
+            </BodyShort>
+            <code>{revision.definitionHash}</code>
+          </div>
+          <Alert variant="info" size="small">
+            Revisjonen er ikke publisert eller live. Git og appens deployløp
+            avgjør hva som kjører i produksjon.
+          </Alert>
+        </aside>
+      </div>
+
+      {previewOpen && validation.document ? (
+        <LumiSurveyDock
+          key={revision.id}
+          surveyId={`revision-preview-${revision.surveyId}`}
+          survey={validation.document}
+          transport={previewTransport}
+          context={{ tags: { environment: "survey-workshop-revision" } }}
+          behavior={{
+            initialOpen: true,
+            hideAfterSubmit: false,
+            questionLayout: "auto",
+            showProgress: true,
+            storageStrategy: "none",
+          }}
+          success={{
+            title: "Preview fullført",
+            body: "Dette var en inert forhåndsvisning. Ingenting ble sendt inn.",
+          }}
+        />
+      ) : null}
+    </main>
+  );
+}
+
+function safeFilename(value: string): string {
+  return value.toLowerCase().replace(/[^a-z0-9_-]+/g, "-") || "survey";
+}
+
+function formatTimestamp(value: string): string {
+  return new Intl.DateTimeFormat("nb-NO", {
+    dateStyle: "medium",
+    timeStyle: "short",
+    timeZone: "Europe/Oslo",
+  }).format(new Date(value));
+}

--- a/apps/lumi-dashboard/app/server/actions/index.ts
+++ b/apps/lumi-dashboard/app/server/actions/index.ts
@@ -43,8 +43,11 @@ export {
 // Survey authoring
 export {
   createSurveyAuthoringProjectServerFn,
+  createSurveyAuthoringRevisionServerFn,
   fetchSurveyAuthoringProjectServerFn,
   fetchSurveyAuthoringProjectsServerFn,
+  fetchSurveyAuthoringRevisionServerFn,
+  fetchSurveyAuthoringRevisionsServerFn,
   saveSurveyAuthoringDraftServerFn,
 } from "./surveyAuthoring";
 // Tags

--- a/apps/lumi-dashboard/app/server/actions/surveyAuthoring.ts
+++ b/apps/lumi-dashboard/app/server/actions/surveyAuthoring.ts
@@ -11,11 +11,16 @@ import {
 import type {
   SurveyAuthoringProject,
   SurveyAuthoringProjectSummary,
+  SurveyAuthoringRevision,
+  SurveyAuthoringRevisionDetail,
+  SurveyAuthoringRevisionSummary,
 } from "~/types/surveyAuthoring";
 import {
   CreateSurveyAuthoringProjectSchema,
+  CreateSurveyAuthoringRevisionSchema,
   SaveSurveyAuthoringDraftSchema,
   SurveyAuthoringProjectIdSchema,
+  SurveyAuthoringRevisionIdSchema,
   SurveyAuthoringTeamSchema,
 } from "~/types/surveyAuthoring";
 import { handleApiResponse } from "../fetchUtils";
@@ -144,3 +149,96 @@ export const saveSurveyAuthoringDraftServerFn = createServerFn({
     await handleApiResponse(response);
     return response.json() as Promise<SurveyAuthoringProject>;
   });
+
+export const fetchSurveyAuthoringRevisionsServerFn = createServerFn({
+  method: "GET",
+})
+  .middleware([authMiddleware])
+  .inputValidator(zodValidator(SurveyAuthoringProjectIdSchema))
+  .handler(
+    async ({ data, context }): Promise<SurveyAuthoringRevisionSummary[]> => {
+      if (isMockMode()) {
+        const { listMockSurveyRevisions } = await import(
+          "~/mock/surveyAuthoring"
+        );
+        await mockDelay();
+        return listMockSurveyRevisions(data.team, data.projectId);
+      }
+
+      const { backendUrl, oboToken } = context as AuthContext;
+      const response = await fetch(
+        buildUrl(
+          backendUrl,
+          `/api/v1/intern/authoring/projects/${encodeURIComponent(data.projectId)}/revisions`,
+          { team: data.team },
+        ),
+        { headers: getHeaders(oboToken) },
+      );
+      await handleApiResponse(response);
+      return response.json() as Promise<SurveyAuthoringRevisionSummary[]>;
+    },
+  );
+
+export const createSurveyAuthoringRevisionServerFn = createServerFn({
+  method: "POST",
+})
+  .middleware([authMiddleware])
+  .inputValidator(zodValidator(CreateSurveyAuthoringRevisionSchema))
+  .handler(async ({ data, context }): Promise<SurveyAuthoringRevision> => {
+    if (isMockMode()) {
+      const { createMockSurveyRevision } = await import(
+        "~/mock/surveyAuthoring"
+      );
+      await mockDelay();
+      return createMockSurveyRevision(data);
+    }
+
+    const { backendUrl, oboToken } = context as AuthContext;
+    const response = await fetch(
+      buildUrl(
+        backendUrl,
+        `/api/v1/intern/authoring/projects/${encodeURIComponent(data.projectId)}/revisions`,
+        { team: data.team },
+      ),
+      {
+        method: "POST",
+        headers: getHeaders(oboToken),
+        body: JSON.stringify({
+          expectedDraftVersion: data.expectedDraftVersion,
+        }),
+      },
+    );
+    await handleApiResponse(response);
+    return response.json() as Promise<SurveyAuthoringRevision>;
+  });
+
+export const fetchSurveyAuthoringRevisionServerFn = createServerFn({
+  method: "GET",
+})
+  .middleware([authMiddleware])
+  .inputValidator(zodValidator(SurveyAuthoringRevisionIdSchema))
+  .handler(
+    async ({ data, context }): Promise<SurveyAuthoringRevisionDetail> => {
+      if (isMockMode()) {
+        const { getMockSurveyRevisionDetail } = await import(
+          "~/mock/surveyAuthoring"
+        );
+        await mockDelay();
+        const detail = getMockSurveyRevisionDetail(data.team, data.revisionId);
+        if (!detail) throw new Error("Survey revision not found");
+        return detail;
+      }
+
+      const { backendUrl, oboToken } = context as AuthContext;
+      const response = await fetch(
+        buildUrl(
+          backendUrl,
+          `/api/v1/intern/authoring/revisions/${encodeURIComponent(data.revisionId)}`,
+          { team: data.team },
+        ),
+        { headers: getHeaders(oboToken) },
+      );
+      await handleApiResponse(response);
+      return response.json() as Promise<SurveyAuthoringRevisionDetail>;
+    },
+  );

--- a/apps/lumi-dashboard/app/types/surveyAuthoring.ts
+++ b/apps/lumi-dashboard/app/types/surveyAuthoring.ts
@@ -17,6 +17,30 @@ export type SurveyAuthoringProjectSummary = Omit<
   "document"
 >;
 
+export interface SurveyAuthoringRevision {
+  id: string;
+  projectId: string;
+  revisionNumber: number;
+  draftVersion: number;
+  name: string;
+  surveyId: string;
+  document: SurveyDocumentV1;
+  documentHash: string;
+  definitionHash: string;
+  createdBy: string;
+  createdAt: string;
+}
+
+export type SurveyAuthoringRevisionSummary = Omit<
+  SurveyAuthoringRevision,
+  "document"
+>;
+
+export interface SurveyAuthoringRevisionDetail {
+  revision: SurveyAuthoringRevision;
+  previousRevision: SurveyAuthoringRevision | null;
+}
+
 const documentSchema = z.custom<SurveyDocumentV1>(
   (value) =>
     Boolean(
@@ -48,3 +72,14 @@ export const SaveSurveyAuthoringDraftSchema =
     projectId: z.string().uuid(),
     expectedVersion: z.number().int().positive(),
   });
+
+export const CreateSurveyAuthoringRevisionSchema =
+  SurveyAuthoringProjectIdSchema.extend({
+    expectedDraftVersion: z.number().int().positive(),
+  });
+
+export const SurveyAuthoringRevisionIdSchema = SurveyAuthoringTeamSchema.extend(
+  {
+    revisionId: z.string().uuid(),
+  },
+);

--- a/apps/lumi-dashboard/app/utils/__tests__/surveyRevision.test.ts
+++ b/apps/lumi-dashboard/app/utils/__tests__/surveyRevision.test.ts
@@ -1,0 +1,130 @@
+import type { SurveyDocumentV1 } from "@navikt/lumi-survey";
+import { describe, expect, it } from "vitest";
+import {
+  analyticalStructure,
+  createRevisionMarkdown,
+  describeRevisionChanges,
+  serializeSurveyDocumentJson,
+  serializeSurveyDocumentTypeScript,
+} from "../surveyRevision";
+
+const document: SurveyDocumentV1 = {
+  authoringSchemaVersion: 1,
+  type: "rating",
+  pages: [
+    {
+      id: "opplevelse",
+      title: "Opplevelsen",
+      questions: [
+        {
+          id: "rating",
+          type: "rating",
+          prompt: "Hvordan gikk det?",
+          required: true,
+        },
+      ],
+    },
+  ],
+};
+
+describe("survey revision exports", () => {
+  it("serializes deterministic JSON and TypeScript", () => {
+    const json = serializeSurveyDocumentJson(document);
+    expect(JSON.parse(json)).toEqual(document);
+    expect(json.indexOf("authoringSchemaVersion")).toBeLessThan(
+      json.indexOf("pages"),
+    );
+    const reorderedKeys = {
+      pages: document.pages,
+      type: document.type,
+      authoringSchemaVersion: 1,
+    } as SurveyDocumentV1;
+    expect(serializeSurveyDocumentJson(reorderedKeys)).toBe(json);
+
+    const typescript = serializeSurveyDocumentTypeScript(document);
+    expect(typescript).toContain(
+      'import type { SurveyDocumentV1 } from "@navikt/lumi-survey";',
+    );
+    expect(typescript).toContain("satisfies SurveyDocumentV1;");
+    expect(typescript).toContain(json.trim());
+  });
+
+  it("normalizes analytical order and rating defaults", () => {
+    const reordered: SurveyDocumentV1 = {
+      ...document,
+      pages: [
+        {
+          ...document.pages[0],
+          questions: [
+            {
+              id: "rating",
+              type: "rating",
+              prompt: "Hvordan gikk det?",
+              required: true,
+              variant: "emoji",
+            },
+          ],
+        },
+      ],
+    };
+    expect(analyticalStructure(reordered)).toBe(analyticalStructure(document));
+  });
+
+  it("describes content changes without treating them as publication state", () => {
+    const changed: SurveyDocumentV1 = {
+      ...document,
+      pages: [
+        {
+          ...document.pages[0],
+          title: "Ny sidetittel",
+          questions: [
+            {
+              ...document.pages[0].questions[0],
+              prompt: "Hvordan opplevde du dette?",
+            },
+          ],
+        },
+      ],
+    };
+
+    expect(describeRevisionChanges(changed, document)).toEqual([
+      "Tittel eller beskrivelse er endret på 1 side(r).",
+      "Teksten er endret i 1 spørsmål.",
+    ]);
+    expect(describeRevisionChanges(document)).toEqual([
+      "Første delbare revisjon i prosjektet.",
+    ]);
+  });
+
+  it("creates a portable markdown link", () => {
+    const revision = {
+      id: "00000000-0000-0000-0000-000000000001",
+      projectId: "00000000-0000-0000-0000-000000000002",
+      revisionNumber: 3,
+      draftVersion: 7,
+      name: "Kvittering",
+      surveyId: "kvittering-v1",
+      document,
+      documentHash: "a".repeat(64),
+      definitionHash: "b".repeat(64),
+      createdBy: "A123456",
+      createdAt: "2026-08-16T12:00:00Z",
+    };
+    const markdown = createRevisionMarkdown(
+      revision,
+      "https://lumi.example/revision/1",
+    );
+
+    expect(markdown).toBe(
+      "[Kvittering – revisjon 3](https://lumi.example/revision/1)",
+    );
+    expect(
+      createRevisionMarkdown(
+        { ...revision, name: "Kvittering [beta]" },
+        "https://lumi.example/revision/1",
+      ),
+    ).toBe(
+      "[Kvittering \\[beta\\] – revisjon 3](https://lumi.example/revision/1)",
+    );
+  });
+});

--- a/apps/lumi-dashboard/app/utils/surveyRevision.ts
+++ b/apps/lumi-dashboard/app/utils/surveyRevision.ts
@@ -1,0 +1,198 @@
+import type {
+  SurveyDocumentV1,
+  SurveyPageV1,
+  SurveyQuestionV1,
+} from "@navikt/lumi-survey";
+import type { SurveyAuthoringRevision } from "~/types/surveyAuthoring";
+
+function sortJson(value: unknown): unknown {
+  if (Array.isArray(value)) return value.map(sortJson);
+  if (value && typeof value === "object") {
+    return Object.fromEntries(
+      Object.entries(value)
+        .sort(([left], [right]) => (left < right ? -1 : left > right ? 1 : 0))
+        .map(([key, child]) => [key, sortJson(child)]),
+    );
+  }
+  return value;
+}
+
+export function serializeSurveyDocumentJson(
+  document: SurveyDocumentV1,
+): string {
+  return `${JSON.stringify(sortJson(document), null, 2)}\n`;
+}
+
+export function serializeSurveyDocumentTypeScript(
+  document: SurveyDocumentV1,
+): string {
+  return [
+    'import type { SurveyDocumentV1 } from "@navikt/lumi-survey";',
+    "",
+    `export const survey = ${JSON.stringify(sortJson(document), null, 2)} satisfies SurveyDocumentV1;`,
+    "",
+  ].join("\n");
+}
+
+export function createRevisionMarkdown(
+  revision: SurveyAuthoringRevision,
+  revisionUrl: string,
+): string {
+  const label =
+    `${revision.name} – revisjon ${revision.revisionNumber}`.replace(
+      /([\\[\]])/g,
+      "\\$1",
+    );
+  return `[${label}](${revisionUrl})`;
+}
+
+interface LocatedQuestion {
+  pageId: string;
+  questionIndex: number;
+  question: SurveyQuestionV1;
+}
+
+function indexQuestions(document: SurveyDocumentV1) {
+  return new Map<string, LocatedQuestion>(
+    document.pages.flatMap((page) =>
+      page.questions.map((question, questionIndex) => [
+        question.id,
+        { pageId: page.id, questionIndex, question },
+      ]),
+    ),
+  );
+}
+
+function withoutText(question: SurveyQuestionV1) {
+  const { prompt: _prompt, description: _description, ...structure } = question;
+  return structure;
+}
+
+function pageText(page: SurveyPageV1) {
+  return { title: page.title, description: page.description };
+}
+
+export function describeRevisionChanges(
+  current: SurveyDocumentV1,
+  previous?: SurveyDocumentV1 | null,
+): string[] {
+  if (!previous) return ["Første delbare revisjon i prosjektet."];
+
+  const changes: string[] = [];
+  if ((current.type ?? "custom") !== (previous.type ?? "custom")) {
+    changes.push(
+      `Surveytype er endret fra ${previous.type ?? "custom"} til ${current.type ?? "custom"}.`,
+    );
+  }
+
+  const currentPages = new Map(current.pages.map((page) => [page.id, page]));
+  const previousPages = new Map(previous.pages.map((page) => [page.id, page]));
+  const addedPages = current.pages.filter(
+    (page) => !previousPages.has(page.id),
+  );
+  const removedPages = previous.pages.filter(
+    (page) => !currentPages.has(page.id),
+  );
+  if (addedPages.length > 0)
+    changes.push(`${addedPages.length} side(r) er lagt til.`);
+  if (removedPages.length > 0)
+    changes.push(`${removedPages.length} side(r) er fjernet.`);
+
+  const currentOrder = current.pages.map((page) => page.id).join("|");
+  const previousOrder = previous.pages.map((page) => page.id).join("|");
+  if (
+    currentOrder !== previousOrder &&
+    addedPages.length === 0 &&
+    removedPages.length === 0
+  ) {
+    changes.push("Rekkefølgen på sidene er endret.");
+  }
+
+  const changedPageText = current.pages.filter((page) => {
+    const previousPage = previousPages.get(page.id);
+    return (
+      previousPage &&
+      JSON.stringify(pageText(page)) !== JSON.stringify(pageText(previousPage))
+    );
+  });
+  if (changedPageText.length > 0) {
+    changes.push(
+      `Tittel eller beskrivelse er endret på ${changedPageText.length} side(r).`,
+    );
+  }
+
+  const currentQuestions = indexQuestions(current);
+  const previousQuestions = indexQuestions(previous);
+  const addedQuestions = [...currentQuestions.keys()].filter(
+    (id) => !previousQuestions.has(id),
+  );
+  const removedQuestions = [...previousQuestions.keys()].filter(
+    (id) => !currentQuestions.has(id),
+  );
+  if (addedQuestions.length > 0)
+    changes.push(`${addedQuestions.length} spørsmål er lagt til.`);
+  if (removedQuestions.length > 0)
+    changes.push(`${removedQuestions.length} spørsmål er fjernet.`);
+
+  let movedQuestions = 0;
+  let changedQuestionText = 0;
+  let changedQuestionStructure = 0;
+  for (const [id, located] of currentQuestions) {
+    const before = previousQuestions.get(id);
+    if (!before) continue;
+    if (
+      before.pageId !== located.pageId ||
+      before.questionIndex !== located.questionIndex
+    ) {
+      movedQuestions += 1;
+    }
+    if (
+      before.question.prompt !== located.question.prompt ||
+      before.question.description !== located.question.description
+    ) {
+      changedQuestionText += 1;
+    }
+    if (
+      JSON.stringify(withoutText(before.question)) !==
+      JSON.stringify(withoutText(located.question))
+    ) {
+      changedQuestionStructure += 1;
+    }
+  }
+  if (movedQuestions > 0)
+    changes.push(`${movedQuestions} spørsmål er flyttet.`);
+  if (changedQuestionText > 0)
+    changes.push(`Teksten er endret i ${changedQuestionText} spørsmål.`);
+  if (changedQuestionStructure > 0)
+    changes.push(
+      `Innstillinger er endret i ${changedQuestionStructure} spørsmål.`,
+    );
+
+  return changes.length > 0
+    ? changes
+    : ["Ingen semantiske endringer oppdaget."];
+}
+
+export function analyticalStructure(document: SurveyDocumentV1): string {
+  return JSON.stringify({
+    type: document.type ?? "custom",
+    fields: document.pages
+      .flatMap((page) =>
+        page.questions.map((question) => ({
+          id: question.id,
+          type: question.type,
+          variant:
+            question.type === "rating"
+              ? (question.variant ?? "emoji")
+              : undefined,
+          options:
+            "options" in question
+              ? question.options.map((option) => option.value)
+              : undefined,
+        })),
+      )
+      .sort((left, right) =>
+        left.id < right.id ? -1 : left.id > right.id ? 1 : 0,
+      ),
+  });
+}

--- a/apps/lumi-dashboard/e2e/survey-workshop.spec.ts
+++ b/apps/lumi-dashboard/e2e/survey-workshop.spec.ts
@@ -1,3 +1,4 @@
+import AxeBuilder from "@axe-core/playwright";
 import { expect, test } from "@playwright/test";
 
 test("creates, saves, reopens and previews a survey draft", async ({
@@ -46,4 +47,39 @@ test("creates, saves, reopens and previews a survey draft", async ({
   });
   await expect(progress).toBeVisible();
   await expect(progress).toHaveAttribute("aria-valuetext", "Steg 1 av 2");
+  await preview.close();
+
+  await page.getByRole("button", { name: "Opprett delbar revisjon" }).click();
+  await expect(page).toHaveURL(
+    /\/surveyverksted\/revisions\/[0-9a-f-]+\?team=team-esyfo/,
+  );
+  await expect(page.getByText("Frosset revisjon")).toBeVisible();
+  await expect(
+    page.getByText("Gyldig SurveyDocumentV1", { exact: false }),
+  ).toBeVisible();
+  await expect(
+    page.getByText("Første delbare revisjon i prosjektet."),
+  ).toBeVisible();
+  await expect(page.getByText("documentHash")).toBeVisible();
+  await expect(
+    page.getByRole("button", { name: "Kopier TypeScript" }),
+  ).toBeVisible();
+  const accessibility = await new AxeBuilder({ page })
+    .withTags(["wcag2a", "wcag2aa", "wcag21a", "wcag21aa"])
+    .analyze();
+  expect(accessibility.violations).toEqual([]);
+
+  const downloadPromise = page.waitForEvent("download");
+  await page.getByRole("button", { name: "Last ned JSON" }).click();
+  const download = await downloadPromise;
+  expect(download.suggestedFilename()).toBe("e2e-survey-v1-revision-1.json");
+
+  await page.getByRole("button", { name: "Start preview" }).click();
+  await expect(
+    page.getByRole("heading", { name: "Detaljer om opplevelsen" }),
+  ).toBeVisible();
+  await page.getByRole("button", { name: "Avslutt preview" }).click();
+  await expect(
+    page.getByRole("heading", { name: "Detaljer om opplevelsen" }),
+  ).not.toBeVisible();
 });

--- a/docs/adr/0004-surveyverksted-er-authoring-ikke-runtime.md
+++ b/docs/adr/0004-surveyverksted-er-authoring-ikke-runtime.md
@@ -31,8 +31,8 @@ konsumenter.
 2. **Draften er ikke en statusmaskin.** Den kan være under arbeid og autosaves.
    UI-et bruker ikke «publisert», «live» eller «overlevert», fordi ingen av
    disse tilstandene kan håndheves av Lumi.
-3. **En eksplisitt authoring-revisjon blir immutable.** Senere slices oppretter
-   revisjoner fra en gyldig draft. En revisjonslenke kan deles i GitHub,
+3. **En eksplisitt authoring-revisjon er immutable.** Revisjoner opprettes fra
+   en gyldig, lagret draft. En revisjonslenke kan deles i GitHub,
    Trello eller Jira og viser preview, diff og deterministisk kodeeksport.
 4. **Produksjon forblir survey-as-code.** Utvikleren tar den eksporterte
    `SurveyDocumentV1` inn i konsumentappen og deployer på vanlig måte. Widgeten
@@ -43,8 +43,8 @@ konsumenter.
 6. **Miljøene synkroniseres ikke.** Produksjon er kanonisk authoring-store;
    utviklingsmiljøets drafts er disposable. Delbare produksjonsrevisjoner er
    teamautoriserte.
-7. **Authoring og analytics har ulike hasher.** En framtidig
-   `authoringDocumentHash` identifiserer hele authoring-revisjonen. Dagens
+7. **Authoring og analytics har ulike hasher.** `documentHash` identifiserer
+   hele authoring-revisjonen. Dagens
    `definitionHash` beskriver bare svarenes analytiske struktur og endres ikke
    av page-titler eller layout.
 
@@ -56,9 +56,16 @@ konsumenter.
 - validere gjennom widgetens offentlige `validateSurveyDocumentV1`
 - åpne en separat, inert forhåndsvisning i den ekte `LumiSurveyDock`
 
-Immutable revisjoner, delbar revisjonslenke, diff og kodeeksport følger som
-egne vertikale slices. Begrensningen er bevisst; første snitt etablerer
-lagrings- og sikkerhetsgrensen de bygger på.
+## Andre vertikale snitt
+
+- opprette en revisjon som et atomisk snapshot av lagret draft-versjon
+- validere `SurveyDocumentV1` og beregne dokument- og definisjonshash i API-et
+- blokkere endret analytisk struktur under samme `surveyId`
+- åpne teamautorisert revisjonslenke med auditdata, diff og inert preview
+- eksportere deterministisk JSON, TypeScript og Markdown-lenke
+
+Revisjoner lagres fortsatt utenfor `survey_definitions`; første reelle
+innsending registrerer fremdeles produksjonens analytiske definisjon.
 
 ## Konsekvenser
 


### PR DESCRIPTION
## Hva

- lagrer immutable, team-scopede authoring-revisjoner fra et lagret draft
- validerer `SurveyDocumentV1` og analytisk struktur på serveren før snapshot
- blokkerer strukturelt inkompatible revisjoner under samme `surveyId`
- viser revisjonshistorikk, auditdata, hashes og semantisk diff i Surveyverkstedet
- tilbyr ekte inert widget-preview samt deterministisk TypeScript, JSON og Markdown-handoff
- dokumenterer at revisjoner er authoring-artefakter, ikke publisering eller runtime-konfigurasjon

## Hvorfor

Designere og produktledere trenger et frosset, delbart resultat etter arbeid i det persistente Surveyverkstedet, mens produksjonsmodellen fortsatt skal være survey-as-code. En revisjon kan derfor deles i teamets eksisterende oppgaveverktøy og committes av utvikleren uten at widgeten får noen ny runtime-avhengighet.

## Sikkerhet og datamodell

- alle revisjonsoperasjoner bruker eksisterende innlogging og teamautorisasjon
- opprettelse tar prosjektlås, sjekker eksakt `draftVersion` og skriver snapshot atomisk
- drafts og revisjoner er adskilt fra `survey_definitions` og feedbackdata
- både `documentHash` og backendens `definitionHash` lagres med ulike formål
- maksimum 500 revisjoner per prosjekt og 256 KiB draftgrense beholdes server-side

## Validering

- `pnpm run lint`
- `pnpm run typecheck`
- `pnpm test`
- `pnpm run e2e` — 35 passed, 1 skipped
- dashboard production build og lokal demo build
- dashboard unit suite — 321 tests
- survey package verification
- full `apps/lumi-api` Gradle test suite
- full submission-proxy Gradle test suite
- målrettede authoring route/validator-tester
- docs build, `docker compose config --quiet` og dependency audit
- axe på revisjonshandoff; to kontrastfunn ble rettet før publisering

Closes #338
