### PR TITLE
Gjør Playwright-installasjonen robust og gate dashboard-deploy på CI

### DIFF
--- a/.github/actions/install-playwright/action.yaml
+++ b/.github/actions/install-playwright/action.yaml
@@ -1,0 +1,31 @@
+name: Install Playwright
+description: >-
+  Install the Chromium headless shell and its system dependencies, retrying
+  past an unresponsive apt mirror instead of hanging until the step times out.
+
+runs:
+  using: composite
+  steps:
+    # `playwright install --with-deps` shells out to apt. When the Ubuntu
+    # mirror stops responding there is no output and no progress, so the step
+    # sat there until its 10-minute timeout and failed the whole run — three
+    # times in 24 hours, against a healthy install that takes ~16 seconds.
+    # Bound each attempt well above the healthy time but far below the step
+    # budget, and retry: a stuck mirror is almost always over by the next try.
+    - shell: bash
+      env:
+        DEBUG: pw:install
+      run: |
+        for attempt in 1 2 3; do
+          if timeout 180 pnpm --filter lumi-dashboard exec \
+            playwright install chromium --with-deps --only-shell; then
+            exit 0
+          fi
+          echo "::warning::Playwright install attempt ${attempt} failed or hung; retrying"
+          # A killed apt can leave dpkg half-configured, which would fail the
+          # next attempt for a different reason than the one we are retrying.
+          sudo dpkg --configure -a || true
+          sleep $((attempt * 15))
+        done
+        echo "::error::Playwright install failed after 3 attempts"
+        exit 1

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -133,9 +133,7 @@ jobs:
           node-version: 22
       - name: Install Playwright
         timeout-minutes: 10
-        run: pnpm --filter lumi-dashboard exec playwright install chromium --with-deps --only-shell
-        env:
-          DEBUG: pw:install
+        uses: ./.github/actions/install-playwright
       - name: Restore Node from package.json
         uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020
         with:

--- a/.github/workflows/deploy-dashboard.yaml
+++ b/.github/workflows/deploy-dashboard.yaml
@@ -3,8 +3,14 @@ name: Deploy dashboard
 on:
   push:
     branches:
-      - main
       - demo-*
+  workflow_run:
+    workflows:
+      - CI
+    types:
+      - completed
+    branches:
+      - main
   workflow_dispatch:
     inputs:
       target:
@@ -28,6 +34,9 @@ permissions:
 jobs:
   checks:
     name: Run checks
+    # CI already runs this full gate for every commit pushed to main. Keep the
+    # standalone gate for demo branches and manual deployments only.
+    if: github.event_name != 'workflow_run'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
@@ -69,15 +78,19 @@ jobs:
     needs: checks
     runs-on: ubuntu-latest
     if: |
-      (github.event_name == 'push' && github.ref_name == 'main') ||
-      startsWith(github.ref_name, 'demo-') ||
-      (github.event_name == 'workflow_dispatch' && inputs.target == 'demo')
+      always() && (
+        (github.event_name == 'workflow_run' && github.event.workflow_run.conclusion == 'success') ||
+        (needs.checks.result == 'success' && (
+          startsWith(github.ref_name, 'demo-') ||
+          (github.event_name == 'workflow_dispatch' && inputs.target == 'demo')
+        ))
+      )
     outputs:
       image: ${{ steps.docker-build-push.outputs.image }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
         with:
-          ref: ${{ inputs.ref || github.ref }}
+          ref: ${{ inputs.ref || github.event.workflow_run.head_sha || github.ref }}
       - uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6.0.10
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020
         with:
@@ -126,14 +139,18 @@ jobs:
     needs: checks
     runs-on: ubuntu-latest
     if: |
-      (github.event_name == 'push' && github.ref_name == 'main') ||
-      (github.event_name == 'workflow_dispatch' && (inputs.target == 'dev' || inputs.target == 'prod'))
+      always() && (
+        (github.event_name == 'workflow_run' && github.event.workflow_run.conclusion == 'success') ||
+        (needs.checks.result == 'success' &&
+          github.event_name == 'workflow_dispatch' &&
+          (inputs.target == 'dev' || inputs.target == 'prod'))
+      )
     outputs:
       image: ${{ steps.docker-build-push.outputs.image }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
         with:
-          ref: ${{ inputs.ref || github.ref }}
+          ref: ${{ inputs.ref || github.event.workflow_run.head_sha || github.ref }}
       - uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6.0.10
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020
         with:
@@ -181,7 +198,7 @@ jobs:
     needs: build-demo
     runs-on: ubuntu-latest
     if: |
-      (github.event_name == 'push' && github.ref_name == 'main') ||
+      github.event_name == 'workflow_run' ||
       startsWith(github.ref_name, 'demo-') ||
       (github.event_name == 'workflow_dispatch' && inputs.target == 'demo')
     environment:
@@ -189,6 +206,8 @@ jobs:
       url: https://lumi-dashboard-demo.ekstern.dev.nav.no
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
+        with:
+          ref: ${{ inputs.ref || github.event.workflow_run.head_sha || github.ref }}
       - uses: nais/deploy/actions/deploy@849e900e3cfa7faf7ad1532bb3a3e6499c932199
         env:
           CLUSTER: dev-gcp
@@ -200,13 +219,15 @@ jobs:
     needs: build-production
     runs-on: ubuntu-latest
     if: |
-      (github.event_name == 'push' && github.ref_name == 'main') ||
+      github.event_name == 'workflow_run' ||
       (github.event_name == 'workflow_dispatch' && inputs.target == 'dev')
     environment:
       name: dev
       url: https://lumi-dashboard.ansatt.dev.nav.no
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
+        with:
+          ref: ${{ inputs.ref || github.event.workflow_run.head_sha || github.ref }}
       - uses: nais/deploy/actions/deploy@849e900e3cfa7faf7ad1532bb3a3e6499c932199
         env:
           CLUSTER: dev-gcp
@@ -218,13 +239,15 @@ jobs:
     needs: [build-production, deploy-dev]
     runs-on: ubuntu-latest
     if: |
-      (github.event_name == 'push' && github.ref_name == 'main') ||
+      github.event_name == 'workflow_run' ||
       (github.event_name == 'workflow_dispatch' && inputs.target == 'prod')
     environment:
       name: prod
       url: https://lumi-dashboard.ansatt.nav.no
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
+        with:
+          ref: ${{ inputs.ref || github.event.workflow_run.head_sha || github.ref }}
       - uses: nais/deploy/actions/deploy@849e900e3cfa7faf7ad1532bb3a3e6499c932199
         env:
           CLUSTER: prod-gcp

--- a/.github/workflows/deploy-dashboard.yaml
+++ b/.github/workflows/deploy-dashboard.yaml
@@ -61,9 +61,7 @@ jobs:
           node-version: 22
       - name: Install Playwright
         timeout-minutes: 10
-        run: pnpm --filter lumi-dashboard exec playwright install chromium --with-deps --only-shell
-        env:
-          DEBUG: pw:install
+        uses: ./.github/actions/install-playwright
       - name: Restore Node from package.json
         uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020
         with:


### PR DESCRIPTION
## Hva

To ting som begge handler om at Playwright-installasjonen feller kjøringer:

1. **`playwright install` gir ikke opp på et hengende apt-speil lenger.** Hvert forsøk er tidsbegrenset og gjentas tre ganger, i én delt composite action brukt av både `ci.yaml` og `deploy-dashboard.yaml`.
2. **Dashboard-deploy på `main` starter først når `CI` er grønn**, og bygger på SHA-et CI faktisk godkjente — i stedet for å kjøre den samme dyre, nettverksavhengige gaten en gang til.

## Hvorfor

`playwright install --with-deps` kaller apt. Når Ubuntu-speilet slutter å svare kommer det verken output eller framdrift, så steget står til 10-minutters-timeouten og feller hele kjøringen.

Målt på de siste kjøringene:

| | |
|---|---|
| Frisk installasjon | **16 sekunder** |
| Ved hengende speil | **10 minutter, så timeout** |
| Feil i `ci.yaml` siste døgn | **3** (18. kl. 16:04, 19. kl. 09:22, 19. kl. 15:20) |

16 sekunder mot 10 minutter er ikke en treg installasjon, det er en henging. Så hvert forsøk bindes godt over frisk tid, men langt under steg-budsjettet, og gjentas. Mellom forsøkene ryddes et halvkonfigurert dpkg, slik at et nytt forsøk ikke feiler av en annen grunn enn den vi prøver på nytt for.

Steget lå identisk i to workflows. Det er nøyaktig mønsteret som råtner når bare den ene blir fikset, så det ligger nå ett sted.

Deploy-gaten er den opprinnelige delen av denne PR-en: deployen for merge-commit `068115b` feilet på nettopp denne installasjonen, mens den ordinære CI-kjøringen for samme commit allerede var grønn — inkludert Playwright. Endringen beholder CI som deploy-gate uten å kjøre den to ganger. De selvstendige kontrollene for `demo-*`-brancher og manuelle deployer er beholdt, og de bruker nå den robuste installasjonen.

## Verifisering

- `actionlint` — grønn
- Retry-løkkas semantikk testet lokalt for alle tre utfallene: suksess på første forsøk, suksess etter flake, og feil etter tre forsøk (exit 1)
- Rebaset på `main`; konfliktene mot #455 var rene SHA-bumper, løst ved å beholde `main` sine nye action-SHA-er og denne branchens `ref:`-endring
- Alle `nais/*`-SHA-er sjekket mot `main` etter rebase