### PR TITLE
Surveyverksted: slett utkast + UI-polering fra brukerfeedback

### DIFF
--- a/apps/lumi-api/src/main/kotlin/no/nav/lumi/repository/SurveyAuthoringProjectRepository.kt
+++ b/apps/lumi-api/src/main/kotlin/no/nav/lumi/repository/SurveyAuthoringProjectRepository.kt
@@ -70,6 +70,15 @@ class SurveyAuthoringProjectRepository {
 
     /** Deletes the project; revisions follow via the DB cascade. */
     suspend fun deleteById(team: String, id: UUID): Boolean = dbQuery {
+        // Same per-project advisory lock as revision creation: a delete must
+        // never commit between the revision flow's project read and its
+        // insert — that would surface as an FK violation (500) instead of a
+        // clean 404/cascade.
+        val connection = TransactionManager.current().connection.connection as Connection
+        connection.prepareStatement("SELECT pg_advisory_xact_lock(hashtext(?))").use { lock ->
+            lock.setString(1, "survey-authoring-revision:$id")
+            lock.execute()
+        }
         SurveyAuthoringProjectTable.deleteWhere {
             (SurveyAuthoringProjectTable.team eq team) and
                 (SurveyAuthoringProjectTable.id eq id)

--- a/apps/lumi-api/src/main/kotlin/no/nav/lumi/repository/SurveyAuthoringProjectRepository.kt
+++ b/apps/lumi-api/src/main/kotlin/no/nav/lumi/repository/SurveyAuthoringProjectRepository.kt
@@ -7,6 +7,7 @@ import no.nav.lumi.domain.SurveyAuthoringProjectSummary
 import org.jetbrains.exposed.v1.core.ResultRow
 import org.jetbrains.exposed.v1.core.SortOrder
 import org.jetbrains.exposed.v1.core.and
+import org.jetbrains.exposed.v1.jdbc.deleteWhere
 import org.jetbrains.exposed.v1.core.eq
 import org.jetbrains.exposed.v1.jdbc.selectAll
 import org.jetbrains.exposed.v1.jdbc.transactions.TransactionManager
@@ -67,6 +68,20 @@ class SurveyAuthoringProjectRepository {
         findByIdInCurrentTransaction(team, id)
     }
 
+    /** Deletes the project; revisions follow via the DB cascade. */
+    suspend fun deleteById(team: String, id: UUID): Boolean = dbQuery {
+        SurveyAuthoringProjectTable.deleteWhere {
+            (SurveyAuthoringProjectTable.team eq team) and
+                (SurveyAuthoringProjectTable.id eq id)
+        } > 0
+    }
+
+    sealed interface DraftUpdateResult {
+        data class Updated(val project: SurveyAuthoringProject) : DraftUpdateResult
+        data object NotFound : DraftUpdateResult
+        data object VersionConflict : DraftUpdateResult
+    }
+
     suspend fun updateDraft(
         team: String,
         id: UUID,
@@ -75,7 +90,7 @@ class SurveyAuthoringProjectRepository {
         surveyId: String,
         document: JsonObject,
         principalIdentity: String,
-    ): SurveyAuthoringProject? = dbQuery {
+    ): DraftUpdateResult = dbQuery {
         val updated = SurveyAuthoringProjectTable.update({
             (SurveyAuthoringProjectTable.id eq id) and
                 (SurveyAuthoringProjectTable.team eq team) and
@@ -89,7 +104,14 @@ class SurveyAuthoringProjectRepository {
             it[updatedAt] = OffsetDateTime.now()
         }
 
-        if (updated == 0) null else findByIdInCurrentTransaction(team, id)
+        when {
+            updated > 0 ->
+                DraftUpdateResult.Updated(checkNotNull(findByIdInCurrentTransaction(team, id)))
+            // Decided in the SAME transaction as the update: a concurrent
+            // delete must classify as NotFound, never as a version conflict.
+            findByIdInCurrentTransaction(team, id) == null -> DraftUpdateResult.NotFound
+            else -> DraftUpdateResult.VersionConflict
+        }
     }
 
     private fun findByIdInCurrentTransaction(team: String, id: UUID): SurveyAuthoringProject? =

--- a/apps/lumi-api/src/main/kotlin/no/nav/lumi/routes/SurveyAuthoringRoutes.kt
+++ b/apps/lumi-api/src/main/kotlin/no/nav/lumi/routes/SurveyAuthoringRoutes.kt
@@ -4,6 +4,7 @@ import io.ktor.http.HttpStatusCode
 import io.ktor.http.HttpHeaders
 import io.ktor.server.application.ApplicationCall
 import io.ktor.server.request.receiveChannel
+import io.ktor.server.resources.delete
 import io.ktor.server.resources.get
 import io.ktor.server.resources.post
 import io.ktor.server.resources.put
@@ -72,6 +73,15 @@ fun Route.surveyAuthoringRoutes(
         call.respond(project)
     }
 
+    delete<ApiV1Intern.Authoring.Projects.Id> { params ->
+        val removed = repository.deleteById(
+            team = call.authorizedTeam,
+            id = parseProjectId(params.projectId),
+        )
+        if (!removed) throw ApiErrorException.NotFoundException("Survey project not found")
+        call.respond(HttpStatusCode.NoContent)
+    }
+
     put<ApiV1Intern.Authoring.Projects.Id.Draft> { params ->
         val request = receiveAuthoringRequest<UpdateSurveyAuthoringDraftRequest>(call)
         if (request.expectedVersion < 1) {
@@ -83,21 +93,25 @@ fun Route.surveyAuthoringRoutes(
         val principalIdentity = stablePrincipalIdentity(call.authorizedPrincipal)
             ?: throw ApiErrorException.BadRequestException("Authenticated user needs a stable identity")
 
-        if (repository.findById(team, projectId) == null) {
-            throw ApiErrorException.NotFoundException("Survey project not found")
+        val project = when (
+            val result = repository.updateDraft(
+                team = team,
+                id = projectId,
+                expectedVersion = request.expectedVersion,
+                name = validated.name,
+                surveyId = validated.surveyId,
+                document = request.document,
+                principalIdentity = principalIdentity,
+            )
+        ) {
+            is SurveyAuthoringProjectRepository.DraftUpdateResult.Updated -> result.project
+            SurveyAuthoringProjectRepository.DraftUpdateResult.NotFound ->
+                throw ApiErrorException.NotFoundException("Survey project not found")
+            SurveyAuthoringProjectRepository.DraftUpdateResult.VersionConflict ->
+                throw ApiErrorException.ConflictException(
+                    "Draft changed since it was loaded. Reload before saving again.",
+                )
         }
-
-        val project = repository.updateDraft(
-            team = team,
-            id = projectId,
-            expectedVersion = request.expectedVersion,
-            name = validated.name,
-            surveyId = validated.surveyId,
-            document = request.document,
-            principalIdentity = principalIdentity,
-        ) ?: throw ApiErrorException.ConflictException(
-            "Draft changed since it was loaded. Reload before saving again.",
-        )
 
         call.respond(project)
     }

--- a/apps/lumi-api/src/test/kotlin/no/nav/lumi/routes/SurveyAuthoringRoutesTest.kt
+++ b/apps/lumi-api/src/test/kotlin/no/nav/lumi/routes/SurveyAuthoringRoutesTest.kt
@@ -3,6 +3,7 @@ package no.nav.lumi.routes
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.string.shouldContain
+import io.ktor.client.request.delete
 import io.ktor.client.request.get
 import io.ktor.client.request.header
 import io.ktor.client.request.post
@@ -69,6 +70,85 @@ class SurveyAuthoringRoutesTest : FunSpec({
             Json.parseToJsonElement(reopened.bodyAsText()).jsonObject
                 .getValue("document").jsonObject
                 .getValue("authoringSchemaVersion").jsonPrimitive.content shouldBe "1"
+        }
+    }
+
+    test("deletes a project with its revisions, scoped to the team") {
+        testApplication {
+            application { testModule() }
+            val client = createTestClient()
+
+            val created = client.post("/api/v1/intern/authoring/projects?team=team-test") {
+                header(HttpHeaders.Authorization, "Bearer test-token")
+                contentType(ContentType.Application.Json)
+                setBody(createBody())
+            }
+            val projectId = Json.parseToJsonElement(created.bodyAsText())
+                .jsonObject.getValue("id").jsonPrimitive.content
+
+            val revision = client.post(
+                "/api/v1/intern/authoring/projects/$projectId/revisions?team=team-test",
+            ) {
+                header(HttpHeaders.Authorization, "Bearer test-token")
+                contentType(ContentType.Application.Json)
+                setBody("""{ "expectedDraftVersion": 1 }""")
+            }
+            revision.status shouldBe HttpStatusCode.Created
+            val revisionId = Json.parseToJsonElement(revision.bodyAsText())
+                .jsonObject.getValue("id").jsonPrimitive.content
+
+            // Another authorized team's scope must not be able to delete it.
+            client.delete("/api/v1/intern/authoring/projects/$projectId?team=flex") {
+                header(HttpHeaders.Authorization, "Bearer test-token")
+            }.status shouldBe HttpStatusCode.NotFound
+
+            client.delete("/api/v1/intern/authoring/projects/$projectId?team=team-test") {
+                header(HttpHeaders.Authorization, "Bearer test-token")
+            }.status shouldBe HttpStatusCode.NoContent
+
+            client.get("/api/v1/intern/authoring/projects/$projectId?team=team-test") {
+                header(HttpHeaders.Authorization, "Bearer test-token")
+            }.status shouldBe HttpStatusCode.NotFound
+
+            // The frozen revision follows the project (DB cascade).
+            client.get("/api/v1/intern/authoring/revisions/$revisionId?team=team-test") {
+                header(HttpHeaders.Authorization, "Bearer test-token")
+            }.status shouldBe HttpStatusCode.NotFound
+
+            // Deleting again is a plain 404, not an error.
+            client.delete("/api/v1/intern/authoring/projects/$projectId?team=team-test") {
+                header(HttpHeaders.Authorization, "Bearer test-token")
+            }.status shouldBe HttpStatusCode.NotFound
+        }
+    }
+
+    test("saving into a deleted project reports not found, never conflict") {
+        // The delete can land between any existence check and the update —
+        // the classification must be decided atomically with the update.
+        testApplication {
+            application { testModule() }
+            val client = createTestClient()
+            val created = client.post("/api/v1/intern/authoring/projects?team=team-test") {
+                header(HttpHeaders.Authorization, "Bearer test-token")
+                contentType(ContentType.Application.Json)
+                setBody(createBody())
+            }
+            val projectId = Json.parseToJsonElement(created.bodyAsText()).jsonObject
+                .getValue("id").jsonPrimitive.content
+
+            client.delete("/api/v1/intern/authoring/projects/$projectId?team=team-test") {
+                header(HttpHeaders.Authorization, "Bearer test-token")
+            }.status shouldBe HttpStatusCode.NoContent
+
+            val save = client.put(
+                "/api/v1/intern/authoring/projects/$projectId/draft?team=team-test",
+            ) {
+                header(HttpHeaders.Authorization, "Bearer test-token")
+                contentType(ContentType.Application.Json)
+                setBody(updateBody(expectedVersion = 1, name = "Etter sletting"))
+            }
+            save.status shouldBe HttpStatusCode.NotFound
+            save.bodyAsText() shouldContain "Survey project not found"
         }
     }
 

--- a/apps/lumi-api/src/test/kotlin/no/nav/lumi/routes/SurveyAuthoringRoutesTest.kt
+++ b/apps/lumi-api/src/test/kotlin/no/nav/lumi/routes/SurveyAuthoringRoutesTest.kt
@@ -1,6 +1,7 @@
 package no.nav.lumi.routes
 
 import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.collections.shouldBeIn
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.string.shouldContain
 import io.ktor.client.request.delete
@@ -15,6 +16,8 @@ import io.ktor.http.HttpHeaders
 import io.ktor.http.HttpStatusCode
 import io.ktor.http.contentType
 import io.ktor.server.testing.testApplication
+import kotlinx.coroutines.async
+import kotlinx.coroutines.coroutineScope
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.jsonArray
 import kotlinx.serialization.json.jsonObject
@@ -119,6 +122,53 @@ class SurveyAuthoringRoutesTest : FunSpec({
             client.delete("/api/v1/intern/authoring/projects/$projectId?team=team-test") {
                 header(HttpHeaders.Authorization, "Bearer test-token")
             }.status shouldBe HttpStatusCode.NotFound
+        }
+    }
+
+    test("a delete racing revision creation never produces a server error") {
+        // The per-project advisory lock must serialize the two flows: the
+        // freeze either commits before the cascade or reports not found -
+        // an FK violation (500) means the lock is gone.
+        testApplication {
+            application { testModule() }
+            val client = createTestClient()
+            repeat(10) {
+                val created = client.post("/api/v1/intern/authoring/projects?team=team-test") {
+                    header(HttpHeaders.Authorization, "Bearer test-token")
+                    contentType(ContentType.Application.Json)
+                    setBody(createBody())
+                }
+                val projectId = Json.parseToJsonElement(created.bodyAsText()).jsonObject
+                    .getValue("id").jsonPrimitive.content
+
+                coroutineScope {
+                    val freeze = async {
+                        client.post(
+                            "/api/v1/intern/authoring/projects/$projectId/revisions?team=team-test",
+                        ) {
+                            header(HttpHeaders.Authorization, "Bearer test-token")
+                            contentType(ContentType.Application.Json)
+                            setBody("""{ "expectedDraftVersion": 1 }""")
+                        }
+                    }
+                    val deletion = async {
+                        client.delete(
+                            "/api/v1/intern/authoring/projects/$projectId?team=team-test",
+                        ) {
+                            header(HttpHeaders.Authorization, "Bearer test-token")
+                        }
+                    }
+                    val freezeStatus = freeze.await().status
+                    val deleteStatus = deletion.await().status
+                    freezeStatus shouldBeIn listOf(HttpStatusCode.Created, HttpStatusCode.NotFound)
+                    deleteStatus shouldBeIn listOf(HttpStatusCode.NoContent, HttpStatusCode.NotFound)
+                }
+
+                // Whoever won, the end state is fully converged.
+                client.get("/api/v1/intern/authoring/projects/$projectId?team=team-test") {
+                    header(HttpHeaders.Authorization, "Bearer test-token")
+                }.status shouldBe HttpStatusCode.NotFound
+            }
         }
     }
 

--- a/apps/lumi-dashboard/app/components/surveyverksted/DeleteDraftDialog.tsx
+++ b/apps/lumi-dashboard/app/components/surveyverksted/DeleteDraftDialog.tsx
@@ -1,0 +1,88 @@
+import { TrashIcon } from "@navikt/aksel-icons";
+import {
+  Alert,
+  BodyLong,
+  Button,
+  HStack,
+  Modal,
+  VStack,
+} from "@navikt/ds-react";
+import { useEffect, useRef } from "react";
+
+export interface DeleteDraftDialogProps {
+  /** Name of the draft up for deletion, or null when the dialog is closed. */
+  name: string | null;
+  isPending: boolean;
+  showError: boolean;
+  onConfirm: () => void;
+  onClose: () => void;
+}
+
+/**
+ * Confirmation for deleting a team draft. While the deletion is in flight
+ * the dialog refuses to close (Escape and the close button included) so a
+ * failure can never strand the user without the error and its retry.
+ */
+export function DeleteDraftDialog({
+  name,
+  isPending,
+  showError,
+  onConfirm,
+  onClose,
+}: DeleteDraftDialogProps) {
+  // isPending arrives one render AFTER the confirm click — the flag closes
+  // the same-frame window where Escape could still slip past the guard.
+  const confirmInFlightRef = useRef(false);
+  useEffect(() => {
+    if (showError || name === null) {
+      confirmInFlightRef.current = false;
+    }
+  }, [showError, name]);
+  return (
+    <Modal
+      open={name !== null}
+      onBeforeClose={() => !(isPending || confirmInFlightRef.current)}
+      onClose={onClose}
+      header={{ heading: "Slett utkastet?", icon: <TrashIcon aria-hidden /> }}
+      width="small"
+    >
+      <Modal.Body>
+        <VStack gap="space-12">
+          <BodyLong>
+            «{name}» slettes for hele teamet, sammen med alle fryste revisjoner
+            i prosjektet. Surveys som allerede er tatt inn i kode påvirkes ikke.
+          </BodyLong>
+          {showError ? (
+            <Alert variant="error">
+              Utkastet kunne ikke slettes. Prøv igjen.
+            </Alert>
+          ) : null}
+        </VStack>
+      </Modal.Body>
+      <Modal.Footer>
+        <HStack gap="space-12" justify="end">
+          <Button
+            type="button"
+            variant="secondary"
+            onClick={onClose}
+            disabled={isPending}
+          >
+            Avbryt
+          </Button>
+          <Button
+            type="button"
+            data-color="danger"
+            variant="primary"
+            loading={isPending}
+            onClick={() => {
+              confirmInFlightRef.current = true;
+              onConfirm();
+            }}
+          >
+            Slett utkastet
+          </Button>
+        </HStack>
+      </Modal.Footer>
+    </Modal>
+  );
+}

--- a/apps/lumi-dashboard/app/components/surveyverksted/EditorTopbar.tsx
+++ b/apps/lumi-dashboard/app/components/surveyverksted/EditorTopbar.tsx
@@ -181,7 +181,7 @@ export const EditorTopbar = memo(function EditorTopbar({
             size="small"
             icon={<ExternalLinkIcon aria-hidden />}
           >
-            Prøv surveyen
+            Prøv i egen fane
           </Button>
         ) : (
           <Tooltip content="Tilgjengelig når utkastet er lagret">
@@ -192,7 +192,7 @@ export const EditorTopbar = memo(function EditorTopbar({
               icon={<ExternalLinkIcon aria-hidden />}
               disabled
             >
-              Prøv surveyen
+              Prøv i egen fane
             </Button>
           </Tooltip>
         )}

--- a/apps/lumi-dashboard/app/components/surveyverksted/QuestionCanvas.tsx
+++ b/apps/lumi-dashboard/app/components/surveyverksted/QuestionCanvas.tsx
@@ -94,7 +94,7 @@ export const QuestionCanvas = memo(function QuestionCanvas({
             onExpire={onUndoExpire}
           />
         ) : null}
-        <VStack gap="space-2">
+        <VStack gap="space-12">
           <TextField
             label="Sidetittel"
             hideLabel

--- a/apps/lumi-dashboard/app/components/surveyverksted/StageSurface.tsx
+++ b/apps/lumi-dashboard/app/components/surveyverksted/StageSurface.tsx
@@ -92,7 +92,7 @@ export const StageSurface = memo(function StageSurface({
             <span />
             <span />
             <span />
-            <span className={styles.stageUrl}>din-tjeneste.no</span>
+            <span className={styles.stageUrl}>nav.no</span>
           </div>
           <div className={styles.stagePage}>
             <span className={styles.stageLine} data-width="55" />

--- a/apps/lumi-dashboard/app/components/surveyverksted/verksted.module.css
+++ b/apps/lumi-dashboard/app/components/surveyverksted/verksted.module.css
@@ -557,7 +557,7 @@
   grid-template-columns: 1.5rem 1fr;
   column-gap: var(--ax-space-8);
   align-items: start;
-  padding: var(--ax-space-10) var(--ax-space-12);
+  padding: var(--ax-space-16) var(--ax-space-16);
   padding-inline-end: var(--ax-space-32);
   color: var(--ax-text-neutral);
   text-align: left;
@@ -659,17 +659,8 @@
   gap: var(--ax-space-12);
 }
 
-.ghostTitle :global(input.aksel-text-field__input),
-.ghostDescription :global(input.aksel-text-field__input) {
-  padding-inline: var(--ax-space-6);
-  margin-inline-start: calc(var(--ax-space-6) * -1);
-  background: transparent;
-  border-color: transparent;
-  transition:
-    border-color 120ms ease,
-    background 120ms ease;
-}
-
+/* Title and description keep their editorial typography but read as
+   ordinary Aksel inputs — invisible borders failed as an affordance. */
 .ghostTitle :global(input.aksel-text-field__input) {
   font-size: var(--ax-font-size-heading-medium);
   font-weight: 700;
@@ -677,18 +668,6 @@
 
 .ghostDescription :global(input.aksel-text-field__input) {
   color: var(--ax-text-neutral-subtle);
-}
-
-.ghostTitle :global(input.aksel-text-field__input:hover),
-.ghostDescription :global(input.aksel-text-field__input:hover) {
-  border-color: var(--ax-border-neutral-subtle);
-  background: var(--ax-bg-default);
-}
-
-.ghostTitle :global(input.aksel-text-field__input:focus),
-.ghostDescription :global(input.aksel-text-field__input:focus) {
-  border-color: var(--ax-border-focus);
-  background: var(--ax-bg-default);
 }
 
 .addQuestion {

--- a/apps/lumi-dashboard/app/mock/__tests__/surveyAuthoring.test.ts
+++ b/apps/lumi-dashboard/app/mock/__tests__/surveyAuthoring.test.ts
@@ -63,4 +63,45 @@ describe("mock survey authoring store", () => {
       }),
     ).toThrow("Draft changed since it was loaded");
   });
+
+  it("deletion returns false for unknown ids and other teams, leaving the project", async () => {
+    const store = await import("../surveyAuthoring");
+    const created = store.createMockSurveyProject({
+      team: "team-a",
+      name: "Mock-slett",
+      surveyId: "mock-slett",
+      document,
+    });
+
+    expect(store.deleteMockSurveyProject("team-a", "finnes-ikke")).toBe(false);
+    expect(store.deleteMockSurveyProject("team-b", created.id)).toBe(false);
+    expect(store.getMockSurveyProject("team-a", created.id)).toBeDefined();
+  });
+
+  it("deletes the project together with its revisions", async () => {
+    const store = await import("../surveyAuthoring");
+    const created = store.createMockSurveyProject({
+      team: "team-a",
+      name: "Mock-slett",
+      surveyId: "mock-slett",
+      document,
+    });
+    const revision = await store.createMockSurveyRevision({
+      team: "team-a",
+      projectId: created.id,
+      expectedDraftVersion: 1,
+    });
+
+    expect(store.deleteMockSurveyProject("team-a", created.id)).toBe(true);
+    expect(store.getMockSurveyProject("team-a", created.id)).toBeUndefined();
+    // API parity: listing revisions for a deleted project is a not-found.
+    expect(() => store.listMockSurveyRevisions("team-a", created.id)).toThrow(
+      /not found/i,
+    );
+    expect(
+      store.getMockSurveyRevisionDetail("team-a", revision.id),
+    ).toBeUndefined();
+    // Idempotent from the caller's view: the second delete reports missing.
+    expect(store.deleteMockSurveyProject("team-a", created.id)).toBe(false);
+  });
 });

--- a/apps/lumi-dashboard/app/mock/__tests__/surveyAuthoring.test.ts
+++ b/apps/lumi-dashboard/app/mock/__tests__/surveyAuthoring.test.ts
@@ -78,6 +78,25 @@ describe("mock survey authoring store", () => {
     expect(store.getMockSurveyProject("team-a", created.id)).toBeDefined();
   });
 
+  it("refuses to freeze a revision when the project is deleted mid-flight", async () => {
+    // Hashing yields to the event loop — a delete landing in that window
+    // must fail the freeze instead of leaving an orphaned revision.
+    const store = await import("../surveyAuthoring");
+    const created = store.createMockSurveyProject({
+      team: "team-a",
+      name: "Race-slett",
+      surveyId: "race-slett",
+      document,
+    });
+    const pendingFreeze = store.createMockSurveyRevision({
+      team: "team-a",
+      projectId: created.id,
+      expectedDraftVersion: 1,
+    });
+    expect(store.deleteMockSurveyProject("team-a", created.id)).toBe(true);
+    await expect(pendingFreeze).rejects.toThrow(/not found/i);
+  });
+
   it("deletes the project together with its revisions", async () => {
     const store = await import("../surveyAuthoring");
     const created = store.createMockSurveyProject({

--- a/apps/lumi-dashboard/app/mock/surveyAuthoring.ts
+++ b/apps/lumi-dashboard/app/mock/surveyAuthoring.ts
@@ -56,6 +56,19 @@ export function createMockSurveyProject(input: {
   return structuredClone(project);
 }
 
+export function deleteMockSurveyProject(
+  team: string,
+  projectId: string,
+): boolean {
+  const project = projects.get(projectId);
+  if (project?.team !== team) return false;
+  projects.delete(projectId);
+  for (const [id, revision] of revisions) {
+    if (revision.projectId === projectId) revisions.delete(id);
+  }
+  return true;
+}
+
 export function saveMockSurveyProject(input: {
   team: string;
   projectId: string;

--- a/apps/lumi-dashboard/app/mock/surveyAuthoring.ts
+++ b/apps/lumi-dashboard/app/mock/surveyAuthoring.ts
@@ -143,6 +143,16 @@ export async function createMockSurveyRevision(input: {
 
   const documentHash = await sha256(serializeSurveyDocumentJson(document));
   const definitionHash = await sha256(analyticalStructure(document));
+  // Hashing yielded to the event loop — mirror the API's advisory lock by
+  // revalidating that the project still exists (and is unchanged) before
+  // committing the revision.
+  const current = projects.get(input.projectId);
+  if (!current || current.team !== input.team) {
+    throw new Error("Survey project not found");
+  }
+  if (current.draftVersion !== input.expectedDraftVersion) {
+    throw new Error("Draft changed since it was validated");
+  }
   const revision: SurveyAuthoringRevision = {
     id: crypto.randomUUID(),
     projectId: project.id,

--- a/apps/lumi-dashboard/app/routes/surveyverksted.index.tsx
+++ b/apps/lumi-dashboard/app/routes/surveyverksted.index.tsx
@@ -1,4 +1,6 @@
+import { MenuElipsisVerticalIcon, TrashIcon } from "@navikt/aksel-icons";
 import {
+  ActionMenu,
   Alert,
   BodyLong,
   BodyShort,
@@ -16,13 +18,16 @@ import type { SurveyDocumentV1 } from "@navikt/lumi-survey";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { createFileRoute, Link } from "@tanstack/react-router";
 import { zodValidator } from "@tanstack/zod-adapter";
-import { useMemo, useState } from "react";
+import { useMemo, useRef, useState } from "react";
 import { z } from "zod";
+import { DeleteDraftDialog } from "~/components/surveyverksted/DeleteDraftDialog";
 import {
   createSurveyAuthoringProjectServerFn,
+  deleteSurveyAuthoringProjectServerFn,
   fetchSurveyAuthoringProjectsServerFn,
   fetchTeamsServerFn,
 } from "~/server/actions";
+import type { SurveyAuthoringRevisionDetail } from "~/types/surveyAuthoring";
 import { suggestSurveyId } from "~/utils/surveyDocument";
 import styles from "./surveyverksted.module.css";
 
@@ -125,6 +130,54 @@ function SurveyWorkshopIndex() {
   });
 
   const canCreate = Boolean(selectedTeam && name.trim() && surveyId.trim());
+
+  const [deleteTarget, setDeleteTarget] = useState<{
+    id: string;
+    name: string;
+  } | null>(null);
+  const projectsHeadingRef = useRef<HTMLHeadingElement | null>(null);
+  // Set on successful deletion: the dialog's close event runs AFTER the
+  // native focus restore (whose target is gone with the card), so the
+  // replacement focus must be applied there, not in onSuccess.
+  const focusListAfterCloseRef = useRef(false);
+  const deleteMutation = useMutation({
+    mutationFn: async (projectId: string) => {
+      if (!selectedTeam) throw new Error("No authorized team selected");
+      try {
+        await deleteSurveyAuthoringProjectServerFn({
+          data: { team: selectedTeam, projectId },
+        });
+      } catch (error) {
+        // A concurrent delete already reached the desired end state —
+        // converge instead of offering an impossible retry.
+        const alreadyGone =
+          error instanceof Error &&
+          error.message.includes("Survey project not found");
+        if (!alreadyGone) throw error;
+      }
+    },
+    onSuccess: async (_result, projectId) => {
+      // Evict everything scoped to the project so stale caches can never
+      // reopen a deleted draft or revision in this tab.
+      queryClient.removeQueries({
+        queryKey: ["survey-authoring-project", selectedTeam, projectId],
+      });
+      queryClient.removeQueries({
+        queryKey: ["survey-authoring-revisions", selectedTeam, projectId],
+      });
+      queryClient.removeQueries({
+        predicate: (query) =>
+          query.queryKey[0] === "survey-authoring-revision" &&
+          (query.state.data as SurveyAuthoringRevisionDetail | undefined)
+            ?.revision.projectId === projectId,
+      });
+      await queryClient.invalidateQueries({
+        queryKey: ["survey-authoring-projects", selectedTeam],
+      });
+      focusListAfterCloseRef.current = true;
+      setDeleteTarget(null);
+    },
+  });
 
   return (
     <Box
@@ -249,7 +302,12 @@ function SurveyWorkshopIndex() {
             <VStack gap="space-16">
               <HStack justify="space-between" align="end" gap="space-8">
                 <div>
-                  <Heading size="medium" level="2">
+                  <Heading
+                    size="medium"
+                    level="2"
+                    ref={projectsHeadingRef}
+                    tabIndex={-1}
+                  >
                     Teamets utkast
                   </Heading>
                   <BodyShort textColor="subtle">{selectedTeam}</BodyShort>
@@ -268,7 +326,7 @@ function SurveyWorkshopIndex() {
               ) : projectsQuery.data?.length ? (
                 <VStack gap="space-8" as="ul" className={styles.projectList}>
                   {projectsQuery.data.map((project) => (
-                    <li key={project.id}>
+                    <li key={project.id} className={styles.projectItem}>
                       <Link
                         to="/surveyverksted/$projectId"
                         params={{ projectId: project.id }}
@@ -295,6 +353,33 @@ function SurveyWorkshopIndex() {
                           Sist endret {formatProjectDate(project.updatedAt)}
                         </BodyShort>
                       </Link>
+                      <ActionMenu>
+                        <ActionMenu.Trigger>
+                          <Button
+                            type="button"
+                            variant="tertiary-neutral"
+                            size="small"
+                            className={styles.projectMenu}
+                            icon={<MenuElipsisVerticalIcon aria-hidden />}
+                            aria-label={`Handlinger for ${project.name} (${project.surveyId})`}
+                          />
+                        </ActionMenu.Trigger>
+                        <ActionMenu.Content align="end">
+                          <ActionMenu.Item
+                            variant="danger"
+                            icon={<TrashIcon aria-hidden />}
+                            onSelect={() => {
+                              deleteMutation.reset();
+                              setDeleteTarget({
+                                id: project.id,
+                                name: project.name,
+                              });
+                            }}
+                          >
+                            Slett utkast
+                          </ActionMenu.Item>
+                        </ActionMenu.Content>
+                      </ActionMenu>
                     </li>
                   ))}
                 </VStack>
@@ -316,6 +401,22 @@ function SurveyWorkshopIndex() {
           </div>
         )}
       </VStack>
+      <DeleteDraftDialog
+        name={deleteTarget?.name ?? null}
+        isPending={deleteMutation.isPending}
+        showError={deleteMutation.isError}
+        onConfirm={() => {
+          if (deleteTarget) deleteMutation.mutate(deleteTarget.id);
+        }}
+        onClose={() => {
+          if (deleteMutation.isPending) return;
+          setDeleteTarget(null);
+          if (focusListAfterCloseRef.current) {
+            focusListAfterCloseRef.current = false;
+            projectsHeadingRef.current?.focus();
+          }
+        }}
+      />
     </Box>
   );
 }

--- a/apps/lumi-dashboard/app/routes/surveyverksted.module.css
+++ b/apps/lumi-dashboard/app/routes/surveyverksted.module.css
@@ -33,11 +33,26 @@
   list-style: none;
 }
 
+.projectItem {
+  position: relative;
+}
+
+.projectMenu {
+  position: absolute;
+  top: var(--ax-space-8);
+  inset-inline-end: var(--ax-space-8);
+}
+
+.deleteError {
+  margin-block-start: var(--ax-space-12);
+}
+
 .projectLink {
   display: flex;
   justify-content: space-between;
   gap: var(--ax-space-16);
   padding: var(--ax-space-16);
+  padding-inline-end: var(--ax-space-48);
   color: inherit;
   text-decoration: none;
   background: var(--ax-bg-raised);

--- a/apps/lumi-dashboard/app/routes/surveyverksted.module.css
+++ b/apps/lumi-dashboard/app/routes/surveyverksted.module.css
@@ -43,10 +43,6 @@
   inset-inline-end: var(--ax-space-8);
 }
 
-.deleteError {
-  margin-block-start: var(--ax-space-12);
-}
-
 .projectLink {
   display: flex;
   justify-content: space-between;

--- a/apps/lumi-dashboard/app/server/actions/index.ts
+++ b/apps/lumi-dashboard/app/server/actions/index.ts
@@ -44,6 +44,7 @@ export {
 export {
   createSurveyAuthoringProjectServerFn,
   createSurveyAuthoringRevisionServerFn,
+  deleteSurveyAuthoringProjectServerFn,
   fetchSurveyAuthoringProjectServerFn,
   fetchSurveyAuthoringProjectsServerFn,
   fetchSurveyAuthoringRevisionServerFn,

--- a/apps/lumi-dashboard/app/server/actions/surveyAuthoring.ts
+++ b/apps/lumi-dashboard/app/server/actions/surveyAuthoring.ts
@@ -79,6 +79,35 @@ export const fetchSurveyAuthoringProjectServerFn = createServerFn({
     return response.json() as Promise<SurveyAuthoringProject>;
   });
 
+export const deleteSurveyAuthoringProjectServerFn = createServerFn({
+  method: "POST",
+})
+  .middleware([authMiddleware])
+  .inputValidator(zodValidator(SurveyAuthoringProjectIdSchema))
+  .handler(async ({ data, context }): Promise<void> => {
+    if (isMockMode()) {
+      const { deleteMockSurveyProject } = await import(
+        "~/mock/surveyAuthoring"
+      );
+      await mockDelay();
+      if (!deleteMockSurveyProject(data.team, data.projectId)) {
+        throw new Error("Survey project not found");
+      }
+      return;
+    }
+
+    const { backendUrl, oboToken } = context as AuthContext;
+    const response = await fetch(
+      buildUrl(
+        backendUrl,
+        `/api/v1/intern/authoring/projects/${encodeURIComponent(data.projectId)}`,
+        { team: data.team },
+      ),
+      { method: "DELETE", headers: getHeaders(oboToken) },
+    );
+    await handleApiResponse(response);
+  });
+
 export const createSurveyAuthoringProjectServerFn = createServerFn({
   method: "POST",
 })

--- a/apps/lumi-dashboard/e2e/survey-workshop.spec.ts
+++ b/apps/lumi-dashboard/e2e/survey-workshop.spec.ts
@@ -67,7 +67,7 @@ test("creates, edits, previews and shares a survey draft", async ({ page }) => {
   await expectNoAxeViolations(page);
 
   const previewPromise = page.waitForEvent("popup");
-  await page.getByRole("button", { name: "Prøv surveyen" }).click();
+  await page.getByRole("button", { name: "Prøv i egen fane" }).click();
   const preview = await previewPromise;
 
   await expect(
@@ -150,6 +150,110 @@ test("creates, edits, previews and shares a survey draft", async ({ page }) => {
     expect(boxes.dock.bottom).toBeLessThanOrEqual(boxes.stage.bottom + 1);
   }
   await expectNoAxeViolations(page);
+});
+
+test("deletes a draft from the index after confirmation", async ({ page }) => {
+  // Mock state outlives CI retries — a unique name keeps reruns isolated.
+  const draftName = `Slette-utkast-${Date.now()}`;
+  await page.goto("/surveyverksted");
+  await page.getByLabel("Navn på utkastet").fill(draftName);
+  await page.getByRole("button", { name: "Opprett utkast" }).click();
+  await page.waitForURL(/\/surveyverksted\/[0-9a-f-]+/);
+
+  // Freeze a revision so the deletion provably takes revisions with it.
+  await page.getByRole("button", { name: "Del med utvikler" }).click();
+  await page
+    .getByRole("button", { name: /Frys revisjon 1 og få delbar lenke/ })
+    .click();
+  await page.waitForURL(/\/surveyverksted\/revisions\//);
+  const revisionUrl = page.url();
+
+  // SPA-navigate back to the index (same QueryClient!) so the revision
+  // detail stays cached — the deletion must evict it, not a full reload.
+  await page.getByRole("link", { name: "Surveyverksted" }).first().click();
+  await page.waitForURL(/\/surveyverksted$/);
+  await page
+    .getByRole("button", { name: `Handlinger for ${draftName}`, exact: false })
+    .click();
+  await page.getByRole("menuitem", { name: "Slett utkast" }).click();
+
+  const dialog = page.getByRole("dialog", { name: "Slett utkastet?" });
+  await expect(dialog.getByText(/fryste revisjoner/)).toBeVisible();
+  await expectNoAxeViolations(page);
+  await dialog.getByRole("button", { name: "Slett utkastet" }).click();
+
+  await expect(dialog).not.toBeVisible();
+  await expect(page.getByText(draftName)).toHaveCount(0);
+  // The native dialog lost its trigger — focus lands on the list heading.
+  await expect(
+    page.getByRole("heading", { name: "Teamets utkast" }),
+  ).toBeFocused();
+
+  // History back is an SPA navigation: with the detail cache evicted the
+  // route must refetch and land in the not-found state — a stale cache
+  // would render the deleted revision from memory.
+  await page.goBack();
+  await expect(page).toHaveURL(revisionUrl);
+  await expect(page.getByText(/Revisjonen finnes ikke/)).toBeVisible({
+    timeout: 10000,
+  });
+});
+
+test("the delete dialog refuses to close while deletion is pending", async ({
+  page,
+}) => {
+  const draftName = `Slette-lås-${Date.now()}`;
+  await page.goto("/surveyverksted");
+  await page.getByLabel("Navn på utkastet").fill(draftName);
+  await page.getByRole("button", { name: "Opprett utkast" }).click();
+  await page.waitForURL(/\/surveyverksted\/[0-9a-f-]+/);
+  await page.goto("/surveyverksted");
+
+  // First delete attempt: slow, then a server failure. The resolver lets
+  // the test wait until the request is provably on the wire.
+  let intercepted = false;
+  let deleteOnTheWire!: () => void;
+  const deleteRequestSent = new Promise<void>((resolve) => {
+    deleteOnTheWire = resolve;
+  });
+  await page.route("**/*", async (route) => {
+    const request = route.request();
+    const body = request.postData() ?? "";
+    if (
+      !intercepted &&
+      request.method() === "POST" &&
+      body.includes('"projectId"') &&
+      !body.includes('"document"') &&
+      !body.includes('"expectedDraftVersion"')
+    ) {
+      intercepted = true;
+      deleteOnTheWire();
+      await new Promise((resolve) => setTimeout(resolve, 1500));
+      await route.fulfill({ status: 500, body: "boom" });
+      return;
+    }
+    await route.continue();
+  });
+
+  await page
+    .getByRole("button", { name: `Handlinger for ${draftName}`, exact: false })
+    .click();
+  await page.getByRole("menuitem", { name: "Slett utkast" }).click();
+  const dialog = page.getByRole("dialog", { name: "Slett utkastet?" });
+  const confirm = dialog.getByRole("button", { name: "Slett utkastet" });
+  await confirm.click();
+  await deleteRequestSent;
+
+  // Escape while the mutation is in flight must not strand the dialog.
+  await page.keyboard.press("Escape");
+  await expect(dialog).toBeVisible();
+
+  // The failure keeps the dialog with the error and a working retry.
+  await expect(dialog.getByText(/kunne ikke slettes/i)).toBeVisible();
+  await page.unroute("**/*");
+  await dialog.getByRole("button", { name: "Slett utkastet" }).click();
+  await expect(dialog).not.toBeVisible();
+  await expect(page.getByText(draftName)).toHaveCount(0);
 });
 
 test("undo restores the deletion without losing later edits, and sharing surfaces missing metadata", async ({


### PR DESCRIPTION
## Hva

**Slette utkast** (manglet helt — første brukerfeedback):
- Nytt `DELETE /authoring/projects/{id}`: team-scopet, 204/404, fryste revisjoner følger via eksisterende DB-cascade. Produksjonstabellene er et separat domene og berøres ikke.
- Kebab-meny på utkastskortene + bekreftelsesdialog etter husmønsteret (`DeleteDraftDialog`): navngir konsekvensene, `data-color="danger"`, blokkerer lukking (Escape/kryss) mens slettingen pågår via Aksels `onBeforeClose` + synkron confirm-ref — en feil kan aldri strande brukeren uten feilmelding og retry.
- Samtidig sletting (404) konvergerer som suksess i stedet for umulig retry.
- Full cache-eviction ved sletting: prosjektdetalj, revisjonsliste og revisjonsdetaljer (predicate på `revision.projectId`) — verifisert med SPA-navigasjonstest som beholder samme QueryClient.
- `updateDraft` returnerer nå `Updated/NotFound/VersionConflict` avgjort atomisk i samme transaksjon: en sletting som racer en lagring rapporteres som «slettet», aldri «endret i en annen fane».
- Fokus etter sletting flyttes til listeoverskriften via dialogens close-event; kortmenyene bærer survey-ID i tilgjengelig navn mot navnekollisjoner.

**Kjent rest-risiko (bevisst akseptert):** sletting broadcastes ikke til andre faner. En åpen editor i en annen fane konvergerer via 404 på neste lagring (klassifisert permanent, ingen retry-løkke); en passivt åpen editor uten endringer viser stale innhold til neste interaksjon. BroadcastChannel-varianten kan bygges hvis behovet melder seg.

**UI-polering fra samme feedbackrunde:**
- Sidetittel/innledning har vanlige Aksel-inputrammer (ghost-stylingen feilet som affordanse) + riktig feltavstand
- Rausere padding i siderailen
- Scene-chromen viser `nav.no`
- «Prøv surveyen» → «Prøv i egen fane» (scenen er allerede live; knappens jobb er ekte viewport + delbar lenke)

## Test

- API: 684 tester inkl. delete-scoping, cascade og atomisk NotFound-klassifisering (rød-grønn: pre-sjekken fjernet først, 409-feilklassifiseringen observert)
- Dashboard: 456 vitest (mock-paritet for sletting), tsc, rot-lint
- E2E: 8/8 — sletteflyt med axe på dialogen, fokusretur, SPA-cache-eviction (goBack til slettet revisjon → not-found), Escape-under-pending med intercept-styrt feil + retry
- To adversarial review-runder verifisert og rettet før PR
