### PR TITLE
Fiks at dashboard-deployene hoppes over etter CI-gaten

### DIFF
--- a/.github/workflows/deploy-dashboard.yaml
+++ b/.github/workflows/deploy-dashboard.yaml
@@ -195,10 +195,16 @@ jobs:
     name: Deploy to dev-gcp (Demo)
     needs: build-demo
     runs-on: ubuntu-latest
+    # `checks` is skipped for workflow_run, so the build jobs only survive via
+    # always(). Without the same treatment here the skip propagates down the
+    # needs chain and every deploy is skipped — state the build result instead
+    # of relying on the implicit success().
     if: |
-      github.event_name == 'workflow_run' ||
-      startsWith(github.ref_name, 'demo-') ||
-      (github.event_name == 'workflow_dispatch' && inputs.target == 'demo')
+      always() && needs.build-demo.result == 'success' && (
+        github.event_name == 'workflow_run' ||
+        startsWith(github.ref_name, 'demo-') ||
+        (github.event_name == 'workflow_dispatch' && inputs.target == 'demo')
+      )
     environment:
       name: demo
       url: https://lumi-dashboard-demo.ekstern.dev.nav.no
@@ -217,8 +223,10 @@ jobs:
     needs: build-production
     runs-on: ubuntu-latest
     if: |
-      github.event_name == 'workflow_run' ||
-      (github.event_name == 'workflow_dispatch' && inputs.target == 'dev')
+      always() && needs.build-production.result == 'success' && (
+        github.event_name == 'workflow_run' ||
+        (github.event_name == 'workflow_dispatch' && inputs.target == 'dev')
+      )
     environment:
       name: dev
       url: https://lumi-dashboard.ansatt.dev.nav.no
@@ -236,9 +244,15 @@ jobs:
     name: Deploy to prod-gcp
     needs: [build-production, deploy-dev]
     runs-on: ubuntu-latest
+    # Prod still waits for dev to land first; that ordering is the point of
+    # the dependency, so assert it rather than inheriting it.
     if: |
-      github.event_name == 'workflow_run' ||
-      (github.event_name == 'workflow_dispatch' && inputs.target == 'prod')
+      always() &&
+      needs.build-production.result == 'success' &&
+      needs.deploy-dev.result == 'success' && (
+        github.event_name == 'workflow_run' ||
+        (github.event_name == 'workflow_dispatch' && inputs.target == 'prod')
+      )
     environment:
       name: prod
       url: https://lumi-dashboard.ansatt.nav.no


### PR DESCRIPTION
## Hva

Deploy-jobbene i `deploy-dashboard.yaml` sier nå eksplisitt hvilket build-resultat de krever, i stedet for å arve det gjennom `needs`.

## Hvorfor

#446 lot `checks` hoppes over når deployen trigges av `workflow_run` — CI har allerede kjørt den runden. Build-jobbene overlever det fordi de har `always() && (...)`. Deploy-jobbene fikk aldri samme behandling, så den implisitte `success()`-sjekken over avhengighetskjeden felte dem.

Observert på begge kjøringene etter merge av #446:

```
Build production: success
Build demo (mock data): success
Run checks: skipped
Deploy to dev-gcp: skipped
Deploy to prod-gcp: skipped
Deploy to dev-gcp (Demo): skipped
```

Bygget gikk altså helt igjennom, og så ble ingenting deployet. Dev og prod har ikke fått ny kode siden `a79c0c9`.

## Endring

- `deploy-demo` krever `needs.build-demo.result == 'success'`
- `deploy-dev` krever `needs.build-production.result == 'success'`
- `deploy-prod` krever begge, **og** `needs.deploy-dev.result == 'success'` — prod skal fortsatt vente på at dev lander først, så den rekkefølgen er skrevet ut i stedet for å arves

Alle tre beholder de eksisterende trigger-betingelsene uendret, så `demo-*`-brancher og manuelle deployer fungerer som før.

## Verifisering

- `actionlint` grønn
- Den ekte testen er merge av denne PR-en: den pusher til `main`, CI kjører, `workflow_run` fyrer, og deploy-jobbene skal da faktisk kjøre. Jeg bekrefter det etterpå.