### PR TITLE
Slipp @navikt/lumi-survey 2.0.0

### DIFF
--- a/packages/lumi-survey/CHANGELOG.md
+++ b/packages/lumi-survey/CHANGELOG.md
@@ -6,6 +6,24 @@ This project follows SemVer.
 
 ## [Unreleased]
 
+## [2.0.0] - 2026-08-19
+
+This release adds the **page-based authoring format** (`SurveyDocumentV1`) — the
+serializable document Surveyverksted produces. A consumer on 1.0.0 cannot
+type-check or render an authored export at all, because the format did not
+exist there.
+
+### BREAKING
+
+- `question.visibleIf` is now typed `VisibleIfCondition` (leaf | group) so it
+  can carry `any`/`all` groups. Code that reads `visibleIf.operator` directly
+  must narrow with `isConditionGroup`/`isLeafCondition` first. Authoring a
+  condition is unchanged — only reading one back is affected. `LogicCondition`
+  stays leaf-only, so `LogicRule` consumers are untouched. (#333)
+
+The dock header renders at the same size as in 1.0.0; only its line height
+tightens. See Changed.
+
 ### Added
 
 - `SurveyDocumentV1` gains optional survey-level screens: `intro` (`title`, `body?`, `startLabel?`) and `success` (`title`, `body?`) as plain strings. `LumiSurveyDock` derives its intro/success screens from the document, with explicit embed props as field-level overrides — a partial `success={{ primaryLabel }}` keeps the authored title and body. Blank titles read as absent (lenient drafts never render an empty screen), and blank `startLabel` falls back to `"Start"` so the intro button always has an accessible name. `validateSurveyDocumentV1` shape-checks the new fields. (#441)

--- a/packages/lumi-survey/package.json
+++ b/packages/lumi-survey/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@navikt/lumi-survey",
-  "version": "1.0.0",
+  "version": "2.0.0",
   "private": false,
   "description": "Aksel-based React widget for configurable NAV Lumi surveys.",
   "type": "module",


### PR DESCRIPTION
## Hva

Versjonsbump til `2.0.0` og lukking av `[Unreleased]` i changeloggen.

## Hvorfor major

`question.visibleIf` er utvidet til `VisibleIfCondition` (leaf | group) for å bære `any`/`all`-grupper (#333). Å *skrive* en betingelse er uendret; det er å *lese* `visibleIf.operator` tilbake som nå må narrowe med `isConditionGroup`/`isLeafCondition` først. Det brekker kompilering for konsumenter som gjør det, så SemVer sier major.

## Hvorfor nå

Siste publiserte versjon er 1.0.0 fra 24. juni — 48 kildefiler i widgeten er endret siden. Viktigere: `SurveyDocumentV1` finnes ikke i 1.0.0. Surveyverksted genererer eksport med `import type { SurveyDocumentV1 }` og `satisfies SurveyDocumentV1`, så en mottaker på 1.0.0 får en typefeil på import-linja, og JSON-eksporten treffer en widget som ikke kan lese `pages`. Verkstedet har i praksis ikke hatt en fungerende overlevering før denne releasen.

## Innhold

Hele `[Unreleased]` blir 2.0.0. Hovedpunkter:

- **Sidebasert authoring-format** — `SurveyDocumentV1`/`SurveyPageV1`/`SurveyQuestionV1`, `validateSurveyDocumentV1`, og embedding-sømmene `initialPageId`/`simulatedViewport`/`panelMaxHeight` (#336, #338)
- **Intro- og takkeskjerm som survey-innhold** (#441)
- **`any`/`all`-grupper i `visibleIf`** (#333) — den brekkende delen
- **Fremdriftsvisning og fokus ved stegnavigasjon** (#334, #418, #417)
- **`visibleIf`-skjulte svar utelates ved innsending** (#357)
- **Typografien i docken** (#416, #447) — rendret headerstørrelse er uendret fra 1.0.0; bare linjehøyden strammes inn, fra 32px til 28px

## Verifisering

- `biome check` og `verify:lumi-survey` grønne
- Dry-run av publiseringsjobben kjøres fra denne branchen før merge. Etter #447 kjører versjon-, changelog-, tag- og diff-vaktene også i dry-run, så den runden tester faktisk det som pleier å felle en release