### PR TITLE
Surveyverksted: OG/ELLER-grupper i betingelsesbyggeren

### DIFF
--- a/apps/lumi-dashboard/app/components/surveyverksted/ConditionEditor.tsx
+++ b/apps/lumi-dashboard/app/components/surveyverksted/ConditionEditor.tsx
@@ -1,43 +1,55 @@
-import { BranchingIcon, XMarkIcon } from "@navikt/aksel-icons";
+import { BranchingIcon, PlusIcon, XMarkIcon } from "@navikt/aksel-icons";
 import {
   BodyShort,
   Button,
   Detail,
   Select,
   TextField,
+  ToggleGroup,
   Tooltip,
 } from "@navikt/ds-react";
+import { useEffect, useRef } from "react";
 import {
   allowedConditionOperators,
+  buildVisibleIf,
+  type ConditionCombinator,
+  type ConditionLeafV1,
   type ConditionValueSuggestion,
+  conditionCombinator,
   isMetadataCondition,
   type ReferenceableQuestion,
   type VisibleIfConditionV1,
+  visibleIfLeaves,
 } from "~/utils/surveyDocument";
 import styles from "./verksted.module.css";
 
-type LeafCondition = Exclude<
-  VisibleIfConditionV1,
-  { any: unknown } | { all: unknown }
->;
+/**
+ * Stable editor-local row identities. Never serialized into visibleIf —
+ * they only keep React keys and focus tied to the RIGHT row when rows
+ * are removed from the middle of the list.
+ */
+function useStableRowIds(count: number) {
+  const nextRef = useRef(0);
+  const idsRef = useRef<number[]>([]);
+  if (idsRef.current.length !== count) {
+    // External shape change (add, undo, question switch): keep existing
+    // positions, mint ids for new rows.
+    idsRef.current = Array.from({ length: count }, (_, index) => {
+      const existing = idsRef.current[index];
+      return existing === undefined ? nextRef.current++ : existing;
+    });
+  }
+  return {
+    ids: idsRef.current,
+    removeAt(index: number) {
+      idsRef.current = idsRef.current.filter((_, i) => i !== index);
+    },
+  };
+}
 
-type AnswerLeaf = Exclude<LeafCondition, { field: "METADATA" }>;
+type AnswerLeaf = Exclude<ConditionLeafV1, { field: "METADATA" }>;
 
 type ValuedOperator = "EQ" | "NEQ" | "GT" | "LT" | "CONTAINS";
-
-function isGroup(
-  condition: VisibleIfConditionV1,
-): condition is Exclude<VisibleIfConditionV1, LeafCondition> {
-  return "any" in condition || "all" in condition;
-}
-
-function isAnswerLeaf(
-  condition: VisibleIfConditionV1,
-): condition is AnswerLeaf {
-  // Field-based like runtime and API: a stray `key` on an ANSWER leaf
-  // must not demote it to a read-only code condition.
-  return !isGroup(condition) && !isMetadataCondition(condition);
-}
 
 /**
  * DOM option values are type-prefixed so the string "3" can never
@@ -64,9 +76,11 @@ export interface ConditionEditorProps {
 }
 
 /**
- * Single-condition builder for question visibility ("Vis bare hvis …").
- * Mirrors the runtime rule that only earlier questions can be referenced.
- * Groups and METADATA conditions authored in code are shown read-only.
+ * Condition builder for question visibility ("Vis bare hvis …").
+ * Several conditions combine with all/any in the same one-level model as
+ * the runtime; a single condition stays a plain leaf. Mirrors the runtime
+ * rule that only earlier questions can be referenced. METADATA conditions
+ * authored in code are shown read-only but can be removed.
  */
 export function ConditionEditor({
   condition,
@@ -74,6 +88,38 @@ export function ConditionEditor({
   suggestionsFor,
   onChange,
 }: ConditionEditorProps) {
+  const leaves = visibleIfLeaves(condition);
+  const rowIds = useStableRowIds(leaves.length);
+  const sectionRef = useRef<HTMLDivElement | null>(null);
+  // `row:<id>` / "add" — resolved to a focus() after the removal renders,
+  // so focus moves with an announcement instead of silently via DOM reuse.
+  const pendingFocusRef = useRef<string | null>(null);
+  useEffect(() => {
+    const pending = pendingFocusRef.current;
+    if (!pending) return;
+    pendingFocusRef.current = null;
+    const root = sectionRef.current;
+    if (!root) return;
+    // Resolve against what actually remains: the requested row, then the
+    // add button, then the header remove button — a collapsed metadata
+    // branch has no add button, and a disabled control cannot take focus.
+    const selectors =
+      pending === "add"
+        ? ["[data-condition-add]", "[data-condition-remove-all]"]
+        : [
+            `[data-condition-remove="${pending}"]`,
+            "[data-condition-add]",
+            "[data-condition-remove-all]",
+          ];
+    for (const selector of selectors) {
+      const target = root.querySelector<HTMLButtonElement>(selector);
+      if (target && !target.disabled) {
+        target.focus();
+        return;
+      }
+    }
+  });
+
   if (condition === undefined) {
     const disabled = referenceable.length === 0;
     const addButton = (
@@ -102,9 +148,11 @@ export function ConditionEditor({
     );
   }
 
-  if (!isAnswerLeaf(condition)) {
+  const combinator = conditionCombinator(condition);
+
+  if (leaves.length === 1 && isMetadataCondition(leaves[0])) {
     return (
-      <div className={styles.conditionSection}>
+      <div ref={sectionRef} className={styles.conditionSection}>
         <div className={styles.conditionHeader}>
           <Detail as="span" className={styles.eyebrow}>
             BETINGELSE
@@ -116,53 +164,221 @@ export function ConditionEditor({
               size="xsmall"
               icon={<XMarkIcon aria-hidden />}
               aria-label="Fjern betingelsen"
+              data-condition-remove-all=""
               onClick={() => onChange(undefined)}
             />
           </Tooltip>
         </div>
         <BodyShort size="small" textColor="subtle">
-          Sammensatt betingelse satt i kode. Den beholdes som den er, eller kan
+          Metadatabetingelse satt i kode. Den beholdes som den er, eller kan
           fjernes her.
         </BodyShort>
       </div>
     );
   }
 
-  const referenced = referenceable.find(
-    (candidate) => candidate.id === condition.questionId,
+  const emit = (
+    nextLeaves: readonly ConditionLeafV1[],
+    nextCombinator: ConditionCombinator = combinator,
+  ) => onChange(buildVisibleIf(nextLeaves, nextCombinator));
+
+  const updateLeaf = (index: number, leaf: ConditionLeafV1) =>
+    emit(leaves.map((current, i) => (i === index ? leaf : current)));
+  const removeLeaf = (index: number) => {
+    pendingFocusRef.current =
+      leaves.length <= 2
+        ? "add"
+        : String(rowIds.ids[index + 1] ?? rowIds.ids[index - 1]);
+    rowIds.removeAt(index);
+    emit(leaves.filter((_, i) => i !== index));
+  };
+  const addLeaf = () =>
+    emit([...leaves, { questionId: referenceable[0].id, operator: "EXISTS" }]);
+
+  return (
+    <div ref={sectionRef} className={styles.conditionSection}>
+      <div className={styles.conditionHeader}>
+        <Detail as="span" className={styles.eyebrow}>
+          VISES BARE HVIS
+        </Detail>
+        <Tooltip content="Fjern betingelsen">
+          <Button
+            type="button"
+            variant="tertiary-neutral"
+            size="xsmall"
+            icon={<XMarkIcon aria-hidden />}
+            aria-label="Fjern betingelsen"
+            data-condition-remove-all=""
+            onClick={() => onChange(undefined)}
+          />
+        </Tooltip>
+      </div>
+      {leaves.length >= 2 ? (
+        <ToggleGroup
+          label="Kombiner betingelsene"
+          size="small"
+          value={combinator}
+          onChange={(next) => emit(leaves, next as ConditionCombinator)}
+        >
+          <ToggleGroup.Item value="all" label="Alle må stemme" />
+          <ToggleGroup.Item value="any" label="Minst én må stemme" />
+        </ToggleGroup>
+      ) : null}
+      {leaves.map((leaf, index) => {
+        const rowId = rowIds.ids[index];
+        const onRemove =
+          leaves.length > 1 ? () => removeLeaf(index) : undefined;
+        const groupLabel =
+          leaves.length > 1 ? `Betingelse ${index + 1}` : undefined;
+        return isMetadataCondition(leaf) ? (
+          <MetadataConditionRow
+            key={rowId}
+            leaf={leaf}
+            rowId={rowId}
+            index={index}
+            groupLabel={groupLabel}
+            onRemove={onRemove}
+          />
+        ) : (
+          <AnswerConditionRow
+            key={rowId}
+            leaf={leaf}
+            rowId={rowId}
+            index={index}
+            groupLabel={groupLabel}
+            referenceable={referenceable}
+            suggestionsFor={suggestionsFor}
+            onLeafChange={(next) => updateLeaf(index, next)}
+            onRemove={onRemove}
+          />
+        );
+      })}
+      <div>
+        <Button
+          type="button"
+          variant="tertiary"
+          size="small"
+          icon={<PlusIcon aria-hidden />}
+          disabled={referenceable.length === 0}
+          data-condition-add=""
+          onClick={addLeaf}
+        >
+          Legg til betingelse
+        </Button>
+      </div>
+    </div>
   );
-  const suggestions = condition.questionId
-    ? suggestionsFor(condition.questionId)
-    : [];
+}
+
+function RemoveRowButton({
+  index,
+  rowId,
+  onRemove,
+}: {
+  index: number;
+  rowId: number;
+  onRemove: () => void;
+}) {
+  const label = `Fjern betingelse ${index + 1}`;
+  return (
+    <Tooltip content={label}>
+      <Button
+        type="button"
+        variant="tertiary-neutral"
+        size="xsmall"
+        className={styles.conditionRowRemove}
+        icon={<XMarkIcon aria-hidden />}
+        aria-label={label}
+        data-condition-remove={rowId}
+        onClick={onRemove}
+      />
+    </Tooltip>
+  );
+}
+
+function MetadataConditionRow({
+  leaf,
+  rowId,
+  index,
+  groupLabel,
+  onRemove,
+}: {
+  leaf: Extract<ConditionLeafV1, { field: "METADATA" }>;
+  rowId: number;
+  index: number;
+  groupLabel: string | undefined;
+  onRemove: (() => void) | undefined;
+}) {
+  return (
+    <div
+      className={styles.conditionRowWrap}
+      {...(groupLabel ? { role: "group", "aria-label": groupLabel } : {})}
+    >
+      <BodyShort
+        size="small"
+        textColor="subtle"
+        className={styles.conditionMetadataRow}
+      >
+        Metadatabetingelse satt i kode (<code>{leaf.key}</code>)
+      </BodyShort>
+      {onRemove ? (
+        <RemoveRowButton index={index} rowId={rowId} onRemove={onRemove} />
+      ) : null}
+    </div>
+  );
+}
+
+function AnswerConditionRow({
+  leaf,
+  rowId,
+  index,
+  groupLabel,
+  referenceable,
+  suggestionsFor,
+  onLeafChange,
+  onRemove,
+}: {
+  leaf: AnswerLeaf;
+  rowId: number;
+  index: number;
+  groupLabel: string | undefined;
+  referenceable: ReferenceableQuestion[];
+  suggestionsFor: (referencedId: string) => ConditionValueSuggestion[];
+  onLeafChange: (leaf: ConditionLeafV1) => void;
+  onRemove: (() => void) | undefined;
+}) {
+  const referenced = referenceable.find(
+    (candidate) => candidate.id === leaf.questionId,
+  );
+  const suggestions = leaf.questionId ? suggestionsFor(leaf.questionId) : [];
   const operators = referenced
     ? allowedConditionOperators(referenced.type)
     : ["EXISTS"];
-  const needsValue = condition.operator !== "EXISTS";
+  const needsValue = leaf.operator !== "EXISTS";
 
   // Stale states render EXPLICITLY as dead, disabled options with a warning
   // — a native select must never pretend the condition was repaired.
-  const referenceMissing = condition.questionId !== undefined && !referenced;
-  const operatorStale =
-    !referenceMissing && !operators.includes(condition.operator);
+  const referenceMissing = leaf.questionId !== undefined && !referenced;
+  const operatorStale = !referenceMissing && !operators.includes(leaf.operator);
   const valueStale =
     needsValue &&
     !referenceMissing &&
     suggestions.length > 0 &&
-    !suggestions.some((candidate) => candidate.value === condition.value);
+    !suggestions.some((candidate) => candidate.value === leaf.value);
   const valueTypeInvalid =
     needsValue &&
     !referenceMissing &&
     suggestions.length === 0 &&
-    condition.value !== undefined &&
-    typeof condition.value !== "string";
+    leaf.value !== undefined &&
+    typeof leaf.value !== "string";
   // Blank text answers never reach runtime answer state, so a blank value
   // makes the condition misleading; the release gates reject it.
   const valueBlank =
     needsValue &&
     !referenceMissing &&
     suggestions.length === 0 &&
-    typeof condition.value === "string" &&
-    condition.value.trim().length === 0;
+    typeof leaf.value === "string" &&
+    leaf.value.trim().length === 0;
   // Repair guidance renders as Aksel field errors: linked to the control
   // via aria-describedby and announced via the built-in polite live region.
   const questionError = referenceMissing
@@ -189,13 +405,11 @@ export function ConditionEditor({
       (candidate) => candidate.id === referencedId,
     )?.type;
     const allowed = nextType ? allowedConditionOperators(nextType) : ["EXISTS"];
-    const operator = allowed.includes(condition.operator)
-      ? condition.operator
-      : "EXISTS";
+    const operator = allowed.includes(leaf.operator) ? leaf.operator : "EXISTS";
     if (operator === "EXISTS") {
-      onChange({ questionId: referencedId, operator: "EXISTS" });
+      onLeafChange({ questionId: referencedId, operator: "EXISTS" });
     } else {
-      onChange({
+      onLeafChange({
         questionId: referencedId,
         operator: operator as ValuedOperator,
         value: firstValueFor(referencedId),
@@ -205,13 +419,13 @@ export function ConditionEditor({
 
   const changeOperator = (operator: string) => {
     if (operator === "EXISTS") {
-      onChange({ questionId: condition.questionId, operator: "EXISTS" });
+      onLeafChange({ questionId: leaf.questionId, operator: "EXISTS" });
       return;
     }
-    onChange({
-      questionId: condition.questionId,
+    onLeafChange({
+      questionId: leaf.questionId,
       operator: operator as ValuedOperator,
-      value: condition.value ?? firstValueFor(condition.questionId ?? ""),
+      value: leaf.value ?? firstValueFor(leaf.questionId ?? ""),
     });
   };
 
@@ -219,41 +433,29 @@ export function ConditionEditor({
     const suggestion = suggestions.find(
       (candidate) => encodeValue(candidate.value) === raw,
     );
-    onChange({
-      questionId: condition.questionId,
-      operator: condition.operator as ValuedOperator,
+    onLeafChange({
+      questionId: leaf.questionId,
+      operator: leaf.operator as ValuedOperator,
       value: suggestion ? suggestion.value : raw,
     });
   };
 
   return (
-    <div className={styles.conditionSection}>
-      <div className={styles.conditionHeader}>
-        <Detail as="span" className={styles.eyebrow}>
-          VISES BARE HVIS
-        </Detail>
-        <Tooltip content="Fjern betingelsen">
-          <Button
-            type="button"
-            variant="tertiary-neutral"
-            size="xsmall"
-            icon={<XMarkIcon aria-hidden />}
-            aria-label="Fjern betingelsen"
-            onClick={() => onChange(undefined)}
-          />
-        </Tooltip>
-      </div>
+    <div
+      className={styles.conditionRowWrap}
+      {...(groupLabel ? { role: "group", "aria-label": groupLabel } : {})}
+    >
       <div className={styles.conditionRow}>
         <Select
           label="Spørsmål"
           size="small"
-          value={condition.questionId ?? ""}
+          value={leaf.questionId ?? ""}
           error={questionError}
           onChange={(event) => changeReferenced(event.target.value)}
         >
           {referenceMissing ? (
-            <option value={condition.questionId} disabled>
-              Finnes ikke lenger ({condition.questionId})
+            <option value={leaf.questionId} disabled>
+              Finnes ikke lenger ({leaf.questionId})
             </option>
           ) : null}
           {referenceable.map((candidate) => (
@@ -266,14 +468,14 @@ export function ConditionEditor({
         <Select
           label="Vilkår"
           size="small"
-          value={condition.operator}
+          value={leaf.operator}
           error={operatorError}
           onChange={(event) => changeOperator(event.target.value)}
         >
           {operatorStale ? (
-            <option value={condition.operator} disabled>
-              {OPERATOR_LABELS[condition.operator] ?? condition.operator}{" "}
-              (passer ikke lenger)
+            <option value={leaf.operator} disabled>
+              {OPERATOR_LABELS[leaf.operator] ?? leaf.operator} (passer ikke
+              lenger)
             </option>
           ) : null}
           {operators.map((operator) => (
@@ -287,13 +489,13 @@ export function ConditionEditor({
             <Select
               label="Verdi"
               size="small"
-              value={encodeValue(condition.value)}
+              value={encodeValue(leaf.value)}
               error={valueError}
               onChange={(event) => changeValue(event.target.value)}
             >
               {valueStale ? (
-                <option value={encodeValue(condition.value)} disabled>
-                  «{String(condition.value ?? "")}» (finnes ikke)
+                <option value={encodeValue(leaf.value)} disabled>
+                  «{String(leaf.value ?? "")}» (finnes ikke)
                 </option>
               ) : null}
               {suggestions.map((suggestion) => (
@@ -309,13 +511,16 @@ export function ConditionEditor({
             <TextField
               label="Verdi"
               size="small"
-              value={String(condition.value ?? "")}
+              value={String(leaf.value ?? "")}
               error={valueError}
               onChange={(event) => changeValue(event.target.value)}
             />
           )
         ) : null}
       </div>
+      {onRemove ? (
+        <RemoveRowButton index={index} rowId={rowId} onRemove={onRemove} />
+      ) : null}
     </div>
   );
 }

--- a/apps/lumi-dashboard/app/components/surveyverksted/QuestionCard.tsx
+++ b/apps/lumi-dashboard/app/components/surveyverksted/QuestionCard.tsx
@@ -20,12 +20,13 @@ import {
 } from "@navikt/ds-react";
 import type { SurveyQuestionV1 } from "@navikt/lumi-survey";
 import { memo, useEffect, useRef } from "react";
-import type {
-  ConditionValueSuggestion,
-  MoveDirection,
-  QuestionTypeId,
-  ReferenceableQuestion,
-  VisibleIfConditionV1,
+import {
+  type ConditionValueSuggestion,
+  type MoveDirection,
+  type QuestionTypeId,
+  type ReferenceableQuestion,
+  type VisibleIfConditionV1,
+  visibleIfLeaves,
 } from "~/utils/surveyDocument";
 import { ConditionEditor } from "./ConditionEditor";
 import { OptionsEditor, type OptionsEditorProps } from "./OptionsEditor";
@@ -80,6 +81,7 @@ export const QuestionCard = memo(function QuestionCard({
   suggestionsFor,
   onChangeVisibleIf,
 }: QuestionCardProps) {
+  const conditionCount = visibleIfLeaves(question.visibleIf).length;
   const collapsedButtonRef = useRef<HTMLButtonElement>(null);
   const promptRef = useRef<HTMLInputElement>(null);
   const restoreFocusRef = useRef(false);
@@ -131,7 +133,9 @@ export const QuestionCard = memo(function QuestionCard({
             {question.visibleIf ? (
               <Detail as="span" className={styles.cardConditional}>
                 <BranchingIcon aria-hidden />
-                Vises betinget
+                {conditionCount > 1
+                  ? `Vises betinget · ${conditionCount}`
+                  : "Vises betinget"}
               </Detail>
             ) : null}
             {question.required ? (

--- a/apps/lumi-dashboard/app/components/surveyverksted/__tests__/ConditionEditor.test.tsx
+++ b/apps/lumi-dashboard/app/components/surveyverksted/__tests__/ConditionEditor.test.tsx
@@ -1,8 +1,12 @@
-import { render, screen } from "@testing-library/react";
+import { render, screen, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
+import { useState } from "react";
 import { describe, expect, it, vi } from "vitest";
 import { ConditionEditor } from "~/components/surveyverksted/ConditionEditor";
-import type { ReferenceableQuestion } from "~/utils/surveyDocument";
+import type {
+  ReferenceableQuestion,
+  VisibleIfConditionV1,
+} from "~/utils/surveyDocument";
 
 const referenceable: ReferenceableQuestion[] = [
   {
@@ -46,6 +50,26 @@ function suggestionsFor(id: string) {
     return [1, 2, 3, 4, 5].map((value) => ({ value, label: String(value) }));
   }
   return [];
+}
+
+function ControlledEditor({
+  initial,
+  referenceable: referenceableOverride,
+}: {
+  initial: VisibleIfConditionV1;
+  referenceable?: ReferenceableQuestion[];
+}) {
+  const [condition, setCondition] = useState<VisibleIfConditionV1 | undefined>(
+    initial,
+  );
+  return (
+    <ConditionEditor
+      condition={condition}
+      referenceable={referenceableOverride ?? referenceable}
+      suggestionsFor={suggestionsFor}
+      onChange={setCondition}
+    />
+  );
 }
 
 describe("ConditionEditor", () => {
@@ -344,11 +368,43 @@ describe("ConditionEditor", () => {
     expect(screen.queryByLabelText("Vilkår")).not.toBeInTheDocument();
   });
 
-  it("shows a read-only note for group conditions authored in code", () => {
+  it("adds a second condition and emits an all-group", async () => {
+    const onChange = vi.fn();
+    render(
+      <ConditionEditor
+        condition={{ questionId: "choice-1", operator: "EQ", value: "soke" }}
+        referenceable={referenceable}
+        suggestionsFor={suggestionsFor}
+        onChange={onChange}
+      />,
+    );
+    await userEvent.click(
+      screen.getByRole("button", { name: "Legg til betingelse" }),
+    );
+    expect(onChange).toHaveBeenCalledWith({
+      all: [
+        { questionId: "choice-1", operator: "EQ", value: "soke" },
+        { questionId: "rating-1", operator: "EXISTS" },
+      ],
+    });
+  });
+
+  it("shows the combinator toggle only with two or more conditions", () => {
+    const { unmount } = render(
+      <ConditionEditor
+        condition={{ questionId: "rating-1", operator: "EXISTS" }}
+        referenceable={referenceable}
+        suggestionsFor={suggestionsFor}
+        onChange={() => {}}
+      />,
+    );
+    expect(screen.queryByText("Alle må stemme")).not.toBeInTheDocument();
+    unmount();
+
     render(
       <ConditionEditor
         condition={{
-          any: [
+          all: [
             { questionId: "rating-1", operator: "EXISTS" },
             { questionId: "choice-1", operator: "EXISTS" },
           ],
@@ -358,7 +414,232 @@ describe("ConditionEditor", () => {
         onChange={() => {}}
       />,
     );
-    expect(screen.getByText(/sammensatt betingelse/i)).toBeInTheDocument();
-    expect(screen.queryByLabelText("Vilkår")).not.toBeInTheDocument();
+    expect(screen.getByText("Alle må stemme")).toBeInTheDocument();
+    expect(screen.getByText("Minst én må stemme")).toBeInTheDocument();
+  });
+
+  it("switches the combinator and emits the other group shape", async () => {
+    const onChange = vi.fn();
+    render(
+      <ConditionEditor
+        condition={{
+          all: [
+            { questionId: "rating-1", operator: "EXISTS" },
+            { questionId: "choice-1", operator: "EXISTS" },
+          ],
+        }}
+        referenceable={referenceable}
+        suggestionsFor={suggestionsFor}
+        onChange={onChange}
+      />,
+    );
+    await userEvent.click(screen.getByText("Minst én må stemme"));
+    expect(onChange).toHaveBeenCalledWith({
+      any: [
+        { questionId: "rating-1", operator: "EXISTS" },
+        { questionId: "choice-1", operator: "EXISTS" },
+      ],
+    });
+  });
+
+  it("removes a row and collapses back to a single leaf", async () => {
+    const onChange = vi.fn();
+    render(
+      <ConditionEditor
+        condition={{
+          any: [
+            { questionId: "rating-1", operator: "EXISTS" },
+            { questionId: "choice-1", operator: "EQ", value: "soke" },
+          ],
+        }}
+        referenceable={referenceable}
+        suggestionsFor={suggestionsFor}
+        onChange={onChange}
+      />,
+    );
+    await userEvent.click(
+      screen.getByRole("button", { name: "Fjern betingelse 2" }),
+    );
+    expect(onChange).toHaveBeenCalledWith({
+      questionId: "rating-1",
+      operator: "EXISTS",
+    });
+  });
+
+  it("edits one row without touching the others", async () => {
+    const onChange = vi.fn();
+    render(
+      <ConditionEditor
+        condition={{
+          all: [
+            { questionId: "rating-1", operator: "EXISTS" },
+            { questionId: "choice-1", operator: "EQ", value: "soke" },
+          ],
+        }}
+        referenceable={referenceable}
+        suggestionsFor={suggestionsFor}
+        onChange={onChange}
+      />,
+    );
+    await userEvent.selectOptions(screen.getAllByLabelText("Vilkår")[1], "NEQ");
+    expect(onChange).toHaveBeenCalledWith({
+      all: [
+        { questionId: "rating-1", operator: "EXISTS" },
+        { questionId: "choice-1", operator: "NEQ", value: "soke" },
+      ],
+    });
+  });
+
+  it("unmounts the removed row instead of reusing its DOM for the next row", async () => {
+    // With index keys React would keep the clicked button's DOM node and
+    // silently let it represent the NEXT row — a second Enter would then
+    // delete the wrong condition.
+    render(
+      <ControlledEditor
+        initial={{
+          any: [
+            { questionId: "rating-1", operator: "EXISTS" },
+            { questionId: "choice-1", operator: "EQ", value: "soke" },
+            { questionId: "multi-1", operator: "EXISTS" },
+          ],
+        }}
+      />,
+    );
+    const removeSecond = screen.getByRole("button", {
+      name: "Fjern betingelse 2",
+    });
+    await userEvent.click(removeSecond);
+    expect(removeSecond).not.toBeInTheDocument();
+    const remaining = screen.getAllByRole("button", {
+      name: /Fjern betingelse \d/,
+    });
+    expect(remaining).toHaveLength(2);
+    // Focus moves EXPLICITLY (with announcement) to the row that took the
+    // deleted row's place — never silently via DOM reuse.
+    expect(
+      screen.getByRole("button", { name: "Fjern betingelse 2" }),
+    ).toHaveFocus();
+  });
+
+  it("moves focus to the add button when the group collapses to one row", async () => {
+    render(
+      <ControlledEditor
+        initial={{
+          any: [
+            { questionId: "rating-1", operator: "EXISTS" },
+            { questionId: "choice-1", operator: "EXISTS" },
+          ],
+        }}
+      />,
+    );
+    await userEvent.click(
+      screen.getByRole("button", { name: "Fjern betingelse 2" }),
+    );
+    expect(
+      screen.getByRole("button", { name: "Legg til betingelse" }),
+    ).toHaveFocus();
+  });
+
+  it("falls back to the header remove button when a mixed group collapses to metadata", async () => {
+    // The remaining METADATA leaf renders through the read-only branch,
+    // which has no add button — focus must still land somewhere real.
+    render(
+      <ControlledEditor
+        initial={{
+          all: [
+            { field: "METADATA", key: "flow", operator: "EXISTS" },
+            { questionId: "rating-1", operator: "EXISTS" },
+          ],
+        }}
+      />,
+    );
+    await userEvent.click(
+      screen.getByRole("button", { name: "Fjern betingelse 2" }),
+    );
+    expect(screen.getByText(/metadatabetingelse satt i kode/i)).toBeVisible();
+    expect(
+      screen.getByRole("button", { name: "Fjern betingelsen" }),
+    ).toHaveFocus();
+  });
+
+  it("falls back past a disabled add button after removing a row", async () => {
+    // Hand-authored refs with no referenceable questions leave the add
+    // button disabled — a disabled control can never take focus.
+    render(
+      <ControlledEditor
+        initial={{
+          all: [
+            { questionId: "borte-1", operator: "EXISTS" },
+            { questionId: "borte-2", operator: "EXISTS" },
+          ],
+        }}
+        referenceable={[]}
+      />,
+    );
+    await userEvent.click(
+      screen.getByRole("button", { name: "Fjern betingelse 2" }),
+    );
+    expect(
+      screen.getByRole("button", { name: "Fjern betingelsen" }),
+    ).toHaveFocus();
+  });
+
+  it("names each row group so screen readers can tell rows apart", () => {
+    const { unmount } = render(
+      <ConditionEditor
+        condition={{
+          all: [
+            { questionId: "rating-1", operator: "EXISTS" },
+            { questionId: "choice-1", operator: "EQ", value: "soke" },
+          ],
+        }}
+        referenceable={referenceable}
+        suggestionsFor={suggestionsFor}
+        onChange={() => {}}
+      />,
+    );
+    const secondRow = screen.getByRole("group", { name: "Betingelse 2" });
+    expect(within(secondRow).getByLabelText("Vilkår")).toBeInTheDocument();
+    unmount();
+
+    // A single condition needs no differentiation.
+    render(
+      <ConditionEditor
+        condition={{ questionId: "rating-1", operator: "EXISTS" }}
+        referenceable={referenceable}
+        suggestionsFor={suggestionsFor}
+        onChange={() => {}}
+      />,
+    );
+    expect(
+      screen.queryByRole("group", { name: /Betingelse/ }),
+    ).not.toBeInTheDocument();
+  });
+
+  it("keeps metadata rows read-only inside a mixed group but removable", async () => {
+    const onChange = vi.fn();
+    render(
+      <ConditionEditor
+        condition={{
+          all: [
+            { field: "METADATA", key: "flow", operator: "EXISTS" },
+            { questionId: "rating-1", operator: "EXISTS" },
+          ],
+        }}
+        referenceable={referenceable}
+        suggestionsFor={suggestionsFor}
+        onChange={onChange}
+      />,
+    );
+    // Only the ANSWER row is editable; the metadata row shows its key.
+    expect(screen.getAllByLabelText("Vilkår")).toHaveLength(1);
+    expect(screen.getByText(/flow/)).toBeInTheDocument();
+    await userEvent.click(
+      screen.getByRole("button", { name: "Fjern betingelse 1" }),
+    );
+    expect(onChange).toHaveBeenCalledWith({
+      questionId: "rating-1",
+      operator: "EXISTS",
+    });
   });
 });

--- a/apps/lumi-dashboard/app/components/surveyverksted/__tests__/QuestionCard.test.tsx
+++ b/apps/lumi-dashboard/app/components/surveyverksted/__tests__/QuestionCard.test.tsx
@@ -64,6 +64,35 @@ describe("QuestionCard collapsed", () => {
   });
 });
 
+describe("QuestionCard collapsed condition indicator", () => {
+  it("shows the condition count when several conditions gate the question", () => {
+    renderCard({
+      question: {
+        ...ratingQuestion,
+        id: "gated",
+        visibleIf: {
+          any: [
+            { questionId: "a", operator: "EXISTS" },
+            { questionId: "b", operator: "EXISTS" },
+          ],
+        },
+      },
+    });
+    expect(screen.getByText("Vises betinget · 2")).toBeInTheDocument();
+  });
+
+  it("shows no count for a single condition", () => {
+    renderCard({
+      question: {
+        ...ratingQuestion,
+        id: "gated",
+        visibleIf: { questionId: "a", operator: "EXISTS" },
+      },
+    });
+    expect(screen.getByText("Vises betinget")).toBeInTheDocument();
+  });
+});
+
 describe("QuestionCard expanded", () => {
   it("focuses the prompt field when the card transitions to expanded", () => {
     const noop = () => {};

--- a/apps/lumi-dashboard/app/components/surveyverksted/verksted.module.css
+++ b/apps/lumi-dashboard/app/components/surveyverksted/verksted.module.css
@@ -302,6 +302,31 @@
   align-items: start;
 }
 
+.conditionRowWrap {
+  display: flex;
+  gap: var(--ax-space-4);
+  align-items: start;
+}
+
+.conditionRowWrap > .conditionRow {
+  flex: 1;
+}
+
+/* Clears the field label so the remove button lines up with the inputs. */
+.conditionRowWrap > .conditionRowRemove {
+  margin-top: 1.65rem;
+}
+
+.conditionMetadataRow {
+  align-self: center;
+  flex: 1;
+}
+
+.conditionMetadataRow code {
+  font-family: var(--ax-font-family-mono, ui-monospace, monospace);
+  font-size: 0.85em;
+}
+
 .conditionAddWrap {
   display: inline-flex;
   align-items: center;

--- a/apps/lumi-dashboard/app/utils/surveyDocument.test.ts
+++ b/apps/lumi-dashboard/app/utils/surveyDocument.test.ts
@@ -5,7 +5,9 @@ import {
   addPage,
   addQuestion,
   allowedConditionOperators,
+  buildVisibleIf,
   changeQuestionType,
+  conditionCombinator,
   conditionValueSuggestions,
   createQuestion,
   documentNeedsWideDock,
@@ -30,6 +32,7 @@ import {
   suggestSurveyId,
   updateOptionLabel,
   updateOptionValue,
+  visibleIfLeaves,
 } from "~/utils/surveyDocument";
 
 function sequentialIds(prefix = "id") {
@@ -750,6 +753,41 @@ describe("allowedConditionOperators", () => {
       "EQ",
       "NEQ",
     ]);
+  });
+});
+
+describe("condition group helpers", () => {
+  const leafA = { questionId: "rating-1", operator: "EXISTS" } as const;
+  const leafB = {
+    questionId: "choice-1",
+    operator: "EQ",
+    value: "soke",
+  } as const;
+
+  it("flattens unset, leaf and group conditions to a leaf list", () => {
+    expect(visibleIfLeaves(undefined)).toEqual([]);
+    expect(visibleIfLeaves(leafA)).toEqual([leafA]);
+    expect(visibleIfLeaves({ any: [leafA, leafB] })).toEqual([leafA, leafB]);
+    expect(visibleIfLeaves({ all: [leafA, leafB] })).toEqual([leafA, leafB]);
+  });
+
+  it("reads the combinator with all as the default", () => {
+    expect(conditionCombinator(undefined)).toBe("all");
+    expect(conditionCombinator(leafA)).toBe("all");
+    expect(conditionCombinator({ all: [leafA, leafB] })).toBe("all");
+    expect(conditionCombinator({ any: [leafA, leafB] })).toBe("any");
+  });
+
+  it("serializes to the exact runtime shape", () => {
+    expect(buildVisibleIf([], "all")).toBeUndefined();
+    // A single condition is a leaf — never a one-member group.
+    expect(buildVisibleIf([leafA], "any")).toEqual(leafA);
+    expect(buildVisibleIf([leafA, leafB], "all")).toEqual({
+      all: [leafA, leafB],
+    });
+    expect(buildVisibleIf([leafA, leafB], "any")).toEqual({
+      any: [leafA, leafB],
+    });
   });
 });
 

--- a/apps/lumi-dashboard/app/utils/surveyDocument.ts
+++ b/apps/lumi-dashboard/app/utils/surveyDocument.ts
@@ -337,11 +337,7 @@ export function duplicatePage(
   for (const question of original.questions) {
     idByOriginal.set(question.id, `${question.type}-${idFactory()}`);
   }
-  type ConditionLeaf = Exclude<
-    VisibleIfConditionV1,
-    { any: unknown } | { all: unknown }
-  >;
-  const remapLeaf = (leaf: ConditionLeaf): ConditionLeaf => {
+  const remapLeaf = (leaf: ConditionLeafV1): ConditionLeafV1 => {
     if (isMetadataCondition(leaf)) return leaf;
     const mapped = idByOriginal.get(leaf.questionId);
     return mapped ? { ...leaf, questionId: mapped } : leaf;
@@ -715,6 +711,44 @@ export function documentNeedsWideDock(document: SurveyDocumentV1): boolean {
 }
 
 export type VisibleIfConditionV1 = NonNullable<SurveyQuestionV1["visibleIf"]>;
+
+/** A single condition — the non-group member of the visibleIf union. */
+export type ConditionLeafV1 = Exclude<
+  VisibleIfConditionV1,
+  { any: unknown } | { all: unknown }
+>;
+
+export type ConditionCombinator = "all" | "any";
+
+/** Flattens a visibleIf into its editable list of leaves. */
+export function visibleIfLeaves(
+  condition: VisibleIfConditionV1 | undefined,
+): ConditionLeafV1[] {
+  if (!condition) return [];
+  if ("any" in condition) return [...condition.any];
+  if ("all" in condition) return [...condition.all];
+  return [condition];
+}
+
+/** The group combinator; leaves and unset conditions read as "all". */
+export function conditionCombinator(
+  condition: VisibleIfConditionV1 | undefined,
+): ConditionCombinator {
+  return condition && "any" in condition ? "any" : "all";
+}
+
+/**
+ * Runtime-exact serialization: no leaves clears the condition, one leaf
+ * stays a plain leaf (never a one-member group), several form a group.
+ */
+export function buildVisibleIf(
+  leaves: readonly ConditionLeafV1[],
+  combinator: ConditionCombinator,
+): VisibleIfConditionV1 | undefined {
+  if (leaves.length === 0) return undefined;
+  if (leaves.length === 1) return leaves[0];
+  return combinator === "any" ? { any: [...leaves] } : { all: [...leaves] };
+}
 
 /**
  * Runtime (`evaluateVisibility`) and the API validator both discriminate

--- a/apps/lumi-dashboard/e2e/survey-workshop.spec.ts
+++ b/apps/lumi-dashboard/e2e/survey-workshop.spec.ts
@@ -434,3 +434,83 @@ test("a visibility condition set in the editor gates the question live in the st
   await page.getByRole("button", { name: "Bytt til mørk modus" }).click();
   await expectNoAxeViolations(page);
 });
+
+test("an any/all group over two conditions gates the question live in the stage", async ({
+  page,
+}) => {
+  await page.goto("/surveyverksted");
+  await page.getByLabel("Navn på utkastet").fill("Gruppe-utkast");
+  await page.getByRole("button", { name: "Opprett utkast" }).click();
+  await page.waitForURL(/\/surveyverksted\/[0-9a-f-]+/);
+
+  // A third question that can reference both seeded questions.
+  await page.getByRole("button", { name: "Legg til spørsmål" }).click();
+  await page.getByRole("menuitem", { name: /Vurdering/ }).click();
+  await page
+    .getByRole("textbox", { name: "Spørsmålstekst" })
+    .last()
+    .fill("Vil du utdype?");
+
+  const stage = page.getByLabel("Forhåndsvisning");
+  await expect(
+    stage.getByRole("group", { name: "Vil du utdype?" }),
+  ).toBeVisible();
+
+  // First condition: rating answered. Second: the text question answered.
+  await page
+    .getByRole("button", { name: /Vis bare hvis/ })
+    .last()
+    .click();
+  await page.getByRole("button", { name: "Legg til betingelse" }).click();
+  await expect(page.getByText("Alle må stemme")).toBeVisible();
+  await page
+    .getByLabel("Spørsmål", { exact: true })
+    .last()
+    .selectOption({ index: 1 });
+
+  // Let the autosave settle first — its completion remounts the stage and
+  // would otherwise wipe answers given in between.
+  await expect(page.locator('[data-state="saved"]')).toBeVisible();
+
+  // ALL: nothing answered yet → hidden; rating alone is not enough.
+  await expect(
+    stage.getByRole("group", { name: "Vil du utdype?" }),
+  ).not.toBeVisible({
+    timeout: 10000,
+  });
+  await stage.getByRole("radio").nth(3).click();
+  await expect(
+    stage.getByRole("group", { name: "Vil du utdype?" }),
+  ).not.toBeVisible();
+
+  // ANY: the document edit remounts the stage (answers reset), and one
+  // answered condition is then enough.
+  await page.getByText("Minst én må stemme").click();
+  await expect(page.locator('[data-state="saved"]')).toBeVisible();
+  await expect(
+    stage.getByRole("group", { name: "Vil du utdype?" }),
+  ).not.toBeVisible({ timeout: 10000 });
+  await stage.getByRole("radio").nth(3).click();
+  await expect(
+    stage.getByRole("group", { name: "Vil du utdype?" }),
+  ).toBeVisible();
+
+  await expect(page.locator('[data-state="saved"]')).toBeVisible();
+  await expectNoAxeViolations(page);
+  await page.getByRole("button", { name: "Bytt til mørk modus" }).click();
+  await expectNoAxeViolations(page);
+
+  // Removing the second row collapses back to a single leaf: the
+  // combinator toggle disappears and the remaining condition still gates.
+  await page.getByRole("button", { name: "Fjern betingelse 2" }).click();
+  await expect(page.getByText("Minst én må stemme")).toHaveCount(0);
+  await expect(page.locator('[data-state="saved"]')).toBeVisible();
+  await expect(
+    stage.getByRole("group", { name: "Vil du utdype?" }),
+  ).not.toBeVisible({ timeout: 10000 });
+  await stage.getByRole("radio").nth(3).click();
+  await expect(
+    stage.getByRole("group", { name: "Vil du utdype?" }),
+  ).toBeVisible();
+  await expect(page.locator('[data-state="saved"]')).toBeVisible();
+});


### PR DESCRIPTION
Closes #434

## Hva

- **Flere betingelser per spørsmål**, kombinert med **alle må stemme** (all/OG) eller **minst én må stemme** (any/ELLER) — samme ettnivå-modell som runtime-typen; grupper kan ikke nøstes.
- **Runtime-eksakt serialisering** via rene hjelpere i mutasjonslaget: ingen betingelser → `undefined`, én → plain leaf (aldri engruppe), flere → `{ all: [...] }` / `{ any: [...] }`. Fjernes nest siste rad kollapser strukturen tilbake til leaf.
- **Radliste-UI**: «Legg til betingelse» under radene; all/any-velger (Aksel ToggleGroup) vises først ved to eller flere; per-rad fjernknapp bare i flerradmodus. Alle stale-tilstander og feltfeil fra #433 gjelder per rad.
- **Stabil radidentitet + eksplisitt fokus**: editor-lokale rad-IDer (aldri serialisert) i stedet for index-keys — sletting av en midtrad unmounter faktisk raden, og fokus flyttes annonsert til raden som tok plassen (fallback forbi disabled kontroller og grener uten add-knapp, f.eks. METADATA-kollaps).
- **Skjermleser-kontekst**: radene grupperes som «Betingelse N» i flerradmodus, så tre identiske «Vilkår»-felter kan skilles i skjemanavigasjon.
- **METADATA-rader** i blandede grupper vises read-only med nøkkelen i mono, men kan fjernes.
- Kollapset kort viser antall: «Vises betinget · 2».

## Test

- Dashboard: 454 vitest (gruppe-hjelpere begge veier, radoperasjoner, fokusregresjoner med kontrollert wrapper, indikator), tsc, rot-lint (biome, 479 filer)
- E2E: 6/6 — nytt løp beviser live OG/ELLER-gating i scenen (all: én besvart er ikke nok; any: én holder), axe i lys og mørk modus med gruppen åpen, og kollaps til leaf
- Ingen API- eller widgetendringer — release-gatene validerer allerede gruppemedlemmer
- Tre adversarial review-runder verifisert og rettet før PR