### PR TITLE
Design-QA: samme feilmelding i to drakter, og en feil i 2.0.0-changeloggen

### DIFF
--- a/.github/actions/install-playwright/action.yaml
+++ b/.github/actions/install-playwright/action.yaml
@@ -1,31 +1,47 @@
 name: Install Playwright
 description: >-
-  Install the Chromium headless shell and its system dependencies, retrying
-  past an unresponsive apt mirror instead of hanging until the step times out.
+  Install the Chromium headless shell for the dashboard E2E run, keeping the
+  reliable browser download separate from the apt call that keeps hanging.
 
 runs:
   using: composite
   steps:
-    # `playwright install --with-deps` shells out to apt. When the Ubuntu
-    # mirror stops responding there is no output and no progress, so the step
-    # sat there until its 10-minute timeout and failed the whole run — three
-    # times in 24 hours, against a healthy install that takes ~16 seconds.
-    # Bound each attempt well above the healthy time but far below the step
-    # budget, and retry: a stuck mirror is almost always over by the next try.
-    - shell: bash
+    # The browser binary comes from Playwright's own CDN and has never been
+    # the problem — a healthy install takes about 15 seconds. Required, with a
+    # retry for ordinary network flakiness.
+    - name: Download Chromium headless shell
+      shell: bash
       env:
         DEBUG: pw:install
       run: |
         for attempt in 1 2 3; do
-          if timeout 180 pnpm --filter lumi-dashboard exec \
-            playwright install chromium --with-deps --only-shell; then
+          if timeout --kill-after=10s 120 pnpm --filter lumi-dashboard exec \
+            playwright install chromium --only-shell; then
             exit 0
           fi
-          echo "::warning::Playwright install attempt ${attempt} failed or hung; retrying"
-          # A killed apt can leave dpkg half-configured, which would fail the
-          # next attempt for a different reason than the one we are retrying.
-          sudo dpkg --configure -a || true
-          sleep $((attempt * 15))
+          echo "::warning::Chromium download attempt ${attempt} failed; retrying"
+          sleep $((attempt * 10))
         done
-        echo "::error::Playwright install failed after 3 attempts"
+        echo "::error::Chromium download failed after 3 attempts"
         exit 1
+
+    # System libraries come from apt, and every CI failure we have seen was an
+    # unresponsive Ubuntu mirror hanging right here — three in 24 hours. The
+    # GitHub runner image already ships these libraries, so treat this as a
+    # safety net rather than a requirement: bound it, clean up after it, and
+    # carry on. If a library really were missing, the E2E run immediately
+    # after fails on a browser that will not launch, which is a far better
+    # signal than a ten-minute hang in a step that normally takes seconds.
+    - name: Ensure system libraries for Chromium
+      shell: bash
+      run: |
+        if timeout --kill-after=10s 120 pnpm --filter lumi-dashboard exec \
+          playwright install-deps chromium; then
+          exit 0
+        fi
+        echo "::warning::Could not verify Chromium system libraries; apt did not respond. Continuing, since the runner image normally ships them."
+        # timeout kills the wrapper, not the apt-get child it spawned. A
+        # surviving apt-get keeps the dpkg lock and makes every later attempt
+        # fail on the lock instead of the thing that actually went wrong.
+        sudo pkill -9 -f apt-get || true
+        exit 0

--- a/apps/lumi-dashboard/app/components/surveyverksted/PageGroupHeader.tsx
+++ b/apps/lumi-dashboard/app/components/surveyverksted/PageGroupHeader.tsx
@@ -1,5 +1,5 @@
 import { PlusIcon } from "@navikt/aksel-icons";
-import { BodyShort, Button, Detail, TextField, VStack } from "@navikt/ds-react";
+import { BodyShort, Button, TextField, VStack } from "@navikt/ds-react";
 import { useEffect, useRef, useState } from "react";
 import styles from "./verksted.module.css";
 
@@ -65,12 +65,10 @@ export function PageGroupHeader({
   }
 
   return (
-    // No landmark here: the eyebrow names the block, and a region sharing
-    // its name with the field inside it just gives everything two names.
+    // No eyebrow and no landmark: the page eyebrow sits directly above, and a
+    // second uppercase micro-label stacked under it is noise for two fields
+    // the author just asked for.
     <div className={styles.screenCardAbsent}>
-      <Detail as="p" className={styles.eyebrow}>
-        FELLES OVERSKRIFT
-      </Detail>
       <VStack gap="space-12">
         <TextField
           ref={titleRef}

--- a/packages/lumi-survey/CHANGELOG.md
+++ b/packages/lumi-survey/CHANGELOG.md
@@ -6,6 +6,10 @@ This project follows SemVer.
 
 ## [Unreleased]
 
+### Fixed
+
+- Rating questions now render their validation message with Aksel's `ErrorMessage`, like every other field type. They used a plain `BodyShort` with a stylesheet colour override, so the same "you must answer this" text appeared in two weights — regular without an icon under a rating, semibold with a warning icon under a text or choice field — inside one panel. The package no longer overrides the error colour either; the design system owns it. (#458)
+
 ## [2.0.0] - 2026-08-19
 
 This release adds the **page-based authoring format** (`SurveyDocumentV1`) — the
@@ -40,7 +44,7 @@ tightens. See Changed.
 - `createTopTasksSurvey` now expresses its flow with `visibleIf` instead of `logic`. Answer-based value conditions (`EQ`/`NEQ`/`GT`/`LT`/`CONTAINS`) automatically enable step mode under `questionLayout: "auto"`, while `EXISTS`-only progressive disclosure remains single-page. (#359)
 - `behavior.showProgress: true` now shows progress from the first question in step mode. Intro and success screens are not counted, and single-step surveys omit the indicator. Branching exposes only the known step number to assistive technology. (#334)
 - Progress indicators now include visible step text: `Steg X av N` for linear surveys and `Steg X` when branching makes the total uncertain. (#418)
-- Dock header typography now comes from Aksel `Heading`/`BodyShort` props instead of `font-size` overrides in the package stylesheet. **Upgrading from 1.0.0 does not change the rendered header size:** 1.0.0 asked for `Heading medium` but the package's own unlayered rule overrode it to 1.25rem, so the header rendered at 20px/600 then and renders at 20px/600 now. Only the line height tightens, from 32px to 28px, and the description is 14px in both. The header is the panel's title block and keeps one scale whatever fills it — an authored page title, the first question standing in for one, intro or success. (#416, #447)
+- Dock header typography now comes from Aksel `Heading`/`BodyShort` props instead of `font-size` overrides in the package stylesheet. **Upgrading from 1.0.0 does not change the rendered header size:** 1.0.0 asked for `Heading medium` but the package's own unlayered rule overrode it to 1.25rem, so the header rendered at 20px/600 then and renders at 20px/600 now. Two smaller things do change: the heading's line height tightens from 32px to 28px, and the panel description grows from 14px to 16px, because it too came from a stylesheet override (`--ax-font-size-small`) and now uses `BodyShort size="small"` — which is 16px in Aksel's scale, not 14px. The header is the panel's title block and keeps one scale whatever fills it — an authored page title, the first question standing in for one, intro or success. (#416, #447)
 - An authored page title now renders at the title scale with a visible group boundary above its questions. It previously shared the field scale with the question headings and labels below it (Aksel `Heading xsmall` and `.aksel-label` are both 1.125rem/bold), so a title, the question under it and the next field label were three identical lines. Applies both in the panel header and inline in `singlePage` layout. New in this release — the page format itself did not exist in 1.0.0. (#447)
 
 ### Fixed

--- a/packages/lumi-survey/src/components/questions/rating/NpsRating.tsx
+++ b/packages/lumi-survey/src/components/questions/rating/NpsRating.tsx
@@ -1,4 +1,11 @@
-import { BodyShort, Box, Heading, HStack, VStack } from "@navikt/ds-react";
+import {
+  BodyShort,
+  Box,
+  ErrorMessage,
+  Heading,
+  HStack,
+  VStack,
+} from "@navikt/ds-react";
 import type React from "react";
 import type { ComponentProps } from "react";
 import { useCallback } from "react";
@@ -204,13 +211,14 @@ export function NpsRating({
         </VStack>
       </Box>
       {isMissing && (
-        <BodyShort
+        <ErrorMessage
           id={errorId}
           className={styles.errorMessage ?? "lumi-survey-rating__error-message"}
           role="alert"
+          showIcon
         >
           {validationErrorMessage}
-        </BodyShort>
+        </ErrorMessage>
       )}
     </VStack>
   );

--- a/packages/lumi-survey/src/components/questions/rating/RatingQuestionField.tsx
+++ b/packages/lumi-survey/src/components/questions/rating/RatingQuestionField.tsx
@@ -1,4 +1,11 @@
-import { BodyShort, Box, Heading, HStack, VStack } from "@navikt/ds-react";
+import {
+  BodyShort,
+  Box,
+  ErrorMessage,
+  Heading,
+  HStack,
+  VStack,
+} from "@navikt/ds-react";
 import type React from "react";
 import type { ComponentProps, ReactElement } from "react";
 import type {
@@ -303,9 +310,14 @@ export const RatingQuestionField = ({
         </HStack>
       </Box>
       {isMissing && (
-        <BodyShort id={errorId} className={CLASS_NAMES.error} role="alert">
+        <ErrorMessage
+          id={errorId}
+          className={CLASS_NAMES.error}
+          role="alert"
+          showIcon
+        >
           {validationErrorMessage}
-        </BodyShort>
+        </ErrorMessage>
       )}
     </VStack>
   );

--- a/packages/lumi-survey/src/components/questions/rating/StarRating.tsx
+++ b/packages/lumi-survey/src/components/questions/rating/StarRating.tsx
@@ -1,5 +1,12 @@
 import { StarFillIcon, StarIcon } from "@navikt/aksel-icons";
-import { BodyShort, Box, Heading, HStack, VStack } from "@navikt/ds-react";
+import {
+  BodyShort,
+  Box,
+  ErrorMessage,
+  Heading,
+  HStack,
+  VStack,
+} from "@navikt/ds-react";
 import type React from "react";
 import type { ComponentProps } from "react";
 import { useCallback, useState } from "react";
@@ -247,13 +254,14 @@ export function StarRating({
         </VStack>
       </Box>
       {isMissing && (
-        <BodyShort
+        <ErrorMessage
           id={errorId}
           className={styles.errorMessage ?? "lumi-survey-rating__error-message"}
           role="alert"
+          showIcon
         >
           {validationErrorMessage}
-        </BodyShort>
+        </ErrorMessage>
       )}
     </VStack>
   );

--- a/packages/lumi-survey/src/components/questions/rating/ThumbsRating.tsx
+++ b/packages/lumi-survey/src/components/questions/rating/ThumbsRating.tsx
@@ -3,6 +3,7 @@ import {
   BodyShort,
   Box,
   Button,
+  ErrorMessage,
   Heading,
   HStack,
   VStack,
@@ -148,13 +149,14 @@ export function ThumbsRating({
         </HStack>
       </Box>
       {isMissing && (
-        <BodyShort
+        <ErrorMessage
           id={errorId}
           className={styles.errorMessage ?? "lumi-survey-rating__error-message"}
           role="alert"
+          showIcon
         >
           {validationErrorMessage}
-        </BodyShort>
+        </ErrorMessage>
       )}
     </VStack>
   );

--- a/packages/lumi-survey/src/components/questions/rating/emo.fallback.css
+++ b/packages/lumi-survey/src/components/questions/rating/emo.fallback.css
@@ -81,7 +81,3 @@
   position: absolute;
   width: 1px;
 }
-
-.lumi-survey-rating__error-message {
-  color: var(--ax-text-danger-subtle);
-}

--- a/packages/lumi-survey/src/components/questions/rating/emo.module.css
+++ b/packages/lumi-survey/src/components/questions/rating/emo.module.css
@@ -81,7 +81,3 @@
   position: absolute;
   width: 1px;
 }
-
-.errorMessage {
-  color: var(--ax-text-danger-subtle);
-}


### PR DESCRIPTION
## Bakgrunn

Systematisk design-QA av widgeten og verkstedet etter typografiendringene. Overskriftene har bommet to ganger nå, så gjennomgangen er gjort med **målte verdier** i stedet for øyemål: et instrument som leser `getComputedStyle` for hver overskrift, etikett og beskrivelse, kjørt over alle ti scenarier i testbenken pluss verkstedets egne flater.

## Det som holder

| Nivå | Verdi |
|---|---|
| Panel-header | 20px / 600 |
| Spørsmål (`H3`, `legend`, `label`) | 18px / 600 |
| Alternativer | 18px / 400 |
| Ingress og beskrivelser | 16px / 400 |

Verifisert på tvers av alle ti scenarier: ingen nivåhopp, ingen tilfeller der et lavere overskriftsnivå er større enn et høyere, og ingen to nabonivåer med identisk størrelse og vekt. Sidetittel + spørsmål på samme side gir 20px over 18px med gruppegrense, som var hele poenget med #447.

Videre: kontrast innenfor WCAG AA i både lys og mørk modus (laveste målte 4,56:1), en 66 tegn lang sidetittel brekker til tre linjer uten overflyt eller horisontal scroll i et 384px panel, minimert dock er 208×52px, og intro- og takkeskjerm ligger på samme 20px-header som resten.

## Funn 1 — samme feilmelding i to drakter

Vurderingsspørsmål rendret valideringsmeldingen som en ren `BodyShort` med egen fargeoverstyring. Alle andre felttyper får Aksels `ErrorMessage`. I ett og samme panel sto derfor samme melding slik:

| Felt | Målt |
|---|---|
| Vurdering | 18px / **400**, **uten** ikon |
| Tekst og valg | 18px / **600**, **med** varselikon |

Vurderingene bruker nå `ErrorMessage`, og pakken overstyrer ikke lenger feilfargen — designsystemet eier den. Det fjerner samtidig en ulagdelt fargeoverstyring av nøyaktig samme type som lot header-typografien drive fra Aksel i utgangspunktet.

Etter fiksen måler begge 18px / 600 med ikon.

## Funn 2 — changeloggen for 2.0.0 var feil

Notatet påsto at ingressen er «14px in both». Det stemmer ikke, og det er allerede publisert.

Aksels `BodyShort`-størrelser er forskjøvet fra token-navnene: `size="small"` bruker `--ax-font-size-medium` og er **16px**, ikke 14px. 1.0.0 rendret ingressen på 14px via sin egen `--ax-font-size-small`-overstyring. Ved oppgradering vokser den altså faktisk fra 14px til 16px.

Overskriftspåstanden står — den ble målt direkte i browser og er fortsatt 20px før og etter.

## Funn 3 — to stablede etiketter i verkstedet

Da felles overskrift ble opt-in i #447 fikk den en «FELLES OVERSKRIFT»-etikett rett under «SIDE 01 AV 01». To små versaler oppå hverandre er støy for to felt forfatteren nettopp ba om. Fjernet.

## Ikke endret, men verdt å vite

Gruppegrensen ligger på `--ax-border-neutral-subtle`, som gir 1,5:1 mot panelbakgrunnen. Det er under 3:1, men linja er en støttende markør — størrelsesforskjellen og luften bærer hierarkiet. `--ax-border-neutral` ville gitt 4,54:1 og lest som en hard strek tvers gjennom et lite panel. Beholdt som den er, bevisst.

De to `aside`-landemerkene i verkstedet mangler tilgjengelig navn. Ikke rørt her.

## Verifisering

- 381 widget-tester, 469 dashboard-tester, 43 e2e — alle grønne
- `typecheck`, `biome check`, `verify:lumi-survey` grønne
- Feilmeldingsfiksen verifisert i browser mot bygget pakke: begge meldinger måler nå identisk