### PR TITLE
Surveyverksted: sticky forhåndsvisning og tydeligere bekreftelse

### DIFF
--- a/apps/lumi-dashboard/app/components/surveyverksted/DeleteDraftDialog.tsx
+++ b/apps/lumi-dashboard/app/components/surveyverksted/DeleteDraftDialog.tsx
@@ -49,8 +49,8 @@ export function DeleteDraftDialog({
       <Modal.Body>
         <VStack gap="space-12">
           <BodyLong>
-            «{name}» slettes for hele teamet, sammen med alle fryste revisjoner
-            i prosjektet. Surveys som allerede er tatt inn i kode påvirkes ikke.
+            «{name}» slettes for hele teamet, sammen med alle delte versjoner i
+            prosjektet. Surveys som allerede er tatt inn i kode påvirkes ikke.
           </BodyLong>
           {showError ? (
             <Alert variant="error">

--- a/apps/lumi-dashboard/app/components/surveyverksted/QuestionCanvas.tsx
+++ b/apps/lumi-dashboard/app/components/surveyverksted/QuestionCanvas.tsx
@@ -218,10 +218,11 @@ export const QuestionCanvas = memo(function QuestionCanvas({
       </SortableList>
       {pageNumber === totalPages ? (
         <SurveyScreenCard
-          regionLabel="Takkskjerm"
-          eyebrow="TAKKSKJERM"
-          addLabel="Legg til takkskjerm"
-          removeLabel="Fjern takkskjermen"
+          regionLabel="Bekreftelse etter innsending"
+          eyebrow="ETTER INNSENDING"
+          description="Vises etter at brukeren har sendt inn svarene. Uten tilpasning brukes standardteksten."
+          addLabel="Tilpass bekreftelsen"
+          removeLabel="Bruk standardbekreftelsen"
           value={success}
           undo={successUndo}
           onChange={onChangeSuccess}

--- a/apps/lumi-dashboard/app/components/surveyverksted/QuestionCanvas.tsx
+++ b/apps/lumi-dashboard/app/components/surveyverksted/QuestionCanvas.tsx
@@ -102,12 +102,13 @@ export const QuestionCanvas = memo(function QuestionCanvas({
     <VStack gap="space-24">
       {pageNumber === 1 ? (
         <SurveyScreenCard
-          regionLabel="Introskjerm"
-          eyebrow="INTROSKJERM"
-          addLabel="Legg til introskjerm"
-          removeLabel="Fjern introskjermen"
+          regionLabel="Velkomstside"
+          eyebrow="VELKOMSTSIDE"
+          description="Vises før det første spørsmålet. Uten en velkomstside starter surveyen rett på spørsmålene."
+          addLabel="Legg til velkomstside"
+          removeLabel="Fjern velkomstsiden"
           startLabelField={{
-            label: "Knappetekst (valgfri)",
+            label: "Tekst på startknappen (valgfri)",
             placeholder: "Start",
           }}
           value={intro}

--- a/apps/lumi-dashboard/app/components/surveyverksted/ShareDialog.tsx
+++ b/apps/lumi-dashboard/app/components/surveyverksted/ShareDialog.tsx
@@ -144,21 +144,21 @@ export function ShareDialog({
               <div>
                 <BodyShort weight="semibold">
                   {nextRevisionNumber === null
-                    ? "Klar til å fryse en ny revisjon"
-                    : `Klar til å fryse revisjon ${nextRevisionNumber}`}
+                    ? "Klar til å dele en ny versjon"
+                    : `Klar til å dele versjon ${nextRevisionNumber}`}
                 </BodyShort>
                 <BodyShort size="small" textColor="subtle">
                   {stats.pages} {stats.pages === 1 ? "side" : "sider"} ·{" "}
-                  {stats.questions} spørsmål · validert mot runtime
+                  {stats.questions} spørsmål · klar til bruk
                 </BodyShort>
               </div>
             </div>
           )}
 
           <BodyShort size="small" textColor="subtle">
-            Revisjonen blir en fast, teamautorisert lenke som aldri endrer seg —
-            lim den inn i GitHub-issuen eller oppgaven. Ingenting publiseres:
-            utvikleren tar koden inn i appen gjennom vanlig deploy.
+            Du får en lenke som viser akkurat denne versjonen. Bare teamet har
+            tilgang. Lim lenken inn i GitHub-saken eller oppgaven. Surveyen
+            publiseres ikke — utvikleren legger den inn i appen.
           </BodyShort>
 
           {freezeError ? <Alert variant="error">{freezeError}</Alert> : null}
@@ -166,7 +166,7 @@ export function ShareDialog({
           {revisions.length > 0 ? (
             <div>
               <Detail as="p" className={styles.eyebrow}>
-                DELTE REVISJONER
+                DELTE VERSJONER
               </Detail>
               <ol className={styles.revisionList}>
                 {revisions.map((revision) => (
@@ -182,7 +182,7 @@ export function ShareDialog({
                       </span>
                       <span>
                         <BodyShort as="span" size="small" weight="semibold">
-                          Revisjon {revision.revisionNumber}
+                          Versjon {revision.revisionNumber}
                         </BodyShort>
                         <Detail as="span" className={styles.revisionMeta}>
                           {formatTimestamp(revision.createdAt)}
@@ -192,7 +192,7 @@ export function ShareDialog({
                     <CopyButton
                       size="xsmall"
                       copyText={revisionUrl(revision.id, team)}
-                      title={`Kopier lenken til revisjon ${revision.revisionNumber}`}
+                      title={`Kopier lenken til versjon ${revision.revisionNumber}`}
                       icon={<LinkIcon aria-hidden />}
                     />
                   </li>
@@ -210,8 +210,8 @@ export function ShareDialog({
           onClick={onFreeze}
         >
           {nextRevisionNumber === null
-            ? "Frys ny revisjon og få delbar lenke"
-            : `Frys revisjon ${nextRevisionNumber} og få delbar lenke`}
+            ? "Del en ny versjon"
+            : `Del versjon ${nextRevisionNumber}`}
         </Button>
         <Button type="button" variant="tertiary" onClick={onClose}>
           Avbryt

--- a/apps/lumi-dashboard/app/components/surveyverksted/SurveyScreenCard.tsx
+++ b/apps/lumi-dashboard/app/components/surveyverksted/SurveyScreenCard.tsx
@@ -1,5 +1,12 @@
 import { PlusIcon, XMarkIcon } from "@navikt/aksel-icons";
-import { Button, Detail, Textarea, TextField, Tooltip } from "@navikt/ds-react";
+import {
+  BodyShort,
+  Button,
+  Detail,
+  Textarea,
+  TextField,
+  Tooltip,
+} from "@navikt/ds-react";
 import { useEffect, useRef } from "react";
 import { UndoNotice } from "./UndoNotice";
 import styles from "./verksted.module.css";
@@ -21,6 +28,7 @@ export interface SurveyScreenCardProps {
   regionLabel: string;
   /** Section heading, e.g. "INTROSKJERM". */
   eyebrow: string;
+  description?: string;
   addLabel: string;
   removeLabel: string;
   /** Shown when the screen has a start button (intro only). */
@@ -32,7 +40,7 @@ export interface SurveyScreenCardProps {
 }
 
 /**
- * Survey-level screen content (intro before the first question, thank-you
+ * Survey-level screen content (intro before the first question, confirmation
  * after submission). Fields commit per keystroke like every other draft
  * field, so the navigation blocker always sees the latest content.
  * Removal is reversible through the same undo pattern as questions and
@@ -42,6 +50,7 @@ export interface SurveyScreenCardProps {
 export function SurveyScreenCard({
   regionLabel,
   eyebrow,
+  description,
   addLabel,
   removeLabel,
   startLabelField,
@@ -66,6 +75,11 @@ export function SurveyScreenCard({
   if (value === undefined) {
     return (
       <div className={styles.screenCardAbsent}>
+        {description ? (
+          <BodyShort size="small" className={styles.screenCardDescription}>
+            {description}
+          </BodyShort>
+        ) : null}
         {undo ? (
           <UndoNotice
             label={undo.label}
@@ -106,6 +120,11 @@ export function SurveyScreenCard({
           />
         </Tooltip>
       </div>
+      {description ? (
+        <BodyShort size="small" className={styles.screenCardDescription}>
+          {description}
+        </BodyShort>
+      ) : null}
       <TextField
         ref={titleRef}
         label="Tittel"

--- a/apps/lumi-dashboard/app/components/surveyverksted/SurveyScreenCard.tsx
+++ b/apps/lumi-dashboard/app/components/surveyverksted/SurveyScreenCard.tsx
@@ -26,7 +26,7 @@ export interface ScreenUndo {
 export interface SurveyScreenCardProps {
   /** Accessible name for the section while the screen exists. */
   regionLabel: string;
-  /** Section heading, e.g. "INTROSKJERM". */
+  /** Section heading, e.g. "VELKOMSTSIDE". */
   eyebrow: string;
   description?: string;
   addLabel: string;
@@ -133,7 +133,7 @@ export function SurveyScreenCard({
         onChange={(event) => onChange({ ...value, title: event.target.value })}
       />
       <Textarea
-        label="Brødtekst (valgfri)"
+        label="Tekst (valgfri)"
         size="small"
         minRows={2}
         value={value.body ?? ""}

--- a/apps/lumi-dashboard/app/components/surveyverksted/questionTypeMeta.tsx
+++ b/apps/lumi-dashboard/app/components/surveyverksted/questionTypeMeta.tsx
@@ -22,13 +22,13 @@ export const QUESTION_TYPES: QuestionTypeMeta[] = [
   {
     id: "rating",
     label: "Vurdering",
-    description: "Fast skala: emoji, tommel, stjerner eller NPS",
+    description: "Svar på en skala med emoji, tommel, stjerner eller NPS",
     Icon: FaceSmileIcon,
   },
   {
     id: "text",
     label: "Fritekst",
-    description: "Åpne svar med respondentens egne ord",
+    description: "Åpne svar med brukerens egne ord",
     Icon: PencilWritingIcon,
   },
   {

--- a/apps/lumi-dashboard/app/components/surveyverksted/verksted.module.css
+++ b/apps/lumi-dashboard/app/components/surveyverksted/verksted.module.css
@@ -343,6 +343,11 @@
   border-radius: var(--ax-radius-12);
 }
 
+.screenCardDescription {
+  max-width: 42rem;
+  color: var(--ax-text-neutral-subtle);
+}
+
 .conditionAddWrap {
   display: inline-flex;
   align-items: center;

--- a/apps/lumi-dashboard/app/routes/surveyverksted-editor.module.css
+++ b/apps/lumi-dashboard/app/routes/surveyverksted-editor.module.css
@@ -56,12 +56,21 @@
 .preview {
   position: sticky;
   top: 64px;
+  box-sizing: border-box;
   height: calc(100vh - 64px);
   min-height: 0;
   padding: var(--ax-space-20) var(--ax-space-16);
 }
 
 @media (max-width: 78rem) {
+  .editorGrid {
+    grid-template-columns:
+      minmax(11rem, 0.45fr) minmax(22rem, 1.25fr)
+      minmax(20rem, 0.85fr);
+  }
+}
+
+@media (max-width: 64rem) {
   .editorGrid {
     grid-template-columns: minmax(13rem, 0.6fr) minmax(24rem, 1.4fr);
   }

--- a/apps/lumi-dashboard/app/routes/surveyverksted.$projectId.tsx
+++ b/apps/lumi-dashboard/app/routes/surveyverksted.$projectId.tsx
@@ -874,7 +874,7 @@ function SurveyWorkshopEditor({
       ? {
           label:
             kind === "intro"
-              ? "Introskjermen ble fjernet."
+              ? "Velkomstsiden ble fjernet."
               : "Tilpasningen av bekreftelsen ble fjernet.",
           onUndo: handleUndo,
           onExpire: () => setUndo(null),
@@ -1015,7 +1015,7 @@ function SurveyWorkshopEditor({
           revisionMutation.isError
             ? revisionMutation.error instanceof Error
               ? revisionMutation.error.message
-              : "Revisjonen kunne ikke opprettes."
+              : "Versjonen kunne ikke deles."
             : null
         }
         onFreeze={() => revisionMutation.mutate()}

--- a/apps/lumi-dashboard/app/routes/surveyverksted.$projectId.tsx
+++ b/apps/lumi-dashboard/app/routes/surveyverksted.$projectId.tsx
@@ -875,7 +875,7 @@ function SurveyWorkshopEditor({
           label:
             kind === "intro"
               ? "Introskjermen ble fjernet."
-              : "Takkskjermen ble fjernet.",
+              : "Tilpasningen av bekreftelsen ble fjernet.",
           onUndo: handleUndo,
           onExpire: () => setUndo(null),
         }

--- a/apps/lumi-dashboard/app/routes/surveyverksted.revisions.$revisionId.tsx
+++ b/apps/lumi-dashboard/app/routes/surveyverksted.revisions.$revisionId.tsx
@@ -54,7 +54,7 @@ function SurveyRevisionRoute() {
   if (revisionQuery.isPending) {
     return (
       <Box as="main" padding="space-32" className={styles.centered}>
-        <Loader size="large" title="Åpner revisjon" />
+        <Loader size="large" title="Åpner delt versjon" />
       </Box>
     );
   }
@@ -63,7 +63,7 @@ function SurveyRevisionRoute() {
     return (
       <Box as="main" padding="space-32" className="main-container">
         <Alert variant="error">
-          Revisjonen finnes ikke, eller du har ikke tilgang til teamet.
+          Den delte versjonen finnes ikke, eller du har ikke tilgang til teamet.
         </Alert>
       </Box>
     );
@@ -141,7 +141,7 @@ function SurveyRevision({
           Tilbake til redigerbart utkast
         </Link>
         <Tag variant="success" size="small">
-          Låst revisjon
+          Delt versjon
         </Tag>
       </div>
 
@@ -156,16 +156,16 @@ function SurveyRevision({
             textColor="subtle"
             className={styles.eyebrow}
           >
-            REVISJON {revision.revisionNumber} · KLAR FOR UTVIKLER
+            VERSJON {revision.revisionNumber} · KLAR FOR UTVIKLER
           </BodyShort>
           <Heading size="xlarge" level="1" spacing>
             {revision.name}
           </Heading>
           <BodyLong size="large">
-            En fast versjon av surveyen som kan prøves, gjennomgås og tas inn i
-            kode. Endringer i utkastet påvirker ikke denne lenken.
+            Dette er en lagret versjon som kan prøves, gjennomgås og deles med
+            utvikleren. Endringer i utkastet påvirker den ikke.
           </BodyLong>
-          <dl className={styles.heroStats} aria-label="Revisjonsomfang">
+          <dl className={styles.heroStats} aria-label="Innhold i versjonen">
             <div>
               <dt>Sider</dt>
               <dd>{revision.document.pages.length}</dd>
@@ -190,7 +190,7 @@ function SurveyRevision({
           >
             {validation.error ? (
               <Alert variant="error">
-                Revisjonen kan ikke brukes av widgeten: {validation.error}
+                Denne versjonen kan ikke forhåndsvises: {validation.error}
               </Alert>
             ) : (
               <div className={styles.validationStatus}>
@@ -200,8 +200,8 @@ function SurveyRevision({
                     Klar til bruk
                   </Heading>
                   <BodyShort size="small">
-                    Dokumentet er validert. Forhåndsvisning og kode bruker
-                    nøyaktig den låste revisjonen.
+                    Denne versjonen kan forhåndsvises og tas i bruk av
+                    utvikleren.
                   </BodyShort>
                 </div>
               </div>
@@ -212,11 +212,10 @@ function SurveyRevision({
             <HStack justify="space-between" align="end" gap="space-16" wrap>
               <div>
                 <Heading id="preview-heading" size="medium" level="2" spacing>
-                  Opplev surveyen som respondent
+                  Prøv surveyen slik brukeren møter den
                 </Heading>
                 <BodyShort textColor="subtle">
-                  Gå gjennom hele flyten i den ekte Lumi-widgeten, rett her.
-                  Svar sendes ikke.
+                  Gå gjennom hele surveyen her. Svarene lagres ikke.
                 </BodyShort>
               </div>
               <Tooltip content="Start forhåndsvisningen på nytt">
@@ -239,8 +238,8 @@ function SurveyRevision({
                   surveyId={`revision-preview-${revision.surveyId}`}
                   environmentTag="survey-workshop-revision"
                   nonce={restartNonce}
-                  successTitle="Forhåndsvisning fullført"
-                  successBody="Dette var en inert forhåndsvisning. Ingenting ble sendt inn."
+                  successTitle="Du har fullført forhåndsvisningen"
+                  successBody="Dette var bare en forhåndsvisning. Ingen svar ble sendt inn."
                 />
               </div>
             ) : null}
@@ -251,7 +250,7 @@ function SurveyRevision({
               Hva er endret?
             </Heading>
             <BodyShort textColor="subtle" spacing>
-              En kort oppsummering mot forrige delte revisjon.
+              Sammenlignet med forrige delte versjon.
             </BodyShort>
             <ul className={styles.changeList}>
               {diff.map((change) => (
@@ -265,8 +264,8 @@ function SurveyRevision({
               Ta surveyen inn i appen
             </Heading>
             <BodyShort textColor="subtle" spacing>
-              TypeScript er den raskeste veien inn i kodebasen. JSON er det
-              komplette, maskinlesbare dokumentet.
+              Utvikleren kan kopiere TypeScript eller laste ned hele oppsettet
+              som JSON.
             </BodyShort>
             <div className={styles.exportGrid}>
               <div className={styles.exportCard} data-featured="true">
@@ -283,7 +282,7 @@ function SurveyRevision({
                     </Tag>
                   </HStack>
                   <BodyShort size="small" textColor="subtle">
-                    Klar til å limes inn som et typesikkert SurveyDocumentV1.
+                    Kan kopieres rett inn i kodebasen.
                   </BodyShort>
                 </div>
                 <CopyButton
@@ -301,7 +300,7 @@ function SurveyRevision({
                     JSON-dokument
                   </Heading>
                   <BodyShort size="small" textColor="subtle">
-                    Bevarer hele dokumentet for arkiv, verktøy og round-trip.
+                    Inneholder hele oppsettet for surveyen.
                   </BodyShort>
                 </div>
                 <Button
@@ -319,7 +318,7 @@ function SurveyRevision({
               <div>
                 <BodyShort weight="semibold">Del i oppgaven</BodyShort>
                 <BodyShort size="small" textColor="subtle">
-                  Kopierer navn, revisjon og teamautorisert lenke som Markdown.
+                  Kopierer et ferdig sammendrag med lenke til denne versjonen.
                 </BodyShort>
               </div>
               <CopyButton
@@ -347,18 +346,18 @@ function SurveyRevision({
             textColor="subtle"
             className={styles.eyebrow}
           >
-            FAST OG DELBAR
+            DELT VERSJON
           </BodyShort>
           <Heading id="metadata-heading" size="medium" level="2" spacing>
-            Om revisjonen
+            Om versjonen
           </Heading>
           <BodyShort size="small" textColor="subtle" spacing>
-            Revisjon {revision.revisionNumber} er et øyeblikksbilde. Den kan
-            alltid brukes til å kontrollere nøyaktig hva som ble delt.
+            Innholdet i versjon {revision.revisionNumber} endres ikke. Dere kan
+            derfor alltid se nøyaktig hva som ble delt.
           </BodyShort>
           <dl>
             <div>
-              <dt>Revisjon</dt>
+              <dt>Versjon</dt>
               <dd>{revision.revisionNumber}</dd>
             </div>
             <div>
@@ -370,7 +369,7 @@ function SurveyRevision({
               <dd>{revision.createdBy}</dd>
             </div>
             <div>
-              <dt>Utkastversjon</dt>
+              <dt>Fra utkast nr.</dt>
               <dd>{revision.draftVersion}</dd>
             </div>
           </dl>
@@ -390,8 +389,8 @@ function SurveyRevision({
             </div>
           </details>
           <Alert variant="info" size="small">
-            Dette er ikke publisering. Git og appens deployløp avgjør hva som
-            kjører i produksjon.
+            Surveyen publiseres ikke fra denne siden. Utvikleren må fortsatt
+            legge den inn i appen.
           </Alert>
         </aside>
       </div>

--- a/apps/lumi-dashboard/app/styles/global.css
+++ b/apps/lumi-dashboard/app/styles/global.css
@@ -28,8 +28,9 @@ body {
   margin: 0;
   padding: 0;
   min-height: 100vh;
-  /* Prevent horizontal overflow on mobile */
-  overflow-x: hidden;
+  /* Clip horizontal overflow without creating a scroll container that breaks
+     position: sticky descendants. */
+  overflow-x: clip;
 }
 
 html[data-theme="light"],

--- a/apps/lumi-dashboard/app/utils/__tests__/surveyRevision.test.ts
+++ b/apps/lumi-dashboard/app/utils/__tests__/surveyRevision.test.ts
@@ -52,10 +52,10 @@ describe("describeRevisionChanges for screens", () => {
       "Introskjermen er endret.",
     );
     expect(describeRevisionChanges(withSuccess, document)).toContain(
-      "Takkskjerm er lagt til.",
+      "Bekreftelse etter innsending er lagt til.",
     );
     expect(describeRevisionChanges(document, withSuccess)).toContain(
-      "Takkskjerm er fjernet.",
+      "Bekreftelse etter innsending er fjernet.",
     );
   });
 });

--- a/apps/lumi-dashboard/app/utils/__tests__/surveyRevision.test.ts
+++ b/apps/lumi-dashboard/app/utils/__tests__/surveyRevision.test.ts
@@ -43,13 +43,13 @@ describe("describeRevisionChanges for screens", () => {
     };
 
     expect(describeRevisionChanges(withIntro, document)).toContain(
-      "Introskjerm er lagt til.",
+      "Velkomstside er lagt til.",
     );
     expect(describeRevisionChanges(document, withIntro)).toContain(
-      "Introskjerm er fjernet.",
+      "Velkomstside er fjernet.",
     );
     expect(describeRevisionChanges(withChangedIntro, withIntro)).toContain(
-      "Introskjermen er endret.",
+      "Velkomstsiden er endret.",
     );
     expect(describeRevisionChanges(withSuccess, document)).toContain(
       "Bekreftelse etter innsending er lagt til.",
@@ -125,7 +125,7 @@ describe("survey revision exports", () => {
       "Teksten er endret i 1 spørsmål.",
     ]);
     expect(describeRevisionChanges(document)).toEqual([
-      "Første delbare revisjon i prosjektet.",
+      "Første delte versjon i prosjektet.",
     ]);
   });
 
@@ -149,7 +149,7 @@ describe("survey revision exports", () => {
     );
 
     expect(markdown).toBe(
-      "[Kvittering – revisjon 3](https://lumi.example/revision/1)",
+      "[Kvittering – versjon 3](https://lumi.example/revision/1)",
     );
     expect(
       createRevisionMarkdown(
@@ -157,7 +157,7 @@ describe("survey revision exports", () => {
         "https://lumi.example/revision/1",
       ),
     ).toBe(
-      "[Kvittering \\[beta\\] – revisjon 3](https://lumi.example/revision/1)",
+      "[Kvittering \\[beta\\] – versjon 3](https://lumi.example/revision/1)",
     );
   });
 });

--- a/apps/lumi-dashboard/app/utils/surveyDocument.test.ts
+++ b/apps/lumi-dashboard/app/utils/surveyDocument.test.ts
@@ -794,9 +794,9 @@ describe("survey screen content", () => {
     expect(issues.some((issue) => /intro.*tittel/i.test(issue.message))).toBe(
       true,
     );
-    expect(issues.some((issue) => /takk.*tittel/i.test(issue.message))).toBe(
-      true,
-    );
+    expect(
+      issues.some((issue) => /bekreftelse.*tittel/i.test(issue.message)),
+    ).toBe(true);
 
     const valid = setSurveySuccess(
       setSurveyIntro(makeDocument(), { title: "Velkommen" }),

--- a/apps/lumi-dashboard/app/utils/surveyDocument.test.ts
+++ b/apps/lumi-dashboard/app/utils/surveyDocument.test.ts
@@ -791,9 +791,9 @@ describe("survey screen content", () => {
       { title: "" },
     );
     const issues = findHandoffIssues(document);
-    expect(issues.some((issue) => /intro.*tittel/i.test(issue.message))).toBe(
-      true,
-    );
+    expect(
+      issues.some((issue) => /velkomst.*tittel/i.test(issue.message)),
+    ).toBe(true);
     expect(
       issues.some((issue) => /bekreftelse.*tittel/i.test(issue.message)),
     ).toBe(true);

--- a/apps/lumi-dashboard/app/utils/surveyDocument.ts
+++ b/apps/lumi-dashboard/app/utils/surveyDocument.ts
@@ -667,7 +667,7 @@ export function findHandoffIssues(document: SurveyDocumentV1): HandoffIssue[] {
   if (document.intro && document.intro.title.trim().length === 0) {
     issues.push({
       questionId: null,
-      message: "Introskjermen mangler tittel.",
+      message: "Velkomstsiden mangler tittel.",
     });
   }
   if (document.success && document.success.title.trim().length === 0) {

--- a/apps/lumi-dashboard/app/utils/surveyDocument.ts
+++ b/apps/lumi-dashboard/app/utils/surveyDocument.ts
@@ -673,7 +673,7 @@ export function findHandoffIssues(document: SurveyDocumentV1): HandoffIssue[] {
   if (document.success && document.success.title.trim().length === 0) {
     issues.push({
       questionId: null,
-      message: "Takkskjermen mangler tittel.",
+      message: "Bekreftelsen etter innsending mangler tittel.",
     });
   }
   const questionById = new Map<string, SurveyQuestionV1>();
@@ -739,7 +739,7 @@ export function setSurveyIntro(
   return { ...document, intro };
 }
 
-/** Sets or clears the survey-level thank-you screen. */
+/** Sets or clears the survey-level confirmation shown after submission. */
 export function setSurveySuccess(
   document: SurveyDocumentV1,
   success: SurveySuccessV1 | undefined,

--- a/apps/lumi-dashboard/app/utils/surveyRevision.ts
+++ b/apps/lumi-dashboard/app/utils/surveyRevision.ts
@@ -110,8 +110,8 @@ export function describeRevisionChanges(
     changes,
     current.success,
     previous.success,
-    "Takkskjerm",
-    "Takkskjermen",
+    "Bekreftelse etter innsending",
+    "Bekreftelsen etter innsending",
   );
   if ((current.type ?? "custom") !== (previous.type ?? "custom")) {
     changes.push(

--- a/apps/lumi-dashboard/app/utils/surveyRevision.ts
+++ b/apps/lumi-dashboard/app/utils/surveyRevision.ts
@@ -38,11 +38,10 @@ export function createRevisionMarkdown(
   revision: SurveyAuthoringRevision,
   revisionUrl: string,
 ): string {
-  const label =
-    `${revision.name} – revisjon ${revision.revisionNumber}`.replace(
-      /([\\[\]])/g,
-      "\\$1",
-    );
+  const label = `${revision.name} – versjon ${revision.revisionNumber}`.replace(
+    /([\\[\]])/g,
+    "\\$1",
+  );
   return `[${label}](${revisionUrl})`;
 }
 
@@ -96,15 +95,15 @@ export function describeRevisionChanges(
   current: SurveyDocumentV1,
   previous?: SurveyDocumentV1 | null,
 ): string[] {
-  if (!previous) return ["Første delbare revisjon i prosjektet."];
+  if (!previous) return ["Første delte versjon i prosjektet."];
 
   const changes: string[] = [];
   describeScreenChange(
     changes,
     current.intro,
     previous.intro,
-    "Introskjerm",
-    "Introskjermen",
+    "Velkomstside",
+    "Velkomstsiden",
   );
   describeScreenChange(
     changes,

--- a/apps/lumi-dashboard/e2e/survey-workshop.spec.ts
+++ b/apps/lumi-dashboard/e2e/survey-workshop.spec.ts
@@ -85,21 +85,19 @@ test("creates, edits, previews and shares a survey draft", async ({ page }) => {
 
   // Share via the release dialog
   await page.getByRole("button", { name: "Del med utvikler" }).click();
-  await expect(page.getByText("Klar til å fryse revisjon 1")).toBeVisible();
+  await expect(page.getByText("Klar til å dele versjon 1")).toBeVisible();
   await expectNoAxeViolations(page);
-  await page
-    .getByRole("button", { name: /Frys revisjon 1 og få delbar lenke/ })
-    .click();
+  await page.getByRole("button", { name: "Del versjon 1" }).click();
 
   await expect(page).toHaveURL(
     /\/surveyverksted\/revisions\/[0-9a-f-]+\?team=team-esyfo/,
   );
-  await expect(page.getByText("Låst revisjon")).toBeVisible();
+  await expect(page.getByText("Delt versjon", { exact: true })).toBeVisible();
   await expect(
     page.getByRole("heading", { name: "Klar til bruk" }),
   ).toBeVisible();
   await expect(
-    page.getByText("Første delbare revisjon i prosjektet."),
+    page.getByText("Første delte versjon i prosjektet."),
   ).toBeVisible();
 
   // The frozen revision is interactive right on the page
@@ -160,14 +158,14 @@ test("authors intro and confirmation screens that render in the real widget", as
   await page.getByRole("button", { name: "Opprett utkast" }).click();
   await page.waitForURL(/\/surveyverksted\/[0-9a-f-]+/);
 
-  await page.getByRole("button", { name: "Legg til introskjerm" }).click();
-  const introCard = page.getByRole("region", { name: "Introskjerm" });
+  await page.getByRole("button", { name: "Legg til velkomstside" }).click();
+  const introCard = page.getByRole("region", { name: "Velkomstside" });
   await expect(introCard).toBeVisible();
   await page.clock.install();
   await page.clock.pauseAt(Date.now());
   await introCard.getByLabel("Tittel").fill("Velkommen");
-  await introCard.getByLabel(/Brødtekst/).fill("To korte spørsmål.");
-  await introCard.getByLabel(/Knappetekst/).fill("Kom i gang");
+  await introCard.getByLabel("Tekst (valgfri)").fill("To korte spørsmål.");
+  await introCard.getByLabel(/Tekst på startknappen/).fill("Kom i gang");
 
   // An explicit restart flushes the latest valid editor state instead of
   // waiting for the stage's normal debounce.
@@ -272,14 +270,14 @@ test("authors intro and confirmation screens that render in the real widget", as
   // Removing the intro is reversible: focus lands on the undo (house
   // pattern for deletions), and undoing restores the content with focus
   // in the title field.
-  await page.getByRole("button", { name: "Fjern introskjermen" }).click();
-  await expect(page.getByText("Introskjermen ble fjernet.")).toBeVisible();
+  await page.getByRole("button", { name: "Fjern velkomstsiden" }).click();
+  await expect(page.getByText("Velkomstsiden ble fjernet.")).toBeVisible();
   await expect(
     page.getByRole("button", { name: "Angre", exact: true }),
   ).toBeFocused();
   await page.getByRole("button", { name: "Angre", exact: true }).click();
   const restoredTitle = page
-    .getByRole("region", { name: "Introskjerm" })
+    .getByRole("region", { name: "Velkomstside" })
     .getByLabel("Tittel");
   await expect(restoredTitle).toHaveValue("Velkommen");
   await expect(restoredTitle).toBeFocused();
@@ -296,9 +294,7 @@ test("deletes a draft from the index after confirmation", async ({ page }) => {
 
   // Freeze a revision so the deletion provably takes revisions with it.
   await page.getByRole("button", { name: "Del med utvikler" }).click();
-  await page
-    .getByRole("button", { name: /Frys revisjon 1 og få delbar lenke/ })
-    .click();
+  await page.getByRole("button", { name: "Del versjon 1" }).click();
   await page.waitForURL(/\/surveyverksted\/revisions\//);
   const revisionUrl = page.url();
 
@@ -312,7 +308,7 @@ test("deletes a draft from the index after confirmation", async ({ page }) => {
   await page.getByRole("menuitem", { name: "Slett utkast" }).click();
 
   const dialog = page.getByRole("dialog", { name: "Slett utkastet?" });
-  await expect(dialog.getByText(/fryste revisjoner/)).toBeVisible();
+  await expect(dialog.getByText(/delte versjoner/)).toBeVisible();
   await expectNoAxeViolations(page);
   await dialog.getByRole("button", { name: "Slett utkastet" }).click();
 
@@ -328,7 +324,7 @@ test("deletes a draft from the index after confirmation", async ({ page }) => {
   // would render the deleted revision from memory.
   await page.goBack();
   await expect(page).toHaveURL(revisionUrl);
-  await expect(page.getByText(/Revisjonen finnes ikke/)).toBeVisible({
+  await expect(page.getByText(/Den delte versjonen finnes ikke/)).toBeVisible({
     timeout: 10000,
   });
 });

--- a/apps/lumi-dashboard/e2e/survey-workshop.spec.ts
+++ b/apps/lumi-dashboard/e2e/survey-workshop.spec.ts
@@ -152,7 +152,7 @@ test("creates, edits, previews and shares a survey draft", async ({ page }) => {
   await expectNoAxeViolations(page);
 });
 
-test("authors intro and thank-you screens that render in the real widget", async ({
+test("authors intro and confirmation screens that render in the real widget", async ({
   page,
 }) => {
   await page.goto("/surveyverksted");
@@ -171,7 +171,7 @@ test("authors intro and thank-you screens that render in the real widget", async
 
   // An explicit restart flushes the latest valid editor state instead of
   // waiting for the stage's normal debounce.
-  const stage = page.getByLabel("Forhåndsvisning");
+  const stage = page.getByRole("region", { name: "Forhåndsvisning" });
   await page
     .getByRole("button", { name: "Start forhåndsvisningen på nytt" })
     .click();
@@ -181,13 +181,41 @@ test("authors intro and thank-you screens that render in the real widget", async
   await expect(stage.getByRole("radio", { name: /5\./ })).toBeVisible();
   await page.clock.resume();
 
-  await page.getByRole("button", { name: "Legg til takkskjerm" }).click();
+  await expect(
+    page.getByText(
+      "Vises etter at brukeren har sendt inn svarene. Uten tilpasning brukes standardteksten.",
+    ),
+  ).toBeVisible();
+  await page.getByRole("button", { name: "Tilpass bekreftelsen" }).click();
   await page
-    .getByRole("region", { name: "Takkskjerm" })
+    .getByRole("region", { name: "Bekreftelse etter innsending" })
     .getByLabel("Tittel")
     .fill("Takk for svaret!");
   await expect(page.locator('[data-state="saved"]')).toBeVisible();
   await expectNoAxeViolations(page);
+
+  // The live stage stays alongside the editor on ordinary laptop widths.
+  await page.setViewportSize({ width: 1100, height: 800 });
+  await page.evaluate(() => window.scrollTo(0, 0));
+  const stickyStageTop = await stage.evaluate((element) => {
+    const preview = element.parentElement;
+    if (!preview) throw new Error("Preview stage is missing its aside");
+    const styles = getComputedStyle(preview);
+    return Math.round(
+      Number.parseFloat(styles.top) + Number.parseFloat(styles.paddingTop),
+    );
+  });
+  await page.evaluate(() => window.scrollTo(0, document.body.scrollHeight));
+  await expect
+    .poll(() =>
+      stage.evaluate((element) =>
+        Math.round(element.getBoundingClientRect().top),
+      ),
+    )
+    .toBe(stickyStageTop);
+  await expect(stage).toBeVisible();
+  await page.setViewportSize({ width: 1280, height: 720 });
+  await page.evaluate(() => window.scrollTo(0, 0));
 
   // The stage keeps editing flowing: no Start-gate in front of questions.
   await expect(stage.getByRole("radio", { name: /5\./ })).toBeVisible();
@@ -195,7 +223,7 @@ test("authors intro and thank-you screens that render in the real widget", async
     stage.getByRole("button", { name: "Kom i gang" }),
   ).not.toBeVisible();
 
-  // The authored thank-you shows after submitting in the stage.
+  // The authored confirmation shows after submitting in the stage.
   await stage.getByRole("radio", { name: /5\./ }).click();
   await stage.getByRole("button", { name: "Send" }).click();
   await expect(


### PR DESCRIPTION
## Hva

- Holder live-forhåndsvisningen sticky på vanlige laptopbredder.
- Beholder trekolonnelayout ned til 64rem og bruker eksisterende stablede layout under dette.
- Erstatter «Takkskjerm» med «Bekreftelse etter innsending», tydelig hjelpetekst og handlinger som beskriver standardfallbacken.
- Bruker «velkomstside» i stedet for «introskjerm» og forklarer når siden vises.
- Forenkler hele delingsløpet fra tekniske ord som «fryse revisjon», «runtime» og «teamautorisert» til utkast, delt versjon og hva utvikleren gjør videre.
- Oppdaterer undo, valideringsmeldinger, revisjonslogg og e2e-språk konsekvent.

## Hvorfor

`overflow-x: hidden` på dokumentroten opprettet en vertikal scroll-container som hindret `position: sticky`. Preview-asiden var i tillegg høyere enn tilgjengelig viewport på grunn av content-box-padding, og den responsive layouten slo av sticky allerede ved 78rem.

«Legg til takkskjerm» var uklart og misvisende fordi surveyen allerede har en standardbekreftelse. Delingsflyten brukte samtidig utviklerord som gjorde den vanskeligere å forstå for designere og produktledere. Den nye teksten forklarer hva brukeren ser, hva som blir delt, hvem som har tilgang og at surveyen ikke publiseres automatisk.

## Verifisering

- Visuell QA ved 1100 × 800 etter 976 px scroll
- Lint: 481 filer
- Vitest: 461/461
- Typecheck
- Produksjonsbygg
- Surveyverksted Playwright: 9/9
- Full Playwright før språkvasken: 43 passert, 1 eksisterende skip
