### PR TITLE
Surveyverksted: forhåndsvis introskjermen live fra scenens omstart-knapp

### DIFF
--- a/apps/lumi-dashboard/app/components/surveyverksted/PreviewStage.tsx
+++ b/apps/lumi-dashboard/app/components/surveyverksted/PreviewStage.tsx
@@ -50,14 +50,23 @@ export const PreviewStage = memo(function PreviewStage({
 
   const [restartNonce, setRestartNonce] = useState(0);
   // "Start på nytt" runs the survey from the very beginning — intro screen
-  // included when one is authored. The flag is keyed to the revision it was
-  // requested for, so the next edit automatically returns the stage to the
-  // selected page without a Start-gate.
-  const [fromStartRevision, setFromStartRevision] = useState<number | null>(
-    null,
-  );
+  // included when one is authored. The request is anchored to the document
+  // revision and editor page it was made from. The next edit or page selection
+  // returns the stage to the selected page without a Start-gate.
+  const [fromStart, setFromStart] = useState<{
+    revision: number;
+    pageId: string;
+  } | null>(null);
+  useEffect(() => {
+    setFromStart((current) =>
+      current?.pageId === initialPageId ? current : null,
+    );
+  }, [initialPageId]);
   const hasIntro = Boolean(stableDocument?.intro?.title.trim());
-  const previewFromStart = hasIntro && fromStartRevision === stable.revision;
+  const previewFromStart =
+    hasIntro &&
+    fromStart?.revision === stable.revision &&
+    fromStart.pageId === initialPageId;
 
   return (
     <section aria-label="Forhåndsvisning" className={styles.stagePanel}>
@@ -78,7 +87,17 @@ export const PreviewStage = memo(function PreviewStage({
             icon={<ArrowCirclepathIcon aria-hidden />}
             aria-label="Start forhåndsvisningen på nytt"
             onClick={() => {
-              setFromStartRevision(stable.revision);
+              const restartRevision =
+                isValid && stableDocument !== document
+                  ? stable.revision + 1
+                  : stable.revision;
+              if (restartRevision !== stable.revision) {
+                setStable({ document, revision: restartRevision });
+              }
+              setFromStart({
+                revision: restartRevision,
+                pageId: initialPageId,
+              });
               setRestartNonce((nonce) => nonce + 1);
             }}
           />

--- a/apps/lumi-dashboard/app/components/surveyverksted/PreviewStage.tsx
+++ b/apps/lumi-dashboard/app/components/surveyverksted/PreviewStage.tsx
@@ -49,6 +49,15 @@ export const PreviewStage = memo(function PreviewStage({
   const stableDocument = stable.document;
 
   const [restartNonce, setRestartNonce] = useState(0);
+  // "Start på nytt" runs the survey from the very beginning — intro screen
+  // included when one is authored. The flag is keyed to the revision it was
+  // requested for, so the next edit automatically returns the stage to the
+  // selected page without a Start-gate.
+  const [fromStartRevision, setFromStartRevision] = useState<number | null>(
+    null,
+  );
+  const hasIntro = Boolean(stableDocument?.intro?.title.trim());
+  const previewFromStart = hasIntro && fromStartRevision === stable.revision;
 
   return (
     <section aria-label="Forhåndsvisning" className={styles.stagePanel}>
@@ -68,7 +77,10 @@ export const PreviewStage = memo(function PreviewStage({
             size="small"
             icon={<ArrowCirclepathIcon aria-hidden />}
             aria-label="Start forhåndsvisningen på nytt"
-            onClick={() => setRestartNonce((nonce) => nonce + 1)}
+            onClick={() => {
+              setFromStartRevision(stable.revision);
+              setRestartNonce((nonce) => nonce + 1);
+            }}
           />
         </Tooltip>
       </div>
@@ -85,7 +97,7 @@ export const PreviewStage = memo(function PreviewStage({
           instanceKey={stable.revision}
           surveyId={`verksted-preview-${surveyId || "utkast"}`}
           environmentTag="survey-workshop-editor"
-          initialPageId={initialPageId}
+          initialPageId={previewFromStart ? undefined : initialPageId}
           nonce={restartNonce}
           successTitle="Slik ser kvitteringen ut"
           successBody="Bare en forhåndsvisning — ingenting ble sendt."

--- a/apps/lumi-dashboard/e2e/survey-workshop.spec.ts
+++ b/apps/lumi-dashboard/e2e/survey-workshop.spec.ts
@@ -162,9 +162,24 @@ test("authors intro and thank-you screens that render in the real widget", async
 
   await page.getByRole("button", { name: "Legg til introskjerm" }).click();
   const introCard = page.getByRole("region", { name: "Introskjerm" });
+  await expect(introCard).toBeVisible();
+  await page.clock.install();
+  await page.clock.pauseAt(Date.now());
   await introCard.getByLabel("Tittel").fill("Velkommen");
   await introCard.getByLabel(/Brødtekst/).fill("To korte spørsmål.");
   await introCard.getByLabel(/Knappetekst/).fill("Kom i gang");
+
+  // An explicit restart flushes the latest valid editor state instead of
+  // waiting for the stage's normal debounce.
+  const stage = page.getByLabel("Forhåndsvisning");
+  await page
+    .getByRole("button", { name: "Start forhåndsvisningen på nytt" })
+    .click();
+  await expect(stage.getByRole("heading", { name: "Velkommen" })).toBeVisible();
+  await expect(stage.getByText("To korte spørsmål.")).toBeVisible();
+  await stage.getByRole("button", { name: "Kom i gang" }).click();
+  await expect(stage.getByRole("radio", { name: /5\./ })).toBeVisible();
+  await page.clock.resume();
 
   await page.getByRole("button", { name: "Legg til takkskjerm" }).click();
   await page
@@ -175,7 +190,6 @@ test("authors intro and thank-you screens that render in the real widget", async
   await expectNoAxeViolations(page);
 
   // The stage keeps editing flowing: no Start-gate in front of questions.
-  const stage = page.getByLabel("Forhåndsvisning");
   await expect(stage.getByRole("radio", { name: /5\./ })).toBeVisible();
   await expect(
     stage.getByRole("button", { name: "Kom i gang" }),
@@ -208,6 +222,24 @@ test("authors intro and thank-you screens that render in the real widget", async
   await preview.getByRole("button", { name: "Kom i gang" }).click();
   await expect(preview.getByRole("radio", { name: /5\./ })).toBeVisible();
   await preview.close();
+
+  // Selecting another editor page exits the from-start walkthrough and makes
+  // the stage follow the selected page again.
+  await page.getByRole("button", { name: "Ny side" }).click();
+  await expect(stage.getByRole("heading", { name: "Ny side" })).toBeVisible();
+  await page
+    .getByRole("button", { name: "Start forhåndsvisningen på nytt" })
+    .click();
+  await expect(stage.getByRole("heading", { name: "Velkommen" })).toBeVisible();
+  await page
+    .getByRole("button", { name: /01.*Fortell om opplevelsen/ })
+    .click();
+  await expect(
+    stage.getByRole("heading", { name: "Fortell om opplevelsen" }),
+  ).toBeVisible();
+  await expect(
+    stage.getByRole("heading", { name: "Velkommen" }),
+  ).not.toBeVisible();
 
   // Removing the intro is reversible: focus lands on the undo (house
   // pattern for deletions), and undoing restores the content with focus

--- a/apps/lumi-dashboard/e2e/survey-workshop.spec.ts
+++ b/apps/lumi-dashboard/e2e/survey-workshop.spec.ts
@@ -188,6 +188,15 @@ test("authors intro and thank-you screens that render in the real widget", async
     stage.getByRole("heading", { name: "Takk for svaret!" }),
   ).toBeVisible();
 
+  // «Start på nytt» previews the intro live in the stage; the walk-through
+  // continues into the questions.
+  await page
+    .getByRole("button", { name: "Start forhåndsvisningen på nytt" })
+    .click();
+  await expect(stage.getByRole("heading", { name: "Velkommen" })).toBeVisible();
+  await stage.getByRole("button", { name: "Kom i gang" }).click();
+  await expect(stage.getByRole("radio", { name: /5\./ })).toBeVisible();
+
   // The full-tab preview runs the real intro flow.
   const previewPromise = page.waitForEvent("popup");
   await page.getByRole("button", { name: "Prøv i egen fane" }).click();


### PR DESCRIPTION
Oppfølging av #441 (brukerfriksjon): introskjermen var kun synlig i «Prøv i egen fane», siden scenen bevisst undertrykker den under redigering (valgt side vinner, ellers Start-klikk per tastetrykk).

**Løsning:** «Start forhåndsvisningen på nytt» (sirkelpilen i scene-headeren) kjører nå surveyen fra den ekte begynnelsen — introskjermen inkludert når den finnes. Flagget er nøklet til dokumentrevisjonen det ble bedt om for, så neste redigering hvor som helst returnerer scenen automatisk til valgt side uten Start-gate. Surveys uten intro beholder dagens omstart-oppførsel uendret.

## Test

- E2e utvidet: omstart i scenen viser introen live med authored innhold, «Kom i gang» går videre til spørsmålene, og redigering etterpå er ugatet (9/9)
- Dashboard 461 vitest, tsc, rot-lint, produksjonsbygg
- Ingen pakke- eller API-endringer