### PR TITLE
Surveyverksted: visibleIf-builder med delt release-gate-semantikk

### DIFF
--- a/apps/lumi-api/src/main/kotlin/no/nav/lumi/validation/SurveyAuthoringDocumentValidator.kt
+++ b/apps/lumi-api/src/main/kotlin/no/nav/lumi/validation/SurveyAuthoringDocumentValidator.kt
@@ -39,6 +39,24 @@ object SurveyAuthoringDocumentValidator {
     private val conditionOperators = setOf("EQ", "NEQ", "GT", "LT", "CONTAINS", "EXISTS")
 
     /**
+     * Operators that can actually match the referenced answer type at
+     * runtime. multiChoice answers are arrays: strict EQ/NEQ never match,
+     * so only EXISTS and CONTAINS are meaningful.
+     */
+    private val conditionOperatorsByType = mapOf(
+        "rating" to setOf("EXISTS", "EQ", "NEQ", "GT", "LT"),
+        "singleChoice" to setOf("EXISTS", "EQ", "NEQ"),
+        "multiChoice" to setOf("EXISTS", "CONTAINS"),
+        "text" to setOf("EXISTS", "EQ", "NEQ", "CONTAINS"),
+    )
+
+    private data class ConditionTargetInfo(
+        val type: String,
+        val optionIds: List<String> = emptyList(),
+        val scale: IntRange? = null,
+    )
+
+    /**
      * Validates the authoring document structure. With [releaseGate] the
      * semantic bar for immutable revisions applies too: prompts, option
      * labels and option values must be non-blank. Drafts stay lenient.
@@ -65,6 +83,7 @@ object SurveyAuthoringDocumentValidator {
         val pageIds = mutableSetOf<String>()
         val questionIds = mutableSetOf<String>()
         val previousQuestionIds = mutableSetOf<String>()
+        val conditionTargets = mutableMapOf<String, ConditionTargetInfo>()
         val fields = mutableListOf<FieldDefinition>()
 
         pages.forEachIndexed { pageIndex, pageElement ->
@@ -94,11 +113,11 @@ object SurveyAuthoringDocumentValidator {
                     invalid("Question '$questionId' uses legacy logic")
                 }
                 question["visibleIf"]?.let {
-                    validateVisibleIf(it, questionId, previousQuestionIds)
+                    validateVisibleIf(it, questionId, previousQuestionIds, conditionTargets, releaseGate)
                 }
 
                 val type = requireString(question, "type", "Question '$questionId'")
-                fields += when (type) {
+                val definition = when (type) {
                     "rating" -> validateRating(question, questionId)
                     "text" -> validateText(question, questionId)
                     "singleChoice" ->
@@ -106,6 +125,22 @@ object SurveyAuthoringDocumentValidator {
                     "multiChoice" ->
                         validateChoice(question, questionId, FieldType.MULTI_CHOICE, releaseGate)
                     else -> invalid("Question '$questionId' has unsupported type '$type'")
+                }
+                fields += definition
+                conditionTargets[questionId] = when (type) {
+                    "rating" -> {
+                        val variantName =
+                            optionalString(question, "variant", "Rating question '$questionId'") ?: "emoji"
+                        val scale = when (variantName) {
+                            "thumbs" -> 1..2
+                            "nps" -> 0..10
+                            else -> 1..5
+                        }
+                        ConditionTargetInfo(type, scale = scale)
+                    }
+                    "singleChoice", "multiChoice" ->
+                        ConditionTargetInfo(type, optionIds = definition.optionIds.orEmpty())
+                    else -> ConditionTargetInfo(type)
                 }
                 previousQuestionIds += questionId
             }
@@ -208,13 +243,15 @@ object SurveyAuthoringDocumentValidator {
         element: JsonElement,
         questionId: String,
         previousQuestionIds: Set<String>,
+        conditionTargets: Map<String, ConditionTargetInfo>,
+        releaseGate: Boolean,
     ) {
         val condition = element as? JsonObject
             ?: invalid("Question '$questionId' has an invalid visibleIf")
         val groupKeys = listOf("any", "all").filter(condition::containsKey)
         if (groupKeys.size > 1) invalid("Question '$questionId' visibleIf must use exactly one group")
         if (groupKeys.isEmpty()) {
-            validateConditionLeaf(condition, questionId, previousQuestionIds)
+            validateConditionLeaf(condition, questionId, previousQuestionIds, conditionTargets, releaseGate)
             return
         }
         val conditions = condition[groupKeys.single()] as? JsonArray
@@ -226,7 +263,7 @@ object SurveyAuthoringDocumentValidator {
             if (leaf.containsKey("any") || leaf.containsKey("all")) {
                 invalid("Question '$questionId' has a nested visibleIf group")
             }
-            validateConditionLeaf(leaf, questionId, previousQuestionIds)
+            validateConditionLeaf(leaf, questionId, previousQuestionIds, conditionTargets, releaseGate)
         }
     }
 
@@ -234,6 +271,8 @@ object SurveyAuthoringDocumentValidator {
         leaf: JsonObject,
         questionId: String,
         previousQuestionIds: Set<String>,
+        conditionTargets: Map<String, ConditionTargetInfo>,
+        releaseGate: Boolean,
     ) {
         val field = optionalString(leaf, "field", "Question '$questionId' visibleIf") ?: "ANSWER"
         if (field !in setOf("ANSWER", "METADATA")) {
@@ -253,10 +292,77 @@ object SurveyAuthoringDocumentValidator {
         }
         if (field == "METADATA") {
             requireNonBlankString(leaf, "key", "Question '$questionId' METADATA visibleIf")
+            // Runtime ignores a stray questionId here, but it reads as an
+            // answer reference to a human — refuse to freeze the ambiguity.
+            if (releaseGate && leaf.containsKey("questionId")) {
+                invalid("Question '$questionId' METADATA visibleIf must not reference a question")
+            }
         } else {
+            if (releaseGate && leaf.containsKey("key")) {
+                invalid("Question '$questionId' ANSWER visibleIf must not carry a metadata key")
+            }
             val referencedId = requireNonBlankString(leaf, "questionId", "Question '$questionId' ANSWER visibleIf")
             if (referencedId !in previousQuestionIds) {
                 invalid("Question '$questionId' visibleIf may only reference an earlier question")
+            }
+            if (releaseGate) {
+                validateConditionSemantics(leaf, questionId, referencedId, operator, conditionTargets)
+            }
+        }
+    }
+
+    /**
+     * Release-gate semantics: the operator must be able to match the
+     * referenced answer type, and values must lie within the referenced
+     * question's domain. Mirrors the dashboard's handoff validation.
+     */
+    private fun validateConditionSemantics(
+        leaf: JsonObject,
+        questionId: String,
+        referencedId: String,
+        operator: String,
+        conditionTargets: Map<String, ConditionTargetInfo>,
+    ) {
+        val target = conditionTargets[referencedId] ?: return
+        val allowed = conditionOperatorsByType[target.type] ?: conditionOperators
+        if (operator !in allowed) {
+            invalid(
+                "Question '$questionId' visibleIf uses operator '$operator' that does not fit question '$referencedId'",
+            )
+        }
+        if (operator == "EXISTS") return
+        val primitive = leaf["value"] as? JsonPrimitive ?: return
+        when (target.type) {
+            "singleChoice", "multiChoice" -> {
+                val stringValue = primitive.takeIf { it.isString }?.content
+                if (stringValue == null || stringValue !in target.optionIds) {
+                    invalid(
+                        "Question '$questionId' visibleIf has a value outside question '$referencedId' options",
+                    )
+                }
+            }
+            "rating" -> {
+                val number = primitive.intOrNull
+                if (number == null || target.scale?.contains(number) != true) {
+                    invalid(
+                        "Question '$questionId' visibleIf has a value outside question '$referencedId' scale",
+                    )
+                }
+            }
+            "text" -> {
+                // Text answers compare strictly at runtime: 3 never matches "3".
+                if (!primitive.isString) {
+                    invalid(
+                        "Question '$questionId' visibleIf needs a string value for text question '$referencedId'",
+                    )
+                }
+                // Blank text answers never reach runtime answer state, so a
+                // blank value makes the condition functionally misleading.
+                if (primitive.isString && primitive.content.isBlank()) {
+                    invalid(
+                        "Question '$questionId' visibleIf needs a non-blank string value for text question '$referencedId'",
+                    )
+                }
             }
         }
     }

--- a/apps/lumi-api/src/test/kotlin/no/nav/lumi/validation/SurveyAuthoringDocumentValidatorTest.kt
+++ b/apps/lumi-api/src/test/kotlin/no/nav/lumi/validation/SurveyAuthoringDocumentValidatorTest.kt
@@ -169,7 +169,150 @@ class SurveyAuthoringDocumentValidatorTest : FunSpec({
             )
         }.errorMessage shouldBe "Option 0 on question 'choice' needs a value before it can be shared"
     }
+
+    test("release gate rejects condition operators that cannot match the referenced type") {
+        val document = conditionDocument(
+            referencedType = "multiChoice",
+            condition = """{ "questionId": "ref", "operator": "EQ", "value": "en" }""",
+        )
+
+        SurveyAuthoringDocumentValidator.validate(document, "survey-v1")
+
+        shouldThrow<ApiErrorException.BadRequestException> {
+            SurveyAuthoringDocumentValidator.validate(document, "survey-v1", releaseGate = true)
+        }.errorMessage shouldBe
+            "Question 'gated' visibleIf uses operator 'EQ' that does not fit question 'ref'"
+    }
+
+    test("release gate rejects condition values outside the referenced domain") {
+        val ratingOutOfScale = conditionDocument(
+            referencedType = "rating",
+            condition = """{ "questionId": "ref", "operator": "EQ", "value": 99 }""",
+        )
+        shouldThrow<ApiErrorException.BadRequestException> {
+            SurveyAuthoringDocumentValidator.validate(ratingOutOfScale, "survey-v1", releaseGate = true)
+        }.errorMessage shouldBe
+            "Question 'gated' visibleIf has a value outside question 'ref' scale"
+
+        val unknownOption = conditionDocument(
+            referencedType = "singleChoice",
+            condition = """{ "questionId": "ref", "operator": "EQ", "value": "finnes-ikke" }""",
+        )
+        shouldThrow<ApiErrorException.BadRequestException> {
+            SurveyAuthoringDocumentValidator.validate(unknownOption, "survey-v1", releaseGate = true)
+        }.errorMessage shouldBe
+            "Question 'gated' visibleIf has a value outside question 'ref' options"
+    }
+
+    test("release gate requires string values against text references") {
+        val numericAgainstText = conditionDocument(
+            referencedType = "text",
+            condition = """{ "questionId": "ref", "operator": "EQ", "value": 3 }""",
+        )
+        SurveyAuthoringDocumentValidator.validate(numericAgainstText, "survey-v1")
+        shouldThrow<ApiErrorException.BadRequestException> {
+            SurveyAuthoringDocumentValidator.validate(numericAgainstText, "survey-v1", releaseGate = true)
+        }.errorMessage shouldBe
+            "Question 'gated' visibleIf needs a string value for text question 'ref'"
+
+        val stringAgainstText = conditionDocument(
+            referencedType = "text",
+            condition = """{ "questionId": "ref", "operator": "EQ", "value": "3" }""",
+        )
+        SurveyAuthoringDocumentValidator.validate(stringAgainstText, "survey-v1", releaseGate = true)
+    }
+
+    test("release gate rejects contradictory condition targets") {
+        // Runtime discriminates on `field` alone, so a stray key/questionId
+        // is ignored there — but it reads as the other target to a human.
+        // Drafts stay lenient; freezing the ambiguity is refused.
+        val answerWithKey = conditionDocument(
+            referencedType = "rating",
+            condition = """{ "field": "ANSWER", "questionId": "ref", "key": "ekstra", "operator": "EXISTS" }""",
+        )
+        SurveyAuthoringDocumentValidator.validate(answerWithKey, "survey-v1")
+        shouldThrow<ApiErrorException.BadRequestException> {
+            SurveyAuthoringDocumentValidator.validate(answerWithKey, "survey-v1", releaseGate = true)
+        }.errorMessage shouldBe
+            "Question 'gated' ANSWER visibleIf must not carry a metadata key"
+
+        val metadataWithQuestionId = conditionDocument(
+            referencedType = "rating",
+            condition = """{ "field": "METADATA", "key": "flow", "questionId": "ref", "operator": "EXISTS" }""",
+        )
+        SurveyAuthoringDocumentValidator.validate(metadataWithQuestionId, "survey-v1")
+        shouldThrow<ApiErrorException.BadRequestException> {
+            SurveyAuthoringDocumentValidator.validate(metadataWithQuestionId, "survey-v1", releaseGate = true)
+        }.errorMessage shouldBe
+            "Question 'gated' METADATA visibleIf must not reference a question"
+    }
+
+    test("release gate rejects blank string values against text references") {
+        // Blank text answers are stripped from runtime answer state, so a
+        // blank value makes EQ unmatchable, NEQ true before any answer and
+        // CONTAINS a match-everything condition.
+        listOf("", "   ").forEach { blank ->
+            val document = conditionDocument(
+                referencedType = "text",
+                condition = """{ "questionId": "ref", "operator": "CONTAINS", "value": "$blank" }""",
+            )
+            SurveyAuthoringDocumentValidator.validate(document, "survey-v1")
+            shouldThrow<ApiErrorException.BadRequestException> {
+                SurveyAuthoringDocumentValidator.validate(document, "survey-v1", releaseGate = true)
+            }.errorMessage shouldBe
+                "Question 'gated' visibleIf needs a non-blank string value for text question 'ref'"
+        }
+    }
+
+    test("release gate accepts semantically valid conditions") {
+        val contains = conditionDocument(
+            referencedType = "multiChoice",
+            condition = """{ "questionId": "ref", "operator": "CONTAINS", "value": "en" }""",
+        )
+        SurveyAuthoringDocumentValidator.validate(contains, "survey-v1", releaseGate = true)
+
+        val ratingEq = conditionDocument(
+            referencedType = "rating",
+            condition = """{ "questionId": "ref", "operator": "EQ", "value": 3 }""",
+        )
+        SurveyAuthoringDocumentValidator.validate(ratingEq, "survey-v1", releaseGate = true)
+    }
 })
+
+private fun conditionDocument(referencedType: String, condition: String): JsonObject {
+    val referenced = when (referencedType) {
+        "rating" -> """{ "id": "ref", "type": "rating", "prompt": "Vurder" }"""
+        "singleChoice", "multiChoice" -> """{
+            "id": "ref",
+            "type": "$referencedType",
+            "prompt": "Velg",
+            "options": [
+                { "value": "en", "label": "En" },
+                { "value": "to", "label": "To" }
+            ]
+        }"""
+        else -> """{ "id": "ref", "type": "text", "prompt": "Skriv" }"""
+    }
+    return Json.parseToJsonElement(
+        """
+        {
+          "authoringSchemaVersion": 1,
+          "pages": [{
+            "id": "page",
+            "questions": [
+              $referenced,
+              {
+                "id": "gated",
+                "type": "text",
+                "prompt": "Utdyp",
+                "visibleIf": $condition
+              }
+            ]
+          }]
+        }
+        """.trimIndent(),
+    ).jsonObject
+}
 
 private fun validDocument(): JsonObject = Json.parseToJsonElement(
     """

--- a/apps/lumi-dashboard/app/components/surveyverksted/ConditionEditor.tsx
+++ b/apps/lumi-dashboard/app/components/surveyverksted/ConditionEditor.tsx
@@ -1,0 +1,321 @@
+import { BranchingIcon, XMarkIcon } from "@navikt/aksel-icons";
+import {
+  BodyShort,
+  Button,
+  Detail,
+  Select,
+  TextField,
+  Tooltip,
+} from "@navikt/ds-react";
+import {
+  allowedConditionOperators,
+  type ConditionValueSuggestion,
+  isMetadataCondition,
+  type ReferenceableQuestion,
+  type VisibleIfConditionV1,
+} from "~/utils/surveyDocument";
+import styles from "./verksted.module.css";
+
+type LeafCondition = Exclude<
+  VisibleIfConditionV1,
+  { any: unknown } | { all: unknown }
+>;
+
+type AnswerLeaf = Exclude<LeafCondition, { field: "METADATA" }>;
+
+type ValuedOperator = "EQ" | "NEQ" | "GT" | "LT" | "CONTAINS";
+
+function isGroup(
+  condition: VisibleIfConditionV1,
+): condition is Exclude<VisibleIfConditionV1, LeafCondition> {
+  return "any" in condition || "all" in condition;
+}
+
+function isAnswerLeaf(
+  condition: VisibleIfConditionV1,
+): condition is AnswerLeaf {
+  // Field-based like runtime and API: a stray `key` on an ANSWER leaf
+  // must not demote it to a read-only code condition.
+  return !isGroup(condition) && !isMetadataCondition(condition);
+}
+
+/**
+ * DOM option values are type-prefixed so the string "3" can never
+ * masquerade as the number 3 across a type change.
+ */
+function encodeValue(value: string | number | boolean | undefined): string {
+  return `${typeof value}:${String(value ?? "")}`;
+}
+
+const OPERATOR_LABELS: Record<string, string> = {
+  EXISTS: "har fått svar",
+  EQ: "er lik",
+  NEQ: "er ikke lik",
+  GT: "er større enn",
+  LT: "er mindre enn",
+  CONTAINS: "inneholder",
+};
+
+export interface ConditionEditorProps {
+  condition: VisibleIfConditionV1 | undefined;
+  referenceable: ReferenceableQuestion[];
+  suggestionsFor: (referencedId: string) => ConditionValueSuggestion[];
+  onChange: (condition: VisibleIfConditionV1 | undefined) => void;
+}
+
+/**
+ * Single-condition builder for question visibility ("Vis bare hvis …").
+ * Mirrors the runtime rule that only earlier questions can be referenced.
+ * Groups and METADATA conditions authored in code are shown read-only.
+ */
+export function ConditionEditor({
+  condition,
+  referenceable,
+  suggestionsFor,
+  onChange,
+}: ConditionEditorProps) {
+  if (condition === undefined) {
+    const disabled = referenceable.length === 0;
+    const addButton = (
+      <Button
+        type="button"
+        variant="tertiary"
+        size="small"
+        icon={<BranchingIcon aria-hidden />}
+        disabled={disabled}
+        onClick={() =>
+          onChange({ questionId: referenceable[0].id, operator: "EXISTS" })
+        }
+      >
+        Vis bare hvis …
+      </Button>
+    );
+    return disabled ? (
+      <div className={styles.conditionAddWrap}>
+        {addButton}
+        <Detail as="span" className={styles.conditionHint}>
+          Ingen tidligere spørsmål å referere til
+        </Detail>
+      </div>
+    ) : (
+      addButton
+    );
+  }
+
+  if (!isAnswerLeaf(condition)) {
+    return (
+      <div className={styles.conditionSection}>
+        <div className={styles.conditionHeader}>
+          <Detail as="span" className={styles.eyebrow}>
+            BETINGELSE
+          </Detail>
+          <Tooltip content="Fjern betingelsen">
+            <Button
+              type="button"
+              variant="tertiary-neutral"
+              size="xsmall"
+              icon={<XMarkIcon aria-hidden />}
+              aria-label="Fjern betingelsen"
+              onClick={() => onChange(undefined)}
+            />
+          </Tooltip>
+        </div>
+        <BodyShort size="small" textColor="subtle">
+          Sammensatt betingelse satt i kode. Den beholdes som den er, eller kan
+          fjernes her.
+        </BodyShort>
+      </div>
+    );
+  }
+
+  const referenced = referenceable.find(
+    (candidate) => candidate.id === condition.questionId,
+  );
+  const suggestions = condition.questionId
+    ? suggestionsFor(condition.questionId)
+    : [];
+  const operators = referenced
+    ? allowedConditionOperators(referenced.type)
+    : ["EXISTS"];
+  const needsValue = condition.operator !== "EXISTS";
+
+  // Stale states render EXPLICITLY as dead, disabled options with a warning
+  // — a native select must never pretend the condition was repaired.
+  const referenceMissing = condition.questionId !== undefined && !referenced;
+  const operatorStale =
+    !referenceMissing && !operators.includes(condition.operator);
+  const valueStale =
+    needsValue &&
+    !referenceMissing &&
+    suggestions.length > 0 &&
+    !suggestions.some((candidate) => candidate.value === condition.value);
+  const valueTypeInvalid =
+    needsValue &&
+    !referenceMissing &&
+    suggestions.length === 0 &&
+    condition.value !== undefined &&
+    typeof condition.value !== "string";
+  // Blank text answers never reach runtime answer state, so a blank value
+  // makes the condition misleading; the release gates reject it.
+  const valueBlank =
+    needsValue &&
+    !referenceMissing &&
+    suggestions.length === 0 &&
+    typeof condition.value === "string" &&
+    condition.value.trim().length === 0;
+  // Repair guidance renders as Aksel field errors: linked to the control
+  // via aria-describedby and announced via the built-in polite live region.
+  const questionError = referenceMissing
+    ? "Spørsmålet betingelsen peker på finnes ikke lenger her — velg et annet spørsmål eller fjern betingelsen."
+    : undefined;
+  const operatorError = operatorStale
+    ? "Vilkåret passer ikke spørsmålet det peker på lenger — velg et annet vilkår."
+    : undefined;
+  const valueError = valueStale
+    ? "Verdien finnes ikke blant alternativene lenger — velg en gyldig verdi."
+    : valueTypeInvalid
+      ? "Verdien må være tekst når den peker på et tekstspørsmål — skriv den på nytt."
+      : valueBlank
+        ? "Verdien kan ikke være tom — skriv inn teksten svaret skal sammenlignes med."
+        : undefined;
+
+  const firstValueFor = (referencedId: string): string | number => {
+    const [first] = suggestionsFor(referencedId);
+    return first ? first.value : "";
+  };
+
+  const changeReferenced = (referencedId: string) => {
+    const nextType = referenceable.find(
+      (candidate) => candidate.id === referencedId,
+    )?.type;
+    const allowed = nextType ? allowedConditionOperators(nextType) : ["EXISTS"];
+    const operator = allowed.includes(condition.operator)
+      ? condition.operator
+      : "EXISTS";
+    if (operator === "EXISTS") {
+      onChange({ questionId: referencedId, operator: "EXISTS" });
+    } else {
+      onChange({
+        questionId: referencedId,
+        operator: operator as ValuedOperator,
+        value: firstValueFor(referencedId),
+      });
+    }
+  };
+
+  const changeOperator = (operator: string) => {
+    if (operator === "EXISTS") {
+      onChange({ questionId: condition.questionId, operator: "EXISTS" });
+      return;
+    }
+    onChange({
+      questionId: condition.questionId,
+      operator: operator as ValuedOperator,
+      value: condition.value ?? firstValueFor(condition.questionId ?? ""),
+    });
+  };
+
+  const changeValue = (raw: string) => {
+    const suggestion = suggestions.find(
+      (candidate) => encodeValue(candidate.value) === raw,
+    );
+    onChange({
+      questionId: condition.questionId,
+      operator: condition.operator as ValuedOperator,
+      value: suggestion ? suggestion.value : raw,
+    });
+  };
+
+  return (
+    <div className={styles.conditionSection}>
+      <div className={styles.conditionHeader}>
+        <Detail as="span" className={styles.eyebrow}>
+          VISES BARE HVIS
+        </Detail>
+        <Tooltip content="Fjern betingelsen">
+          <Button
+            type="button"
+            variant="tertiary-neutral"
+            size="xsmall"
+            icon={<XMarkIcon aria-hidden />}
+            aria-label="Fjern betingelsen"
+            onClick={() => onChange(undefined)}
+          />
+        </Tooltip>
+      </div>
+      <div className={styles.conditionRow}>
+        <Select
+          label="Spørsmål"
+          size="small"
+          value={condition.questionId ?? ""}
+          error={questionError}
+          onChange={(event) => changeReferenced(event.target.value)}
+        >
+          {referenceMissing ? (
+            <option value={condition.questionId} disabled>
+              Finnes ikke lenger ({condition.questionId})
+            </option>
+          ) : null}
+          {referenceable.map((candidate) => (
+            <option key={candidate.id} value={candidate.id}>
+              {candidate.pageNumber}.{candidate.questionNumber}{" "}
+              {candidate.prompt.trim() || "Uten tekst"}
+            </option>
+          ))}
+        </Select>
+        <Select
+          label="Vilkår"
+          size="small"
+          value={condition.operator}
+          error={operatorError}
+          onChange={(event) => changeOperator(event.target.value)}
+        >
+          {operatorStale ? (
+            <option value={condition.operator} disabled>
+              {OPERATOR_LABELS[condition.operator] ?? condition.operator}{" "}
+              (passer ikke lenger)
+            </option>
+          ) : null}
+          {operators.map((operator) => (
+            <option key={operator} value={operator}>
+              {OPERATOR_LABELS[operator]}
+            </option>
+          ))}
+        </Select>
+        {needsValue ? (
+          suggestions.length > 0 ? (
+            <Select
+              label="Verdi"
+              size="small"
+              value={encodeValue(condition.value)}
+              error={valueError}
+              onChange={(event) => changeValue(event.target.value)}
+            >
+              {valueStale ? (
+                <option value={encodeValue(condition.value)} disabled>
+                  «{String(condition.value ?? "")}» (finnes ikke)
+                </option>
+              ) : null}
+              {suggestions.map((suggestion) => (
+                <option
+                  key={encodeValue(suggestion.value)}
+                  value={encodeValue(suggestion.value)}
+                >
+                  {suggestion.label}
+                </option>
+              ))}
+            </Select>
+          ) : (
+            <TextField
+              label="Verdi"
+              size="small"
+              value={String(condition.value ?? "")}
+              error={valueError}
+              onChange={(event) => changeValue(event.target.value)}
+            />
+          )
+        ) : null}
+      </div>
+    </div>
+  );
+}

--- a/apps/lumi-dashboard/app/components/surveyverksted/PageRail.tsx
+++ b/apps/lumi-dashboard/app/components/surveyverksted/PageRail.tsx
@@ -1,6 +1,7 @@
 import {
   ArrowDownIcon,
   ArrowUpIcon,
+  BranchingIcon,
   FilesIcon,
   MenuElipsisVerticalIcon,
   PlusIcon,
@@ -96,6 +97,9 @@ const RailItem = memo(function RailItem({
   onDelete: (pageId: string) => void;
 }) {
   const sortable = useSortableItem(page.id);
+  const conditionalCount = page.questions.filter(
+    (question) => question.visibleIf,
+  ).length;
 
   return (
     <li
@@ -119,10 +123,22 @@ const RailItem = memo(function RailItem({
           <BodyShort as="span" size="small" weight="semibold">
             {page.title?.trim() || "Side uten tittel"}
           </BodyShort>
+          {conditionalCount > 0 ? (
+            <span className={styles.srOnly}>
+              {conditionalCount === 1
+                ? "1 betinget spørsmål"
+                : `${conditionalCount} betingede spørsmål`}
+            </span>
+          ) : null}
           <span className={styles.railIcons} aria-hidden>
             {page.questions.map((question) => {
               const meta = questionTypeMeta(question.type);
-              return <meta.Icon key={question.id} aria-hidden />;
+              return (
+                <span key={question.id} className={styles.railIconPair}>
+                  <meta.Icon aria-hidden />
+                  {question.visibleIf ? <BranchingIcon aria-hidden /> : null}
+                </span>
+              );
             })}
           </span>
         </span>

--- a/apps/lumi-dashboard/app/components/surveyverksted/QuestionCanvas.tsx
+++ b/apps/lumi-dashboard/app/components/surveyverksted/QuestionCanvas.tsx
@@ -2,7 +2,13 @@ import { PlusIcon } from "@navikt/aksel-icons";
 import { Detail, TextField, VStack } from "@navikt/ds-react";
 import type { SurveyPageV1, SurveyQuestionV1 } from "@navikt/lumi-survey";
 import { Fragment, memo, useCallback, useMemo } from "react";
-import type { MoveDirection, QuestionTypeId } from "~/utils/surveyDocument";
+import type {
+  ConditionValueSuggestion,
+  MoveDirection,
+  QuestionTypeId,
+  ReferenceableQuestion,
+  VisibleIfConditionV1,
+} from "~/utils/surveyDocument";
 import type { OptionsEditorProps } from "./OptionsEditor";
 import { QuestionCard } from "./QuestionCard";
 import { SortableList, useSortableItem } from "./sortable";
@@ -40,6 +46,12 @@ export interface QuestionCanvasProps {
   onMoveQuestion: (questionId: string, direction: MoveDirection) => void;
   onReorderQuestion: (questionId: string, toIndex: number) => void;
   optionHandlersFor: (questionId: string) => OptionHandlers;
+  referenceableByQuestion: ReadonlyMap<string, ReferenceableQuestion[]>;
+  suggestionsFor: (referencedId: string) => ConditionValueSuggestion[];
+  onChangeVisibleIf: (
+    questionId: string,
+    condition: VisibleIfConditionV1 | undefined,
+  ) => void;
   onAddQuestion: (type: QuestionTypeId) => void;
 }
 
@@ -62,6 +74,9 @@ export const QuestionCanvas = memo(function QuestionCanvas({
   onMoveQuestion,
   onReorderQuestion,
   optionHandlersFor,
+  referenceableByQuestion,
+  suggestionsFor,
+  onChangeVisibleIf,
   onAddQuestion,
 }: QuestionCanvasProps) {
   const pad = (value: number) => String(value).padStart(2, "0");
@@ -140,6 +155,13 @@ export const QuestionCanvas = memo(function QuestionCanvas({
                 onDelete={onDelete}
                 onMoveQuestion={onMoveQuestion}
                 optionHandlersFor={optionHandlersFor}
+                referenceable={
+                  expandedIds.has(question.id)
+                    ? referenceableByQuestion.get(question.id)
+                    : undefined
+                }
+                suggestionsFor={suggestionsFor}
+                onChangeVisibleIf={onChangeVisibleIf}
               />
             </Fragment>
           ))}
@@ -187,6 +209,9 @@ const CanvasQuestion = memo(function CanvasQuestion({
   onDelete,
   onMoveQuestion,
   optionHandlersFor,
+  referenceable,
+  suggestionsFor,
+  onChangeVisibleIf,
 }: {
   question: SurveyQuestionV1;
   index: number;
@@ -203,6 +228,9 @@ const CanvasQuestion = memo(function CanvasQuestion({
   onDelete: (questionId: string) => void;
   onMoveQuestion: (questionId: string, direction: MoveDirection) => void;
   optionHandlersFor: (questionId: string) => OptionHandlers;
+  referenceable: ReferenceableQuestion[] | undefined;
+  suggestionsFor: (referencedId: string) => ConditionValueSuggestion[];
+  onChangeVisibleIf: QuestionCanvasProps["onChangeVisibleIf"];
 }) {
   const questionId = question.id;
   const sortable = useSortableItem(questionId, expanded);
@@ -244,6 +272,11 @@ const CanvasQuestion = memo(function CanvasQuestion({
     (direction: MoveDirection) => onMoveQuestion(questionId, direction),
     [onMoveQuestion, questionId],
   );
+  const handleVisibleIf = useCallback(
+    (condition: VisibleIfConditionV1 | undefined) =>
+      onChangeVisibleIf(questionId, condition),
+    [onChangeVisibleIf, questionId],
+  );
 
   return (
     <div
@@ -270,6 +303,9 @@ const CanvasQuestion = memo(function CanvasQuestion({
         onDelete={handleDelete}
         onMove={handleMove}
         optionHandlers={optionHandlers}
+        referenceable={referenceable}
+        suggestionsFor={expanded ? suggestionsFor : undefined}
+        onChangeVisibleIf={expanded ? handleVisibleIf : undefined}
       />
     </div>
   );

--- a/apps/lumi-dashboard/app/components/surveyverksted/QuestionCard.tsx
+++ b/apps/lumi-dashboard/app/components/surveyverksted/QuestionCard.tsx
@@ -1,6 +1,7 @@
 import {
   ArrowDownIcon,
   ArrowUpIcon,
+  BranchingIcon,
   ChevronDownIcon,
   ChevronUpIcon,
   FilesIcon,
@@ -19,7 +20,14 @@ import {
 } from "@navikt/ds-react";
 import type { SurveyQuestionV1 } from "@navikt/lumi-survey";
 import { memo, useEffect, useRef } from "react";
-import type { MoveDirection, QuestionTypeId } from "~/utils/surveyDocument";
+import type {
+  ConditionValueSuggestion,
+  MoveDirection,
+  QuestionTypeId,
+  ReferenceableQuestion,
+  VisibleIfConditionV1,
+} from "~/utils/surveyDocument";
+import { ConditionEditor } from "./ConditionEditor";
 import { OptionsEditor, type OptionsEditorProps } from "./OptionsEditor";
 import { QuestionMiniPreview } from "./QuestionMiniPreview";
 import {
@@ -47,6 +55,9 @@ export interface QuestionCardProps {
   onDelete: () => void;
   onMove: (direction: MoveDirection) => void;
   optionHandlers?: Omit<OptionsEditorProps, "questionId" | "options">;
+  referenceable?: ReferenceableQuestion[];
+  suggestionsFor?: (referencedId: string) => ConditionValueSuggestion[];
+  onChangeVisibleIf?: (condition: VisibleIfConditionV1 | undefined) => void;
 }
 
 export const QuestionCard = memo(function QuestionCard({
@@ -65,6 +76,9 @@ export const QuestionCard = memo(function QuestionCard({
   onDelete,
   onMove,
   optionHandlers,
+  referenceable,
+  suggestionsFor,
+  onChangeVisibleIf,
 }: QuestionCardProps) {
   const collapsedButtonRef = useRef<HTMLButtonElement>(null);
   const promptRef = useRef<HTMLInputElement>(null);
@@ -113,11 +127,19 @@ export const QuestionCard = memo(function QuestionCard({
               {question.prompt.trim() || "Spørsmål uten tekst"}
             </BodyShort>
           </span>
-          {question.required ? (
-            <Detail as="span" className={styles.cardRequired}>
-              Må besvares
-            </Detail>
-          ) : null}
+          <span className={styles.cardTriggerMeta}>
+            {question.visibleIf ? (
+              <Detail as="span" className={styles.cardConditional}>
+                <BranchingIcon aria-hidden />
+                Vises betinget
+              </Detail>
+            ) : null}
+            {question.required ? (
+              <Detail as="span" className={styles.cardRequired}>
+                Må besvares
+              </Detail>
+            ) : null}
+          </span>
         </button>
         <QuestionMiniPreview question={question} />
       </article>
@@ -208,6 +230,15 @@ export const QuestionCard = memo(function QuestionCard({
             questionId={question.id}
             options={question.options}
             {...optionHandlers}
+          />
+        ) : null}
+
+        {referenceable && suggestionsFor && onChangeVisibleIf ? (
+          <ConditionEditor
+            condition={question.visibleIf}
+            referenceable={referenceable}
+            suggestionsFor={suggestionsFor}
+            onChange={onChangeVisibleIf}
           />
         ) : null}
       </VStack>

--- a/apps/lumi-dashboard/app/components/surveyverksted/__tests__/ConditionEditor.test.tsx
+++ b/apps/lumi-dashboard/app/components/surveyverksted/__tests__/ConditionEditor.test.tsx
@@ -1,0 +1,364 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it, vi } from "vitest";
+import { ConditionEditor } from "~/components/surveyverksted/ConditionEditor";
+import type { ReferenceableQuestion } from "~/utils/surveyDocument";
+
+const referenceable: ReferenceableQuestion[] = [
+  {
+    id: "rating-1",
+    prompt: "Hvordan opplevde du tjenesten?",
+    type: "rating",
+    pageNumber: 1,
+    questionNumber: 1,
+  },
+  {
+    id: "choice-1",
+    prompt: "Hva kom du for å gjøre?",
+    type: "singleChoice",
+    pageNumber: 1,
+    questionNumber: 2,
+  },
+  {
+    id: "multi-1",
+    prompt: "Hva er viktigst?",
+    type: "multiChoice",
+    pageNumber: 1,
+    questionNumber: 3,
+  },
+  {
+    id: "text-1",
+    prompt: "Fortell mer",
+    type: "text",
+    pageNumber: 1,
+    questionNumber: 4,
+  },
+];
+
+function suggestionsFor(id: string) {
+  if (id === "choice-1") {
+    return [
+      { value: "soke", label: "Søke" },
+      { value: "sjekke-status", label: "Sjekke status" },
+    ];
+  }
+  if (id === "rating-1") {
+    return [1, 2, 3, 4, 5].map((value) => ({ value, label: String(value) }));
+  }
+  return [];
+}
+
+describe("ConditionEditor", () => {
+  it("is disabled with a keyboard-reachable explanation when no earlier questions exist", () => {
+    render(
+      <ConditionEditor
+        condition={undefined}
+        referenceable={[]}
+        suggestionsFor={suggestionsFor}
+        onChange={() => {}}
+      />,
+    );
+    expect(
+      screen.getByRole("button", { name: /vis bare hvis/i }),
+    ).toBeDisabled();
+    expect(
+      screen.getByText("Ingen tidligere spørsmål å referere til"),
+    ).toBeVisible();
+  });
+
+  it("offers only EXISTS and CONTAINS against a multiChoice reference", () => {
+    render(
+      <ConditionEditor
+        condition={{ questionId: "multi-1", operator: "EXISTS" }}
+        referenceable={referenceable}
+        suggestionsFor={suggestionsFor}
+        onChange={() => {}}
+      />,
+    );
+    expect(screen.getByLabelText("Vilkår")).toBeInTheDocument();
+    expect(
+      screen.getByRole("option", { name: "inneholder" }),
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByRole("option", { name: "er lik" }),
+    ).not.toBeInTheDocument();
+  });
+
+  it("shows a missing reference explicitly instead of pretending it is repaired", () => {
+    render(
+      <ConditionEditor
+        condition={{ questionId: "borte", operator: "EXISTS" }}
+        referenceable={referenceable}
+        suggestionsFor={suggestionsFor}
+        onChange={() => {}}
+      />,
+    );
+    expect(screen.getByLabelText("Spørsmål", { exact: true })).toHaveValue(
+      "borte",
+    );
+    expect(
+      screen.getByRole("option", { name: /finnes ikke lenger/i }),
+    ).toBeInTheDocument();
+    expect(screen.getByText(/velg et annet spørsmål/i)).toBeVisible();
+  });
+
+  it("keeps an operator that no longer fits and warns", () => {
+    render(
+      <ConditionEditor
+        condition={{ questionId: "text-1", operator: "GT", value: 1 }}
+        referenceable={referenceable}
+        suggestionsFor={suggestionsFor}
+        onChange={() => {}}
+      />,
+    );
+    expect(screen.getByLabelText("Vilkår")).toHaveValue("GT");
+    expect(screen.getByText(/passer ikke spørsmålet/i)).toBeVisible();
+  });
+
+  it("keeps a value that no longer exists and warns", () => {
+    render(
+      <ConditionEditor
+        condition={{ questionId: "choice-1", operator: "EQ", value: "gammel" }}
+        referenceable={referenceable}
+        suggestionsFor={suggestionsFor}
+        onChange={() => {}}
+      />,
+    );
+    expect(screen.getByLabelText("Verdi")).toHaveDisplayValue(
+      /gammel.*finnes ikke/i,
+    );
+    expect(
+      screen.getByRole("option", { name: /gammel.*finnes ikke/i }),
+    ).toBeInTheDocument();
+    expect(screen.getByText(/finnes ikke blant alternativene/i)).toBeVisible();
+  });
+
+  it("creates a default EXISTS condition on the first earlier question", async () => {
+    const onChange = vi.fn();
+    render(
+      <ConditionEditor
+        condition={undefined}
+        referenceable={referenceable}
+        suggestionsFor={suggestionsFor}
+        onChange={onChange}
+      />,
+    );
+    await userEvent.click(
+      screen.getByRole("button", { name: /vis bare hvis/i }),
+    );
+    expect(onChange).toHaveBeenCalledWith({
+      questionId: "rating-1",
+      operator: "EXISTS",
+    });
+  });
+
+  it("hides the value field for EXISTS and shows suggestions for EQ", async () => {
+    const onChange = vi.fn();
+    render(
+      <ConditionEditor
+        condition={{ questionId: "choice-1", operator: "EXISTS" }}
+        referenceable={referenceable}
+        suggestionsFor={suggestionsFor}
+        onChange={onChange}
+      />,
+    );
+    expect(screen.queryByLabelText("Verdi")).not.toBeInTheDocument();
+
+    await userEvent.selectOptions(screen.getByLabelText("Vilkår"), "EQ");
+    expect(onChange).toHaveBeenCalledWith({
+      questionId: "choice-1",
+      operator: "EQ",
+      value: "soke",
+    });
+  });
+
+  it("uses the referenced question's suggestions as value options", () => {
+    render(
+      <ConditionEditor
+        condition={{ questionId: "choice-1", operator: "EQ", value: "soke" }}
+        referenceable={referenceable}
+        suggestionsFor={suggestionsFor}
+        onChange={() => {}}
+      />,
+    );
+    const value = screen.getByLabelText("Verdi");
+    expect(value).toHaveDisplayValue("Søke");
+    expect(
+      screen.getByRole("option", { name: "Sjekke status" }),
+    ).toBeInTheDocument();
+  });
+
+  it("treats a string value against a rating reference as stale", () => {
+    render(
+      <ConditionEditor
+        condition={{ questionId: "rating-1", operator: "EQ", value: "3" }}
+        referenceable={referenceable}
+        suggestionsFor={suggestionsFor}
+        onChange={() => {}}
+      />,
+    );
+    expect(
+      screen.getByRole("option", { name: /finnes ikke/i }),
+    ).toBeInTheDocument();
+    expect(screen.getByText(/velg en gyldig verdi/i)).toBeVisible();
+  });
+
+  it("emits typed values from suggestions", async () => {
+    const onChange = vi.fn();
+    render(
+      <ConditionEditor
+        condition={{ questionId: "rating-1", operator: "EQ", value: 3 }}
+        referenceable={referenceable}
+        suggestionsFor={suggestionsFor}
+        onChange={onChange}
+      />,
+    );
+    await userEvent.selectOptions(
+      screen.getByLabelText("Verdi"),
+      screen.getByRole("option", { name: "4" }),
+    );
+    expect(onChange).toHaveBeenCalledWith({
+      questionId: "rating-1",
+      operator: "EQ",
+      value: 4,
+    });
+  });
+
+  it("warns about non-string values against text references", () => {
+    render(
+      <ConditionEditor
+        condition={{ questionId: "text-1", operator: "EQ", value: 3 }}
+        referenceable={referenceable}
+        suggestionsFor={suggestionsFor}
+        onChange={() => {}}
+      />,
+    );
+    expect(screen.getByText(/må være tekst/i)).toBeVisible();
+  });
+
+  it("warns about empty and whitespace-only values against text references", () => {
+    for (const value of ["", "   "]) {
+      const { unmount } = render(
+        <ConditionEditor
+          condition={{ questionId: "text-1", operator: "CONTAINS", value }}
+          referenceable={referenceable}
+          suggestionsFor={suggestionsFor}
+          onChange={() => {}}
+        />,
+      );
+      expect(screen.getByText(/kan ikke være tom/i)).toBeVisible();
+      expect(screen.getByLabelText("Verdi")).toHaveAccessibleDescription(
+        /kan ikke være tom/i,
+      );
+      unmount();
+    }
+  });
+
+  it("emits an empty default when switching to EQ against a text reference", async () => {
+    // The empty default is allowed in the draft; the editor must warn and
+    // the release gates must block it.
+    const onChange = vi.fn();
+    render(
+      <ConditionEditor
+        condition={{ questionId: "text-1", operator: "EXISTS" }}
+        referenceable={referenceable}
+        suggestionsFor={suggestionsFor}
+        onChange={onChange}
+      />,
+    );
+    await userEvent.selectOptions(screen.getByLabelText("Vilkår"), "EQ");
+    expect(onChange).toHaveBeenCalledWith({
+      questionId: "text-1",
+      operator: "EQ",
+      value: "",
+    });
+  });
+
+  it("associates repair warnings with the controls they describe", () => {
+    render(
+      <ConditionEditor
+        condition={{ questionId: "text-1", operator: "GT", value: 1 }}
+        referenceable={referenceable}
+        suggestionsFor={suggestionsFor}
+        onChange={() => {}}
+      />,
+    );
+    expect(screen.getByLabelText("Vilkår")).toHaveAccessibleDescription(
+      /passer ikke spørsmålet/i,
+    );
+  });
+
+  it("removes the condition", async () => {
+    const onChange = vi.fn();
+    render(
+      <ConditionEditor
+        condition={{ questionId: "rating-1", operator: "EXISTS" }}
+        referenceable={referenceable}
+        suggestionsFor={suggestionsFor}
+        onChange={onChange}
+      />,
+    );
+    await userEvent.click(
+      screen.getByRole("button", { name: /fjern betingelsen/i }),
+    );
+    expect(onChange).toHaveBeenCalledWith(undefined);
+  });
+
+  it("treats an explicit ANSWER leaf with a stray metadata key as editable", async () => {
+    // Runtime and API discriminate on `field` — a stray `key` must not
+    // turn an ANSWER condition into a read-only "code condition".
+    const onChange = vi.fn();
+    const stray = {
+      field: "ANSWER" as const,
+      questionId: "rating-1",
+      key: "ekstra-felt",
+      operator: "EXISTS" as const,
+    };
+    render(
+      <ConditionEditor
+        condition={stray}
+        referenceable={referenceable}
+        suggestionsFor={suggestionsFor}
+        onChange={onChange}
+      />,
+    );
+    const operatorSelect = screen.getByLabelText("Vilkår");
+    // Editing normalizes the leaf: the stray key is dropped on emit.
+    await userEvent.selectOptions(operatorSelect, "EQ");
+    expect(onChange).toHaveBeenCalledWith({
+      questionId: "rating-1",
+      operator: "EQ",
+      value: 1,
+    });
+  });
+
+  it("shows a metadata condition authored in code read-only", () => {
+    render(
+      <ConditionEditor
+        condition={{ field: "METADATA", key: "flow", operator: "EXISTS" }}
+        referenceable={referenceable}
+        suggestionsFor={suggestionsFor}
+        onChange={() => {}}
+      />,
+    );
+    expect(screen.queryByLabelText("Vilkår")).not.toBeInTheDocument();
+  });
+
+  it("shows a read-only note for group conditions authored in code", () => {
+    render(
+      <ConditionEditor
+        condition={{
+          any: [
+            { questionId: "rating-1", operator: "EXISTS" },
+            { questionId: "choice-1", operator: "EXISTS" },
+          ],
+        }}
+        referenceable={referenceable}
+        suggestionsFor={suggestionsFor}
+        onChange={() => {}}
+      />,
+    );
+    expect(screen.getByText(/sammensatt betingelse/i)).toBeInTheDocument();
+    expect(screen.queryByLabelText("Vilkår")).not.toBeInTheDocument();
+  });
+});

--- a/apps/lumi-dashboard/app/components/surveyverksted/__tests__/QuestionCanvas.test.tsx
+++ b/apps/lumi-dashboard/app/components/surveyverksted/__tests__/QuestionCanvas.test.tsx
@@ -1,0 +1,110 @@
+import type { SurveyPageV1 } from "@navikt/lumi-survey";
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { QuestionCanvas } from "~/components/surveyverksted/QuestionCanvas";
+import type { ReferenceableQuestion } from "~/utils/surveyDocument";
+
+const page: SurveyPageV1 = {
+  id: "page-1",
+  title: "Side 1",
+  questions: [
+    {
+      id: "q1",
+      type: "rating",
+      prompt: "Hvordan opplevde du tjenesten?",
+      variant: "emoji",
+      required: true,
+    },
+    {
+      id: "q2",
+      type: "text",
+      prompt: "Fortell mer",
+      required: false,
+      visibleIf: { questionId: "q1", operator: "GT", value: 3 },
+    },
+  ],
+};
+
+const noop = () => {};
+
+function canvasProps(
+  referenceableByQuestion: ReadonlyMap<string, ReferenceableQuestion[]>,
+) {
+  return {
+    page,
+    pageNumber: 1,
+    totalPages: 1,
+    expandedIds: new Set(["q2"]),
+    focusQuestionId: null,
+    undo: null,
+    onUndo: noop,
+    onUndoExpire: noop,
+    onExpand: noop,
+    onCollapse: noop,
+    onUpdatePage: noop,
+    onQuestionChange: noop,
+    onChangeType: noop,
+    onDuplicate: noop,
+    onDelete: noop,
+    onMoveQuestion: noop,
+    onReorderQuestion: noop,
+    optionHandlersFor: () => ({
+      onAdd: noop,
+      onUpdateLabel: noop,
+      onUpdateValue: noop,
+      onRemove: noop,
+      onMove: noop,
+    }),
+    referenceableByQuestion,
+    suggestionsFor: () => [],
+    onChangeVisibleIf: noop,
+    onAddQuestion: noop,
+  };
+}
+
+describe("QuestionCanvas condition freshness", () => {
+  // Regression for a memo-staleness bug: the expanded card computed its
+  // referenceable list behind the CanvasQuestion memo boundary, so a type
+  // change on the REFERENCED question never reached an open editor.
+  it("propagates a reference type change into an open condition editor", () => {
+    const asRating = new Map<string, ReferenceableQuestion[]>([
+      [
+        "q2",
+        [
+          {
+            id: "q1",
+            prompt: "Hvordan opplevde du tjenesten?",
+            type: "rating",
+            pageNumber: 1,
+            questionNumber: 1,
+          },
+        ],
+      ],
+    ]);
+    // Every other prop keeps its identity across the rerender — exactly the
+    // route contract (stable useCallbacks) — so only the map may invalidate
+    // the CanvasQuestion memo.
+    const stableProps = canvasProps(asRating);
+    const { rerender } = render(<QuestionCanvas {...stableProps} />);
+    expect(screen.queryByText(/passer ikke spørsmålet/i)).toBeNull();
+
+    const asText = new Map<string, ReferenceableQuestion[]>([
+      [
+        "q2",
+        [
+          {
+            id: "q1",
+            prompt: "Hvordan opplevde du tjenesten?",
+            type: "text",
+            pageNumber: 1,
+            questionNumber: 1,
+          },
+        ],
+      ],
+    ]);
+    rerender(
+      <QuestionCanvas {...stableProps} referenceableByQuestion={asText} />,
+    );
+    expect(screen.getByText(/passer ikke spørsmålet/i)).toBeVisible();
+  });
+});

--- a/apps/lumi-dashboard/app/components/surveyverksted/verksted.module.css
+++ b/apps/lumi-dashboard/app/components/surveyverksted/verksted.module.css
@@ -274,6 +274,62 @@
   gap: var(--ax-space-2);
 }
 
+/* ---------- Condition editor ---------- */
+
+.conditionSection {
+  display: flex;
+  flex-direction: column;
+  gap: var(--ax-space-8);
+  padding: var(--ax-space-12);
+  background: var(--ax-bg-neutral-soft);
+  border: 1px solid var(--ax-border-neutral-subtle);
+  border-radius: var(--ax-radius-8);
+}
+
+.conditionHeader {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: var(--ax-space-8);
+}
+
+.conditionRow {
+  display: grid;
+  grid-template-columns: minmax(12rem, 2fr) minmax(8rem, 1fr) minmax(8rem, 1fr);
+  gap: var(--ax-space-8);
+  /* Top-aligned: a field error must grow its own column downward without
+     dragging the neighbouring fields with it. */
+  align-items: start;
+}
+
+.conditionAddWrap {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--ax-space-8);
+}
+
+.conditionHint {
+  color: var(--ax-text-neutral-subtle);
+}
+
+.cardConditional {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--ax-space-4);
+  color: var(--ax-text-neutral-subtle);
+  white-space: nowrap;
+}
+
+.cardConditional svg {
+  font-size: 1rem;
+}
+
+@media (max-width: 60rem) {
+  .conditionRow {
+    grid-template-columns: 1fr;
+  }
+}
+
 /* ---------- Shared utilities ---------- */
 
 .eyebrow {
@@ -535,6 +591,24 @@
   gap: var(--ax-space-4);
   color: var(--ax-text-neutral-subtle);
   font-size: 0.95rem;
+}
+
+.railIconPair {
+  display: inline-flex;
+  align-items: center;
+  gap: 1px;
+}
+
+.railIconPair svg + svg {
+  font-size: 0.8rem;
+  opacity: 0.8;
+}
+
+.cardTriggerMeta {
+  display: inline-flex;
+  flex-direction: column;
+  gap: var(--ax-space-2);
+  align-items: flex-end;
 }
 
 .railMenu {

--- a/apps/lumi-dashboard/app/routes/surveyverksted.$projectId.tsx
+++ b/apps/lumi-dashboard/app/routes/surveyverksted.$projectId.tsx
@@ -39,16 +39,22 @@ import {
   isDraftConflictError,
   isRetryableSaveError,
 } from "~/utils/surveyAuthoringErrors";
+import type {
+  ReferenceableQuestion,
+  VisibleIfConditionV1,
+} from "~/utils/surveyDocument";
 import {
   addOption,
   addPage,
   addQuestion,
   changeQuestionType,
+  conditionValueSuggestions,
   duplicatePage,
   duplicateQuestion,
   findHandoffIssues,
   insertPageAt,
   insertQuestionAt,
+  listReferenceableQuestions,
   locateQuestion,
   type MoveDirection,
   moveOption,
@@ -60,6 +66,7 @@ import {
   removeOption,
   removePage,
   removeQuestion,
+  setQuestionVisibleIf,
   updateOptionLabel,
   updateOptionValue,
 } from "~/utils/surveyDocument";
@@ -674,6 +681,37 @@ function SurveyWorkshopEditor({
     setSettingsOpen(true);
   }, []);
 
+  // Computed per document/expansion change so an open condition editor
+  // always sees the CURRENT types and prompts of earlier questions — a
+  // stable callback here would let the CanvasQuestion memo freeze stale
+  // reference data. Collapsed cards are absent and stay undefined.
+  const expandedReferenceable = useMemo(() => {
+    const map = new Map<string, ReferenceableQuestion[]>();
+    for (const id of expandedIds) {
+      map.set(id, listReferenceableQuestions(draft.document, id));
+    }
+    return map;
+  }, [draft.document, expandedIds]);
+
+  const suggestionsFor = useCallback(
+    (referencedId: string) =>
+      conditionValueSuggestions(draftRef.current.document, referencedId),
+    [],
+  );
+
+  const handleChangeVisibleIf = useCallback(
+    (questionId: string, condition: VisibleIfConditionV1 | undefined) =>
+      updateDocument(
+        setQuestionVisibleIf(
+          draftRef.current.document,
+          selectedPageRef.current,
+          questionId,
+          condition,
+        ),
+      ),
+    [updateDocument],
+  );
+
   const optionHandlersFor = useCallback(
     (questionId: string) => ({
       onAdd: () =>
@@ -883,6 +921,9 @@ function SurveyWorkshopEditor({
             onMoveQuestion={handleMoveQuestion}
             onReorderQuestion={handleReorderQuestion}
             optionHandlersFor={optionHandlersFor}
+            referenceableByQuestion={expandedReferenceable}
+            suggestionsFor={suggestionsFor}
+            onChangeVisibleIf={handleChangeVisibleIf}
             onAddQuestion={handleAddQuestion}
           />
         </section>

--- a/apps/lumi-dashboard/app/utils/surveyDocument.test.ts
+++ b/apps/lumi-dashboard/app/utils/surveyDocument.test.ts
@@ -4,7 +4,9 @@ import {
   addOption,
   addPage,
   addQuestion,
+  allowedConditionOperators,
   changeQuestionType,
+  conditionValueSuggestions,
   createQuestion,
   documentNeedsWideDock,
   duplicatePage,
@@ -12,6 +14,7 @@ import {
   findHandoffIssues,
   insertPageAt,
   insertQuestionAt,
+  listReferenceableQuestions,
   locateQuestion,
   moveOption,
   movePage,
@@ -22,6 +25,7 @@ import {
   removeOption,
   removePage,
   removeQuestion,
+  setQuestionVisibleIf,
   slugifyOptionValue,
   suggestSurveyId,
   updateOptionLabel,
@@ -352,14 +356,14 @@ describe("duplicatePage", () => {
     const next = duplicatePage(document, "side-a", sequentialIds());
     expect(next.pages.map((page) => page.id)).toEqual([
       "side-a",
-      "side-id-1",
+      "side-id-3",
       "side-b",
     ]);
     const copy = next.pages[1];
     expect(copy.title).toBe("Første side");
     expect(copy.questions.map((question) => question.id)).toEqual([
-      "rating-id-2",
-      "text-id-3",
+      "rating-id-1",
+      "text-id-2",
     ]);
     expect(copy.questions[0]).toMatchObject({ type: "rating" });
   });
@@ -403,6 +407,74 @@ describe("moveQuestionToIndex", () => {
     expect(moveQuestionToIndex(document, "side-a", "finnes-ikke", 1)).toBe(
       document,
     );
+  });
+});
+
+describe("duplicatePage condition remapping", () => {
+  it("rewrites internal references to the copied questions", () => {
+    const document = makeDocument();
+    document.pages[0].questions[1] = {
+      ...document.pages[0].questions[1],
+      visibleIf: { questionId: "rating-1", operator: "EXISTS" },
+    };
+    const next = duplicatePage(document, "side-a", sequentialIds());
+    const copy = next.pages[1];
+    const [copiedRating, copiedText] = copy.questions;
+    expect(copiedText.visibleIf).toEqual({
+      questionId: copiedRating.id,
+      operator: "EXISTS",
+    });
+  });
+
+  it("rewrites references inside groups but keeps external references", () => {
+    const document = makeDocument();
+    document.pages[1].questions[0] = {
+      ...document.pages[1].questions[0],
+      visibleIf: {
+        all: [
+          { questionId: "rating-1", operator: "EXISTS" },
+          { questionId: "choice-1", operator: "EXISTS" },
+        ],
+      },
+    };
+    const next = duplicatePage(document, "side-b", sequentialIds());
+    const copy = next.pages[2];
+    const condition = copy.questions[0].visibleIf;
+    if (!condition || !("all" in condition)) throw new Error("missing group");
+    // choice-1 lives on the copied page → remapped; rating-1 is external → kept.
+    expect(condition.all[0]).toEqual({
+      questionId: "rating-1",
+      operator: "EXISTS",
+    });
+    const internal = condition.all[1];
+    if (!("questionId" in internal)) throw new Error("expected answer leaf");
+    expect(internal.questionId).toBe(copy.questions[0].id);
+  });
+});
+
+describe("duplicatePage target discrimination", () => {
+  it("remaps an explicit ANSWER leaf even when it carries a stray metadata key", () => {
+    // Runtime and API discriminate on `field`, so this leaf is ANSWER
+    // semantics — a stray `key` must not make the builder treat it as
+    // METADATA and skip the remap.
+    const document = makeDocument();
+    const stray = {
+      field: "ANSWER" as const,
+      questionId: "rating-1",
+      key: "ekstra-felt",
+      operator: "EXISTS" as const,
+    };
+    document.pages[0].questions[1] = {
+      ...document.pages[0].questions[1],
+      visibleIf: stray,
+    };
+    const next = duplicatePage(document, "side-a", sequentialIds());
+    const copy = next.pages[1];
+    const condition = copy.questions[1].visibleIf;
+    if (!condition || !("questionId" in condition)) {
+      throw new Error("expected answer leaf");
+    }
+    expect(condition.questionId).toBe(copy.questions[0].id);
   });
 });
 
@@ -577,6 +649,349 @@ describe("documentNeedsWideDock", () => {
       prompt: "Hvor sannsynlig er det at du anbefaler oss?",
     };
     expect(documentNeedsWideDock(document)).toBe(true);
+  });
+});
+
+describe("setQuestionVisibleIf", () => {
+  it("sets a leaf condition on the question", () => {
+    const document = makeDocument();
+    const next = setQuestionVisibleIf(document, "side-a", "text-1", {
+      questionId: "rating-1",
+      operator: "EXISTS",
+    });
+    expect(next.pages[0].questions[1].visibleIf).toEqual({
+      questionId: "rating-1",
+      operator: "EXISTS",
+    });
+  });
+
+  it("clears the condition when given undefined", () => {
+    const document = makeDocument();
+    const withCondition = setQuestionVisibleIf(document, "side-a", "text-1", {
+      questionId: "rating-1",
+      operator: "EXISTS",
+    });
+    const cleared = setQuestionVisibleIf(
+      withCondition,
+      "side-a",
+      "text-1",
+      undefined,
+    );
+    expect("visibleIf" in cleared.pages[0].questions[1]).toBe(false);
+  });
+});
+
+describe("listReferenceableQuestions", () => {
+  it("returns only strictly earlier questions in page order", () => {
+    const document = makeDocument();
+    expect(
+      listReferenceableQuestions(document, "choice-1").map(
+        (candidate) => candidate.id,
+      ),
+    ).toEqual(["rating-1", "text-1"]);
+    expect(
+      listReferenceableQuestions(document, "text-1").map(
+        (candidate) => candidate.id,
+      ),
+    ).toEqual(["rating-1"]);
+  });
+
+  it("is empty for the first question and unknown ids", () => {
+    const document = makeDocument();
+    expect(listReferenceableQuestions(document, "rating-1")).toEqual([]);
+    expect(listReferenceableQuestions(document, "finnes-ikke")).toEqual([]);
+  });
+
+  it("labels each candidate with page and question number", () => {
+    const document = makeDocument();
+    const [first] = listReferenceableQuestions(document, "choice-1");
+    expect(first).toMatchObject({
+      id: "rating-1",
+      pageNumber: 1,
+      questionNumber: 1,
+      prompt: "Hvordan opplevde du tjenesten?",
+    });
+  });
+});
+
+describe("conditionValueSuggestions", () => {
+  it("suggests option values for choice questions", () => {
+    const document = makeDocument();
+    expect(conditionValueSuggestions(document, "choice-1")).toEqual([
+      { value: "soke", label: "Søke" },
+      { value: "sjekke-status", label: "Sjekke status" },
+    ]);
+  });
+
+  it("suggests the fixed scale for rating variants", () => {
+    const document = makeDocument();
+    expect(
+      conditionValueSuggestions(document, "rating-1").map(
+        (suggestion) => suggestion.value,
+      ),
+    ).toEqual([1, 2, 3, 4, 5]);
+  });
+
+  it("suggests nothing for text questions and unknown ids", () => {
+    const document = makeDocument();
+    expect(conditionValueSuggestions(document, "text-1")).toEqual([]);
+    expect(conditionValueSuggestions(document, "finnes-ikke")).toEqual([]);
+  });
+});
+
+describe("allowedConditionOperators", () => {
+  it("gives multiChoice only EXISTS and CONTAINS", () => {
+    expect(allowedConditionOperators("multiChoice")).toEqual([
+      "EXISTS",
+      "CONTAINS",
+    ]);
+    expect(allowedConditionOperators("singleChoice")).toEqual([
+      "EXISTS",
+      "EQ",
+      "NEQ",
+    ]);
+  });
+});
+
+describe("findHandoffIssues for conditions", () => {
+  function withCondition(
+    condition: NonNullable<
+      SurveyDocumentV1["pages"][number]["questions"][number]["visibleIf"]
+    >,
+  ): SurveyDocumentV1 {
+    const document = makeDocument();
+    document.pages[1].questions[0] = {
+      ...document.pages[1].questions[0],
+      visibleIf: condition,
+    };
+    return document;
+  }
+
+  it("flags EQ against a multiChoice reference", () => {
+    const document = makeDocument();
+    document.pages[0].questions[1] = {
+      id: "multi-1",
+      type: "multiChoice",
+      prompt: "Velg flere",
+      options: [
+        { value: "en", label: "En" },
+        { value: "to", label: "To" },
+      ],
+    };
+    document.pages[1].questions[0] = {
+      ...document.pages[1].questions[0],
+      visibleIf: { questionId: "multi-1", operator: "EQ", value: "en" },
+    };
+    const issues = findHandoffIssues(document);
+    expect(
+      issues.some((issue) => /vilkår som ikke passer/i.test(issue.message)),
+    ).toBe(true);
+    expect(issues[0].questionId).toBe("choice-1");
+  });
+
+  it("flags a value outside the referenced choice options", () => {
+    const issues = findHandoffIssues(
+      withCondition({
+        questionId: "rating-1",
+        operator: "EQ",
+        value: 99,
+      }),
+    );
+    expect(issues.some((issue) => /utenfor skalaen/i.test(issue.message))).toBe(
+      true,
+    );
+  });
+
+  it("accepts a valid CONTAINS condition and EXISTS", () => {
+    expect(
+      findHandoffIssues(
+        withCondition({ questionId: "rating-1", operator: "EXISTS" }),
+      ),
+    ).toEqual([]);
+    expect(
+      findHandoffIssues(
+        withCondition({ questionId: "rating-1", operator: "EQ", value: 3 }),
+      ),
+    ).toEqual([]);
+  });
+
+  it("requires string values against text references", () => {
+    const issues = findHandoffIssues(
+      withCondition({ questionId: "text-1", operator: "EQ", value: 3 }),
+    );
+    expect(issues.some((issue) => /må være tekst/i.test(issue.message))).toBe(
+      true,
+    );
+    expect(
+      findHandoffIssues(
+        withCondition({ questionId: "text-1", operator: "EQ", value: "3" }),
+      ),
+    ).toEqual([]);
+  });
+
+  it("rejects empty and whitespace-only values against text references", () => {
+    // Blank text answers are stripped from runtime answer state, so EQ ""
+    // can never match, NEQ "" is true before any answer, and CONTAINS ""
+    // matches every non-empty answer.
+    for (const value of ["", "   "]) {
+      const issues = findHandoffIssues(
+        withCondition({ questionId: "text-1", operator: "CONTAINS", value }),
+      );
+      expect(
+        issues.some((issue) => /kan ikke være tom/i.test(issue.message)),
+      ).toBe(true);
+    }
+  });
+
+  it("validates ANSWER semantics when the leaf carries a stray metadata key", () => {
+    const stray = {
+      field: "ANSWER" as const,
+      questionId: "text-1",
+      key: "ekstra-felt",
+      operator: "GT" as const,
+      value: 2,
+    };
+    const issues = findHandoffIssues(withCondition(stray));
+    expect(
+      issues.some((issue) => /vilkår som ikke passer/i.test(issue.message)),
+    ).toBe(true);
+  });
+
+  it("flags contradictory targets in both directions", () => {
+    const answerWithKey = {
+      field: "ANSWER" as const,
+      questionId: "rating-1",
+      key: "ekstra-felt",
+      operator: "EXISTS" as const,
+    };
+    expect(
+      findHandoffIssues(withCondition(answerWithKey)).some((issue) =>
+        /metadata-nøkkel/i.test(issue.message),
+      ),
+    ).toBe(true);
+
+    const metadataWithQuestionId = {
+      field: "METADATA" as const,
+      key: "flow",
+      questionId: "rating-1",
+      operator: "EXISTS" as const,
+    };
+    expect(
+      findHandoffIssues(withCondition(metadataWithQuestionId)).some((issue) =>
+        /spørsmålsreferanse/i.test(issue.message),
+      ),
+    ).toBe(true);
+  });
+
+  it("validates leaves inside groups too", () => {
+    const issues = findHandoffIssues(
+      withCondition({
+        any: [
+          { questionId: "rating-1", operator: "EQ", value: 3 },
+          { questionId: "rating-1", operator: "EQ", value: 42 },
+        ],
+      }),
+    );
+    expect(issues).toHaveLength(1);
+    expect(issues[0].message).toMatch(/utenfor skalaen/i);
+  });
+});
+
+describe("updateOptionValue condition migration", () => {
+  it("migrates later leaf conditions referencing the renamed value", () => {
+    const document = makeDocument();
+    document.pages[1].questions[0] = {
+      ...document.pages[1].questions[0],
+      visibleIf: undefined,
+    };
+    const withFollowUp: SurveyDocumentV1 = {
+      ...document,
+      pages: [
+        document.pages[0],
+        {
+          ...document.pages[1],
+          questions: [
+            document.pages[1].questions[0],
+            {
+              id: "text-2",
+              type: "text",
+              prompt: "Utdyp",
+              visibleIf: {
+                questionId: "choice-1",
+                operator: "EQ",
+                value: "soke",
+              },
+            },
+          ],
+        },
+      ] as SurveyDocumentV1["pages"],
+    };
+    const next = updateOptionValue(
+      withFollowUp,
+      "side-b",
+      "choice-1",
+      0,
+      "sok-om-stotte",
+    );
+    expect(next.pages[1].questions[1].visibleIf).toEqual({
+      questionId: "choice-1",
+      operator: "EQ",
+      value: "sok-om-stotte",
+    });
+  });
+
+  it("migrates a leaf that carries a stray metadata key", () => {
+    const document = makeDocument();
+    const stray = {
+      field: "ANSWER" as const,
+      questionId: "choice-1",
+      key: "ekstra-felt",
+      operator: "EQ" as const,
+      value: "soke",
+    };
+    document.pages[1].questions[0] = {
+      ...document.pages[1].questions[0],
+      visibleIf: stray,
+    };
+    const next = updateOptionValue(document, "side-b", "choice-1", 0, "ny-id");
+    const condition = next.pages[1].questions[0].visibleIf;
+    if (!condition || !("questionId" in condition)) {
+      throw new Error("expected answer leaf");
+    }
+    expect(condition.value).toBe("ny-id");
+  });
+
+  it("never rewrites group conditions implicitly", () => {
+    const document = makeDocument();
+    const group = {
+      any: [{ questionId: "choice-1", operator: "EQ" as const, value: "soke" }],
+    };
+    const withGroup: SurveyDocumentV1 = {
+      ...document,
+      pages: [
+        document.pages[0],
+        {
+          ...document.pages[1],
+          questions: [
+            document.pages[1].questions[0],
+            {
+              id: "text-2",
+              type: "text",
+              prompt: "Utdyp",
+              visibleIf: group,
+            },
+          ],
+        },
+      ] as SurveyDocumentV1["pages"],
+    };
+    const next = updateOptionValue(
+      withGroup,
+      "side-b",
+      "choice-1",
+      0,
+      "ny-verdi",
+    );
+    expect(next.pages[1].questions[1].visibleIf).toEqual(group);
   });
 });
 

--- a/apps/lumi-dashboard/app/utils/surveyDocument.ts
+++ b/apps/lumi-dashboard/app/utils/surveyDocument.ts
@@ -330,13 +330,42 @@ export function duplicatePage(
   const index = document.pages.findIndex((page) => page.id === pageId);
   if (index === -1) return document;
   const original = document.pages[index];
+  // New ids for the copies, and a map so INTERNAL condition references
+  // follow their copied questions. External references and METADATA
+  // conditions are kept as-is.
+  const idByOriginal = new Map<string, string>();
+  for (const question of original.questions) {
+    idByOriginal.set(question.id, `${question.type}-${idFactory()}`);
+  }
+  type ConditionLeaf = Exclude<
+    VisibleIfConditionV1,
+    { any: unknown } | { all: unknown }
+  >;
+  const remapLeaf = (leaf: ConditionLeaf): ConditionLeaf => {
+    if (isMetadataCondition(leaf)) return leaf;
+    const mapped = idByOriginal.get(leaf.questionId);
+    return mapped ? { ...leaf, questionId: mapped } : leaf;
+  };
   const copy: SurveyPageV1 = {
     ...structuredClone(original),
     id: `side-${idFactory()}`,
-    questions: original.questions.map((question) => ({
-      ...structuredClone(question),
-      id: `${question.type}-${idFactory()}`,
-    })) as QuestionList,
+    questions: original.questions.map((question) => {
+      const cloned: SurveyQuestionV1 = {
+        ...structuredClone(question),
+        id: idByOriginal.get(question.id) ?? question.id,
+      };
+      const condition = cloned.visibleIf;
+      if (condition) {
+        if ("any" in condition) {
+          cloned.visibleIf = { any: condition.any.map(remapLeaf) };
+        } else if ("all" in condition) {
+          cloned.visibleIf = { all: condition.all.map(remapLeaf) };
+        } else {
+          cloned.visibleIf = remapLeaf(condition);
+        }
+      }
+      return cloned;
+    }) as QuestionList,
   };
   const pages = [...document.pages];
   pages.splice(index + 1, 0, copy);
@@ -413,12 +442,49 @@ export function updateOptionValue(
   optionIndex: number,
   value: string,
 ): SurveyDocumentV1 {
-  return updateChoiceOptions(document, pageId, questionId, (options) => {
-    if (optionIndex < 0 || optionIndex >= options.length) return null;
-    const next = [...options];
-    next[optionIndex] = { ...next[optionIndex], value };
-    return next;
-  });
+  let previousValue: string | undefined;
+  const updated = updateChoiceOptions(
+    document,
+    pageId,
+    questionId,
+    (options) => {
+      if (optionIndex < 0 || optionIndex >= options.length) return null;
+      previousValue = options[optionIndex].value;
+      const next = [...options];
+      next[optionIndex] = { ...next[optionIndex], value };
+      return next;
+    },
+  );
+  if (updated === document || previousValue === undefined) return updated;
+
+  // Follow the rename into DIRECT leaf conditions that reference it, so an
+  // explicit value edit does not silently break later visibility. Groups
+  // and METADATA conditions are never rewritten implicitly.
+  const migrated = previousValue;
+  return {
+    ...updated,
+    pages: updated.pages.map((page) => ({
+      ...page,
+      questions: page.questions.map((question) => {
+        const condition = question.visibleIf;
+        if (!condition || "any" in condition || "all" in condition) {
+          return question;
+        }
+        if (isMetadataCondition(condition)) return question;
+        if (
+          condition.questionId === questionId &&
+          condition.operator !== "EXISTS" &&
+          condition.value === migrated
+        ) {
+          return {
+            ...question,
+            visibleIf: { ...condition, value },
+          };
+        }
+        return question;
+      }) as SurveyPageV1["questions"],
+    })) as SurveyDocumentV1["pages"],
+  };
 }
 
 export function removeOption(
@@ -476,6 +542,26 @@ export function insertPageAt(
   return { ...document, pages: pages as PageList };
 }
 
+/**
+ * Operators that behave correctly against the referenced question type at
+ * runtime. multiChoice answers are arrays: strict EQ/NEQ never match, so
+ * only EXISTS and CONTAINS are offered.
+ */
+export function allowedConditionOperators(
+  type: SurveyQuestionV1["type"],
+): string[] {
+  switch (type) {
+    case "rating":
+      return ["EXISTS", "EQ", "NEQ", "GT", "LT"];
+    case "singleChoice":
+      return ["EXISTS", "EQ", "NEQ"];
+    case "multiChoice":
+      return ["EXISTS", "CONTAINS"];
+    default:
+      return ["EXISTS", "EQ", "NEQ", "CONTAINS"];
+  }
+}
+
 export interface HandoffIssue {
   questionId: string;
   message: string;
@@ -487,10 +573,107 @@ export interface HandoffIssue {
  * adds the semantic bar a handoff deserves. Deliberately NOT part of the
  * widget package — production consumers stay untouched.
  */
+function leafConditionIssues(
+  question: SurveyQuestionV1,
+  questionById: Map<string, SurveyQuestionV1>,
+): HandoffIssue[] {
+  const condition = question.visibleIf;
+  if (!condition) return [];
+  const leaves =
+    "any" in condition
+      ? condition.any
+      : "all" in condition
+        ? condition.all
+        : [condition];
+  const issues: HandoffIssue[] = [];
+  for (const leaf of leaves) {
+    if (isMetadataCondition(leaf)) {
+      if ("questionId" in leaf) {
+        issues.push({
+          questionId: question.id,
+          message:
+            "Betingelsen peker på metadata, men har også en spørsmålsreferanse — fjern «questionId» eller sett field til ANSWER.",
+        });
+      }
+      continue; // METADATA: no schema to validate against
+    }
+    if ("key" in leaf) {
+      // The stray key is ignored by runtime, but it reads as METADATA to a
+      // human — refuse to freeze the ambiguity. ANSWER semantics are still
+      // validated below.
+      issues.push({
+        questionId: question.id,
+        message:
+          "Betingelsen peker på et spørsmål, men har også en metadata-nøkkel — fjern «key» eller sett field til METADATA.",
+      });
+    }
+    if (!leaf.questionId) continue;
+    const referenced = questionById.get(leaf.questionId);
+    if (!referenced) continue; // Missing/forward refs are runtime-validated
+    if (!allowedConditionOperators(referenced.type).includes(leaf.operator)) {
+      issues.push({
+        questionId: question.id,
+        message:
+          "Betingelsen bruker et vilkår som ikke passer spørsmålet det peker på.",
+      });
+      continue;
+    }
+    if (leaf.operator === "EXISTS") continue;
+    if (
+      referenced.type === "singleChoice" ||
+      referenced.type === "multiChoice"
+    ) {
+      const known = referenced.options.some(
+        (option) => option.value === leaf.value,
+      );
+      if (!known) {
+        issues.push({
+          questionId: question.id,
+          message:
+            "Betingelsens verdi finnes ikke blant alternativene til spørsmålet det peker på.",
+        });
+      }
+    } else if (referenced.type === "rating") {
+      const scale = RATING_SCALES[referenced.variant ?? "emoji"] ?? [];
+      if (typeof leaf.value !== "number" || !scale.includes(leaf.value)) {
+        issues.push({
+          questionId: question.id,
+          message:
+            "Betingelsens verdi er utenfor skalaen til spørsmålet det peker på.",
+        });
+      }
+    } else if (typeof leaf.value !== "string") {
+      // Text answers compare strictly at runtime: 3 never matches "3".
+      issues.push({
+        questionId: question.id,
+        message:
+          "Betingelsens verdi må være tekst når den peker på et tekstspørsmål.",
+      });
+    } else if (leaf.value.trim().length === 0) {
+      // Blank text answers are stripped from runtime answer state, so a
+      // blank value gives EQ that never matches, NEQ that is true before
+      // any answer, and CONTAINS that matches everything.
+      issues.push({
+        questionId: question.id,
+        message:
+          "Betingelsens verdi kan ikke være tom når den peker på et tekstspørsmål.",
+      });
+    }
+  }
+  return issues;
+}
+
 export function findHandoffIssues(document: SurveyDocumentV1): HandoffIssue[] {
   const issues: HandoffIssue[] = [];
+  const questionById = new Map<string, SurveyQuestionV1>();
   for (const page of document.pages) {
     for (const question of page.questions) {
+      questionById.set(question.id, question);
+    }
+  }
+  for (const page of document.pages) {
+    for (const question of page.questions) {
+      issues.push(...leafConditionIssues(question, questionById));
       if (!question.prompt.trim()) {
         issues.push({
           questionId: question.id,
@@ -529,6 +712,104 @@ export function documentNeedsWideDock(document: SurveyDocumentV1): boolean {
       (question) => question.type === "rating" && question.variant === "nps",
     ),
   );
+}
+
+export type VisibleIfConditionV1 = NonNullable<SurveyQuestionV1["visibleIf"]>;
+
+/**
+ * Runtime (`evaluateVisibility`) and the API validator both discriminate
+ * the condition target on `field` ALONE — a stray `key` on an ANSWER leaf
+ * must never make the builder treat it as METADATA. Keep in sync with
+ * the widget package.
+ */
+export function isMetadataCondition<
+  T extends { field?: "ANSWER" | "METADATA" },
+>(leaf: T): leaf is Extract<T, { field: "METADATA" }> {
+  return leaf.field === "METADATA";
+}
+
+/** Sets or clears a question's visibility condition. */
+export function setQuestionVisibleIf(
+  document: SurveyDocumentV1,
+  pageId: string,
+  questionId: string,
+  condition: VisibleIfConditionV1 | undefined,
+): SurveyDocumentV1 {
+  return updateQuestion(document, pageId, questionId, (question) => {
+    if (condition === undefined) {
+      const { visibleIf: _removed, ...rest } = question;
+      return rest as SurveyQuestionV1;
+    }
+    return { ...question, visibleIf: condition };
+  });
+}
+
+export interface ReferenceableQuestion {
+  id: string;
+  prompt: string;
+  type: SurveyQuestionV1["type"];
+  pageNumber: number;
+  questionNumber: number;
+}
+
+/**
+ * Questions a visibleIf condition on `questionId` may reference: strictly
+ * earlier in flattened page order, mirroring the runtime validator's rule.
+ */
+export function listReferenceableQuestions(
+  document: SurveyDocumentV1,
+  questionId: string,
+): ReferenceableQuestion[] {
+  const earlier: ReferenceableQuestion[] = [];
+  for (const [pageIndex, page] of document.pages.entries()) {
+    for (const [questionIndex, question] of page.questions.entries()) {
+      if (question.id === questionId) return earlier;
+      earlier.push({
+        id: question.id,
+        prompt: question.prompt,
+        type: question.type,
+        pageNumber: pageIndex + 1,
+        questionNumber: questionIndex + 1,
+      });
+    }
+  }
+  return [];
+}
+
+export interface ConditionValueSuggestion {
+  value: string | number;
+  label: string;
+}
+
+const RATING_SCALES: Record<string, number[]> = {
+  emoji: [1, 2, 3, 4, 5],
+  stars: [1, 2, 3, 4, 5],
+  thumbs: [1, 2],
+  nps: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10],
+};
+
+/** Value suggestions for a condition referencing the given question. */
+export function conditionValueSuggestions(
+  document: SurveyDocumentV1,
+  referencedQuestionId: string,
+): ConditionValueSuggestion[] {
+  for (const page of document.pages) {
+    for (const question of page.questions) {
+      if (question.id !== referencedQuestionId) continue;
+      if (question.type === "singleChoice" || question.type === "multiChoice") {
+        return question.options.map((option) => ({
+          value: option.value,
+          label: option.label,
+        }));
+      }
+      if (question.type === "rating") {
+        const scale = RATING_SCALES[question.variant ?? "emoji"] ?? [];
+        return scale.map((value) => ({ value, label: String(value) }));
+      }
+      return [];
+    }
+  }
+  return [];
 }
 
 export interface QuestionLocation {

--- a/apps/lumi-dashboard/e2e/survey-workshop.spec.ts
+++ b/apps/lumi-dashboard/e2e/survey-workshop.spec.ts
@@ -247,7 +247,7 @@ test("undo restores the deletion without losing later edits, and sharing surface
   await page.goBack();
   await expect(page).toHaveURL(/\/surveyverksted\?team=/);
   await expect(
-    page.getByRole("link", { name: /Nytt navn uten blur/ }),
+    page.getByRole("link", { name: /Nytt navn uten blur/ }).first(),
   ).toBeVisible();
 });
 
@@ -363,4 +363,74 @@ test("a flush inherits a failed save instead of repeating it", async ({
   await expect(page).toHaveURL(/\/surveyverksted\/[0-9a-f-]+/);
   await expect(page.getByText(/endret i en annen fane/)).toBeVisible();
   await page.unroute("**/*");
+});
+
+test("a visibility condition set in the editor gates the question live in the stage", async ({
+  page,
+}) => {
+  await page.goto("/surveyverksted");
+  await page.getByLabel("Navn på utkastet").fill("Betinget-utkast");
+  await page.getByRole("button", { name: "Opprett utkast" }).click();
+  await page.waitForURL(/\/surveyverksted\/[0-9a-f-]+/);
+
+  const stage = page.getByLabel("Forhåndsvisning");
+  await expect(
+    stage.getByRole("textbox", { name: /Hva kan vi gjøre bedre/ }),
+  ).toBeVisible();
+
+  // Both seeded questions are expanded; add a condition on the follow-up.
+  await page
+    .getByRole("button", { name: /Vis bare hvis/ })
+    .last()
+    .click();
+  await expect(page.getByLabel("Spørsmål", { exact: true })).toHaveValue(
+    "rating",
+  );
+  await expect(page.getByLabel("Vilkår")).toHaveValue("EXISTS");
+
+  // The stage now hides the follow-up until the rating is answered.
+  await expect(
+    stage.getByRole("textbox", { name: /Hva kan vi gjøre bedre/ }),
+  ).not.toBeVisible({ timeout: 10000 });
+  await stage.getByRole("radio").nth(2).click();
+  await expect(
+    stage.getByRole("textbox", { name: /Hva kan vi gjøre bedre/ }),
+  ).toBeVisible();
+
+  await expect(page.locator('[data-state="saved"]')).toBeVisible();
+  await expectNoAxeViolations(page);
+
+  // Removing the condition brings the question back unconditionally.
+  await page.getByRole("button", { name: "Fjern betingelsen" }).click();
+  await expect(
+    stage.getByRole("textbox", { name: /Hva kan vi gjøre bedre/ }),
+  ).toBeVisible({ timeout: 10000 });
+
+  // multiChoice references only offer operators that can match arrays,
+  // and CONTAINS gates live in the stage.
+  await page.getByRole("button", { name: "Vurdering" }).click();
+  await page.getByRole("menuitem", { name: /Flervalg/ }).click();
+  await page
+    .getByRole("button", { name: /Vis bare hvis/ })
+    .last()
+    .click();
+  await expect(page.getByRole("option", { name: "inneholder" })).toBeAttached();
+  await expect(page.getByRole("option", { name: "er lik" })).toHaveCount(0);
+  await page.getByLabel("Vilkår").selectOption("CONTAINS");
+  await expect(
+    page.getByLabel("Verdi", { exact: true }).locator("option:checked"),
+  ).toHaveText("Alternativ 1");
+  await expect(
+    stage.getByRole("textbox", { name: /Hva kan vi gjøre bedre/ }),
+  ).not.toBeVisible({ timeout: 10000 });
+  await stage.getByRole("checkbox", { name: "Alternativ 1" }).click();
+  await expect(
+    stage.getByRole("textbox", { name: /Hva kan vi gjøre bedre/ }),
+  ).toBeVisible();
+  await expect(page.locator('[data-state="saved"]')).toBeVisible();
+
+  // The full condition UI (question/operator/value + warnings-free state)
+  // must also pass axe in dark mode.
+  await page.getByRole("button", { name: "Bytt til mørk modus" }).click();
+  await expectNoAxeViolations(page);
 });


### PR DESCRIPTION
Closes #433

## Hva

- **Betingelsesseksjon** på hvert ekspandert spørsmålskort: «Vis bare hvis …» med spørsmål/vilkår/verdi, typede verdiforslag fra det refererte spørsmålet (options/skala), og live gating i forhåndsvisningsscenen.
- **Operator-allowlist per referert type** delt mellom editor, dashboard-handoff og API-release-gaten — multiChoice-svar er arrays, så kun EXISTS/CONTAINS; tekst kun EXISTS/EQ/NEQ/CONTAINS med strengverdier.
- **Stale betingelser** (referanse/vilkår/verdi som ikke lenger passer) rendres som eksplisitte døde options med feltfeil via Aksels error-props (aria-describedby + polite live region) — en native select later aldri som betingelsen er reparert.
- **Release-gaten håndheves server-side**: operator/type-mismatch, verdier utenfor options/skala, ikke-streng eller blank verdi mot tekstspørsmål, og blandede target-felter (key på ANSWER / questionId på METADATA) avvises ved frysing. Utkast forblir leniente. Dashboard-handoffen speiler samme regler.
- **Konsistent target-diskriminering**: builderen følger runtime-kontrakten (field === "METADATA") i editor, sidekopiering, option-migrering og handoff-validering.
- **Strukturelle garantier**: sidekopiering remapper interne referanser til de kopierte spørsmålene; eksplisitt verdi-rename migrerer direkte leaf-referanser; referansedata beregnes per dokumentendring uten å bryte memo-bailout for kollapsede kort.
- Betingede spørsmål får forgreningsindikator i rail og kanvas (sr-only-teller i railen).

## Test

- Dashboard: 439 vitest (mutasjoner, editor-tilstander, memo-regresjon), tsc, biome
- API: 682 tester inkl. release-gate-semantikk begge veier
- E2E: 5/5 — live gating i scenen (EXISTS + CONTAINS), axe i lys/mørk modus
- Fire adversarial review-runder verifisert og rettet før PR