### PR TITLE
Gjør spesialiserte surveytyper klare for bruk

### DIFF
--- a/.github/skills/lumi-survey/SKILL.md
+++ b/.github/skills/lumi-survey/SKILL.md
@@ -66,15 +66,15 @@ Presenter alternativer med anbefalinger:
 | **Discovery** | Forstå brukermål — "hva prøvde du å gjøre?" | Best for nye tjenester eller store redesign |
 | **Top Tasks** | Måle oppgavesuksess/-feilrate (McGovern-metoden) | Best for etablerte tjenester med kjente brukeroppgaver |
 | **Task Priority** | Rangere hva som betyr mest for brukerne (Long Neck-metoden) | Best for veikartprioritering |
-| **Tilpasset** | Skreddersydde spørsmålsflyter med forgreningslogikk | Kun når forhåndsdefinerte typer ikke passer |
+| **Tilpasset** | Egne spørsmål og relevante oppfølginger | Kun når forhåndsdefinerte typer ikke passer |
 
 Hvis utvikleren er usikker, anbefal **Rating med emoji-variant** — det er det mest utprøvde mønsteret i Nav.
 
 ### Spørsmål 2: Oppfølgingsspørsmål (kun for Rating)
 
-Hvis utvikleren valgte en rating-survey, spør: *"Vil du ha et oppfølgingsspørsmål ved lav score? (anbefalt: ja — fritekstfelt ved score ≤ 2)"*
+Hvis utvikleren valgte en rating-survey, spør: *"Når skal et eventuelt oppfølgingsspørsmål vises?"* Tilby **etter alle svar** som enkel standard, eller **bare ved lav score** når teamet har et konkret behov for det.
 
-Anbefaling: Ja — fritekst ved lav rating gir handlingsbar innsikt med minimal brukerbelastning. `DEFAULT_SURVEY_RATING` har dette innebygd.
+Ikke påstå at standarddokumentet viser kommentarfeltet bare ved lav score. `DEFAULT_RATING_SURVEY_DOCUMENT` viser det etter at ratingen er besvart. En lavscorevariant må konfigureres eksplisitt med `visibleIf`.
 
 For andre survey-typer (Discovery, Top Tasks, etc.) har de innebygde oppfølgingsspørsmål allerede — ikke spør.
 
@@ -112,167 +112,105 @@ import "@navikt/lumi-survey/styles.css";  // Deretter lumi-survey
 **Viktig**: `@navikt/ds-css` MÅ importeres før `@navikt/lumi-survey/styles.css`.
 ## Fase 4: Survey-komponent
 
-### 4a. Opprett survey-konfigurasjon
+### 4a. Opprett et `SurveyDocumentV1`
 
-Lag en egen fil for survey-konfigurasjonen (f.eks. `survey.ts` eller `lumiSurvey.ts`). Bruk `satisfies LumiSurveyConfig` for typesikkerhet.
+For nye surveyer er `SurveyDocumentV1` den eneste anbefalte modellen. Den gjør sider, rekkefølge, velkomst og bekreftelse eksplisitt. Bruk helst **Surveyverksted** og kopier TypeScript fra en frosset versjon. Hvis surveyen skal ligge i kode fra starten, bruk dokumentbyggerne under.
 
-Guiding: Basert på survey-typen valgt i Fase 2, hjelp utvikleren med å bygge opp konfigurasjonen steg for steg. Tilpass spørsmålstekster til tjenesten — bruk norsk og vær konkret.
+Ikke generer `LumiSurveyConfig`, `questions` på rotnivå, `logic`, `questionLayout="steps"` eller `DEFAULT_SURVEY_*` for en ny integrasjon. Disse finnes bare for bakoverkompatibilitet.
 
-#### Rating-survey
+#### Rating
 
 ```tsx
-import type { LumiSurveyConfig } from "@navikt/lumi-survey";
+import { createRatingSurveyDocument } from "@navikt/lumi-survey";
 
-export const survey = {
-  type: "rating",
-  questions: [
-    {
-      id: "inntrykk",
-      type: "rating",
-      variant: "emoji",       // "emoji" | "thumbs" | "stars" | "nps"
-      prompt: "Hva er ditt inntrykk av tjenesten?",
-      required: true,
-    },
+export const survey = createRatingSurveyDocument({
+  ratingPrompt: "Hvordan var det å sende inn søknaden?",
+  variant: "emoji", // "emoji" | "thumbs" | "stars" | "nps"
+  followUpQuestions: [
     {
       id: "innspill",
       type: "text",
-      prompt: "Har du noen kommentarer eller innspill?",
+      prompt: "Hva kan vi gjøre bedre?",
       maxLength: 1000,
       visibleIf: {
-        field: "ANSWER",
-        questionId: "inntrykk",
-        operator: "EXISTS",
+        questionId: "rating",
+        operator: "LT",
+        value: 3,
       },
     },
   ],
-} satisfies LumiSurveyConfig;
+});
 ```
 
-Tilpass til tjenesten:
-- Endre `prompt`-tekster til noe som passer appen (f.eks. *"Hvordan var det å søke om sykepenger?"*)
-- Juster `visibleIf` — vis oppfølging kun ved lav score (`operator: "LT", value: 3`) eller alltid (`operator: "EXISTS"`)
-- Legg til flere spørsmål ved behov (se spørsmålstyper under)
+Fjern `visibleIf` fra oppfølgingsspørsmålet hvis det skal vises etter alle besvarte ratinger; byggeren legger da automatisk til `EXISTS`.
 
-#### Discovery-survey
+#### Discovery
 
 ```tsx
-import type { LumiSurveyConfig } from "@navikt/lumi-survey";
+import { createDiscoverySurveyDocument } from "@navikt/lumi-survey";
 
-export const survey = {
-  type: "discovery",
-  questions: [
-    {
-      id: "oppgave",
-      type: "text",
-      prompt: "Hva prøvde du å gjøre i dag?",
-      maxLength: 500,
-      required: true,
-    },
-    {
-      id: "fullfort",
-      type: "singleChoice",
-      prompt: "Fikk du gjort det du kom for?",
-      options: [
-        { value: "ja", label: "Ja" },
-        { value: "delvis", label: "Delvis" },
-        { value: "nei", label: "Nei" },
-      ],
-      required: true,
-    },
-    {
-      id: "blokkering",
-      type: "text",
-      prompt: "Hva hindret deg?",
-      maxLength: 1000,
-      visibleIf: {
-        field: "ANSWER",
-        questionId: "fullfort",
-        operator: "EQ",
-        value: "nei",
-      },
-    },
-  ],
-} satisfies LumiSurveyConfig;
+export const survey = createDiscoverySurveyDocument({
+  taskPrompt: "Hva kom du hit for å gjøre?",
+});
 ```
 
-#### Top Tasks-survey
+#### Top Tasks
 
 ```tsx
-import type { LumiSurveyConfig } from "@navikt/lumi-survey";
+import { createTopTasksSurveyDocument } from "@navikt/lumi-survey";
 
-export const survey = {
-  type: "topTasks",
-  questions: [
-    {
-      id: "oppgave",
-      type: "singleChoice",
-      prompt: "Hva kom du hit for å gjøre?",
-      options: [
-        { value: "soke", label: "Søke om ytelse" },
-        { value: "status", label: "Sjekke status på søknad" },
-        { value: "dokument", label: "Sende inn dokumentasjon" },
-        { value: "annet", label: "Annet" },
-      ],
-      randomize: true,
-      required: true,
-    },
-    {
-      id: "fullfort",
-      type: "singleChoice",
-      prompt: "Fikk du gjort det?",
-      options: [
-        { value: "ja", label: "Ja" },
-        { value: "delvis", label: "Delvis" },
-        { value: "nei", label: "Nei" },
-      ],
-      required: true,
-    },
-    {
-      id: "blokkering",
-      type: "text",
-      prompt: "Hva hindret deg?",
-      maxLength: 1000,
-      visibleIf: {
-        field: "ANSWER",
-        questionId: "fullfort",
-        operator: "NEQ",
-        value: "ja",
-      },
-    },
+export const survey = createTopTasksSurveyDocument({
+  tasks: [
+    { value: "soke", label: "Søke om ytelse" },
+    { value: "status", label: "Sjekke status på søknad" },
+    { value: "dokument", label: "Sende inn dokumentasjon" },
   ],
-} satisfies LumiSurveyConfig;
+  includeOtherTask: true,
+});
 ```
 
-#### Task Priority-survey
+#### Oppgaveprioritering
 
 ```tsx
-import type { LumiSurveyConfig } from "@navikt/lumi-survey";
+import { createTaskPrioritySurveyDocument } from "@navikt/lumi-survey";
 
-export const survey = {
-  type: "taskPriority",
-  questions: [
-    {
-      id: "viktigst",
-      type: "multiChoice",
-      variant: "checkbox",
-      prompt: "Hvilke oppgaver er viktigst for deg? (velg inntil 5)",
-      maxSelections: 5,
-      randomize: true,
-      options: [
-        { value: "soke", label: "Søke om ytelse" },
-        { value: "status", label: "Sjekke status" },
-        { value: "dokument", label: "Sende dokumentasjon" },
-        { value: "endring", label: "Melde endring" },
-        { value: "utbetaling", label: "Se utbetalinger" },
-        // Legg til 15-40 oppgaver for robust Long Neck-analyse
-      ],
-      required: true,
-    },
+export const survey = createTaskPrioritySurveyDocument({
+  tasks: [
+    { value: "soke", label: "Søke om ytelse" },
+    { value: "status", label: "Sjekke status" },
+    { value: "dokument", label: "Sende dokumentasjon" },
   ],
-} satisfies LumiSurveyConfig;
+  maxSelections: 2,
+});
 ```
 
-Anbefaling: Inkluder 20-50 oppgaver for god Long Neck-analyse. Bruk `randomize: true` for å unngå rekkefølgebias.
+For Top Tasks og oppgaveprioritering er `value` en stabil analyse-ID. Behold den når bare ordlyden i `label` endres. Ikke håndskriv de tekniske analysefeltene eller ID-ene; bruk byggeren eller Surveyverksted.
+
+#### Tilpasset dokument
+
+Når ingen spesialisert analyse passer, lag et `SurveyDocumentV1` med `type: "custom"`. Legg spørsmål som skal vises sammen på samme side, og bruk én side per spørsmål når brukeren skal få ett spørsmål om gangen.
+
+```tsx
+import type { SurveyDocumentV1 } from "@navikt/lumi-survey";
+
+export const survey = {
+  authoringSchemaVersion: 1,
+  type: "custom",
+  pages: [
+    {
+      id: "tilbakemelding",
+      questions: [
+        {
+          id: "innspill",
+          type: "text",
+          prompt: "Hva kan vi gjøre bedre?",
+          maxLength: 1000,
+        },
+      ],
+    },
+  ],
+} satisfies SurveyDocumentV1;
+```
 
 #### Tilgjengelige spørsmålstyper
 
@@ -293,7 +231,7 @@ Vis spørsmål basert på tidligere svar:
 | `LT` | Mindre enn (tall) | Vis ved lav rating (`value: 3`) |
 | `GT` | Større enn (tall) | Vis ved høy rating |
 | `EQ` | Lik (tekst/tall) | Vis ved spesifikt svar (`value: "nei"`) |
-| `NEQ` | Ulik | Vis når svaret IKKE er en bestemt verdi |
+| `NEQ` | Ulik | Vis når svaret er ulikt en bestemt verdi; kombiner med `EXISTS` hvis ubesvart ikke skal telle |
 | `CONTAINS` | Inneholder (multi-choice) | Vis når et bestemt valg er valgt |
 
 ### 4b. Implementer transporten
@@ -386,7 +324,7 @@ Etter implementasjon, verifiser hele flyten:
 - [ ] `@navikt/lumi-survey` installert og stiler importert (ds-css FØR lumi-survey)
 - [ ] Aksel v8+ bekreftet (`@navikt/ds-react` ≥ 8.0.0)
 - [ ] `LumiSurveyDock` rendres i appen med en unik `surveyId`
-- [ ] Survey-konfigurasjon bruker `satisfies LumiSurveyConfig`
+- [ ] Surveyen er et `SurveyDocumentV1` fra Surveyverksted, en dokumentbygger eller `satisfies SurveyDocumentV1`
 - [ ] Transport sin `submit`-funksjon kaller ditt backend-endepunkt
 - [ ] Backend-endepunkt utveksler token og videresender til Lumi API via `LUMI_FEEDBACK_PATH`
 - [ ] NAIS-manifest har `LUMI_API_HOST`, `LUMI_AUDIENCE`, `LUMI_FEEDBACK_PATH` og `accessPolicy`
@@ -396,27 +334,29 @@ Etter implementasjon, verifiser hele flyten:
 - [ ] Lagringsstrategi matcher app-type (consent for offentlige, localStorage for interne)
 - [ ] Surveyen dukker opp i riktig Lumi-dashboard etter testinnsending (dev: https://lumi-dashboard.ansatt.dev.nav.no, prod: https://lumi-dashboard.ansatt.nav.no/)
 
-## Hurtigstart: Forhåndsdefinerte surveys
+## Hurtigstart: anbefalt standarddokument
 
 Hvis du bare vil komme raskt i gang uten skreddersøm, finnes det ferdige presets:
 
 ```tsx
-import { LumiSurveyDock, DEFAULT_SURVEY_RATING } from "@navikt/lumi-survey";
+import {
+  DEFAULT_RATING_SURVEY_DOCUMENT,
+  LumiSurveyDock,
+} from "@navikt/lumi-survey";
 
-<LumiSurveyDock surveyId="<app-navn>-feedback" survey={DEFAULT_SURVEY_RATING} transport={transport} />
+<LumiSurveyDock
+  surveyId="<app-navn>-feedback"
+  survey={DEFAULT_RATING_SURVEY_DOCUMENT}
+  transport={transport}
+/>
 ```
 
-| Import | Type | Beskrivelse |
-|--------|------|-------------|
-| `DEFAULT_SURVEY_RATING` | Rating (emoji) | 5-punkts emoji + tekstoppfølging ved lav score |
-| `DEFAULT_SURVEY_THUMBS` | Rating (tommel) | Binær tommel opp/ned + tekstoppfølging |
-| `DEFAULT_SURVEY_STARS` | Rating (stjerner) | 5-stjerners rating + tekstoppfølging |
-| `DEFAULT_SURVEY_NPS` | Rating (NPS) | 0-10 Net Promoter Score |
-| `DEFAULT_SURVEY_DISCOVERY` | Discovery | Mål + fullføring + blokkeringsanalyse |
-| `DEFAULT_SURVEY_SERVICE_FEEDBACK` | Service feedback | Rating + forhåndsdefinerte årsaker + tekst |
+Standarddokumentet er nyttig for en rask rating-prototype. Tilpass alltid spørsmålsteksten til situasjonen før produksjon. Bruk `createRatingSurveyDocument` når dere trenger andre tekster eller oppfølgingsspørsmål.
 
-Anbefaling: Bruk presets kun for rask prototyping. For produksjon, lag en skreddersydd konfigurasjon (Fase 4a) med spørsmålstekster tilpasset tjenesten.
+## Eksisterende flat konfigurasjon
+
+Pakken kjører fortsatt eldre `LumiSurveyConfig`, `DEFAULT_SURVEY_*`, `logic` og `questionLayout="steps"` i 2.x. Ikke bygg nye surveyer med disse API-ene. Når du møter dem i en eksisterende app, behold oppførselen til surveyen er migrert kontrollert til `SurveyDocumentV1`; se den offentlige migreringsguiden i Lumi-dokumentasjonen.
 
 ## Avansert konfigurasjon
 
-Se [references/avansert-konfigurasjon.md](references/avansert-konfigurasjon.md) for forgreningslogikk, events og øvrige avanserte tilpasninger.
+Se [references/avansert-konfigurasjon.md](references/avansert-konfigurasjon.md) for betinget synlighet, events og øvrige avanserte tilpasninger.

--- a/.github/skills/lumi-survey/references/avansert-konfigurasjon.md
+++ b/.github/skills/lumi-survey/references/avansert-konfigurasjon.md
@@ -1,10 +1,12 @@
 ## Avansert konfigurasjon
 
-For avanserte brukstilfeller (forgreningslogikk, steg-for-steg-flyter, egendefinerte events, intro-skjermer, egne labels, styling):
+For avanserte brukstilfeller (betinget synlighet, sider, events, velkomst, bekreftelse, egne tekster og styling):
 
 1. Les de eksporterte TypeScript-typene: `node_modules/@navikt/lumi-survey/dist/index.d.ts`
-2. Nøkkelgrensesnitt: `LumiSurveyDockProps`, `LumiSurveyConfig`, `LumiSurveyQuestion`, `LumiSurveyBehavior`, `LumiSurveyEvents`, `LumiSurveyStyle`
+2. Nøkkelgrensesnitt: `SurveyDocumentV1`, `SurveyPageV1`, `SurveyQuestionV1`, `LumiSurveyDockProps`, `LumiSurveyBehavior`, `LumiSurveyEvents`, `LumiSurveyStyle`
 3. Full dokumentasjon: https://navikt.github.io/lumi/
+
+Bruk `SurveyDocumentV1.pages` for steg og gruppering, og `visibleIf` for å vise bare relevante spørsmål. Ikke bruk legacy `logic`, flat `LumiSurveyConfig` eller `questionLayout="steps"` i ny kode. De er tilgjengelige i 2.x bare for eksisterende integrasjoner.
 
 **Events for analyseintegrasjon:**
 

--- a/apps/lumi-api/src/main/kotlin/no/nav/lumi/domain/DefinitionHash.kt
+++ b/apps/lumi-api/src/main/kotlin/no/nav/lumi/domain/DefinitionHash.kt
@@ -9,7 +9,8 @@ data class FieldDefinition(
     val fieldType: FieldType,
     val ratingVariant: RatingVariant?,
     val ratingScale: Int?,
-    val optionIds: List<String>?
+    val optionIds: List<String>?,
+    val maxSelections: Int? = null,
 )
 
 @Serializable
@@ -27,7 +28,8 @@ data class SurveyDefinition(
                     fieldType = answer.fieldType,
                     ratingVariant = (answer.value as? AnswerValue.Rating)?.ratingVariant,
                     ratingScale = (answer.value as? AnswerValue.Rating)?.ratingScale,
-                    optionIds = if (isChoiceType) answer.question.options?.map { it.id } else null
+                    optionIds = if (isChoiceType) answer.question.options?.map { it.id } else null,
+                    maxSelections = null,
                 )
             }
 
@@ -44,7 +46,8 @@ fun FieldDefinition.isStructurallyEqualTo(other: FieldDefinition): Boolean {
     return fieldType == other.fieldType &&
         ratingVariant == other.ratingVariant &&
         ratingScale == other.ratingScale &&
-        optionIds == other.optionIds
+        optionIds == other.optionIds &&
+        maxSelections == other.maxSelections
 }
 
 fun SurveyDefinition.mergeWith(incoming: SurveyDefinition): SurveyDefinition {
@@ -61,6 +64,33 @@ fun SurveyDefinition.mergeWith(incoming: SurveyDefinition): SurveyDefinition {
         surveyType = incoming.surveyType,
         fields = mergedFields
     )
+}
+
+/**
+ * One-time enrichment for definitions stored before maxSelections was part of
+ * the V2 contract. It only fills a missing limit when every previously known
+ * structural property is unchanged; subsequent limit changes remain conflicts.
+ */
+fun SurveyDefinition.withMissingMaxSelectionsFrom(incoming: SurveyDefinition): SurveyDefinition {
+    val incomingById = incoming.fields.associateBy { it.fieldId }
+    var changed = false
+    val enriched = fields.map { storedField ->
+        val incomingField = incomingById[storedField.fieldId]
+        if (
+            storedField.maxSelections == null &&
+            incomingField?.maxSelections != null &&
+            storedField.fieldType == incomingField.fieldType &&
+            storedField.ratingVariant == incomingField.ratingVariant &&
+            storedField.ratingScale == incomingField.ratingScale &&
+            storedField.optionIds == incomingField.optionIds
+        ) {
+            changed = true
+            storedField.copy(maxSelections = incomingField.maxSelections)
+        } else {
+            storedField
+        }
+    }
+    return if (changed) copy(fields = enriched) else this
 }
 
 data class FieldChange(
@@ -181,6 +211,9 @@ fun diff(stored: SurveyDefinition, incoming: SurveyDefinition): DefinitionDiff {
                 if (storedField.optionIds != incomingField.optionIds) {
                     add("optionIds ${storedField.optionIds} -> ${incomingField.optionIds}")
                 }
+                if (storedField.maxSelections != incomingField.maxSelections) {
+                    add("maxSelections ${storedField.maxSelections} -> ${incomingField.maxSelections}")
+                }
             }
 
             if (changes.isNotEmpty()) {
@@ -222,6 +255,10 @@ private fun SurveyDefinition.toCanonicalJson(): String {
                     append(jsonString(optionId))
                 }
                 append("]")
+            }
+            if (field.maxSelections != null) {
+                append(",\"maxSelections\":")
+                append(field.maxSelections)
             }
             append("}")
         }

--- a/apps/lumi-api/src/main/kotlin/no/nav/lumi/domain/Models.kt
+++ b/apps/lumi-api/src/main/kotlin/no/nav/lumi/domain/Models.kt
@@ -30,7 +30,18 @@ enum class SurveyType {
     @SerialName("topTasks") TOP_TASKS,
     @SerialName("discovery") DISCOVERY,
     @SerialName("taskPriority") TASK_PRIORITY,
-    @SerialName("custom") CUSTOM
+    @SerialName("custom") CUSTOM;
+
+    companion object {
+        fun fromWireName(value: String?): SurveyType? = when (value) {
+            "rating", "RATING" -> RATING
+            "topTasks", "TOP_TASKS" -> TOP_TASKS
+            "discovery", "DISCOVERY" -> DISCOVERY
+            "taskPriority", "TASK_PRIORITY" -> TASK_PRIORITY
+            "custom", "CUSTOM" -> CUSTOM
+            else -> null
+        }
+    }
 }
 
 // ============================================
@@ -463,6 +474,7 @@ data class StatsQuery(
 
 @Serializable
 data class TaskVote(
+    val taskId: String,
     val task: String,
     val votes: Int,
     val percentage: Int
@@ -550,6 +562,7 @@ data class TimelineResponse(
 
 @Serializable
 data class TopTaskStats(
+    val taskId: String,
     val task: String,
     val totalCount: Int,
     val successCount: Int,

--- a/apps/lumi-api/src/main/kotlin/no/nav/lumi/domain/SurveyDefinitionPayload.kt
+++ b/apps/lumi-api/src/main/kotlin/no/nav/lumi/domain/SurveyDefinitionPayload.kt
@@ -17,7 +17,8 @@ data class SurveyDefinitionPayload(
                     fieldType = field.fieldType,
                     ratingVariant = field.ratingVariant,
                     ratingScale = field.ratingScale,
-                    optionIds = field.optionIds
+                    optionIds = field.optionIds,
+                    maxSelections = field.maxSelections,
                 )
             }
         )
@@ -30,7 +31,8 @@ data class SubmissionFieldDefinitionPayload(
     val fieldType: FieldType,
     val ratingVariant: RatingVariant? = null,
     val ratingScale: Int? = null,
-    val optionIds: List<String>? = null
+    val optionIds: List<String>? = null,
+    val maxSelections: Int? = null,
 )
 
 @Serializable

--- a/apps/lumi-api/src/main/kotlin/no/nav/lumi/domain/SurveyFieldIds.kt
+++ b/apps/lumi-api/src/main/kotlin/no/nav/lumi/domain/SurveyFieldIds.kt
@@ -1,15 +1,30 @@
 package no.nav.lumi.domain
 
 /**
- * Canonical answer field IDs used by the widget presets.
- *
- * If a team builds a completely custom Top Tasks survey with different IDs, the analytics endpoints
- * will not be able to reliably infer which answer represents the task/blocker without extra metadata.
+ * Canonical answer field IDs shared by specialized widget templates and analytics.
+ * Submission validation rejects specialized surveys that repurpose these fields.
  */
-object TopTasksFieldIds {
-    /** Task selection field. */
-    val task: Set<String> = setOf("task")
+object SpecializedSurveyFieldIds {
+    const val TASK = "task"
+    const val SUCCESS = "success"
+    const val BLOCKER = "blocker"
+    const val PRIORITY = "priority"
 
-    /** Blocker text field. */
-    val blocker: Set<String> = setOf("blocker")
+    const val LEGACY_DISCOVERY_TASK = "discoveredTask"
+    const val LEGACY_SUCCESS = "taskSuccess"
+    const val LEGACY_PRIORITY = "priorities"
+
+    fun findTask(surveyType: SurveyType?, answers: List<Answer>): Answer? =
+        answers.firstOrNull { it.fieldId == TASK }
+            ?: if (surveyType == SurveyType.DISCOVERY) {
+                answers.firstOrNull { it.fieldId == LEGACY_DISCOVERY_TASK }
+            } else null
+
+    fun findSuccess(answers: List<Answer>): Answer? =
+        answers.firstOrNull { it.fieldId == SUCCESS }
+            ?: answers.firstOrNull { it.fieldId == LEGACY_SUCCESS }
+
+    fun findPriority(answers: List<Answer>): Answer? =
+        answers.firstOrNull { it.fieldId == PRIORITY }
+            ?: answers.firstOrNull { it.fieldId == LEGACY_PRIORITY }
 }

--- a/apps/lumi-api/src/main/kotlin/no/nav/lumi/repository/Extensions.kt
+++ b/apps/lumi-api/src/main/kotlin/no/nav/lumi/repository/Extensions.kt
@@ -55,15 +55,8 @@ fun FeedbackDbRecord.toDto(tags: List<String> = emptyList()): FeedbackDto {
     val durationMs = jsonObj["timeToCompleteMs"]?.jsonPrimitive?.longOrNull
     
     val surveyTypeStr = jsonObj["surveyType"]?.jsonPrimitive?.contentOrNull
-    val surveyType = when (surveyTypeStr) {
-        "rating", "RATING" -> SurveyType.RATING
-        "topTasks", "TOP_TASKS" -> SurveyType.TOP_TASKS
-        "discovery", "DISCOVERY" -> SurveyType.DISCOVERY
-        "taskPriority", "TASK_PRIORITY" -> SurveyType.TASK_PRIORITY
-        "custom", "CUSTOM" -> SurveyType.CUSTOM
-        null -> null
-        else -> SurveyType.CUSTOM
-    }
+    val surveyType = SurveyType.fromWireName(surveyTypeStr)
+        ?: surveyTypeStr?.let { SurveyType.CUSTOM }
     
     val context = jsonObj["context"]?.jsonObject?.let { ctxObj ->
         val viewportObj = ctxObj["viewport"]?.jsonObject

--- a/apps/lumi-api/src/main/kotlin/no/nav/lumi/repository/FeedbackContextTagsRepository.kt
+++ b/apps/lumi-api/src/main/kotlin/no/nav/lumi/repository/FeedbackContextTagsRepository.kt
@@ -3,7 +3,7 @@ package no.nav.lumi.repository
 import no.nav.lumi.domain.AnswerValue
 import no.nav.lumi.domain.FieldType
 import no.nav.lumi.domain.MetadataValueWithCount
-import no.nav.lumi.domain.TopTasksFieldIds
+import no.nav.lumi.domain.SpecializedSurveyFieldIds
 import org.jetbrains.exposed.v1.core.IColumnType
 import org.jetbrains.exposed.v1.core.VarCharColumnType
 import org.jetbrains.exposed.v1.core.eq
@@ -215,13 +215,10 @@ class FeedbackContextTagsRepository {
                 if (!matchesSegments) return@filter false
             }
 
-            val taskAnswer = feedback.answers.find { a ->
-                a.fieldId in TopTasksFieldIds.task
-            }
+            val taskAnswer = SpecializedSurveyFieldIds.findTask(feedback.surveyType, feedback.answers)
             if (taskAnswer != null && taskAnswer.fieldType == FieldType.SINGLE_CHOICE) {
                 val selectedId = (taskAnswer.value as? AnswerValue.SingleChoice)?.selectedOptionId
-                val option = taskAnswer.question.options?.find { it.id == selectedId }
-                option?.label == task
+                selectedId == task
             } else {
                 false
             }

--- a/apps/lumi-api/src/main/kotlin/no/nav/lumi/repository/FeedbackRepositorySupport.kt
+++ b/apps/lumi-api/src/main/kotlin/no/nav/lumi/repository/FeedbackRepositorySupport.kt
@@ -138,11 +138,10 @@ internal fun normalizeTag(tag: String): String? {
 internal fun matchesTaskFilter(feedback: FeedbackDto, task: String?): Boolean {
     if (task.isNullOrBlank()) return true
 
-    val taskAnswer = feedback.answers.find { a -> a.fieldId in TopTasksFieldIds.task }
+    val taskAnswer = SpecializedSurveyFieldIds.findTask(feedback.surveyType, feedback.answers)
     if (taskAnswer != null && taskAnswer.fieldType == FieldType.SINGLE_CHOICE) {
         val selectedId = (taskAnswer.value as? AnswerValue.SingleChoice)?.selectedOptionId
-        val option = taskAnswer.question.options?.find { it.id == selectedId }
-        return option?.label == task
+        return selectedId == task
     }
     return false
 }
@@ -154,7 +153,7 @@ internal fun matchesThemeFilter(
 ): Boolean {
     if (themeId.isNullOrBlank()) return true
 
-    val taskAnswer = feedback.answers.find { it.fieldId == "task" }
+    val taskAnswer = SpecializedSurveyFieldIds.findTask(feedback.surveyType, feedback.answers)
     val taskText = (taskAnswer?.value as? AnswerValue.Text)?.text ?: return false
     val matchedTheme = matchThemeName(taskText, themes)
 

--- a/apps/lumi-api/src/main/kotlin/no/nav/lumi/repository/FeedbackStatsRepository.kt
+++ b/apps/lumi-api/src/main/kotlin/no/nav/lumi/repository/FeedbackStatsRepository.kt
@@ -11,6 +11,7 @@ import org.jetbrains.exposed.v1.jdbc.*
 import org.slf4j.LoggerFactory
 import java.time.Duration
 import java.time.Instant
+import java.time.OffsetDateTime
 
 class FeedbackStatsRepository {
     private val json = Json { ignoreUnknownKeys = true }
@@ -279,13 +280,10 @@ class FeedbackStatsRepository {
         val dtos = records.map { it.toDto() }
         val filteredRecords = query.task?.let { taskFilter ->
             dtos.filter { feedback ->
-                val taskAnswer = feedback.answers.find { a ->
-                    a.fieldId in TopTasksFieldIds.task
-                }
+                val taskAnswer = SpecializedSurveyFieldIds.findTask(feedback.surveyType, feedback.answers)
                 if (taskAnswer != null && taskAnswer.fieldType == FieldType.SINGLE_CHOICE) {
                     val selectedId = (taskAnswer.value as? AnswerValue.SingleChoice)?.selectedOptionId
-                    val option = taskAnswer.question.options?.find { it.id == selectedId }
-                    option?.label == taskFilter
+                    selectedId == taskFilter
                 } else {
                     false
                 }
@@ -317,9 +315,7 @@ class FeedbackStatsRepository {
         for (row in distinctRows) {
             if (row.surveyId.isBlank()) continue
             if (seenSurveys.containsKey(row.surveyId)) continue
-            val parsedType = row.surveyType?.let {
-                try { SurveyType.valueOf(it.uppercase()) } catch (_: Exception) { SurveyType.CUSTOM }
-            } ?: SurveyType.CUSTOM
+            val parsedType = SurveyType.fromWireName(row.surveyType) ?: SurveyType.CUSTOM
             seenSurveys[row.surveyId] = parsedType
             surveyTypeCounts[parsedType] = (surveyTypeCounts[parsedType] ?: 0) + 1
         }
@@ -347,16 +343,16 @@ class FeedbackStatsRepository {
         val voteCounts = mutableMapOf<String, Int>()
         val taskLabels = mutableMapOf<String, String>()
 
-        for (feedback in dtos) {
-            val priorityAnswer = feedback.answers.find { a ->
-                a.fieldId == "priority" && a.fieldType == FieldType.MULTI_CHOICE
-            } ?: continue
+        for (feedback in dtos.sortedBy { OffsetDateTime.parse(it.submittedAt) }) {
+            val priorityAnswer = SpecializedSurveyFieldIds.findPriority(feedback.answers)
+                ?.takeIf { it.fieldType == FieldType.MULTI_CHOICE }
+                ?: continue
 
             val selectedIds = (priorityAnswer.value as? AnswerValue.MultiChoice)?.selectedOptionIds.orEmpty()
             if (selectedIds.isEmpty()) continue
 
             priorityAnswer.question.options?.forEach { opt ->
-                taskLabels.putIfAbsent(opt.id, opt.label)
+                taskLabels[opt.id] = opt.label
             }
 
             for (taskId in selectedIds) {
@@ -368,6 +364,7 @@ class FeedbackStatsRepository {
             .sortedByDescending { it.value }
             .map { (taskId, votes) ->
                 TaskVote(
+                    taskId = taskId,
                     task = taskLabels[taskId] ?: taskId,
                     votes = votes,
                     percentage = 0
@@ -420,14 +417,12 @@ class FeedbackStatsRepository {
 
         for (feedback in dtos) {
             val blockerAnswer = feedback.answers.find { a ->
-                a.fieldId in TopTasksFieldIds.blocker
+                a.fieldId == SpecializedSurveyFieldIds.BLOCKER
             }
             val blockerText = (blockerAnswer?.value as? AnswerValue.Text)?.text?.trim().orEmpty()
             if (blockerText.isBlank()) continue
 
-            val taskAnswer = feedback.answers.find { a ->
-                a.fieldId in TopTasksFieldIds.task
-            }
+            val taskAnswer = SpecializedSurveyFieldIds.findTask(feedback.surveyType, feedback.answers)
 
             val taskLabel = when {
                 taskAnswer != null && taskAnswer.fieldType == FieldType.SINGLE_CHOICE -> {
@@ -438,7 +433,8 @@ class FeedbackStatsRepository {
                 else -> "Ukjent oppgave"
             }
 
-            if (query.task != null && taskLabel != query.task) continue
+            val taskId = (taskAnswer?.value as? AnswerValue.SingleChoice)?.selectedOptionId
+            if (query.task != null && taskId != query.task) continue
 
             blockerResponses.add(
                 RecentBlockerResponse(

--- a/apps/lumi-api/src/main/kotlin/no/nav/lumi/repository/FeedbackTopTasksProcessor.kt
+++ b/apps/lumi-api/src/main/kotlin/no/nav/lumi/repository/FeedbackTopTasksProcessor.kt
@@ -3,22 +3,30 @@ package no.nav.lumi.repository
 import no.nav.lumi.domain.AnswerValue
 import no.nav.lumi.domain.DailyStat
 import no.nav.lumi.domain.FeedbackDto
+import no.nav.lumi.domain.SpecializedSurveyFieldIds
 import no.nav.lumi.domain.TopTaskStats
 import no.nav.lumi.domain.TopTasksResponse
 import java.time.LocalDate
+import java.time.OffsetDateTime
 
 internal fun processTopTasks(feedbacks: List<FeedbackDto>): TopTasksResponse {
     val taskStatsMap = mutableMapOf<String, MutableMap<String, Int>>()
+    val taskLabels = mutableMapOf<String, Pair<String, OffsetDateTime>>()
     var totalSubmissions = 0
     val dailyStats = mutableMapOf<String, MutableMap<String, Int>>()
     var questionText: String? = null
 
     feedbacks.forEach { dto ->
-        val taskAnswer = dto.answers.find { it.fieldId == "task" }
+        val taskAnswer = SpecializedSurveyFieldIds.findTask(dto.surveyType, dto.answers)
         if (taskAnswer == null) return@forEach
 
         totalSubmissions++
 
+        val taskId = when (val v = taskAnswer.value) {
+            is AnswerValue.SingleChoice -> v.selectedOptionId
+            is AnswerValue.Text -> v.text
+            else -> "unknown"
+        }
         val taskLabel = when (val v = taskAnswer.value) {
             is AnswerValue.SingleChoice -> {
                 val optId = v.selectedOptionId
@@ -27,18 +35,23 @@ internal fun processTopTasks(feedbacks: List<FeedbackDto>): TopTasksResponse {
             is AnswerValue.Text -> v.text
             else -> "Ukjent oppgave"
         }
+        val submittedAt = OffsetDateTime.parse(dto.submittedAt)
+        val previousLabel = taskLabels[taskId]
+        if (previousLabel == null || submittedAt >= previousLabel.second) {
+            taskLabels[taskId] = taskLabel to submittedAt
+        }
 
         if (questionText == null) {
             questionText = taskAnswer.question.label
         }
 
-        val successAnswer = dto.answers.find { it.fieldId == "taskSuccess" }
+        val successAnswer = SpecializedSurveyFieldIds.findSuccess(dto.answers)
         val successValue = when (val v = successAnswer?.value) {
             is AnswerValue.SingleChoice -> v.selectedOptionId // "yes", "partial", "no"
             else -> null
         }
 
-        val blockerAnswer = dto.answers.find { it.fieldId == "blocker" }
+        val blockerAnswer = dto.answers.find { it.fieldId == SpecializedSurveyFieldIds.BLOCKER }
         val blockerValue = when (val v = blockerAnswer?.value) {
             is AnswerValue.SingleChoice -> v.selectedOptionId
             is AnswerValue.Text -> v.text
@@ -54,7 +67,7 @@ internal fun processTopTasks(feedbacks: List<FeedbackDto>): TopTasksResponse {
         }
 
         // Task stats
-        val stats = taskStatsMap.getOrPut(taskLabel) {
+        val stats = taskStatsMap.getOrPut(taskId) {
             mutableMapOf("total" to 0, "success" to 0, "partial" to 0, "failure" to 0)
         }
         stats["total"] = (stats["total"] ?: 0) + 1
@@ -70,7 +83,7 @@ internal fun processTopTasks(feedbacks: List<FeedbackDto>): TopTasksResponse {
         }
     }
 
-    val taskStatsList = taskStatsMap.map { (task, stats) ->
+    val taskStatsList = taskStatsMap.map { (taskId, stats) ->
         val total = stats["total"] ?: 0
         val success = stats["success"] ?: 0
         val partial = stats["partial"] ?: 0
@@ -79,7 +92,17 @@ internal fun processTopTasks(feedbacks: List<FeedbackDto>): TopTasksResponse {
         val formattedRate = "${(successRate * 100).toInt()}%"
         val blockers = stats.filterKeys { it.startsWith("blocker_") }.mapKeys { it.key.removePrefix("blocker_") }
 
-        TopTaskStats(task, total, success, partial, failure, successRate, formattedRate, blockers)
+        TopTaskStats(
+            taskId,
+            taskLabels[taskId]?.first ?: taskId,
+            total,
+            success,
+            partial,
+            failure,
+            successRate,
+            formattedRate,
+            blockers,
+        )
     }.sortedByDescending { it.totalCount }
 
     val dailyStatsResult = dailyStats.mapValues { (_, v) ->

--- a/apps/lumi-api/src/main/kotlin/no/nav/lumi/service/DiscoveryService.kt
+++ b/apps/lumi-api/src/main/kotlin/no/nav/lumi/service/DiscoveryService.kt
@@ -61,21 +61,21 @@ class DiscoveryService(
         
         for (dto in feedbacks) {
             // Extract task text (first TEXT answer typically)
-            val taskAnswer = dto.answers.find { it.fieldId == "task" }
+            val taskAnswer = SpecializedSurveyFieldIds.findTask(dto.surveyType, dto.answers)
             val taskText = when (val v = taskAnswer?.value) {
                 is AnswerValue.Text -> v.text
                 else -> continue
             }
             
             // Extract success status
-            val successAnswer = dto.answers.find { it.fieldId == "success" }
+            val successAnswer = SpecializedSurveyFieldIds.findSuccess(dto.answers)
             val successValue = when (val v = successAnswer?.value) {
                 is AnswerValue.SingleChoice -> v.selectedOptionId
                 else -> "unknown"
             }
             
             // Extract blocker if present
-            val blockerAnswer = dto.answers.find { it.fieldId == "blocker" }
+            val blockerAnswer = dto.answers.find { it.fieldId == SpecializedSurveyFieldIds.BLOCKER }
             val blockerText = when (val v = blockerAnswer?.value) {
                 is AnswerValue.Text -> v.text
                 else -> null

--- a/apps/lumi-api/src/main/kotlin/no/nav/lumi/service/StatsService.kt
+++ b/apps/lumi-api/src/main/kotlin/no/nav/lumi/service/StatsService.kt
@@ -155,8 +155,8 @@ class StatsService(
                 toDate = query.toDate,
                 days = days
             ),
-            surveyType = stats.surveyType?.let { 
-                try { SurveyType.valueOf(it.uppercase()) } catch(e: Exception) { SurveyType.CUSTOM }
+            surveyType = stats.surveyType?.let {
+                SurveyType.fromWireName(it) ?: SurveyType.CUSTOM
             },
             ratingByDate = if (stats.masked) emptyMap() else analytics?.ratingByDate.orEmpty(),
             byDevice = if (stats.masked) emptyMap() else analytics?.byDevice.orEmpty(),

--- a/apps/lumi-api/src/main/kotlin/no/nav/lumi/service/SurveyDefinitionService.kt
+++ b/apps/lumi-api/src/main/kotlin/no/nav/lumi/service/SurveyDefinitionService.kt
@@ -7,6 +7,7 @@ import no.nav.lumi.domain.SurveyDefinition
 import no.nav.lumi.domain.computeHash
 import no.nav.lumi.domain.diff
 import no.nav.lumi.domain.mergeWith
+import no.nav.lumi.domain.withMissingMaxSelectionsFrom
 import no.nav.lumi.repository.StoredSurveyDefinition
 import no.nav.lumi.repository.SurveyDefinitionRepository
 import no.nav.lumi.repository.SurveyDefinitionSource
@@ -188,7 +189,9 @@ class SurveyDefinitionService(
         updateDefinition: suspend (String, String, String, SurveyDefinition, String) -> Boolean
     ): ExistingDefinitionResult {
         if (!allowDefinitionExpansion) {
-            val definitionDiff = diff(stored.definition, incomingDefinition)
+            val enrichedStoredDefinition =
+                stored.definition.withMissingMaxSelectionsFrom(incomingDefinition)
+            val definitionDiff = diff(enrichedStoredDefinition, incomingDefinition)
             if (stored.source == SurveyDefinitionSource.AUTO && incomingSource == SurveyDefinitionSource.API) {
                 if (definitionDiff.changedFields.isNotEmpty() || definitionDiff.removedFields.isNotEmpty()) {
                     throwDefinitionConflict(team, stored.surveyId, definitionDiff, redactIdentifiers = true)
@@ -207,6 +210,24 @@ class SurveyDefinitionService(
 
             if (definitionDiff.hasChanges()) {
                 throwDefinitionConflict(team, stored.surveyId, definitionDiff, redactIdentifiers = true)
+            }
+
+            if (enrichedStoredDefinition !== stored.definition) {
+                val enrichedHash = enrichedStoredDefinition.computeHash()
+                val updated = updateDefinition(
+                    team,
+                    stored.surveyId,
+                    stored.definitionHash,
+                    enrichedStoredDefinition,
+                    enrichedHash,
+                )
+                return if (updated) {
+                    ExistingDefinitionResult.Resolved(
+                        RegistrationResult(stored.surveyId, enrichedHash)
+                    )
+                } else {
+                    ExistingDefinitionResult.Retry
+                }
             }
 
             return ExistingDefinitionResult.Resolved(

--- a/apps/lumi-api/src/main/kotlin/no/nav/lumi/validation/SpecializedSurveyContractValidator.kt
+++ b/apps/lumi-api/src/main/kotlin/no/nav/lumi/validation/SpecializedSurveyContractValidator.kt
@@ -1,0 +1,339 @@
+package no.nav.lumi.validation
+
+import no.nav.lumi.config.exception.ApiErrorException
+import no.nav.lumi.domain.Answer
+import no.nav.lumi.domain.AnswerValue
+import no.nav.lumi.domain.FieldType
+import no.nav.lumi.domain.SubmissionFieldDefinitionPayload
+import no.nav.lumi.domain.SpecializedSurveyFieldIds
+import no.nav.lumi.domain.SurveyType
+
+/**
+ * Analytics for specialized survey types relies on a small, explicit field
+ * contract. Reject mismatches at ingestion so a seemingly successful survey
+ * can never produce an empty or misleading dashboard.
+ */
+object SpecializedSurveyContractValidator {
+    data class AuthoringField(
+        val id: String,
+        val type: FieldType,
+        val optionIds: List<String> = emptyList(),
+        val optionLabels: List<String> = emptyList(),
+        val required: Boolean = false,
+        val conditionallyVisible: Boolean = false,
+        val maxSelections: Int? = null,
+    )
+
+    private data class RequiredField(
+        val id: String,
+        val type: FieldType,
+        val optional: Boolean = false,
+        val optionIds: Set<String> = emptySet()
+    )
+
+    private val successOptions = setOf("yes", "partial", "no")
+    private const val TEMPLATE_OPTION_PREFIX = "__lumi_example_task__"
+    private val templateOptionLabels = setOf(
+        "Bytt ut med en oppgave dere vil måle",
+        "Bytt ut med den første oppgaven",
+        "Bytt ut med den andre oppgaven",
+    )
+
+    private val contracts = mapOf(
+        SurveyType.DISCOVERY to listOf(
+            RequiredField(SpecializedSurveyFieldIds.TASK, FieldType.TEXT),
+            RequiredField(
+                SpecializedSurveyFieldIds.SUCCESS,
+                FieldType.SINGLE_CHOICE,
+                optionIds = successOptions
+            ),
+            RequiredField(SpecializedSurveyFieldIds.BLOCKER, FieldType.TEXT, optional = true)
+        ),
+        SurveyType.TOP_TASKS to listOf(
+            RequiredField(SpecializedSurveyFieldIds.TASK, FieldType.SINGLE_CHOICE),
+            RequiredField(
+                SpecializedSurveyFieldIds.SUCCESS,
+                FieldType.SINGLE_CHOICE,
+                optionIds = successOptions
+            ),
+            RequiredField(SpecializedSurveyFieldIds.BLOCKER, FieldType.TEXT, optional = true)
+        ),
+        SurveyType.TASK_PRIORITY to listOf(
+            RequiredField(SpecializedSurveyFieldIds.PRIORITY, FieldType.MULTI_CHOICE)
+        )
+    )
+
+    private val legacyContracts = mapOf(
+        SurveyType.DISCOVERY to listOf(
+            RequiredField("discoveredTask", FieldType.TEXT),
+            RequiredField("taskSuccess", FieldType.SINGLE_CHOICE, optionIds = successOptions),
+            RequiredField(SpecializedSurveyFieldIds.BLOCKER, FieldType.TEXT, optional = true)
+        ),
+        SurveyType.TOP_TASKS to listOf(
+            RequiredField(SpecializedSurveyFieldIds.TASK, FieldType.SINGLE_CHOICE),
+            RequiredField("taskSuccess", FieldType.SINGLE_CHOICE, optionIds = successOptions),
+            RequiredField(SpecializedSurveyFieldIds.BLOCKER, FieldType.TEXT, optional = true)
+        ),
+        SurveyType.TASK_PRIORITY to listOf(
+            RequiredField("priorities", FieldType.MULTI_CHOICE)
+        )
+    )
+
+    private fun contractFor(
+        surveyType: SurveyType,
+        fieldIds: Set<String>,
+        allowLegacyFieldIds: Boolean,
+    ): List<RequiredField>? {
+        val canonical = contracts[surveyType] ?: return null
+        if (!allowLegacyFieldIds) return canonical
+        val hasRequiredFields = { candidate: List<RequiredField> ->
+            candidate.all { it.optional || it.id in fieldIds }
+        }
+        val legacy = legacyContracts[surveyType]
+        return if (!hasRequiredFields(canonical) && legacy != null && hasRequiredFields(legacy)) legacy else canonical
+    }
+
+    fun validateAnswers(
+        surveyType: SurveyType,
+        answers: List<Answer>,
+        definitionValidated: Boolean = false,
+    ) {
+        if (
+            surveyType == SurveyType.TASK_PRIORITY &&
+            answers.any { it.fieldId == SpecializedSurveyFieldIds.PRIORITY } &&
+            !definitionValidated
+        ) {
+            invalid(
+                surveyType,
+                "canonical field 'priority' requires schemaVersion 2 with a validated definition"
+            )
+        }
+        validateFields(
+            surveyType = surveyType,
+            fields = answers.map { answer ->
+                ContractField(
+                    id = answer.fieldId,
+                    type = answer.fieldType,
+                    optionIds = answer.question.options?.map { it.id }.orEmpty()
+                )
+            },
+            source = "answers",
+            allowLegacyFieldIds = true,
+        )
+        validateAnswerValues(surveyType, answers)
+    }
+
+    fun validateDefinition(
+        surveyType: SurveyType,
+        fields: List<SubmissionFieldDefinitionPayload>
+    ) {
+        validateFields(
+            surveyType = surveyType,
+            fields = fields.map { field ->
+                ContractField(
+                    id = field.fieldId,
+                    type = field.fieldType,
+                    optionIds = field.optionIds.orEmpty(),
+                    maxSelections = field.maxSelections,
+                )
+            },
+            source = "definition.fields",
+            enforceCanonicalTaskPrioritySemantics = true,
+            allowLegacyFieldIds = true,
+        )
+    }
+
+    fun validateAuthoringFields(surveyType: SurveyType, fields: List<AuthoringField>) {
+        validateFields(
+            surveyType = surveyType,
+            fields = fields.map { field ->
+                ContractField(
+                    id = field.id,
+                    type = field.type,
+                    optionIds = field.optionIds,
+                    optionLabels = field.optionLabels,
+                    required = field.required,
+                    conditionallyVisible = field.conditionallyVisible,
+                    maxSelections = field.maxSelections,
+                )
+            },
+            source = "document",
+            enforceAuthoringSemantics = true,
+            enforceCanonicalTaskPrioritySemantics = true,
+            allowLegacyFieldIds = false,
+        )
+    }
+
+    private data class ContractField(
+        val id: String,
+        val type: FieldType,
+        val optionIds: List<String>,
+        val optionLabels: List<String> = emptyList(),
+        val required: Boolean = false,
+        val conditionallyVisible: Boolean = false,
+        val maxSelections: Int? = null,
+    )
+
+    private fun validateFields(
+        surveyType: SurveyType,
+        fields: List<ContractField>,
+        source: String,
+        enforceAuthoringSemantics: Boolean = false,
+        enforceCanonicalTaskPrioritySemantics: Boolean = false,
+        allowLegacyFieldIds: Boolean,
+    ) {
+        if (allowLegacyFieldIds) {
+            val fieldIds = fields.mapTo(mutableSetOf()) { it.id }
+            val aliasPairs = buildList {
+                if (surveyType == SurveyType.DISCOVERY) {
+                    add(SpecializedSurveyFieldIds.TASK to SpecializedSurveyFieldIds.LEGACY_DISCOVERY_TASK)
+                }
+                if (surveyType == SurveyType.DISCOVERY || surveyType == SurveyType.TOP_TASKS) {
+                    add(SpecializedSurveyFieldIds.SUCCESS to SpecializedSurveyFieldIds.LEGACY_SUCCESS)
+                }
+                if (surveyType == SurveyType.TASK_PRIORITY) {
+                    add(SpecializedSurveyFieldIds.PRIORITY to SpecializedSurveyFieldIds.LEGACY_PRIORITY)
+                }
+            }
+            aliasPairs.firstOrNull { (canonical, legacy) -> canonical in fieldIds && legacy in fieldIds }
+                ?.let { (canonical, legacy) ->
+                    invalid(surveyType, "$source must not include both '$canonical' and legacy alias '$legacy'")
+                }
+        }
+        val contract = contractFor(surveyType, fields.map { it.id }.toSet(), allowLegacyFieldIds) ?: return
+        val fieldsById = fields.associateBy { it.id }
+
+        for (required in contract) {
+            val actual = fieldsById[required.id]
+            if (actual == null) {
+                if (required.optional) continue
+                invalid(surveyType, "$source must include '${required.id}'")
+            }
+            if (actual.type != required.type) {
+                invalid(
+                    surveyType,
+                    "$source field '${required.id}' must be ${required.type}"
+                )
+            }
+            if (
+                required.optionIds.isNotEmpty() &&
+                (actual.optionIds.size != required.optionIds.size || actual.optionIds.toSet() != required.optionIds)
+            ) {
+                invalid(
+                    surveyType,
+                    "$source field '${required.id}' must have exactly options yes, partial and no"
+                )
+            }
+            if (enforceAuthoringSemantics && !required.optional && !actual.required) {
+                invalid(surveyType, "$source field '${required.id}' must be required")
+            }
+            if (enforceAuthoringSemantics && !required.optional && actual.conditionallyVisible) {
+                invalid(surveyType, "$source field '${required.id}' must always be visible")
+            }
+        }
+        val usesLegacyContract = contract === legacyContracts[surveyType]
+        if (
+            enforceCanonicalTaskPrioritySemantics &&
+            surveyType == SurveyType.TASK_PRIORITY &&
+            !usesLegacyContract
+        ) {
+            val priorityFieldId = contract.firstOrNull { it.type == FieldType.MULTI_CHOICE && !it.optional }?.id
+            val priority = priorityFieldId?.let(fieldsById::get)
+            if (priority != null && priority.type == FieldType.MULTI_CHOICE) {
+                if (priority.optionIds.size < 2) {
+                    invalid(surveyType, "$source field 'priority' must have at least two task options")
+                }
+                val maxSelections = priority.maxSelections
+                if (maxSelections == null || maxSelections !in 1..priority.optionIds.size) {
+                    invalid(
+                        surveyType,
+                        "$source field 'priority' maxSelections must be between 1 and the number of task options"
+                    )
+                }
+            }
+        }
+        if (enforceAuthoringSemantics && surveyType in setOf(SurveyType.TOP_TASKS, SurveyType.TASK_PRIORITY)) {
+            val taskFieldId = if (surveyType == SurveyType.TOP_TASKS) {
+                SpecializedSurveyFieldIds.TASK
+            } else {
+                SpecializedSurveyFieldIds.PRIORITY
+            }
+            val taskField = fieldsById[taskFieldId]
+            if (
+                taskField != null &&
+                (taskField.optionIds.any { it.startsWith(TEMPLATE_OPTION_PREFIX) } ||
+                    taskField.optionLabels.any { it.trim() in templateOptionLabels })
+            ) {
+                invalid(surveyType, "$source field '$taskFieldId' contains an unfinished example task")
+            }
+            if (
+                surveyType == SurveyType.TOP_TASKS &&
+                taskField != null &&
+                taskField.optionIds.all { it == "other" }
+            ) {
+                invalid(surveyType, "$source field 'task' must include at least one known task")
+            }
+        }
+    }
+
+    private fun validateAnswerValues(surveyType: SurveyType, answers: List<Answer>) {
+        val contract = contractFor(surveyType, answers.map { it.fieldId }.toSet(), allowLegacyFieldIds = true) ?: return
+        val answersById = answers.associateBy { it.fieldId }
+
+        for (required in contract) {
+            val answer = answersById[required.id] ?: continue
+            val valueMatchesField = when (required.type) {
+                FieldType.TEXT -> answer.value is AnswerValue.Text
+                FieldType.SINGLE_CHOICE -> answer.value is AnswerValue.SingleChoice
+                FieldType.MULTI_CHOICE -> answer.value is AnswerValue.MultiChoice
+                else -> false
+            }
+            if (!valueMatchesField) {
+                invalid(
+                    surveyType,
+                    "answers field '${required.id}' value must match ${required.type}"
+                )
+            }
+
+            when (val value = answer.value) {
+                is AnswerValue.Text -> {
+                    if (value.text.isBlank()) {
+                        invalid(surveyType, "answers field '${required.id}' must be non-blank")
+                    }
+                }
+                is AnswerValue.SingleChoice -> {
+                    val optionIds = answer.question.options?.map { it.id }.orEmpty()
+                    if (value.selectedOptionId !in optionIds) {
+                        invalid(
+                            surveyType,
+                            "answers field '${required.id}' must select a declared option"
+                        )
+                    }
+                }
+                is AnswerValue.MultiChoice -> {
+                    val optionIds = answer.question.options?.map { it.id }?.toSet().orEmpty()
+                    if (value.selectedOptionIds.any { it !in optionIds }) {
+                        invalid(
+                            surveyType,
+                            "answers field '${required.id}' must select only declared options"
+                        )
+                    }
+                }
+                else -> Unit
+            }
+        }
+    }
+
+    private fun invalid(surveyType: SurveyType, detail: String): Nothing {
+        val wireType = when (surveyType) {
+            SurveyType.DISCOVERY -> "discovery"
+            SurveyType.TOP_TASKS -> "topTasks"
+            SurveyType.TASK_PRIORITY -> "taskPriority"
+            SurveyType.RATING -> "rating"
+            SurveyType.CUSTOM -> "custom"
+        }
+        throw ApiErrorException.BadRequestException(
+            "Invalid $wireType survey contract: $detail"
+        )
+    }
+}

--- a/apps/lumi-api/src/main/kotlin/no/nav/lumi/validation/SubmissionV2Validator.kt
+++ b/apps/lumi-api/src/main/kotlin/no/nav/lumi/validation/SubmissionV2Validator.kt
@@ -24,6 +24,15 @@ object SubmissionV2Validator {
 
         val definition = submission.definition.toSurveyDefinition(submission.surveyId)
         SurveyDefinitionValidator.validateDefinition(definition)
+        SpecializedSurveyContractValidator.validateDefinition(
+            surveyType = submission.surveyType,
+            fields = submission.definition.fields
+        )
+        SpecializedSurveyContractValidator.validateAnswers(
+            surveyType = submission.surveyType,
+            answers = submission.answers,
+            definitionValidated = true,
+        )
 
         val fieldIds = definition.fields.map { it.fieldId }.toSet()
         val invalidFieldIds = submission.answers.map { it.fieldId }.filterNot(fieldIds::contains)

--- a/apps/lumi-api/src/main/kotlin/no/nav/lumi/validation/SubmissionValidator.kt
+++ b/apps/lumi-api/src/main/kotlin/no/nav/lumi/validation/SubmissionValidator.kt
@@ -43,6 +43,10 @@ object SubmissionValidator {
             context = submission.context,
             answers = submission.answers
         )
+        SpecializedSurveyContractValidator.validateAnswers(
+            surveyType = submission.surveyType,
+            answers = submission.answers
+        )
     }
 
     internal fun validateCommonSubmission(

--- a/apps/lumi-api/src/main/kotlin/no/nav/lumi/validation/SurveyAuthoringDocumentValidator.kt
+++ b/apps/lumi-api/src/main/kotlin/no/nav/lumi/validation/SurveyAuthoringDocumentValidator.kt
@@ -59,7 +59,8 @@ object SurveyAuthoringDocumentValidator {
     /**
      * Validates the authoring document structure. With [releaseGate] the
      * semantic bar for immutable revisions applies too: prompts, option
-     * labels and option values must be non-blank. Drafts stay lenient.
+     * labels and values must be non-blank, and specialized analytics fields
+     * must keep their required contract. Drafts stay lenient.
      */
     fun validate(
         document: JsonObject,
@@ -88,6 +89,7 @@ object SurveyAuthoringDocumentValidator {
         val previousQuestionIds = mutableSetOf<String>()
         val conditionTargets = mutableMapOf<String, ConditionTargetInfo>()
         val fields = mutableListOf<FieldDefinition>()
+        val authoringFields = mutableListOf<SpecializedSurveyContractValidator.AuthoringField>()
 
         pages.forEachIndexed { pageIndex, pageElement ->
             val page = pageElement as? JsonObject
@@ -111,7 +113,7 @@ object SurveyAuthoringDocumentValidator {
                 }
                 optionalString(question, "description", "Question '$questionId'")
                 optionalString(question, "analyticsId", "Question '$questionId'")
-                optionalBoolean(question, "required", "Question '$questionId'")
+                val required = optionalBoolean(question, "required", "Question '$questionId'") ?: false
                 if (question.containsKey("logic")) {
                     invalid("Question '$questionId' uses legacy logic")
                 }
@@ -130,6 +132,19 @@ object SurveyAuthoringDocumentValidator {
                     else -> invalid("Question '$questionId' has unsupported type '$type'")
                 }
                 fields += definition
+                authoringFields += SpecializedSurveyContractValidator.AuthoringField(
+                    id = questionId,
+                    type = definition.fieldType,
+                    optionIds = definition.optionIds.orEmpty(),
+                    optionLabels = (question["options"] as? JsonArray)
+                        ?.map { option ->
+                            ((option as JsonObject)["label"] as JsonPrimitive).content
+                        }
+                        .orEmpty(),
+                    required = required,
+                    conditionallyVisible = question.containsKey("visibleIf"),
+                    maxSelections = (question["maxSelections"] as? JsonPrimitive)?.intOrNull,
+                )
                 conditionTargets[questionId] = when (type) {
                     "rating" -> {
                         val variantName =
@@ -150,6 +165,9 @@ object SurveyAuthoringDocumentValidator {
         }
 
         val definition = SurveyDefinition(surveyId = surveyId, surveyType = surveyType, fields = fields)
+        if (releaseGate) {
+            SpecializedSurveyContractValidator.validateAuthoringFields(surveyType, authoringFields)
+        }
         SurveyDefinitionValidator.validateDefinition(definition)
         return ValidatedSurveyAuthoringDocument(
             documentHash = sha256(canonicalJson(document)),
@@ -233,13 +251,21 @@ object SurveyAuthoringDocumentValidator {
                 invalid("Choice question '$questionId' has unsupported variant '$variant'")
             }
         }
-        question["maxSelections"]?.let {
-            val maxSelections = (it as? JsonPrimitive)?.intOrNull
-            if (maxSelections == null || maxSelections <= 0) {
+        val maxSelections = question["maxSelections"]?.let {
+            val parsed = (it as? JsonPrimitive)?.intOrNull
+            if (parsed == null || parsed <= 0) {
                 invalid("Choice question '$questionId' has invalid maxSelections")
             }
+            parsed
         }
-        return FieldDefinition(questionId, fieldType, null, null, optionIds)
+        return FieldDefinition(
+            questionId,
+            fieldType,
+            null,
+            null,
+            optionIds,
+            maxSelections.takeIf { releaseGate },
+        )
     }
 
     private fun validateVisibleIf(

--- a/apps/lumi-api/src/main/kotlin/no/nav/lumi/validation/SurveyDefinitionValidator.kt
+++ b/apps/lumi-api/src/main/kotlin/no/nav/lumi/validation/SurveyDefinitionValidator.kt
@@ -48,6 +48,11 @@ object SurveyDefinitionValidator {
                             "Invalid payload: fieldId=${field.fieldId} (RATING) must not include optionIds"
                         )
                     }
+                    if (field.maxSelections != null) {
+                        throw ApiErrorException.BadRequestException(
+                            "Invalid payload: fieldId=${field.fieldId} (RATING) must not include maxSelections"
+                        )
+                    }
                 }
 
                 FieldType.SINGLE_CHOICE, FieldType.MULTI_CHOICE -> {
@@ -68,6 +73,20 @@ object SurveyDefinitionValidator {
                             "Invalid payload: fieldId=${field.fieldId} (${field.fieldType}) must not include ratingVariant or ratingScale"
                         )
                     }
+                    if (
+                        field.fieldType == FieldType.MULTI_CHOICE &&
+                        field.maxSelections != null &&
+                        field.maxSelections !in 1..field.optionIds.size
+                    ) {
+                        throw ApiErrorException.BadRequestException(
+                            "Invalid payload: fieldId=${field.fieldId} maxSelections must be between 1 and the number of options"
+                        )
+                    }
+                    if (field.fieldType != FieldType.MULTI_CHOICE && field.maxSelections != null) {
+                        throw ApiErrorException.BadRequestException(
+                            "Invalid payload: fieldId=${field.fieldId} (${field.fieldType}) must not include maxSelections"
+                        )
+                    }
                 }
 
                 else -> {
@@ -79,6 +98,11 @@ object SurveyDefinitionValidator {
                     if (field.optionIds != null) {
                         throw ApiErrorException.BadRequestException(
                             "Invalid payload: fieldId=${field.fieldId} (${field.fieldType}) must not include optionIds"
+                        )
+                    }
+                    if (field.maxSelections != null) {
+                        throw ApiErrorException.BadRequestException(
+                            "Invalid payload: fieldId=${field.fieldId} (${field.fieldType}) must not include maxSelections"
                         )
                     }
                 }
@@ -144,6 +168,14 @@ object SurveyDefinitionValidator {
                     if (invalidIds.isNotEmpty()) {
                         throw ApiErrorException.BadRequestException(
                             "Invalid payload: selectedOptionIds=$invalidIds are not valid for fieldId=${answer.fieldId}"
+                        )
+                    }
+                    if (
+                        field.maxSelections != null &&
+                        value.selectedOptionIds.size > field.maxSelections
+                    ) {
+                        throw ApiErrorException.BadRequestException(
+                            "Invalid payload: selectedOptionIds exceeds maxSelections=${field.maxSelections} for fieldId=${answer.fieldId}"
                         )
                     }
                 }

--- a/apps/lumi-api/src/test/kotlin/no/nav/lumi/domain/DefinitionHashTest.kt
+++ b/apps/lumi-api/src/test/kotlin/no/nav/lumi/domain/DefinitionHashTest.kt
@@ -54,6 +54,33 @@ class DefinitionHashTest : FunSpec({
         definition.computeHash() shouldBe "38202779b74caab0a97c5d0bcc1556660322ce19a700d665b02712a90af3fc9c"
     }
 
+    test("computeHash preserves the old bytes when maxSelections is absent and locks a supplied limit") {
+        val withoutLimit = SurveyDefinition(
+            surveyId = "survey-priority",
+            surveyType = SurveyType.TASK_PRIORITY,
+            fields = listOf(
+                FieldDefinition("priority", FieldType.MULTI_CHOICE, null, null, listOf("a", "b"))
+            )
+        )
+        val withLimit = withoutLimit.copy(
+            fields = listOf(
+                FieldDefinition("priority", FieldType.MULTI_CHOICE, null, null, listOf("a", "b"), 1)
+            )
+        )
+
+        withoutLimit.computeHash() shouldBe
+            SurveyDefinition(
+                surveyId = "another-id",
+                surveyType = SurveyType.TASK_PRIORITY,
+                fields = listOf(
+                    FieldDefinition("priority", FieldType.MULTI_CHOICE, null, null, listOf("a", "b"))
+                )
+            ).computeHash()
+        (withoutLimit.computeHash() == withLimit.computeHash()) shouldBe false
+        diff(withoutLimit, withLimit).changedFields.single().change shouldContain
+            "maxSelections null -> 1"
+    }
+
     test("computeHash treats structural option order as significant") {
         val first = submission(
             surveyId = "survey-choice",

--- a/apps/lumi-api/src/test/kotlin/no/nav/lumi/domain/SurveyTypeTest.kt
+++ b/apps/lumi-api/src/test/kotlin/no/nav/lumi/domain/SurveyTypeTest.kt
@@ -1,0 +1,27 @@
+package no.nav.lumi.domain
+
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+class SurveyTypeTest : FunSpec({
+    test("parses every public wire name and stored enum name") {
+        val expected = mapOf(
+            "rating" to SurveyType.RATING,
+            "topTasks" to SurveyType.TOP_TASKS,
+            "discovery" to SurveyType.DISCOVERY,
+            "taskPriority" to SurveyType.TASK_PRIORITY,
+            "custom" to SurveyType.CUSTOM,
+            "RATING" to SurveyType.RATING,
+            "TOP_TASKS" to SurveyType.TOP_TASKS,
+            "DISCOVERY" to SurveyType.DISCOVERY,
+            "TASK_PRIORITY" to SurveyType.TASK_PRIORITY,
+            "CUSTOM" to SurveyType.CUSTOM,
+        )
+
+        expected.forEach { (wireName, surveyType) ->
+            SurveyType.fromWireName(wireName) shouldBe surveyType
+        }
+        SurveyType.fromWireName("top-tasks") shouldBe null
+        SurveyType.fromWireName(null) shouldBe null
+    }
+})

--- a/apps/lumi-api/src/test/kotlin/no/nav/lumi/repository/FeedbackRepositoryTest.kt
+++ b/apps/lumi-api/src/test/kotlin/no/nav/lumi/repository/FeedbackRepositoryTest.kt
@@ -408,7 +408,7 @@ class FeedbackRepositoryTest : FunSpec({
             )
 
             val (content, _, _) = repository.findPaginated(
-                FeedbackQuery(team = "team-test", task = "Soknad")
+                FeedbackQuery(team = "team-test", task = "opt-1")
             )
 
             content shouldHaveSize 1
@@ -1384,7 +1384,7 @@ class FeedbackRepositoryTest : FunSpec({
                         val result = repository.findContextTagsForSurvey(
                                 surveyId = surveyId,
                                 team = "team-test",
-                                task = "Soknad",
+                                task = "opt-2",
                                 segments = listOf("k" to "v"),
                                 deviceType = "mobile",
                                 hasText = true,

--- a/apps/lumi-api/src/test/kotlin/no/nav/lumi/repository/FeedbackTopTasksProcessorTest.kt
+++ b/apps/lumi-api/src/test/kotlin/no/nav/lumi/repository/FeedbackTopTasksProcessorTest.kt
@@ -1,0 +1,144 @@
+package no.nav.lumi.repository
+
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.collections.shouldHaveSize
+import io.kotest.matchers.shouldBe
+import no.nav.lumi.domain.Answer
+import no.nav.lumi.domain.AnswerValue
+import no.nav.lumi.domain.ChoiceOption
+import no.nav.lumi.domain.FeedbackDto
+import no.nav.lumi.domain.FieldType
+import no.nav.lumi.domain.Question
+import no.nav.lumi.domain.SurveyType
+
+class FeedbackTopTasksProcessorTest : FunSpec({
+    test("reads the canonical task, success and blocker fields") {
+        val taskOptions = listOf(ChoiceOption("apply", "Søke"))
+        val successOptions = listOf(
+            ChoiceOption("yes", "Ja"),
+            ChoiceOption("partial", "Delvis"),
+            ChoiceOption("no", "Nei")
+        )
+        val feedback = FeedbackDto(
+            id = "feedback-1",
+            submittedAt = "2026-08-20T12:00:00Z",
+            app = "test-app",
+            surveyId = "top-tasks-test",
+            surveyType = SurveyType.TOP_TASKS,
+            answers = listOf(
+                Answer(
+                    fieldId = "task",
+                    fieldType = FieldType.SINGLE_CHOICE,
+                    question = Question("Hva prøvde du å gjøre?", options = taskOptions),
+                    value = AnswerValue.SingleChoice("apply")
+                ),
+                Answer(
+                    fieldId = "success",
+                    fieldType = FieldType.SINGLE_CHOICE,
+                    question = Question("Klarte du det?", options = successOptions),
+                    value = AnswerValue.SingleChoice("partial")
+                ),
+                Answer(
+                    fieldId = "blocker",
+                    fieldType = FieldType.TEXT,
+                    question = Question("Hva hindret deg?"),
+                    value = AnswerValue.Text("Fant ikke skjemaet")
+                )
+            )
+        )
+
+        val result = processTopTasks(listOf(feedback))
+
+        result.totalSubmissions shouldBe 1
+        result.tasks.shouldHaveSize(1)
+        result.tasks.single().task shouldBe "Søke"
+        result.tasks.single().taskId shouldBe "apply"
+        result.tasks.single().partialCount shouldBe 1
+        result.tasks.single().blockerCounts shouldBe mapOf("Fant ikke skjemaet" to 1)
+    }
+
+    test("groups by stable task id when the displayed label changes") {
+        fun feedback(id: String, submittedAt: String, label: String) = FeedbackDto(
+            id = id,
+            submittedAt = submittedAt,
+            app = "test-app",
+            surveyId = "top-tasks-test",
+            surveyType = SurveyType.TOP_TASKS,
+            answers = listOf(
+                Answer(
+                    fieldId = "task",
+                    fieldType = FieldType.SINGLE_CHOICE,
+                    question = Question("Hva prøvde du å gjøre?", options = listOf(ChoiceOption("apply", label))),
+                    value = AnswerValue.SingleChoice("apply")
+                ),
+                Answer(
+                    fieldId = "success",
+                    fieldType = FieldType.SINGLE_CHOICE,
+                    question = Question(
+                        "Klarte du det?",
+                        options = listOf(
+                            ChoiceOption("yes", "Ja"),
+                            ChoiceOption("partial", "Delvis"),
+                            ChoiceOption("no", "Nei")
+                        )
+                    ),
+                    value = AnswerValue.SingleChoice("yes")
+                )
+            )
+        )
+
+        val result = processTopTasks(
+            listOf(
+                feedback("first", "2026-08-19T12:00:00Z", "Søke"),
+                feedback("second", "2026-08-20T12:00:00Z", "Sende søknad"),
+            )
+        )
+
+        result.tasks.shouldHaveSize(1)
+        result.tasks.single().taskId shouldBe "apply"
+        result.tasks.single().task shouldBe "Sende søknad"
+        result.tasks.single().totalCount shouldBe 2
+    }
+
+    test("ignores the discovery-only legacy task alias in Top Tasks") {
+        val successOptions = listOf(
+            ChoiceOption("yes", "Ja"),
+            ChoiceOption("partial", "Delvis"),
+            ChoiceOption("no", "Nei")
+        )
+        val feedback = FeedbackDto(
+            id = "feedback-alias",
+            submittedAt = "2026-08-20T12:00:00Z",
+            app = "test-app",
+            surveyId = "top-tasks-test",
+            surveyType = SurveyType.TOP_TASKS,
+            answers = listOf(
+                Answer(
+                    fieldId = "discoveredTask",
+                    fieldType = FieldType.TEXT,
+                    question = Question("Ekstra discovery-felt"),
+                    value = AnswerValue.Text("Feil oppgave")
+                ),
+                Answer(
+                    fieldId = "task",
+                    fieldType = FieldType.SINGLE_CHOICE,
+                    question = Question(
+                        "Hva prøvde du å gjøre?",
+                        options = listOf(ChoiceOption("apply", "Søke"))
+                    ),
+                    value = AnswerValue.SingleChoice("apply")
+                ),
+                Answer(
+                    fieldId = "success",
+                    fieldType = FieldType.SINGLE_CHOICE,
+                    question = Question("Klarte du det?", options = successOptions),
+                    value = AnswerValue.SingleChoice("yes")
+                )
+            )
+        )
+
+        val result = processTopTasks(listOf(feedback))
+        result.tasks.single().taskId shouldBe "apply"
+        result.tasks.single().task shouldBe "Søke"
+    }
+})

--- a/apps/lumi-api/src/test/kotlin/no/nav/lumi/routes/BlockerRoutesTest.kt
+++ b/apps/lumi-api/src/test/kotlin/no/nav/lumi/routes/BlockerRoutesTest.kt
@@ -60,7 +60,7 @@ class BlockerRoutesTest : FunSpec({
                   "value": {"type": "singleChoice", "selectedOptionId": "$selectedTaskId"}
                 },
                 {
-                  "fieldId": "taskSuccess",
+                  "fieldId": "success",
                   "fieldType": "SINGLE_CHOICE",
                   "question": {
                     "label": "Klarte du det?",

--- a/apps/lumi-api/src/test/kotlin/no/nav/lumi/routes/BlockersRoutesTest.kt
+++ b/apps/lumi-api/src/test/kotlin/no/nav/lumi/routes/BlockersRoutesTest.kt
@@ -129,7 +129,7 @@ class BlockersRoutesTest : FunSpec({
             stats.recentBlockers.first().task shouldBe "Endre"
 
             // Task filter
-            val filteredResponse = createTestClient().get("/api/v1/intern/stats/blockers?team=$team&app=$app&surveyId=$surveyId&task=Søk") {
+            val filteredResponse = createTestClient().get("/api/v1/intern/stats/blockers?team=$team&app=$app&surveyId=$surveyId&task=a") {
                 header(HttpHeaders.Authorization, "Bearer test-token")
             }
 

--- a/apps/lumi-api/src/test/kotlin/no/nav/lumi/routes/InternalSubmissionRoutesTest.kt
+++ b/apps/lumi-api/src/test/kotlin/no/nav/lumi/routes/InternalSubmissionRoutesTest.kt
@@ -210,7 +210,7 @@ class InternalSubmissionRoutesTest : FunSpec({
                     {
                       "schemaVersion": 1,
                       "surveyId": "internal-immutable",
-                      "surveyType": "topTasks",
+                      "surveyType": "custom",
                       "submittedAt": "2026-01-10T12:00:12Z",
                       "answers": [
                         {
@@ -239,7 +239,7 @@ class InternalSubmissionRoutesTest : FunSpec({
                     {
                       "schemaVersion": 1,
                       "surveyId": "internal-immutable",
-                      "surveyType": "topTasks",
+                      "surveyType": "custom",
                       "submittedAt": "2026-01-10T12:01:12Z",
                       "answers": [
                         {
@@ -664,7 +664,7 @@ class InternalSubmissionRoutesTest : FunSpec({
                             {
                               "schemaVersion": 1,
                               "surveyId": "modia-dedup-race-conflict-survey",
-                              "surveyType": "topTasks",
+                              "surveyType": "custom",
                               "submittedAt": "2026-01-10T12:00:12Z",
                               "deduplicationKey": "client-key-123456",
                               "answers": [
@@ -694,7 +694,7 @@ class InternalSubmissionRoutesTest : FunSpec({
                             {
                               "schemaVersion": 1,
                               "surveyId": "modia-dedup-race-conflict-survey",
-                              "surveyType": "topTasks",
+                              "surveyType": "custom",
                               "submittedAt": "2026-01-10T12:01:12Z",
                               "deduplicationKey": "client-key-123456",
                               "answers": [

--- a/apps/lumi-api/src/test/kotlin/no/nav/lumi/routes/SubmissionRoutesTest.kt
+++ b/apps/lumi-api/src/test/kotlin/no/nav/lumi/routes/SubmissionRoutesTest.kt
@@ -151,7 +151,7 @@ class SubmissionRoutesTest : FunSpec({
                     {
                       "schemaVersion": 1,
                       "surveyId": "immutable-survey",
-                      "surveyType": "topTasks",
+                      "surveyType": "custom",
                       "submittedAt": "2026-01-10T12:00:12Z",
                       "answers": [
                         {
@@ -178,7 +178,7 @@ class SubmissionRoutesTest : FunSpec({
                     {
                       "schemaVersion": 1,
                       "surveyId": "immutable-survey",
-                      "surveyType": "topTasks",
+                      "surveyType": "custom",
                       "submittedAt": "2026-01-10T12:01:12Z",
                       "answers": [
                         {
@@ -218,7 +218,7 @@ class SubmissionRoutesTest : FunSpec({
                     {
                       "schemaVersion": 1,
                       "surveyId": "label-survey",
-                      "surveyType": "topTasks",
+                      "surveyType": "custom",
                       "submittedAt": "2026-01-10T12:00:12Z",
                       "answers": [
                         {
@@ -245,7 +245,7 @@ class SubmissionRoutesTest : FunSpec({
                     {
                       "schemaVersion": 1,
                       "surveyId": "label-survey",
-                      "surveyType": "topTasks",
+                      "surveyType": "custom",
                       "submittedAt": "2026-01-10T12:01:12Z",
                       "answers": [
                         {
@@ -1028,7 +1028,7 @@ class SubmissionRoutesTest : FunSpec({
                 {
                   "schemaVersion": 1,
                   "surveyId": "dp-feedback",
-                  "surveyType": "topTasks",
+                  "surveyType": "custom",
                   "submittedAt": "2026-01-10T12:00:12Z",
                   "answers": [
                     {
@@ -1101,7 +1101,7 @@ class SubmissionRoutesTest : FunSpec({
                 {
                   "schemaVersion": 1,
                   "surveyId": "dp-feedback",
-                  "surveyType": "topTasks",
+                  "surveyType": "custom",
                   "submittedAt": "2026-01-10T12:00:12Z",
                   "answers": [
                     {
@@ -1140,7 +1140,7 @@ class SubmissionRoutesTest : FunSpec({
                 {
                   "schemaVersion": 1,
                   "surveyId": "dp-feedback",
-                  "surveyType": "topTasks",
+                  "surveyType": "custom",
                   "submittedAt": "2026-01-10T12:00:12Z",
                   "answers": [
                     {
@@ -1173,11 +1173,11 @@ class SubmissionRoutesTest : FunSpec({
                 {
                   "schemaVersion": 1,
                   "surveyId": "dp-feedback",
-                  "surveyType": "taskPriority",
+                  "surveyType": "custom",
                   "submittedAt": "2026-01-10T12:00:12Z",
                   "answers": [
                     {
-                      "fieldId": "priorities",
+                      "fieldId": "choices",
                       "fieldType": "MULTI_CHOICE",
                       "question": { "label": "Hva er viktigst?" },
                       "value": { "type": "multiChoice", "selectedOptionIds": ["ok", " "] }
@@ -1207,11 +1207,11 @@ class SubmissionRoutesTest : FunSpec({
                 {
                   "schemaVersion": 1,
                   "surveyId": "dp-feedback",
-                  "surveyType": "taskPriority",
+                  "surveyType": "custom",
                   "submittedAt": "2026-01-10T12:00:12Z",
                   "answers": [
                     {
-                      "fieldId": "priorities",
+                      "fieldId": "choices",
                       "fieldType": "MULTI_CHOICE",
                       "question": { "label": "Hva er viktigst?" },
                       "value": { "type": "multiChoice", "selectedOptionIds": ["ok", "$tooLongSelectedId"] }
@@ -1288,7 +1288,7 @@ class SubmissionRoutesTest : FunSpec({
                     {
                       "schemaVersion": 1,
                       "surveyId": "dedup-conflict-survey",
-                      "surveyType": "topTasks",
+                      "surveyType": "custom",
                       "submittedAt": "2026-01-10T12:00:12Z",
                       "deduplicationKey": "client-key-123456",
                       "answers": [
@@ -1319,7 +1319,7 @@ class SubmissionRoutesTest : FunSpec({
                     {
                       "schemaVersion": 1,
                       "surveyId": "dedup-conflict-survey",
-                      "surveyType": "topTasks",
+                      "surveyType": "custom",
                       "submittedAt": "2026-01-10T12:01:12Z",
                       "deduplicationKey": "client-key-123456",
                       "answers": [
@@ -1367,7 +1367,7 @@ class SubmissionRoutesTest : FunSpec({
                     {
                       "schemaVersion": 1,
                       "surveyId": "dedup-new-key-conflict-survey",
-                      "surveyType": "topTasks",
+                      "surveyType": "custom",
                       "submittedAt": "2026-01-10T12:00:12Z",
                       "deduplicationKey": "client-key-123456",
                       "answers": [
@@ -1393,7 +1393,7 @@ class SubmissionRoutesTest : FunSpec({
                     {
                       "schemaVersion": 1,
                       "surveyId": "dedup-new-key-conflict-survey",
-                      "surveyType": "topTasks",
+                      "surveyType": "custom",
                       "submittedAt": "2026-01-10T12:01:12Z",
                       "deduplicationKey": "client-key-654321",
                       "answers": [
@@ -1740,7 +1740,7 @@ class SubmissionRoutesTest : FunSpec({
                             {
                               "schemaVersion": 1,
                               "surveyId": "dedup-race-conflict-survey",
-                              "surveyType": "topTasks",
+                              "surveyType": "custom",
                               "submittedAt": "2026-01-10T12:00:12Z",
                               "deduplicationKey": "client-key-123456",
                               "answers": [
@@ -1768,7 +1768,7 @@ class SubmissionRoutesTest : FunSpec({
                             {
                               "schemaVersion": 1,
                               "surveyId": "dedup-race-conflict-survey",
-                              "surveyType": "topTasks",
+                              "surveyType": "custom",
                               "submittedAt": "2026-01-10T12:01:12Z",
                               "deduplicationKey": "client-key-123456",
                               "answers": [

--- a/apps/lumi-api/src/test/kotlin/no/nav/lumi/routes/SubmissionV2RoutesTest.kt
+++ b/apps/lumi-api/src/test/kotlin/no/nav/lumi/routes/SubmissionV2RoutesTest.kt
@@ -87,6 +87,58 @@ private fun submissionPayloadV2Raw(
     }
 """.trimIndent()
 
+private fun topTasksPayloadV2(successFieldId: String = "success") = """
+    {
+      "schemaVersion": 2,
+      "surveyId": "top-tasks-contract",
+      "surveyType": "topTasks",
+      "submittedAt": "2026-01-10T12:00:12Z",
+      "deduplicationKey": "top-tasks-contract-key",
+      "definition": {
+        "surveyType": "topTasks",
+        "fields": [
+          {
+            "fieldId": "task",
+            "fieldType": "SINGLE_CHOICE",
+            "optionIds": ["apply", "status"]
+          },
+          {
+            "fieldId": "$successFieldId",
+            "fieldType": "SINGLE_CHOICE",
+            "optionIds": ["yes", "partial", "no"]
+          }
+        ]
+      },
+      "answers": [
+        {
+          "fieldId": "task",
+          "fieldType": "SINGLE_CHOICE",
+          "question": {
+            "label": "Hva prøvde du å gjøre?",
+            "options": [
+              {"id": "apply", "label": "Søke"},
+              {"id": "status", "label": "Sjekke status"}
+            ]
+          },
+          "value": {"type": "singleChoice", "selectedOptionId": "apply"}
+        },
+        {
+          "fieldId": "$successFieldId",
+          "fieldType": "SINGLE_CHOICE",
+          "question": {
+            "label": "Klarte du det?",
+            "options": [
+              {"id": "yes", "label": "Ja"},
+              {"id": "partial", "label": "Delvis"},
+              {"id": "no", "label": "Nei"}
+            ]
+          },
+          "value": {"type": "singleChoice", "selectedOptionId": "yes"}
+        }
+      ]
+    }
+""".trimIndent()
+
 private fun repeatedTextFieldsJson(count: Int): String =
     (1..count).joinToString(prefix = "[", postfix = "]") { index ->
         """
@@ -165,6 +217,46 @@ class SubmissionV2RoutesTest : FunSpec({
                             it.fields.map { field -> field.fieldId } == listOf("feedback")
                     }
                 )
+            }
+        }
+    }
+
+    test("v2 accepts the canonical specialized survey contract") {
+        val submissionService = mockk<SubmissionService>()
+        coEvery {
+            submissionService.submit(any(), any(), any(), any(), any())
+        } returns SubmissionOutcome(SaveResult.Created("created-specialized"), "hash-specialized")
+
+        testApplication {
+            application { submissionRoutesTestModule(submissionService) }
+            val response = createTestClient().post("/api/tokenx/v1/feedback") {
+                contentType(ContentType.Application.Json)
+                setBody(topTasksPayloadV2())
+            }
+
+            response.status shouldBe HttpStatusCode.Created
+            coVerify(exactly = 1) {
+                submissionService.submit(any(), any(), any(), any(), any())
+            }
+        }
+    }
+
+    test("v2 accepts the success field emitted by deprecated Top Tasks builders") {
+        val submissionService = mockk<SubmissionService>()
+        coEvery {
+            submissionService.submit(any(), any(), any(), any(), any())
+        } returns SubmissionOutcome(SaveResult.Created("created-legacy"), "hash-legacy")
+
+        testApplication {
+            application { submissionRoutesTestModule(submissionService) }
+            val response = createTestClient().post("/api/tokenx/v1/feedback") {
+                contentType(ContentType.Application.Json)
+                setBody(topTasksPayloadV2(successFieldId = "taskSuccess"))
+            }
+
+            response.status shouldBe HttpStatusCode.Created
+            coVerify(exactly = 1) {
+                submissionService.submit(any(), any(), any(), any(), any())
             }
         }
     }
@@ -674,6 +766,53 @@ class SubmissionV2RoutesTest : FunSpec({
             coVerify(exactly = 1) {
                 submissionService.submit(any(), any(), any(), any(), any())
             }
+        }
+    }
+
+    test("v2 rejects more multi choice answers than maxSelections") {
+        val submissionService = mockk<SubmissionService>()
+
+        testApplication {
+            application { submissionRoutesTestModule(submissionService) }
+            val client = createTestClient()
+
+            val response = client.post("/api/tokenx/v1/feedback") {
+                contentType(ContentType.Application.Json)
+                setBody(
+                    submissionPayloadV2Raw(
+                        definitionFieldsJson = """
+                        [
+                          {
+                            "fieldId": "category",
+                            "fieldType": "MULTI_CHOICE",
+                            "optionIds": ["bug", "feature"],
+                            "maxSelections": 1
+                          }
+                        ]
+                        """.trimIndent(),
+                        answersJson = """
+                        [
+                          {
+                            "fieldId": "category",
+                            "fieldType": "MULTI_CHOICE",
+                            "question": {
+                              "label": "Kategori?",
+                              "options": [
+                                { "id": "bug", "label": "Bug" },
+                                { "id": "feature", "label": "Feature" }
+                              ]
+                            },
+                            "value": { "type": "multiChoice", "selectedOptionIds": ["bug", "feature"] }
+                          }
+                        ]
+                        """.trimIndent()
+                    )
+                )
+            }
+
+            response.status shouldBe HttpStatusCode.BadRequest
+            response.bodyAsText() shouldContain "exceeds maxSelections=1"
+            coVerify(exactly = 0) { submissionService.submit(any(), any(), any(), any(), any()) }
         }
     }
 

--- a/apps/lumi-api/src/test/kotlin/no/nav/lumi/routes/SurveyAuthoringRoutesTest.kt
+++ b/apps/lumi-api/src/test/kotlin/no/nav/lumi/routes/SurveyAuthoringRoutesTest.kt
@@ -518,6 +518,31 @@ class SurveyAuthoringRoutesTest : FunSpec({
         }
     }
 
+    test("specialized analytics contracts may be drafted but never frozen invalid") {
+        testApplication {
+            application { testModule() }
+            val client = createTestClient()
+            val created = client.post("/api/v1/intern/authoring/projects?team=team-test") {
+                header(HttpHeaders.Authorization, "Bearer test-token")
+                contentType(ContentType.Application.Json)
+                setBody(invalidTopTasksBody())
+            }
+            created.status shouldBe HttpStatusCode.Created
+            val projectId = Json.parseToJsonElement(created.bodyAsText()).jsonObject
+                .getValue("id").jsonPrimitive.content
+
+            val response = client.post(
+                "/api/v1/intern/authoring/projects/$projectId/revisions?team=team-test",
+            ) {
+                header(HttpHeaders.Authorization, "Bearer test-token")
+                contentType(ContentType.Application.Json)
+                setBody("""{"expectedDraftVersion":1}""")
+            }
+            response.status shouldBe HttpStatusCode.BadRequest
+            response.bodyAsText() shouldContain "document field 'task' must be required"
+        }
+    }
+
     test("revision links are team scoped") {
         testApplication {
             application { testModule() }
@@ -562,6 +587,40 @@ private fun createBody() = """
             "prompt": "Hvordan gikk det?",
             "required": true
           }]
+        }]
+      }
+    }
+""".trimIndent()
+
+private fun invalidTopTasksBody() = """
+    {
+      "name": "Oppgaver",
+      "surveyId": "top-tasks-test",
+      "document": {
+        "authoringSchemaVersion": 1,
+        "type": "topTasks",
+        "pages": [{
+          "id": "oppgaver",
+          "questions": [
+            {
+              "id": "task",
+              "type": "singleChoice",
+              "prompt": "Hva skulle du gjøre?",
+              "required": false,
+              "options": [{"value": "apply", "label": "Søke"}]
+            },
+            {
+              "id": "success",
+              "type": "singleChoice",
+              "prompt": "Fikk du gjort det?",
+              "required": true,
+              "options": [
+                {"value": "yes", "label": "Ja"},
+                {"value": "partial", "label": "Delvis"},
+                {"value": "no", "label": "Nei"}
+              ]
+            }
+          ]
         }]
       }
     }

--- a/apps/lumi-api/src/test/kotlin/no/nav/lumi/routes/TaskPriorityRoutesTest.kt
+++ b/apps/lumi-api/src/test/kotlin/no/nav/lumi/routes/TaskPriorityRoutesTest.kt
@@ -27,6 +27,7 @@ class TaskPriorityRoutesTest : FunSpec({
     fun taskPriorityJson(
         surveyId: String,
         selectedTaskIds: List<String>,
+        primaryTaskLabel: String = "Sjekke utbetalinger",
     ): String {
         val selectedIdsArray = selectedTaskIds.joinToString { "\"$it\"" }
 
@@ -43,7 +44,7 @@ class TaskPriorityRoutesTest : FunSpec({
                   "question": {
                     "label": "Hva er de viktigste tingene du trenger å gjøre på nav.no?",
                     "options": [
-                      {"id": "sjekke-utbetaling", "label": "Sjekke utbetalinger"},
+                      {"id": "sjekke-utbetaling", "label": "$primaryTaskLabel"},
                       {"id": "sok-dagpenger", "label": "Søke dagpenger"},
                       {"id": "melde-sykefravaer", "label": "Melde sykefravær"},
                       {"id": "sjekke-status", "label": "Sjekke søknadsstatus"},
@@ -147,6 +148,54 @@ class TaskPriorityRoutesTest : FunSpec({
             // sjekke-status should have 1 vote
             val thirdTask = stats.tasks.first { it.task == "Sjekke søknadsstatus" }
             thirdTask.votes shouldBe 1
+        }
+    }
+
+    test("GET /api/v1/intern/stats/task-priority returns the stable id and newest label") {
+        testApplication {
+            application { testModule() }
+            val team = "flex"
+            val app = "spinnsyn"
+            val surveyId = "survey-priority-label"
+            val oldTime = OffsetDateTime.parse("2025-10-26T02:30:00+02:00")
+            val newTime = OffsetDateTime.parse("2025-10-26T02:15:00+01:00")
+
+            repeat(4) { index ->
+                insertTestFeedbackWithJson(
+                    team = team,
+                    app = app,
+                    feedbackJson = taskPriorityJson(
+                        surveyId,
+                        listOf("sjekke-utbetaling"),
+                        primaryTaskLabel = "Gammel tekst",
+                    ),
+                    opprettet = oldTime.plusMinutes(index.toLong())
+                )
+            }
+            insertTestFeedbackWithJson(
+                team = team,
+                app = app,
+                feedbackJson = taskPriorityJson(
+                    surveyId,
+                    listOf("sjekke-utbetaling"),
+                    primaryTaskLabel = "Ny tekst",
+                ),
+                opprettet = newTime
+            )
+
+            val response = createTestClient().get(
+                "/api/v1/intern/stats/task-priority?team=$team&app=$app&surveyId=$surveyId"
+            ) {
+                header(HttpHeaders.Authorization, "Bearer test-token")
+            }
+            response.status shouldBe HttpStatusCode.OK
+            val stats = json.decodeFromString<TaskPriorityResponse>(response.bodyAsText())
+            stats.tasks.single() shouldBe no.nav.lumi.domain.TaskVote(
+                taskId = "sjekke-utbetaling",
+                task = "Ny tekst",
+                votes = 5,
+                percentage = 100,
+            )
         }
     }
 

--- a/apps/lumi-api/src/test/kotlin/no/nav/lumi/routes/TopTasksRoutesTest.kt
+++ b/apps/lumi-api/src/test/kotlin/no/nav/lumi/routes/TopTasksRoutesTest.kt
@@ -68,7 +68,7 @@ class TopTasksRoutesTest : FunSpec({
                   "value": {"type": "singleChoice", "selectedOptionId": "$selectedTaskId"}
                 },
                 {
-                  "fieldId": "taskSuccess",
+                  "fieldId": "success",
                   "fieldType": "SINGLE_CHOICE",
                   "question": {
                     "label": "Klarte du det?",
@@ -186,7 +186,7 @@ class TopTasksRoutesTest : FunSpec({
             allStats.tasks.size shouldBe 2
 
             // Filter by specific task
-            val filteredResponse = createTestClient().get("/api/v1/intern/stats/top-tasks?team=$team&app=$app&surveyId=$surveyId&task=Lage%20oppf%C3%B8lgingsplan") {
+            val filteredResponse = createTestClient().get("/api/v1/intern/stats/top-tasks?team=$team&app=$app&surveyId=$surveyId&task=task-a") {
                 header(HttpHeaders.Authorization, "Bearer test-token")
             }
 
@@ -195,6 +195,7 @@ class TopTasksRoutesTest : FunSpec({
 
             filteredStats.tasks.size shouldBe 1
             filteredStats.tasks[0].task shouldBe "Lage oppfølgingsplan"
+            filteredStats.tasks[0].taskId shouldBe "task-a"
             filteredStats.tasks[0].totalCount shouldBe 2
         }
     }
@@ -332,7 +333,7 @@ class TopTasksRoutesTest : FunSpec({
                       },
                       "answers": [
                         {"fieldId": "task", "fieldType": "SINGLE_CHOICE", "question": {"label": "Hva?"}, "value": {"type": "singleChoice", "selectedOptionId": "a"}},
-                        {"fieldId": "taskSuccess", "fieldType": "SINGLE_CHOICE", "question": {"label": "Klarte du det?"}, "value": {"type": "singleChoice", "selectedOptionId": "yes"}}
+                        {"fieldId": "success", "fieldType": "SINGLE_CHOICE", "question": {"label": "Klarte du det?"}, "value": {"type": "singleChoice", "selectedOptionId": "yes"}}
                       ]
                     }
                 """.trimIndent(),
@@ -354,7 +355,7 @@ class TopTasksRoutesTest : FunSpec({
                       },
                       "answers": [
                         {"fieldId": "task", "fieldType": "SINGLE_CHOICE", "question": {"label": "Hva?"}, "value": {"type": "singleChoice", "selectedOptionId": "b"}},
-                        {"fieldId": "taskSuccess", "fieldType": "SINGLE_CHOICE", "question": {"label": "Klarte du det?"}, "value": {"type": "singleChoice", "selectedOptionId": "yes"}}
+                        {"fieldId": "success", "fieldType": "SINGLE_CHOICE", "question": {"label": "Klarte du det?"}, "value": {"type": "singleChoice", "selectedOptionId": "yes"}}
                       ]
                     }
                 """.trimIndent(),

--- a/apps/lumi-api/src/test/kotlin/no/nav/lumi/service/SurveyDefinitionServiceTest.kt
+++ b/apps/lumi-api/src/test/kotlin/no/nav/lumi/service/SurveyDefinitionServiceTest.kt
@@ -223,6 +223,132 @@ class SurveyDefinitionServiceTest : FunSpec({
         result shouldBe RegistrationResult("survey-1", fullHash)
     }
 
+    test("schemaVersion=2 enriches a pre-maxSelections definition once") {
+        val repository = mockk<SurveyDefinitionRepository>()
+        val service = SurveyDefinitionService(repository)
+        val storedDefinition = SurveyDefinition(
+            surveyId = "survey-priority",
+            surveyType = SurveyType.CUSTOM,
+            fields = listOf(
+                FieldDefinition("topics", FieldType.MULTI_CHOICE, null, null, listOf("a", "b"))
+            )
+        )
+        val incomingDefinition = storedDefinition.copy(
+            fields = listOf(
+                FieldDefinition("topics", FieldType.MULTI_CHOICE, null, null, listOf("a", "b"), 1)
+            )
+        )
+        val storedHash = storedDefinition.computeHash()
+        val incomingHash = incomingDefinition.computeHash()
+        val submission = FeedbackSubmissionV1(
+            schemaVersion = 2,
+            surveyId = "survey-priority",
+            surveyType = SurveyType.CUSTOM,
+            submittedAt = "2026-01-10T12:00:12Z",
+            deduplicationKey = "client-key-123456",
+            answers = listOf(
+                Answer(
+                    fieldId = "topics",
+                    fieldType = FieldType.MULTI_CHOICE,
+                    question = Question(
+                        label = "Tema",
+                        options = listOf(ChoiceOption("a", "A"), ChoiceOption("b", "B"))
+                    ),
+                    value = AnswerValue.MultiChoice(listOf("a"))
+                )
+            )
+        )
+
+        coEvery { repository.findByTeamAndSurveyId("team-a", "survey-priority") } returns
+            StoredSurveyDefinition(
+                team = "team-a",
+                surveyId = "survey-priority",
+                definitionHash = storedHash,
+                definition = storedDefinition,
+                source = SurveyDefinitionSource.API,
+            )
+        coEvery {
+            repository.updateApiDefinitionIfHashMatches(
+                "team-a",
+                "survey-priority",
+                storedHash,
+                incomingDefinition,
+                incomingHash,
+            )
+        } returns true
+
+        service.registerOrValidateV2("team-a", submission, incomingDefinition) shouldBe
+            RegistrationResult("survey-priority", incomingHash)
+        coVerify(exactly = 1) {
+            repository.updateApiDefinitionIfHashMatches(
+                "team-a",
+                "survey-priority",
+                storedHash,
+                incomingDefinition,
+                incomingHash,
+            )
+        }
+    }
+
+    test("api takeover can enrich maxSelections and add a field atomically") {
+        val repository = mockk<SurveyDefinitionRepository>()
+        val service = SurveyDefinitionService(repository)
+        val storedDefinition = SurveyDefinition(
+            surveyId = "survey-priority-takeover",
+            surveyType = SurveyType.CUSTOM,
+            fields = listOf(
+                FieldDefinition("topics", FieldType.MULTI_CHOICE, null, null, listOf("a", "b"))
+            )
+        )
+        val incomingDefinition = storedDefinition.copy(
+            fields = listOf(
+                FieldDefinition("topics", FieldType.MULTI_CHOICE, null, null, listOf("a", "b"), 1),
+                FieldDefinition("comment", FieldType.TEXT, null, null, null),
+            )
+        )
+        val storedHash = storedDefinition.computeHash()
+        val incomingHash = incomingDefinition.computeHash()
+        val submission = FeedbackSubmissionV1(
+            schemaVersion = 2,
+            surveyId = "survey-priority-takeover",
+            surveyType = SurveyType.CUSTOM,
+            submittedAt = "2026-01-10T12:00:12Z",
+            deduplicationKey = "client-key-123456",
+            answers = listOf(
+                Answer(
+                    fieldId = "topics",
+                    fieldType = FieldType.MULTI_CHOICE,
+                    question = Question(
+                        label = "Tema",
+                        options = listOf(ChoiceOption("a", "A"), ChoiceOption("b", "B"))
+                    ),
+                    value = AnswerValue.MultiChoice(listOf("a"))
+                )
+            )
+        )
+
+        coEvery { repository.findByTeamAndSurveyId("team-a", "survey-priority-takeover") } returns
+            StoredSurveyDefinition(
+                team = "team-a",
+                surveyId = "survey-priority-takeover",
+                definitionHash = storedHash,
+                definition = storedDefinition,
+                source = SurveyDefinitionSource.AUTO,
+            )
+        coEvery {
+            repository.updateApiDefinitionIfHashMatches(
+                "team-a",
+                "survey-priority-takeover",
+                storedHash,
+                incomingDefinition,
+                incomingHash,
+            )
+        } returns true
+
+        service.registerOrValidateV2("team-a", submission, incomingDefinition) shouldBe
+            RegistrationResult("survey-priority-takeover", incomingHash)
+    }
+
     test("v1 answered subset after schemaVersion=2 definition keeps api definition hash") {
         val repository = mockk<SurveyDefinitionRepository>()
         val service = SurveyDefinitionService(repository)

--- a/apps/lumi-api/src/test/kotlin/no/nav/lumi/validation/SpecializedSurveyContractValidatorTest.kt
+++ b/apps/lumi-api/src/test/kotlin/no/nav/lumi/validation/SpecializedSurveyContractValidatorTest.kt
@@ -1,0 +1,239 @@
+package no.nav.lumi.validation
+
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import no.nav.lumi.config.exception.ApiErrorException
+import no.nav.lumi.domain.Answer
+import no.nav.lumi.domain.AnswerValue
+import no.nav.lumi.domain.ChoiceOption
+import no.nav.lumi.domain.FieldType
+import no.nav.lumi.domain.Question
+import no.nav.lumi.domain.SubmissionFieldDefinitionPayload
+import no.nav.lumi.domain.SurveyType
+
+class SpecializedSurveyContractValidatorTest : FunSpec({
+    val outcomeOptions = listOf(
+        ChoiceOption("yes", "Ja"),
+        ChoiceOption("partial", "Delvis"),
+        ChoiceOption("no", "Nei")
+    )
+
+    fun textAnswer(id: String) = Answer(
+        fieldId = id,
+        fieldType = FieldType.TEXT,
+        question = Question("Oppgave"),
+        value = AnswerValue.Text("Søke")
+    )
+
+    fun choiceAnswer(id: String, options: List<ChoiceOption> = outcomeOptions) = Answer(
+        fieldId = id,
+        fieldType = FieldType.SINGLE_CHOICE,
+        question = Question("Valg", options = options),
+        value = AnswerValue.SingleChoice(options.first().id)
+    )
+
+    fun multiChoiceAnswer(id: String) = Answer(
+        fieldId = id,
+        fieldType = FieldType.MULTI_CHOICE,
+        question = Question(
+            "Prioriter",
+            options = listOf(ChoiceOption("apply", "Søke"))
+        ),
+        value = AnswerValue.MultiChoice(listOf("apply"))
+    )
+
+    test("accepts the canonical contracts for every specialized survey type") {
+        SpecializedSurveyContractValidator.validateAnswers(
+            SurveyType.DISCOVERY,
+            listOf(textAnswer("task"), choiceAnswer("success"))
+        )
+        SpecializedSurveyContractValidator.validateAnswers(
+            SurveyType.TOP_TASKS,
+            listOf(choiceAnswer("task", listOf(ChoiceOption("apply", "Søke"))), choiceAnswer("success"))
+        )
+        SpecializedSurveyContractValidator.validateAnswers(
+            SurveyType.TASK_PRIORITY,
+            listOf(multiChoiceAnswer("priority")),
+            definitionValidated = true,
+        )
+    }
+
+    test("accepts the field IDs emitted by deprecated 2.0.1 builders") {
+        SpecializedSurveyContractValidator.validateAnswers(
+            SurveyType.DISCOVERY,
+            listOf(textAnswer("discoveredTask"), choiceAnswer("taskSuccess"))
+        )
+        SpecializedSurveyContractValidator.validateAnswers(
+            SurveyType.TOP_TASKS,
+            listOf(choiceAnswer("task", listOf(ChoiceOption("apply", "Søke"))), choiceAnswer("taskSuccess"))
+        )
+        SpecializedSurveyContractValidator.validateAnswers(
+            SurveyType.TASK_PRIORITY,
+            listOf(multiChoiceAnswer("priorities"))
+        )
+    }
+
+    test("canonical task priority answers require a schema v2 definition") {
+        val error = shouldThrow<ApiErrorException.BadRequestException> {
+            SpecializedSurveyContractValidator.validateAnswers(
+                SurveyType.TASK_PRIORITY,
+                listOf(multiChoiceAnswer("priority"))
+            )
+        }
+        error.message shouldBe
+            "Invalid taskPriority survey contract: canonical field 'priority' requires schemaVersion 2 with a validated definition"
+    }
+
+    test("rejects a specialized definition with the wrong field type") {
+        val error = shouldThrow<ApiErrorException.BadRequestException> {
+            SpecializedSurveyContractValidator.validateDefinition(
+                SurveyType.DISCOVERY,
+                listOf(
+                    SubmissionFieldDefinitionPayload("task", FieldType.SINGLE_CHOICE),
+                    SubmissionFieldDefinitionPayload(
+                        "success",
+                        FieldType.SINGLE_CHOICE,
+                        optionIds = listOf("yes", "partial", "no")
+                    )
+                )
+            )
+        }
+
+        error.message shouldBe
+            "Invalid discovery survey contract: definition.fields field 'task' must be TEXT"
+    }
+
+    test("canonical task priority definitions require two options and maxSelections") {
+        val missingMax = shouldThrow<ApiErrorException.BadRequestException> {
+            SpecializedSurveyContractValidator.validateDefinition(
+                SurveyType.TASK_PRIORITY,
+                listOf(
+                    SubmissionFieldDefinitionPayload(
+                        "priority",
+                        FieldType.MULTI_CHOICE,
+                        optionIds = listOf("apply", "status")
+                    )
+                )
+            )
+        }
+        missingMax.message shouldBe
+            "Invalid taskPriority survey contract: definition.fields field 'priority' maxSelections must be between 1 and the number of task options"
+
+        val oneOption = shouldThrow<ApiErrorException.BadRequestException> {
+            SpecializedSurveyContractValidator.validateDefinition(
+                SurveyType.TASK_PRIORITY,
+                listOf(
+                    SubmissionFieldDefinitionPayload(
+                        "priority",
+                        FieldType.MULTI_CHOICE,
+                        optionIds = listOf("apply"),
+                        maxSelections = 1,
+                    )
+                )
+            )
+        }
+        oneOption.message shouldBe
+            "Invalid taskPriority survey contract: definition.fields field 'priority' must have at least two task options"
+
+        SpecializedSurveyContractValidator.validateDefinition(
+            SurveyType.TASK_PRIORITY,
+            listOf(
+                SubmissionFieldDefinitionPayload(
+                    "priorities",
+                    FieldType.MULTI_CHOICE,
+                    optionIds = listOf("apply")
+                )
+            )
+        )
+    }
+
+    test("rejects canonical and legacy aliases in the same submission") {
+        val error = shouldThrow<ApiErrorException.BadRequestException> {
+            SpecializedSurveyContractValidator.validateAnswers(
+                SurveyType.DISCOVERY,
+                listOf(
+                    textAnswer("task"),
+                    textAnswer("discoveredTask"),
+                    choiceAnswer("success")
+                )
+            )
+        }
+        error.message shouldBe
+            "Invalid discovery survey contract: answers must not include both 'task' and legacy alias 'discoveredTask'"
+    }
+
+    test("rejects success fields that analytics cannot classify") {
+        val error = shouldThrow<ApiErrorException.BadRequestException> {
+            SpecializedSurveyContractValidator.validateAnswers(
+                SurveyType.TOP_TASKS,
+                listOf(
+                    choiceAnswer("task", listOf(ChoiceOption("apply", "Søke"))),
+                    choiceAnswer("success", listOf(ChoiceOption("done", "Ferdig")))
+                )
+            )
+        }
+
+        error.message shouldBe
+            "Invalid topTasks survey contract: answers field 'success' must have exactly options yes, partial and no"
+    }
+
+    test("rejects extra success outcomes and a blocker with the wrong type") {
+        val extraOutcomeError = shouldThrow<ApiErrorException.BadRequestException> {
+            SpecializedSurveyContractValidator.validateAnswers(
+                SurveyType.TOP_TASKS,
+                listOf(
+                    choiceAnswer("task", listOf(ChoiceOption("apply", "Søke"))),
+                    choiceAnswer(
+                        "success",
+                        outcomeOptions + ChoiceOption("unknown", "Vet ikke")
+                    )
+                )
+            )
+        }
+        extraOutcomeError.message shouldBe
+            "Invalid topTasks survey contract: answers field 'success' must have exactly options yes, partial and no"
+
+        val blockerTypeError = shouldThrow<ApiErrorException.BadRequestException> {
+            SpecializedSurveyContractValidator.validateAnswers(
+                SurveyType.DISCOVERY,
+                listOf(
+                    textAnswer("task"),
+                    choiceAnswer("success"),
+                    choiceAnswer("blocker")
+                )
+            )
+        }
+        blockerTypeError.message shouldBe
+            "Invalid discovery survey contract: answers field 'blocker' must be TEXT"
+    }
+
+    test("rejects an answer value that does not match its declared field") {
+        val invalidSuccess = Answer(
+            fieldId = "success",
+            fieldType = FieldType.SINGLE_CHOICE,
+            question = Question("Fikk du gjort det?", options = outcomeOptions),
+            value = AnswerValue.Text("yes")
+        )
+
+        val error = shouldThrow<ApiErrorException.BadRequestException> {
+            SpecializedSurveyContractValidator.validateAnswers(
+                SurveyType.DISCOVERY,
+                listOf(textAnswer("task"), invalidSuccess)
+            )
+        }
+        error.message shouldBe
+            "Invalid discovery survey contract: answers field 'success' value must match SINGLE_CHOICE"
+    }
+
+    test("does not impose specialized fields on rating or custom surveys") {
+        SpecializedSurveyContractValidator.validateAnswers(
+            SurveyType.RATING,
+            listOf(textAnswer("anything"))
+        )
+        SpecializedSurveyContractValidator.validateDefinition(
+            SurveyType.CUSTOM,
+            listOf(SubmissionFieldDefinitionPayload("anything", FieldType.TEXT))
+        )
+    }
+})

--- a/apps/lumi-api/src/test/kotlin/no/nav/lumi/validation/SurveyAuthoringDocumentValidatorTest.kt
+++ b/apps/lumi-api/src/test/kotlin/no/nav/lumi/validation/SurveyAuthoringDocumentValidatorTest.kt
@@ -312,7 +312,126 @@ class SurveyAuthoringDocumentValidatorTest : FunSpec({
             SurveyAuthoringDocumentValidator.validate(nonStringTitle, "survey-v1")
         }.errorMessage shouldBe "Document intro needs a string title"
     }
+
+    test("release gate enforces the specialized analytics contract") {
+        val valid = specializedTopTasksDocument()
+        SurveyAuthoringDocumentValidator.validate(valid, "top-tasks", releaseGate = true)
+
+        val cases = listOf(
+            valid.toString().replace("\"required\":true", "\"required\":false") to
+                "Invalid topTasks survey contract: document field 'task' must be required",
+            valid.toString().replace("\"id\":\"task\"", "\"id\":\"old-task\"") to
+                "Invalid topTasks survey contract: document must include 'task'",
+            valid.toString().replace(
+                "\"id\":\"success\",\"type\":\"singleChoice\"",
+                "\"id\":\"success\",\"type\":\"multiChoice\"",
+            ) to "Invalid topTasks survey contract: document field 'success' must be SINGLE_CHOICE",
+            valid.toString().replace(
+                "\"required\":true,\"options\":[{\"value\":\"yes\"",
+                "\"required\":true,\"visibleIf\":{\"questionId\":\"task\",\"operator\":\"EXISTS\"}," +
+                    "\"options\":[{\"value\":\"yes\"",
+            ) to "Invalid topTasks survey contract: document field 'success' must always be visible",
+        )
+
+        cases.forEach { (json, expectedMessage) ->
+            val document = Json.parseToJsonElement(json).jsonObject
+            SurveyAuthoringDocumentValidator.validate(document, "top-tasks")
+            shouldThrow<ApiErrorException.BadRequestException> {
+                SurveyAuthoringDocumentValidator.validate(document, "top-tasks", releaseGate = true)
+            }.errorMessage shouldBe expectedMessage
+        }
+    }
+
+    test("release gate requires a usable Task Priority selection limit") {
+        val document = Json.parseToJsonElement(
+            """
+            {
+              "authoringSchemaVersion": 1,
+              "type": "taskPriority",
+              "pages": [{
+                "id": "priority",
+                "questions": [{
+                  "id": "priority",
+                  "type": "multiChoice",
+                  "prompt": "Hva er viktigst?",
+                  "required": true,
+                  "maxSelections": 3,
+                  "options": [
+                    {"value": "first", "label": "Første"},
+                    {"value": "second", "label": "Andre"}
+                  ]
+                }]
+              }]
+            }
+            """.trimIndent(),
+        ).jsonObject
+
+        SurveyAuthoringDocumentValidator.validate(document, "priority")
+        shouldThrow<ApiErrorException.BadRequestException> {
+            SurveyAuthoringDocumentValidator.validate(document, "priority", releaseGate = true)
+        }.errorMessage shouldBe
+            "Invalid taskPriority survey contract: document field 'priority' maxSelections must be between 1 and the number of task options"
+    }
+
+    test("release gate rejects unfinished task template options even if their value was edited") {
+        val document = Json.parseToJsonElement(
+            specializedTopTasksDocument().toString()
+                .replace("\"value\":\"apply\"", "\"value\":\"manually-changed\"")
+                .replace("\"label\":\"Søke\"", "\"label\":\"Bytt ut med en oppgave dere vil måle\"")
+        ).jsonObject
+
+        SurveyAuthoringDocumentValidator.validate(document, "top-tasks")
+        shouldThrow<ApiErrorException.BadRequestException> {
+            SurveyAuthoringDocumentValidator.validate(document, "top-tasks", releaseGate = true)
+        }.errorMessage shouldBe
+            "Invalid topTasks survey contract: document field 'task' contains an unfinished example task"
+    }
+
+    test("release gate requires a known Top Tasks option in addition to other") {
+        val document = Json.parseToJsonElement(
+            specializedTopTasksDocument().toString()
+                .replace("\"value\":\"apply\"", "\"value\":\"other\"")
+                .replace("\"label\":\"Søke\"", "\"label\":\"Noe annet\"")
+        ).jsonObject
+
+        shouldThrow<ApiErrorException.BadRequestException> {
+            SurveyAuthoringDocumentValidator.validate(document, "top-tasks", releaseGate = true)
+        }.errorMessage shouldBe
+            "Invalid topTasks survey contract: document field 'task' must include at least one known task"
+    }
 })
+
+private fun specializedTopTasksDocument(): JsonObject = Json.parseToJsonElement(
+    """
+    {
+      "authoringSchemaVersion": 1,
+      "type": "topTasks",
+      "pages": [{
+        "id": "page",
+        "questions": [
+          {
+            "id": "task",
+            "type": "singleChoice",
+            "prompt": "Hva skulle du gjøre?",
+            "required": true,
+            "options": [{"value": "apply", "label": "Søke"}]
+          },
+          {
+            "id": "success",
+            "type": "singleChoice",
+            "prompt": "Fikk du gjort det?",
+            "required": true,
+            "options": [
+              {"value": "yes", "label": "Ja"},
+              {"value": "partial", "label": "Delvis"},
+              {"value": "no", "label": "Nei"}
+            ]
+          }
+        ]
+      }]
+    }
+    """.trimIndent(),
+).jsonObject
 
 private fun conditionDocument(referencedType: String, condition: String): JsonObject {
     val referenced = when (referencedType) {

--- a/apps/lumi-dashboard/app/components/dashboard/views/TaskPriority/index.tsx
+++ b/apps/lumi-dashboard/app/components/dashboard/views/TaskPriority/index.tsx
@@ -82,7 +82,7 @@ export function TaskPriorityAnalysis({ data }: TaskPriorityAnalysisProps) {
               const isTopTask = index < longNeckCutoff;
 
               return (
-                <div key={task.task}>
+                <div key={task.taskId}>
                   <HStack justify="space-between" align="baseline" wrap={false}>
                     <BodyShort
                       size="small"

--- a/apps/lumi-dashboard/app/components/dashboard/views/TopTasks/Overview.tsx
+++ b/apps/lumi-dashboard/app/components/dashboard/views/TopTasks/Overview.tsx
@@ -54,9 +54,9 @@ export function TopTasksOverview() {
   // Task filter from URL (global filter, shown in ActiveFiltersChips)
   const selectedTask = params.task ?? null;
 
-  const handleTaskSelect = (taskName: string | null) => {
+  const handleTaskSelect = (taskId: string | null) => {
     setParams({
-      task: taskName ?? undefined,
+      task: taskId ?? undefined,
       page: "1",
     });
   };
@@ -73,7 +73,7 @@ export function TopTasksOverview() {
 
   // Filter tasks if a quadrant point is selected
   const displayTasks = selectedTask
-    ? sortedTasks.filter((t) => t.task === selectedTask)
+    ? sortedTasks.filter((t) => t.taskId === selectedTask)
     : sortedTasks;
 
   return (
@@ -152,7 +152,7 @@ export function TopTasksOverview() {
 
                 return (
                   <Table.ExpandableRow
-                    key={task.task}
+                    key={task.taskId}
                     togglePlacement="right"
                     expansionDisabled={!hasBlockers}
                     content={

--- a/apps/lumi-dashboard/app/components/export/TopTasksExport.tsx
+++ b/apps/lumi-dashboard/app/components/export/TopTasksExport.tsx
@@ -29,6 +29,7 @@ export function escapeCsvCell(value: string): string {
 export function TopTasksExport({ data, surveyId }: TopTasksExportProps) {
   const exportCsv = () => {
     const headers = [
+      "Oppgave-ID",
       "Oppgave",
       "Antall svar",
       "Suksessrate",
@@ -40,6 +41,7 @@ export function TopTasksExport({ data, surveyId }: TopTasksExportProps) {
     ];
 
     const rows = data.tasks.map((task) => [
+      task.taskId,
       task.task,
       task.totalCount.toString(),
       task.formattedSuccessRate,
@@ -72,6 +74,7 @@ export function TopTasksExport({ data, surveyId }: TopTasksExportProps) {
         avgCompletionTimeMs: data.avgCompletionTimeMs,
       },
       tasks: data.tasks.map((task) => ({
+        taskId: task.taskId,
         task: task.task,
         totalCount: task.totalCount,
         successRate: task.successRate,

--- a/apps/lumi-dashboard/app/components/shared/ActiveFiltersChips/index.tsx
+++ b/apps/lumi-dashboard/app/components/shared/ActiveFiltersChips/index.tsx
@@ -7,6 +7,7 @@ import { useSearchParams } from "~/hooks/useSearchParams";
 import { useSegmentFilter } from "~/hooks/useSegmentFilter";
 import { useStats } from "~/hooks/useStats";
 import { useThemes } from "~/hooks/useThemes";
+import type { ChoiceStats } from "~/types/api";
 import { getFilterLabels } from "~/utils/filterLabels";
 import { formatMetadataLabel } from "~/utils/segmentUtils";
 import styles from "./ActiveFiltersChips.module.css";
@@ -39,6 +40,11 @@ export function ActiveFiltersChips() {
   });
 
   const chips: FilterChip[] = [];
+  const taskField = statsQuery.data?.fieldStats?.find(
+    (field) => field.fieldId === "task",
+  );
+  const taskLabel = (taskField?.stats as ChoiceStats | undefined)
+    ?.distribution?.[params.task ?? ""]?.label;
 
   if (params.deviceType && params.deviceType !== "alle") {
     chips.push({
@@ -57,7 +63,7 @@ export function ActiveFiltersChips() {
     chips.push({
       key: "task",
       label: "Oppgave",
-      value: params.task,
+      value: taskLabel ?? (statsQuery.data ? params.task : "…"),
       onRemove: () =>
         setParams({
           task: undefined,

--- a/apps/lumi-dashboard/app/components/shared/Charts/TaskQuadrantChart.tsx
+++ b/apps/lumi-dashboard/app/components/shared/Charts/TaskQuadrantChart.tsx
@@ -52,6 +52,7 @@ const VOLUME_THRESHOLD = 50; // Tasks with >= 50 responses are "high volume"
 const SUCCESS_THRESHOLD = 70; // Tasks with < 70% success need attention
 
 interface TaskDataPoint {
+  id: string;
   name: string;
   volume: number;
   successRate: number;
@@ -106,8 +107,8 @@ function getZoneTextClass(zone: TaskDataPoint["zone"]): string {
 
 interface TaskQuadrantChartProps {
   /** Callback when a task point is clicked */
-  onTaskSelect?: (taskName: string | null) => void;
-  /** Currently selected task name */
+  onTaskSelect?: (taskId: string | null) => void;
+  /** Currently selected stable task id */
   selectedTask?: string | null;
 }
 
@@ -132,6 +133,7 @@ export function TaskQuadrantChart({
 
   // Transform tasks to scatter data
   const data: TaskDataPoint[] = stats.tasks.map((task) => ({
+    id: task.taskId,
     name: task.task,
     volume: task.totalCount,
     successRate: Math.round(task.successRate * 100),
@@ -147,7 +149,7 @@ export function TaskQuadrantChart({
   const handleClick = (data: TaskDataPoint) => {
     if (onTaskSelect) {
       // Toggle selection: if clicking the same task, deselect
-      onTaskSelect(data.name === selectedTask ? null : data.name);
+      onTaskSelect(data.id === selectedTask ? null : data.id);
     }
   };
 
@@ -156,7 +158,7 @@ export function TaskQuadrantChart({
       return null;
     }
 
-    const isSelected = payload.name === selectedTask;
+    const isSelected = payload.id === selectedTask;
     const fill = getZoneColor(payload.zone, colors);
     const pointSize = typeof size === "number" ? size : 100;
     const radius = Math.max(4, Math.sqrt(pointSize / Math.PI));

--- a/apps/lumi-dashboard/app/components/surveyverksted/OptionsEditor.tsx
+++ b/apps/lumi-dashboard/app/components/surveyverksted/OptionsEditor.tsx
@@ -20,9 +20,13 @@ export interface OptionsEditorProps {
   options: readonly { value: string; label: string }[];
   onAdd: () => void;
   onUpdateLabel: (index: number, label: string) => void;
+  onCommitLabel: (index: number, label: string) => void;
   onUpdateValue: (index: number, value: string) => void;
   onRemove: (index: number) => void;
   onMove: (index: number, direction: MoveDirection) => void;
+  lockValues?: boolean;
+  lockStructure?: boolean;
+  minOptions?: number;
 }
 
 /**
@@ -35,9 +39,13 @@ export function OptionsEditor({
   options,
   onAdd,
   onUpdateLabel,
+  onCommitLabel,
   onUpdateValue,
   onRemove,
   onMove,
+  lockValues = false,
+  lockStructure = false,
+  minOptions = 1,
 }: OptionsEditorProps) {
   const rowRefs = useRef<(HTMLInputElement | null)[]>([]);
   const previousCount = useRef(options.length);
@@ -76,16 +84,18 @@ export function OptionsEditor({
               value={option.label}
               className={styles.optionField}
               onChange={(event) => onUpdateLabel(index, event.target.value)}
+              onBlur={() => onCommitLabel(index, option.label)}
               onKeyDown={(event) => {
                 if (event.key === "Enter") {
                   event.preventDefault();
-                  if (index === options.length - 1) onAdd();
+                  if (index === options.length - 1 && !lockStructure) onAdd();
                   else rowRefs.current[index + 1]?.focus();
                 }
                 if (
                   event.key === "Backspace" &&
                   option.label === "" &&
-                  options.length > 1
+                  options.length > minOptions &&
+                  !lockStructure
                 ) {
                   event.preventDefault();
                   onRemove(index);
@@ -93,15 +103,17 @@ export function OptionsEditor({
                 }
               }}
             />
-            <OptionValue
-              index={index}
-              value={option.value}
-              duplicate={
-                options.filter((other) => other.value === option.value).length >
-                1
-              }
-              onCommit={(value) => onUpdateValue(index, value)}
-            />
+            {lockValues ? null : (
+              <OptionValue
+                index={index}
+                value={option.value}
+                duplicate={
+                  options.filter((other) => other.value === option.value)
+                    .length > 1
+                }
+                onCommit={(value) => onUpdateValue(index, value)}
+              />
+            )}
             <div className={styles.optionRowActions}>
               <Tooltip content="Flytt opp">
                 <Button
@@ -132,7 +144,7 @@ export function OptionsEditor({
                   size="xsmall"
                   icon={<XMarkIcon aria-hidden />}
                   aria-label={`Fjern alternativ ${index + 1}`}
-                  disabled={options.length <= 1}
+                  disabled={options.length <= minOptions || lockStructure}
                   onClick={() => onRemove(index)}
                 />
               </Tooltip>
@@ -140,15 +152,22 @@ export function OptionsEditor({
           </li>
         ))}
       </ol>
-      <Button
-        type="button"
-        variant="tertiary"
-        size="small"
-        icon={<PlusIcon aria-hidden />}
-        onClick={onAdd}
-      >
-        Legg til alternativ
-      </Button>
+      {lockStructure ? (
+        <Detail>
+          Svarene brukes i analysen. Du kan endre teksten, men ikke legge til
+          eller fjerne svar.
+        </Detail>
+      ) : (
+        <Button
+          type="button"
+          variant="tertiary"
+          size="small"
+          icon={<PlusIcon aria-hidden />}
+          onClick={onAdd}
+        >
+          Legg til alternativ
+        </Button>
+      )}
     </div>
   );
 }

--- a/apps/lumi-dashboard/app/components/surveyverksted/PageRail.tsx
+++ b/apps/lumi-dashboard/app/components/surveyverksted/PageRail.tsx
@@ -18,6 +18,7 @@ import styles from "./verksted.module.css";
 export interface PageRailProps {
   pages: readonly SurveyPageV1[];
   selectedPageId: string;
+  protectedPageIds?: ReadonlySet<string>;
   onSelect: (pageId: string) => void;
   onAdd: () => void;
   onMove: (pageId: string, direction: MoveDirection) => void;
@@ -29,6 +30,7 @@ export interface PageRailProps {
 export const PageRail = memo(function PageRail({
   pages,
   selectedPageId,
+  protectedPageIds = new Set(),
   onSelect,
   onAdd,
   onMove,
@@ -65,6 +67,7 @@ export const PageRail = memo(function PageRail({
               index={index}
               totalPages={pages.length}
               selected={page.id === selectedPageId}
+              protectedFromDeletion={protectedPageIds.has(page.id)}
               onSelect={onSelect}
               onMove={onMove}
               onDuplicate={onDuplicate}
@@ -82,6 +85,7 @@ const RailItem = memo(function RailItem({
   index,
   totalPages,
   selected,
+  protectedFromDeletion,
   onSelect,
   onMove,
   onDuplicate,
@@ -91,6 +95,7 @@ const RailItem = memo(function RailItem({
   index: number;
   totalPages: number;
   selected: boolean;
+  protectedFromDeletion: boolean;
   onSelect: (pageId: string) => void;
   onMove: (pageId: string, direction: MoveDirection) => void;
   onDuplicate: (pageId: string) => void;
@@ -181,11 +186,13 @@ const RailItem = memo(function RailItem({
           <ActionMenu.Divider />
           <ActionMenu.Item
             variant="danger"
-            disabled={totalPages === 1}
+            disabled={totalPages === 1 || protectedFromDeletion}
             onSelect={() => onDelete(page.id)}
             icon={<TrashIcon aria-hidden />}
           >
-            Slett side
+            {protectedFromDeletion
+              ? "Kan ikke slettes – brukes i analysen"
+              : "Slett side"}
           </ActionMenu.Item>
         </ActionMenu.Content>
       </ActionMenu>

--- a/apps/lumi-dashboard/app/components/surveyverksted/QuestionCanvas.tsx
+++ b/apps/lumi-dashboard/app/components/surveyverksted/QuestionCanvas.tsx
@@ -5,6 +5,7 @@ import type {
   SurveyPageV1,
   SurveyQuestionV1,
 } from "@navikt/lumi-survey";
+import { SPECIALIZED_SURVEY_FIELD_IDS } from "@navikt/lumi-survey";
 import { Fragment, memo, useCallback, useMemo } from "react";
 import type {
   ConditionValueSuggestion,
@@ -12,6 +13,10 @@ import type {
   QuestionTypeId,
   ReferenceableQuestion,
   VisibleIfConditionV1,
+} from "~/utils/surveyDocument";
+import {
+  isRequiredSpecializedQuestion,
+  isSpecializedQuestionContractValid,
 } from "~/utils/surveyDocument";
 import type { OptionsEditorProps } from "./OptionsEditor";
 import { PageGroupHeader } from "./PageGroupHeader";
@@ -34,6 +39,7 @@ export interface QuestionCanvasProps {
   page: SurveyPageV1;
   pageNumber: number;
   totalPages: number;
+  surveyType: SurveyDocumentV1["type"];
   expandedIds: ReadonlySet<string>;
   focusQuestionId: string | null;
   undo: CanvasUndo | null;
@@ -71,6 +77,7 @@ export const QuestionCanvas = memo(function QuestionCanvas({
   page,
   pageNumber,
   totalPages,
+  surveyType,
   expandedIds,
   focusQuestionId,
   undo,
@@ -161,7 +168,20 @@ export const QuestionCanvas = memo(function QuestionCanvas({
                 index={index}
                 expanded={expandedIds.has(question.id)}
                 focusOnMount={focusQuestionId === question.id}
-                canDelete={page.questions.length > 1}
+                canDelete={
+                  page.questions.length > 1 &&
+                  !isRequiredSpecializedQuestion(surveyType, question.id)
+                }
+                contractLocked={isSpecializedQuestionContractValid(
+                  surveyType,
+                  question,
+                )}
+                minOptions={
+                  surveyType === "taskPriority" &&
+                  question.id === SPECIALIZED_SURVEY_FIELD_IDS.priority
+                    ? 2
+                    : 1
+                }
                 canMoveUp={index > 0}
                 canMoveDown={index < page.questions.length - 1}
                 onExpand={onExpand}
@@ -228,6 +248,8 @@ const CanvasQuestion = memo(function CanvasQuestion({
   expanded,
   focusOnMount,
   canDelete,
+  contractLocked,
+  minOptions,
   canMoveUp,
   canMoveDown,
   onExpand,
@@ -247,6 +269,8 @@ const CanvasQuestion = memo(function CanvasQuestion({
   expanded: boolean;
   focusOnMount: boolean;
   canDelete: boolean;
+  contractLocked: boolean;
+  minOptions: number;
   canMoveUp: boolean;
   canMoveDown: boolean;
   onExpand: (questionId: string) => void;
@@ -322,6 +346,8 @@ const CanvasQuestion = memo(function CanvasQuestion({
         expanded={expanded}
         focusOnMount={focusOnMount}
         canDelete={canDelete}
+        contractLocked={contractLocked}
+        minOptions={minOptions}
         canMoveUp={canMoveUp}
         canMoveDown={canMoveDown}
         onExpand={handleExpand}

--- a/apps/lumi-dashboard/app/components/surveyverksted/QuestionCard.tsx
+++ b/apps/lumi-dashboard/app/components/surveyverksted/QuestionCard.tsx
@@ -18,10 +18,14 @@ import {
   Tooltip,
   VStack,
 } from "@navikt/ds-react";
-import type { SurveyQuestionV1 } from "@navikt/lumi-survey";
+import {
+  SPECIALIZED_SURVEY_FIELD_IDS,
+  type SurveyQuestionV1,
+} from "@navikt/lumi-survey";
 import { memo, useEffect, useRef } from "react";
 import {
   type ConditionValueSuggestion,
+  isSurveyTemplatePlaceholderValue,
   type MoveDirection,
   type QuestionTypeId,
   type ReferenceableQuestion,
@@ -48,6 +52,8 @@ export interface QuestionCardProps {
   canDelete: boolean;
   canMoveUp: boolean;
   canMoveDown: boolean;
+  contractLocked?: boolean;
+  minOptions?: number;
   onExpand: () => void;
   onCollapse: () => void;
   onChange: (updater: (question: SurveyQuestionV1) => SurveyQuestionV1) => void;
@@ -69,6 +75,8 @@ export const QuestionCard = memo(function QuestionCard({
   canDelete,
   canMoveUp,
   canMoveDown,
+  contractLocked = false,
+  minOptions = 1,
   onExpand,
   onCollapse,
   onChange,
@@ -164,24 +172,38 @@ export const QuestionCard = memo(function QuestionCard({
     >
       <div className={styles.cardHeader}>
         <span className={styles.cardNumber}>{index + 1}</span>
-        <TypeGallery
-          label="Bytt spørsmålstype"
-          currentType={question.type}
-          onSelect={onChangeType}
-          trigger={
-            <Button
-              type="button"
-              variant="tertiary-neutral"
-              size="small"
-              icon={<meta.Icon aria-hidden />}
-              iconPosition="left"
-              className={styles.cardTypeButton}
-            >
+        {contractLocked ? (
+          <HStack
+            as="span"
+            gap="space-4"
+            align="center"
+            className={styles.cardTypeButton}
+          >
+            <meta.Icon aria-hidden />
+            <BodyShort as="span" size="small">
               {meta.label}
-              <ChevronDownIcon aria-hidden className={styles.cardTypeCaret} />
-            </Button>
-          }
-        />
+            </BodyShort>
+          </HStack>
+        ) : (
+          <TypeGallery
+            label="Bytt spørsmålstype"
+            currentType={question.type}
+            onSelect={onChangeType}
+            trigger={
+              <Button
+                type="button"
+                variant="tertiary-neutral"
+                size="small"
+                icon={<meta.Icon aria-hidden />}
+                iconPosition="left"
+                className={styles.cardTypeButton}
+              >
+                {meta.label}
+                <ChevronDownIcon aria-hidden className={styles.cardTypeCaret} />
+              </Button>
+            }
+          />
+        )}
         <Tooltip content="Lukk redigering">
           <Button
             type="button"
@@ -199,6 +221,13 @@ export const QuestionCard = memo(function QuestionCard({
       </div>
 
       <VStack gap="space-16" className={styles.cardFields}>
+        {contractLocked ? (
+          <Detail>
+            Dette spørsmålet må være med for at analysen skal virke. Du kan
+            endre teksten, men ikke typen, kravet om svar eller når spørsmålet
+            vises.
+          </Detail>
+        ) : null}
         <TextField
           ref={promptRef}
           label="Spørsmålstekst"
@@ -234,10 +263,66 @@ export const QuestionCard = memo(function QuestionCard({
             questionId={question.id}
             options={question.options}
             {...optionHandlers}
+            lockValues={
+              (contractLocked &&
+                question.id === SPECIALIZED_SURVEY_FIELD_IDS.success) ||
+              question.options.some((option) =>
+                isSurveyTemplatePlaceholderValue(option.value),
+              )
+            }
+            lockStructure={
+              contractLocked &&
+              question.id === SPECIALIZED_SURVEY_FIELD_IDS.success
+            }
+            minOptions={minOptions}
           />
         ) : null}
 
-        {referenceable && suggestionsFor && onChangeVisibleIf ? (
+        {question.type === "multiChoice" ? (
+          <TextField
+            type="number"
+            label="Maks antall alternativer brukeren kan velge"
+            description={
+              contractLocked
+                ? `Velg et tall mellom 1 og ${question.options.length}.`
+                : `Velg et tall mellom 1 og ${question.options.length}, eller la feltet stå tomt uten en grense.`
+            }
+            min={1}
+            max={question.options.length}
+            value={
+              question.maxSelections === undefined
+                ? ""
+                : String(question.maxSelections)
+            }
+            error={
+              question.maxSelections === undefined && contractLocked
+                ? "Velg hvor mange oppgaver brukeren kan krysse av."
+                : question.maxSelections !== undefined &&
+                    question.maxSelections > question.options.length
+                  ? `Tallet kan ikke være høyere enn ${question.options.length}.`
+                  : undefined
+            }
+            onChange={(event) => {
+              const value = Number(event.target.value);
+              onChange((current) =>
+                current.type === "multiChoice"
+                  ? {
+                      ...current,
+                      maxSelections:
+                        Number.isInteger(value) && value > 0
+                          ? value
+                          : undefined,
+                    }
+                  : current,
+              );
+            }}
+          />
+        ) : null}
+
+        {!contractLocked &&
+        referenceable &&
+        suggestionsFor &&
+        onChangeVisibleIf ? (
           <ConditionEditor
             condition={question.visibleIf}
             referenceable={referenceable}
@@ -251,6 +336,7 @@ export const QuestionCard = memo(function QuestionCard({
         <Switch
           size="small"
           checked={question.required ?? false}
+          disabled={contractLocked}
           onChange={(event) =>
             onChange((current) => ({
               ...current,
@@ -293,7 +379,13 @@ export const QuestionCard = memo(function QuestionCard({
               onClick={onDuplicate}
             />
           </Tooltip>
-          <Tooltip content="Slett spørsmålet">
+          <Tooltip
+            content={
+              contractLocked
+                ? "Spørsmålet brukes i analysen og kan ikke slettes"
+                : "Slett spørsmålet"
+            }
+          >
             <Button
               type="button"
               variant="tertiary-neutral"

--- a/apps/lumi-dashboard/app/components/surveyverksted/__tests__/OptionsEditor.test.tsx
+++ b/apps/lumi-dashboard/app/components/surveyverksted/__tests__/OptionsEditor.test.tsx
@@ -15,6 +15,7 @@ function renderEditor(
   const handlers = {
     onAdd: vi.fn(),
     onUpdateLabel: vi.fn(),
+    onCommitLabel: vi.fn(),
     onUpdateValue: vi.fn(),
     onRemove: vi.fn(),
     onMove: vi.fn(),
@@ -25,6 +26,7 @@ function renderEditor(
       options={options}
       onAdd={handlers.onAdd}
       onUpdateLabel={handlers.onUpdateLabel}
+      onCommitLabel={handlers.onCommitLabel}
       onUpdateValue={handlers.onUpdateValue}
       onRemove={handlers.onRemove}
       onMove={handlers.onMove}
@@ -61,12 +63,48 @@ describe("OptionsEditor", () => {
     expect(handlers.onRemove).toHaveBeenCalledWith(2);
   });
 
+  it("keeps the required minimum for a task-priority list", async () => {
+    const handlers = renderEditor({ minOptions: 2 });
+    expect(
+      screen.getByRole("button", { name: /fjern alternativ 1/i }),
+    ).toBeDisabled();
+    const second = screen.getByDisplayValue("Sjekke status");
+    await userEvent.clear(second);
+    await userEvent.keyboard("{Backspace}");
+    expect(handlers.onRemove).not.toHaveBeenCalled();
+  });
+
   it("reports label edits without touching the value", async () => {
     const handlers = renderEditor();
     const first = screen.getByDisplayValue("Søke");
     await userEvent.type(first, "r");
     expect(handlers.onUpdateLabel).toHaveBeenCalledWith(0, "Søker");
     expect(handlers.onUpdateValue).not.toHaveBeenCalled();
+  });
+
+  it("commits a label on blur so templates can replace their placeholder id", async () => {
+    const handlers = renderEditor();
+    const first = screen.getByDisplayValue("Søke");
+    await userEvent.click(first);
+    await userEvent.tab();
+    expect(handlers.onCommitLabel).toHaveBeenCalledWith(0, "Søke");
+  });
+
+  it("keeps analytics answer identities and structure fixed", async () => {
+    const handlers = renderEditor({ lockValues: true, lockStructure: true });
+    expect(
+      screen.queryByRole("button", { name: /endre verdi/i }),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: /legg til alternativ/i }),
+    ).not.toBeInTheDocument();
+    expect(screen.getByText(/svarene brukes i analysen/i)).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: /fjern alternativ 1/i }),
+    ).toBeDisabled();
+    await userEvent.click(screen.getByDisplayValue("Sjekke status"));
+    await userEvent.keyboard("{Enter}");
+    expect(handlers.onAdd).not.toHaveBeenCalled();
   });
 
   it("commits value edits to the draft on every keystroke", async () => {
@@ -80,6 +118,7 @@ describe("OptionsEditor", () => {
           options={current}
           onAdd={() => {}}
           onUpdateLabel={() => {}}
+          onCommitLabel={() => {}}
           onUpdateValue={(index, value) =>
             setCurrent((previous) =>
               previous.map((option, candidate) =>

--- a/apps/lumi-dashboard/app/components/surveyverksted/__tests__/PageRail.test.tsx
+++ b/apps/lumi-dashboard/app/components/surveyverksted/__tests__/PageRail.test.tsx
@@ -1,5 +1,6 @@
 import type { SurveyPageV1 } from "@navikt/lumi-survey";
 import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import { describe, expect, it } from "vitest";
 import { PageRail } from "~/components/surveyverksted/PageRail";
 
@@ -21,11 +22,15 @@ function makePage(over: Partial<SurveyPageV1> = {}): SurveyPageV1 {
   };
 }
 
-function renderRail(pages: SurveyPageV1[]) {
+function renderRail(
+  pages: SurveyPageV1[],
+  protectedPageIds?: ReadonlySet<string>,
+) {
   return render(
     <PageRail
       pages={pages}
       selectedPageId={pages[0].id}
+      protectedPageIds={protectedPageIds}
       onSelect={noop}
       onAdd={noop}
       onMove={noop}
@@ -63,5 +68,19 @@ describe("PageRail", () => {
     ]);
 
     expect(screen.getByRole("button", { name: /Side 1/ })).toBeInTheDocument();
+  });
+
+  it("explains why a page with a fixed analytics field cannot be deleted", async () => {
+    const pages = [makePage(), makePage({ id: "side-b" })];
+    renderRail(pages, new Set(["side-a"]));
+
+    await userEvent.click(
+      screen.getByRole("button", { name: "Handlinger for side 1" }),
+    );
+    expect(
+      screen.getByRole("menuitem", {
+        name: /kan ikke slettes.*brukes i analysen/i,
+      }),
+    ).toHaveAttribute("aria-disabled", "true");
   });
 });

--- a/apps/lumi-dashboard/app/components/surveyverksted/__tests__/QuestionCanvas.test.tsx
+++ b/apps/lumi-dashboard/app/components/surveyverksted/__tests__/QuestionCanvas.test.tsx
@@ -2,7 +2,10 @@ import type { SurveyPageV1 } from "@navikt/lumi-survey";
 import { render, screen } from "@testing-library/react";
 import { describe, expect, it } from "vitest";
 import { QuestionCanvas } from "~/components/surveyverksted/QuestionCanvas";
-import type { ReferenceableQuestion } from "~/utils/surveyDocument";
+import {
+  type ReferenceableQuestion,
+  SURVEY_TEMPLATE_PLACEHOLDER_OPTION_VALUE,
+} from "~/utils/surveyDocument";
 
 const page: SurveyPageV1 = {
   id: "page-1",
@@ -34,6 +37,7 @@ function canvasProps(
     page,
     pageNumber: 1,
     totalPages: 1,
+    surveyType: "custom" as const,
     expandedIds: new Set(["q2"]),
     focusQuestionId: null,
     undo: null,
@@ -57,6 +61,7 @@ function canvasProps(
     optionHandlersFor: () => ({
       onAdd: noop,
       onUpdateLabel: noop,
+      onCommitLabel: noop,
       onUpdateValue: noop,
       onRemove: noop,
       onMove: noop,
@@ -112,5 +117,75 @@ describe("QuestionCanvas condition freshness", () => {
       <QuestionCanvas {...stableProps} referenceableByQuestion={asText} />,
     );
     expect(screen.getByText(/passer ikke spørsmålet/i)).toBeVisible();
+  });
+});
+
+describe("QuestionCanvas specialized contracts", () => {
+  it("locks the fixed analysis field but leaves its wording editable", () => {
+    const taskPage: SurveyPageV1 = {
+      id: "task",
+      questions: [
+        {
+          id: "task",
+          type: "text",
+          prompt: "Hva kom du for å gjøre?",
+          required: true,
+        },
+      ],
+    };
+    render(
+      <QuestionCanvas
+        {...canvasProps(new Map())}
+        page={taskPage}
+        surveyType="discovery"
+        expandedIds={new Set(["task"])}
+      />,
+    );
+
+    expect(screen.getByLabelText("Spørsmålstekst")).toBeEnabled();
+    expect(
+      screen.getByRole("checkbox", { name: "Må besvares" }),
+    ).toBeDisabled();
+    expect(
+      screen.getByRole("button", { name: "Slett spørsmålet" }),
+    ).toBeDisabled();
+    expect(
+      screen.getByText(/må være med for at analysen skal virke/i),
+    ).toBeInTheDocument();
+  });
+
+  it("keeps a template option value hidden until its instruction is replaced", () => {
+    const taskPage: SurveyPageV1 = {
+      id: "task",
+      questions: [
+        {
+          id: "task",
+          type: "singleChoice",
+          prompt: "Hva skulle du gjøre?",
+          required: true,
+          options: [
+            {
+              value: SURVEY_TEMPLATE_PLACEHOLDER_OPTION_VALUE,
+              label: "Bytt ut med en oppgave dere vil måle",
+            },
+          ],
+        },
+      ],
+    };
+    render(
+      <QuestionCanvas
+        {...canvasProps(new Map())}
+        page={taskPage}
+        surveyType="topTasks"
+        expandedIds={new Set(["task"])}
+      />,
+    );
+
+    expect(
+      screen.queryByRole("button", { name: /endre verdi for alternativ 1/i }),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.getByDisplayValue("Bytt ut med en oppgave dere vil måle"),
+    ).toBeEnabled();
   });
 });

--- a/apps/lumi-dashboard/app/mock/generators.ts
+++ b/apps/lumi-dashboard/app/mock/generators.ts
@@ -1,3 +1,4 @@
+import { SPECIALIZED_SURVEY_FIELD_IDS } from "@navikt/lumi-survey";
 import type { Answer, FeedbackDto } from "~/types/api";
 import {
   createContext,
@@ -413,19 +414,25 @@ export function generateTopTasksMockData(): FeedbackDto[] {
         ),
         answers: [
           createSingleChoiceAnswer(
-            "task",
+            SPECIALIZED_SURVEY_FIELD_IDS.task,
             "Hva prøvde du å gjøre?",
             selectedTask.id,
             undefined,
             tasks.map((t) => ({ id: t.id, label: t.label })),
           ),
           createSingleChoiceAnswer(
-            "taskSuccess",
+            SPECIALIZED_SURVEY_FIELD_IDS.success,
             "Klarte du det?",
             successValue,
           ),
           ...(blocker
-            ? [createTextAnswer("blocker", "Hva hindret deg?", blocker)]
+            ? [
+                createTextAnswer(
+                  SPECIALIZED_SURVEY_FIELD_IDS.blocker,
+                  "Hva hindret deg?",
+                  blocker,
+                ),
+              ]
             : []),
         ],
         // Add metadata to match segment data
@@ -668,9 +675,13 @@ export function generateDiscoveryMockData(): FeedbackDto[] {
     ];
 
     const answers = [
-      createTextAnswer("task", "Hva kom du for å gjøre i dag?", response.text),
+      createTextAnswer(
+        SPECIALIZED_SURVEY_FIELD_IDS.task,
+        "Hva kom du for å gjøre i dag?",
+        response.text,
+      ),
       createSingleChoiceAnswer(
-        "success",
+        SPECIALIZED_SURVEY_FIELD_IDS.success,
         "Fikk du gjort det?",
         successValue,
         undefined,
@@ -685,7 +696,7 @@ export function generateDiscoveryMockData(): FeedbackDto[] {
     if (successValue !== "yes" && randomFloat() > 0.3) {
       answers.push(
         createTextAnswer(
-          "blocker",
+          SPECIALIZED_SURVEY_FIELD_IDS.blocker,
           "Hva hindret deg?",
           blockerTexts[Math.floor(randomFloat() * blockerTexts.length)],
         ),
@@ -786,7 +797,7 @@ export function generateTaskPriorityMockData(): FeedbackDto[] {
       ),
       answers: [
         createMultiChoiceAnswer(
-          "priority",
+          SPECIALIZED_SURVEY_FIELD_IDS.priority,
           "Hva er de viktigste tingene du trenger å gjøre på nav.no? (Velg inntil 5)",
           selectedIds,
           undefined,

--- a/apps/lumi-dashboard/app/mock/mockData.test.ts
+++ b/apps/lumi-dashboard/app/mock/mockData.test.ts
@@ -274,19 +274,20 @@ describe("Mock Data Generation", () => {
   });
 
   describe("Task Filter", () => {
-    it("should filter Top Tasks stats by task name", () => {
+    it("should filter Top Tasks stats by stable task id", () => {
       // First get all tasks without filter
       const unfiltered = getMockTopTasksStats(new URLSearchParams());
       expect(unfiltered.tasks.length).toBeGreaterThan(1);
 
       // Pick a task to filter by
-      const targetTask = unfiltered.tasks[0].task;
-      const params = new URLSearchParams({ task: targetTask });
+      const targetTask = unfiltered.tasks[0];
+      const params = new URLSearchParams({ task: targetTask.taskId });
       const filtered = getMockTopTasksStats(params);
 
       // Should only have the filtered task
       expect(filtered.tasks.length).toBe(1);
-      expect(filtered.tasks[0].task).toBe(targetTask);
+      expect(filtered.tasks[0].taskId).toBe(targetTask.taskId);
+      expect(filtered.tasks[0].task).toBe(targetTask.task);
 
       // Total submissions should be reduced
       expect(filtered.totalSubmissions).toBeLessThanOrEqual(
@@ -294,7 +295,7 @@ describe("Mock Data Generation", () => {
       );
     });
 
-    it("should filter Blocker stats by task name", () => {
+    it("should filter Blocker stats by stable task id", () => {
       // First get all blockers without filter
       const unfiltered = getMockBlockerStats(new URLSearchParams());
 
@@ -309,8 +310,12 @@ describe("Mock Data Generation", () => {
       // Get the first task from recent blockers
       const targetTask = unfiltered.recentBlockers[0]?.task;
       if (!targetTask) return;
+      const targetTaskId = getMockTopTasksStats(
+        new URLSearchParams(),
+      ).tasks.find((task) => task.task === targetTask)?.taskId;
+      if (!targetTaskId) return;
 
-      const params = new URLSearchParams({ task: targetTask });
+      const params = new URLSearchParams({ task: targetTaskId });
       const filtered = getMockBlockerStats(params);
 
       // All recent blockers should be for the filtered task

--- a/apps/lumi-dashboard/app/mock/mockData.ts
+++ b/apps/lumi-dashboard/app/mock/mockData.ts
@@ -1,3 +1,4 @@
+import { SPECIALIZED_SURVEY_FIELD_IDS } from "@navikt/lumi-survey";
 import type {
   BlockerResponse,
   DiscoveryResponse,
@@ -772,22 +773,17 @@ export function getMockContextTags(
     });
   }
 
-  // Task filter: filter by specific task name (for Top Tasks drill-down)
+  // Task filter: use the stable option id so label edits keep one history.
   if (task) {
     surveyItems = surveyItems.filter((item) => {
       if (item.surveyType !== "topTasks") return false;
 
-      const taskAnswer = item.answers.find((a) => a.fieldId === "task");
+      const taskAnswer = item.answers.find(
+        (a) => a.fieldId === SPECIALIZED_SURVEY_FIELD_IDS.task,
+      );
       if (!taskAnswer || taskAnswer.fieldType !== "SINGLE_CHOICE") return false;
 
-      const taskOption = taskAnswer.question.options?.find(
-        (o) => o.id === taskAnswer.value.selectedOptionId,
-      );
-      const taskName = taskOption
-        ? taskOption.label
-        : taskAnswer.value.selectedOptionId;
-
-      return taskName === task;
+      return taskAnswer.value.selectedOptionId === task;
     });
   }
 

--- a/apps/lumi-dashboard/app/mock/stats.ts
+++ b/apps/lumi-dashboard/app/mock/stats.ts
@@ -1,3 +1,7 @@
+import {
+  LEGACY_SPECIALIZED_SURVEY_FIELD_IDS,
+  SPECIALIZED_SURVEY_FIELD_IDS,
+} from "@navikt/lumi-survey";
 import dayjs from "dayjs";
 import { mockThemes } from "~/mock/themes";
 import type {
@@ -17,6 +21,16 @@ import { getScreenResolutionBucket } from "~/utils/screenResolution";
 import { getTopKeywords, IGNORED_WORDS } from "~/utils/wordAnalysis";
 import { getRating, hasTextResponse } from "./helpers";
 import { extractPhrases } from "./stats/phrases";
+
+const isDiscoveryTaskField = (fieldId: string) =>
+  fieldId === SPECIALIZED_SURVEY_FIELD_IDS.task ||
+  fieldId === LEGACY_SPECIALIZED_SURVEY_FIELD_IDS.discoveryTask;
+const isSuccessField = (fieldId: string) =>
+  fieldId === SPECIALIZED_SURVEY_FIELD_IDS.success ||
+  fieldId === LEGACY_SPECIALIZED_SURVEY_FIELD_IDS.success;
+const isPriorityField = (fieldId: string) =>
+  fieldId === SPECIALIZED_SURVEY_FIELD_IDS.priority ||
+  fieldId === LEGACY_SPECIALIZED_SURVEY_FIELD_IDS.priority;
 
 // Note: circular dependency if we import mockFeedbackItems here directly while mockData imports stats.
 // To avoid this, we will accept items as arguments in the functions.
@@ -411,7 +425,7 @@ export function calculateStats(
     });
   }
 
-  // Task filter: filter by specific task name (for Top Tasks drill-down)
+  // Task filter: use the stable option id so label edits keep one history.
   const taskFilter = params.get("task");
   if (taskFilter) {
     filtered = filtered.filter((item) => {
@@ -419,18 +433,11 @@ export function calculateStats(
       if (item.surveyType !== "topTasks") return false;
 
       const taskAnswer = item.answers.find(
-        (a) => a.fieldId === "task" || a.fieldId === "category",
+        (a) => a.fieldId === SPECIALIZED_SURVEY_FIELD_IDS.task,
       );
       if (!taskAnswer || taskAnswer.fieldType !== "SINGLE_CHOICE") return false;
 
-      const taskOption = taskAnswer.question.options?.find(
-        (o) => o.id === taskAnswer.value.selectedOptionId,
-      );
-      const taskName = taskOption
-        ? taskOption.label
-        : taskAnswer.value.selectedOptionId;
-
-      return taskName === taskFilter;
+      return taskAnswer.value.selectedOptionId === taskFilter;
     });
   }
 
@@ -713,8 +720,12 @@ export function getMockDiscoveryStats(
   );
 
   const responses = filtered.map((item) => {
-    const taskAnswer = item.answers.find((a) => a.fieldId === "task");
-    const successAnswer = item.answers.find((a) => a.fieldId === "success");
+    const taskAnswer = item.answers.find((answer) =>
+      isDiscoveryTaskField(answer.fieldId),
+    );
+    const successAnswer = item.answers.find((answer) =>
+      isSuccessField(answer.fieldId),
+    );
 
     let task = "Ukjent oppgave";
     if (taskAnswer) {
@@ -915,18 +926,20 @@ export function getMockTaskPriorityStats(
   const voteCounts = new Map<string, number>();
   const taskLabels = new Map<string, string>();
 
-  for (const item of filtered) {
+  for (const item of [...filtered].sort(
+    (left, right) =>
+      new Date(left.submittedAt).getTime() -
+      new Date(right.submittedAt).getTime(),
+  )) {
     const priorityAnswer = item.answers.find(
-      (a) => a.fieldId === "priority" && a.fieldType === "MULTI_CHOICE",
+      (a) => isPriorityField(a.fieldId) && a.fieldType === "MULTI_CHOICE",
     );
 
     if (priorityAnswer && priorityAnswer.fieldType === "MULTI_CHOICE") {
       // Cache labels
       if (priorityAnswer.question.options) {
         for (const opt of priorityAnswer.question.options) {
-          if (!taskLabels.has(opt.id)) {
-            taskLabels.set(opt.id, opt.label);
-          }
+          taskLabels.set(opt.id, opt.label);
         }
       }
 
@@ -939,6 +952,7 @@ export function getMockTaskPriorityStats(
   const tasks = Array.from(voteCounts.entries())
     .map(([taskId, count]) => {
       return {
+        taskId,
         task: taskLabels.get(taskId) || taskId,
         votes: count,
         percentage: 0,
@@ -987,6 +1001,7 @@ interface InternalTaskStats
   totalDurationMs: number;
   durationCount: number;
   blockerTexts: string[]; // Raw blocker texts for theme matching
+  latestSubmittedAt: string;
 }
 
 export function getMockTopTasksStats(
@@ -1002,22 +1017,21 @@ export function getMockTopTasksStats(
     if (item.surveyType !== "topTasks") continue;
 
     const taskAnswer = item.answers.find(
-      (a) => a.fieldId === "task" || a.fieldId === "category",
+      (a) => a.fieldId === SPECIALIZED_SURVEY_FIELD_IDS.task,
     );
     if (!taskAnswer || taskAnswer.fieldType !== "SINGLE_CHOICE") continue;
 
     const taskOption = taskAnswer.question.options?.find(
       (o) => o.id === taskAnswer.value.selectedOptionId,
     );
-    const task = taskOption
-      ? taskOption.label
-      : taskAnswer.value.selectedOptionId;
+    const taskId = taskAnswer.value.selectedOptionId;
+    const task = taskOption ? taskOption.label : taskId;
 
     // Task filter: skip if task doesn't match the filter
-    if (taskFilter && task !== taskFilter) continue;
+    if (taskFilter && taskId !== taskFilter) continue;
 
-    const successAnswer = item.answers.find(
-      (a) => a.fieldId === "taskSuccess" || a.fieldId === "success",
+    const successAnswer = item.answers.find((answer) =>
+      isSuccessField(answer.fieldId),
     );
     const successValue =
       successAnswer?.fieldType === "SINGLE_CHOICE"
@@ -1025,15 +1039,16 @@ export function getMockTopTasksStats(
         : "unknown";
 
     const blockerAnswer = item.answers.find(
-      (a) => a.fieldId === "blocker" || a.fieldId === "hindring",
+      (a) => a.fieldId === SPECIALIZED_SURVEY_FIELD_IDS.blocker,
     );
     const blocker =
       blockerAnswer?.fieldType === "TEXT" && blockerAnswer.value.text
         ? blockerAnswer.value.text
         : null;
 
-    if (!taskMap.has(task)) {
-      taskMap.set(task, {
+    if (!taskMap.has(taskId)) {
+      taskMap.set(taskId, {
+        taskId,
         task,
         totalCount: 0,
         successCount: 0,
@@ -1045,16 +1060,24 @@ export function getMockTopTasksStats(
         totalDurationMs: 0,
         durationCount: 0,
         blockerTexts: [],
+        latestSubmittedAt: item.submittedAt,
       });
     }
 
-    const stats = taskMap.get(task);
+    const stats = taskMap.get(taskId);
     if (stats) {
+      if (
+        new Date(item.submittedAt).getTime() >=
+        new Date(stats.latestSubmittedAt).getTime()
+      ) {
+        stats.task = task;
+        stats.latestSubmittedAt = item.submittedAt;
+      }
       stats.totalCount++;
 
-      if (successValue === "Ja") stats.successCount++;
-      else if (successValue === "Delvis") stats.partialCount++;
-      else if (successValue === "Nei") stats.failureCount++;
+      if (successValue === "yes") stats.successCount++;
+      else if (successValue === "partial") stats.partialCount++;
+      else if (successValue === "no") stats.failureCount++;
 
       if (blocker) {
         stats.blockerCounts[blocker] = (stats.blockerCounts[blocker] || 0) + 1;
@@ -1074,7 +1097,7 @@ export function getMockTopTasksStats(
       dailyStats[date] = { total: 0, success: 0 };
     }
     dailyStats[date].total++;
-    if (successValue === "Ja") {
+    if (successValue === "yes") {
       dailyStats[date].success++;
     }
   }
@@ -1187,7 +1210,13 @@ export function getMockTopTasksStats(
     }
 
     // Remove internal aggregation fields before returning
-    const { totalDurationMs, durationCount: dc, blockerTexts, ...rest } = stats;
+    const {
+      totalDurationMs,
+      durationCount: dc,
+      blockerTexts,
+      latestSubmittedAt,
+      ...rest
+    } = stats;
 
     return {
       ...rest,
@@ -1240,7 +1269,8 @@ export function getMockTopTasksStats(
     dailyStats,
     questionText: filtered
       .find((i) => i.surveyType === "topTasks")
-      ?.answers.find((a) => a.fieldId === "task")?.question.label,
+      ?.answers.find((a) => a.fieldId === SPECIALIZED_SURVEY_FIELD_IDS.task)
+      ?.question.label,
     overallTpi,
     avgCompletionTimeMs,
     otherTasksPercentage,
@@ -1270,8 +1300,12 @@ export function getMockBlockerStats(
   }> = [];
 
   for (const item of filtered) {
-    const blockerAnswer = item.answers.find((a) => a.fieldId === "blocker");
-    const taskAnswer = item.answers.find((a) => a.fieldId === "task");
+    const blockerAnswer = item.answers.find(
+      (a) => a.fieldId === SPECIALIZED_SURVEY_FIELD_IDS.blocker,
+    );
+    const taskAnswer = item.answers.find(
+      (a) => a.fieldId === SPECIALIZED_SURVEY_FIELD_IDS.task,
+    );
 
     if (blockerAnswer?.fieldType === "TEXT" && blockerAnswer.value.text) {
       const taskOption = taskAnswer?.question.options?.find(
@@ -1280,9 +1314,13 @@ export function getMockBlockerStats(
           o.id === taskAnswer.value.selectedOptionId,
       );
       const task = taskOption?.label ?? "Ukjent oppgave";
+      const taskId =
+        taskAnswer?.fieldType === "SINGLE_CHOICE"
+          ? taskAnswer.value.selectedOptionId
+          : undefined;
 
       // Task filter: skip if task doesn't match the filter
-      if (taskFilter && task !== taskFilter) continue;
+      if (taskFilter && taskId !== taskFilter) continue;
 
       blockerResponses.push({
         blocker: blockerAnswer.value.text,

--- a/apps/lumi-dashboard/app/mock/stats/blocker.ts
+++ b/apps/lumi-dashboard/app/mock/stats/blocker.ts
@@ -4,6 +4,7 @@
  * Analyzes blocker text from failed/partial tasks using theme clustering.
  */
 
+import { SPECIALIZED_SURVEY_FIELD_IDS } from "@navikt/lumi-survey";
 import type { BlockerResponse, FeedbackDto } from "~/types/api";
 import { mockThemes } from "../themes";
 import { applyFeedbackFilters, STOP_WORDS, stemNorwegian } from "./common";
@@ -29,8 +30,12 @@ export function getMockBlockerStats(
   }> = [];
 
   for (const item of filtered) {
-    const blockerAnswer = item.answers.find((a) => a.fieldId === "blocker");
-    const taskAnswer = item.answers.find((a) => a.fieldId === "task");
+    const blockerAnswer = item.answers.find(
+      (a) => a.fieldId === SPECIALIZED_SURVEY_FIELD_IDS.blocker,
+    );
+    const taskAnswer = item.answers.find(
+      (a) => a.fieldId === SPECIALIZED_SURVEY_FIELD_IDS.task,
+    );
 
     if (blockerAnswer?.fieldType === "TEXT" && blockerAnswer.value.text) {
       const taskOption = taskAnswer?.question.options?.find(
@@ -39,9 +44,13 @@ export function getMockBlockerStats(
           o.id === taskAnswer.value.selectedOptionId,
       );
       const task = taskOption?.label ?? "Ukjent oppgave";
+      const taskId =
+        taskAnswer?.fieldType === "SINGLE_CHOICE"
+          ? taskAnswer.value.selectedOptionId
+          : undefined;
 
       // Task filter: skip if task doesn't match the filter
-      if (taskFilter && task !== taskFilter) continue;
+      if (taskFilter && taskId !== taskFilter) continue;
 
       blockerResponses.push({
         blocker: blockerAnswer.value.text,

--- a/apps/lumi-dashboard/app/mock/stats/common.ts
+++ b/apps/lumi-dashboard/app/mock/stats/common.ts
@@ -17,6 +17,7 @@ export {
   getBlockerTextFromFeedback,
   getDurationFromFeedback,
   getSuccessStatusFromFeedback,
+  getTaskIdFromFeedback,
   getTaskNameFromFeedback,
   TopTasksFieldIds,
 } from "../utils/extractors";

--- a/apps/lumi-dashboard/app/mock/stats/discovery.ts
+++ b/apps/lumi-dashboard/app/mock/stats/discovery.ts
@@ -6,6 +6,7 @@
 
 import type { DiscoveryResponse, FeedbackDto } from "~/types/api";
 import { mockThemes } from "../themes";
+import { DiscoveryFieldIds } from "../utils/extractors";
 import { applyFeedbackFilters, STOP_WORDS, stemNorwegian } from "./common";
 
 /**
@@ -21,8 +22,16 @@ export function getMockDiscoveryStats(
   );
 
   const responses = filtered.map((item) => {
-    const taskAnswer = item.answers.find((a) => a.fieldId === "task");
-    const successAnswer = item.answers.find((a) => a.fieldId === "success");
+    const taskAnswer = item.answers.find((answer) =>
+      DiscoveryFieldIds.task.includes(
+        answer.fieldId as (typeof DiscoveryFieldIds.task)[number],
+      ),
+    );
+    const successAnswer = item.answers.find((answer) =>
+      DiscoveryFieldIds.success.includes(
+        answer.fieldId as (typeof DiscoveryFieldIds.success)[number],
+      ),
+    );
 
     let task = "Ukjent oppgave";
     if (taskAnswer) {

--- a/apps/lumi-dashboard/app/mock/stats/index.ts
+++ b/apps/lumi-dashboard/app/mock/stats/index.ts
@@ -21,6 +21,7 @@ export {
   getBlockerTextFromFeedback,
   getDurationFromFeedback,
   getSuccessStatusFromFeedback,
+  getTaskIdFromFeedback,
   getTaskNameFromFeedback,
   STOP_WORDS,
   stemNorwegian,

--- a/apps/lumi-dashboard/app/mock/stats/specializedLegacyAliases.test.ts
+++ b/apps/lumi-dashboard/app/mock/stats/specializedLegacyAliases.test.ts
@@ -1,0 +1,157 @@
+import { describe, expect, it } from "vitest";
+import {
+  getMockDiscoveryStats as getMonolithicDiscoveryStats,
+  getMockTaskPriorityStats as getMonolithicTaskPriorityStats,
+  getMockTopTasksStats as getMonolithicTopTasksStats,
+} from "~/mock/stats";
+import { getMockDiscoveryStats } from "~/mock/stats/discovery";
+import { getMockTaskPriorityStats } from "~/mock/stats/taskPriority";
+import { getMockTopTasksStats } from "~/mock/stats/topTasks";
+import type { FeedbackDto } from "~/types/api";
+
+const base = {
+  submittedAt: "2026-08-20T10:00:00Z",
+  app: "test-app",
+  surveyId: "legacy-specialized",
+  sensitiveDataRedacted: false,
+} as const;
+
+describe("legacy specialized field aliases", () => {
+  it("reads Discovery answers emitted by the deprecated builder", () => {
+    const feedback: FeedbackDto = {
+      ...base,
+      id: "legacy-discovery",
+      surveyType: "discovery",
+      answers: [
+        {
+          fieldId: "discoveredTask",
+          fieldType: "TEXT",
+          question: { label: "Hva kom du for å gjøre?" },
+          value: { type: "text", text: "Søke om sykepenger" },
+        },
+        {
+          fieldId: "taskSuccess",
+          fieldType: "SINGLE_CHOICE",
+          question: {
+            label: "Klarte du det?",
+            options: [{ id: "yes", label: "Ja" }],
+          },
+          value: { type: "singleChoice", selectedOptionId: "yes" },
+        },
+      ],
+    };
+
+    for (const getStats of [
+      getMockDiscoveryStats,
+      getMonolithicDiscoveryStats,
+    ]) {
+      expect(
+        getStats([feedback], new URLSearchParams()).recentResponses[0],
+      ).toMatchObject({ task: "Søke om sykepenger", success: "yes" });
+    }
+  });
+
+  it("reads the legacy Top Tasks success field", () => {
+    const feedback: FeedbackDto = {
+      ...base,
+      id: "legacy-top-tasks",
+      surveyType: "topTasks",
+      answers: [
+        {
+          fieldId: "task",
+          fieldType: "SINGLE_CHOICE",
+          question: {
+            label: "Hva skulle du gjøre?",
+            options: [{ id: "apply", label: "Søke" }],
+          },
+          value: { type: "singleChoice", selectedOptionId: "apply" },
+        },
+        {
+          fieldId: "taskSuccess",
+          fieldType: "SINGLE_CHOICE",
+          question: {
+            label: "Klarte du det?",
+            options: [{ id: "yes", label: "Ja" }],
+          },
+          value: { type: "singleChoice", selectedOptionId: "yes" },
+        },
+      ],
+    };
+
+    for (const getStats of [getMockTopTasksStats, getMonolithicTopTasksStats]) {
+      expect(
+        getStats([feedback], new URLSearchParams()).tasks[0],
+      ).toMatchObject({ taskId: "apply", successCount: 1 });
+    }
+  });
+
+  it("reads Task Priority answers emitted by the deprecated builder", () => {
+    const feedback: FeedbackDto = {
+      ...base,
+      id: "legacy-priority",
+      surveyType: "taskPriority",
+      answers: [
+        {
+          fieldId: "priorities",
+          fieldType: "MULTI_CHOICE",
+          question: {
+            label: "Hva er viktigst?",
+            options: [{ id: "apply", label: "Søke" }],
+          },
+          value: { type: "multiChoice", selectedOptionIds: ["apply"] },
+        },
+      ],
+    };
+
+    for (const getStats of [
+      getMockTaskPriorityStats,
+      getMonolithicTaskPriorityStats,
+    ]) {
+      expect(
+        getStats([feedback], new URLSearchParams()).tasks[0],
+      ).toMatchObject({ taskId: "apply", task: "Søke", votes: 1 });
+    }
+  });
+
+  it("shows the newest Task Priority label for a stable task id", () => {
+    const feedback = (
+      id: string,
+      submittedAt: string,
+      label: string,
+    ): FeedbackDto => ({
+      ...base,
+      id,
+      submittedAt,
+      surveyType: "taskPriority",
+      answers: [
+        {
+          fieldId: "priority",
+          fieldType: "MULTI_CHOICE",
+          question: {
+            label: "Hva er viktigst?",
+            options: [{ id: "apply", label }],
+          },
+          value: { type: "multiChoice", selectedOptionIds: ["apply"] },
+        },
+      ],
+    });
+
+    for (const getStats of [
+      getMockTaskPriorityStats,
+      getMonolithicTaskPriorityStats,
+    ]) {
+      const result = getStats(
+        [
+          feedback("new", "2026-08-20T10:00:00Z", "Sende søknad"),
+          feedback("old", "2026-08-19T10:00:00Z", "Søke"),
+        ],
+        new URLSearchParams(),
+      );
+      expect(result.tasks[0]).toMatchObject({
+        taskId: "apply",
+        task: "Sende søknad",
+        votes: 2,
+      });
+    }
+  });
+});

--- a/apps/lumi-dashboard/app/mock/stats/taskPriority.ts
+++ b/apps/lumi-dashboard/app/mock/stats/taskPriority.ts
@@ -5,6 +5,7 @@
  */
 
 import type { FeedbackDto, TaskPriorityResponse } from "~/types/api";
+import { TaskPriorityFieldIds } from "../utils/extractors";
 import { applyFeedbackFilters } from "./common";
 
 /**
@@ -22,18 +23,23 @@ export function getMockTaskPriorityStats(
   const voteCounts = new Map<string, number>();
   const taskLabels = new Map<string, string>();
 
-  for (const item of filtered) {
+  for (const item of [...filtered].sort(
+    (left, right) =>
+      new Date(left.submittedAt).getTime() -
+      new Date(right.submittedAt).getTime(),
+  )) {
     const priorityAnswer = item.answers.find(
-      (a) => a.fieldId === "priority" && a.fieldType === "MULTI_CHOICE",
+      (answer) =>
+        TaskPriorityFieldIds.priority.includes(
+          answer.fieldId as (typeof TaskPriorityFieldIds.priority)[number],
+        ) && answer.fieldType === "MULTI_CHOICE",
     );
 
     if (priorityAnswer && priorityAnswer.fieldType === "MULTI_CHOICE") {
       // Cache labels
       if (priorityAnswer.question.options) {
         for (const opt of priorityAnswer.question.options) {
-          if (!taskLabels.has(opt.id)) {
-            taskLabels.set(opt.id, opt.label);
-          }
+          taskLabels.set(opt.id, opt.label);
         }
       }
 
@@ -46,6 +52,7 @@ export function getMockTaskPriorityStats(
   const tasks = Array.from(voteCounts.entries())
     .map(([taskId, count]) => {
       return {
+        taskId,
         task: taskLabels.get(taskId) || taskId,
         votes: count,
         percentage: 0,

--- a/apps/lumi-dashboard/app/mock/stats/topTasks.test.ts
+++ b/apps/lumi-dashboard/app/mock/stats/topTasks.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it } from "vitest";
+import { getMockTopTasksStats as getMonolithicTopTasksStats } from "~/mock/stats";
+import { getMockTopTasksStats } from "~/mock/stats/topTasks";
+import type { FeedbackDto } from "~/types/api";
+
+function topTaskFeedback(
+  id: string,
+  submittedAt: string,
+  taskLabel: string,
+): FeedbackDto {
+  return {
+    id,
+    submittedAt,
+    app: "test-app",
+    surveyId: "top-tasks-test",
+    surveyType: "topTasks",
+    sensitiveDataRedacted: false,
+    answers: [
+      {
+        fieldId: "task",
+        fieldType: "SINGLE_CHOICE",
+        question: {
+          label: "Hva skulle du gjøre?",
+          options: [{ id: "apply", label: taskLabel }],
+        },
+        value: { type: "singleChoice", selectedOptionId: "apply" },
+      },
+      {
+        fieldId: "success",
+        fieldType: "SINGLE_CHOICE",
+        question: {
+          label: "Fikk du gjort det?",
+          options: [
+            { id: "yes", label: "Ja" },
+            { id: "partial", label: "Delvis" },
+            { id: "no", label: "Nei" },
+          ],
+        },
+        value: { type: "singleChoice", selectedOptionId: "yes" },
+      },
+    ],
+  };
+}
+
+describe("mock Top Tasks identity", () => {
+  it("groups by option id and keeps the newest displayed label", () => {
+    for (const getStats of [getMockTopTasksStats, getMonolithicTopTasksStats]) {
+      const result = getStats(
+        [
+          topTaskFeedback("old", "2025-10-26T02:30:00+02:00", "Søke"),
+          topTaskFeedback("new", "2025-10-26T02:15:00+01:00", "Sende søknad"),
+        ],
+        new URLSearchParams(),
+      );
+
+      expect(result.tasks).toHaveLength(1);
+      expect(result.tasks[0]).toMatchObject({
+        taskId: "apply",
+        task: "Sende søknad",
+        totalCount: 2,
+        successCount: 2,
+      });
+    }
+  });
+});

--- a/apps/lumi-dashboard/app/mock/stats/topTasks.ts
+++ b/apps/lumi-dashboard/app/mock/stats/topTasks.ts
@@ -6,6 +6,7 @@
 
 import type { FeedbackDto, TopTaskStats, TopTasksResponse } from "~/types/api";
 import { mockThemes } from "../themes";
+import { TopTasksFieldIds } from "../utils/extractors";
 import { applyFeedbackFilters, stemNorwegian } from "./common";
 
 // Internal type for aggregation with additional fields
@@ -17,6 +18,7 @@ interface InternalTaskStats
   totalDurationMs: number;
   durationCount: number;
   blockerTexts: string[];
+  latestSubmittedAt: string;
 }
 
 /**
@@ -35,39 +37,45 @@ export function getMockTopTasksStats(
   for (const item of filtered) {
     if (item.surveyType !== "topTasks") continue;
 
-    const taskAnswer = item.answers.find(
-      (a) => a.fieldId === "task" || a.fieldId === "category",
+    const taskAnswer = item.answers.find((answer) =>
+      TopTasksFieldIds.task.includes(
+        answer.fieldId as (typeof TopTasksFieldIds.task)[number],
+      ),
     );
     if (!taskAnswer || taskAnswer.fieldType !== "SINGLE_CHOICE") continue;
 
     const taskOption = taskAnswer.question.options?.find(
       (o) => o.id === taskAnswer.value.selectedOptionId,
     );
-    const task = taskOption
-      ? taskOption.label
-      : taskAnswer.value.selectedOptionId;
+    const taskId = taskAnswer.value.selectedOptionId;
+    const task = taskOption ? taskOption.label : taskId;
 
     // Task filter: skip if task doesn't match the filter
-    if (taskFilter && task !== taskFilter) continue;
+    if (taskFilter && taskId !== taskFilter) continue;
 
-    const successAnswer = item.answers.find(
-      (a) => a.fieldId === "taskSuccess" || a.fieldId === "success",
+    const successAnswer = item.answers.find((answer) =>
+      TopTasksFieldIds.success.includes(
+        answer.fieldId as (typeof TopTasksFieldIds.success)[number],
+      ),
     );
     const successValue =
       successAnswer?.fieldType === "SINGLE_CHOICE"
         ? successAnswer.value.selectedOptionId
         : "unknown";
 
-    const blockerAnswer = item.answers.find(
-      (a) => a.fieldId === "blocker" || a.fieldId === "hindring",
+    const blockerAnswer = item.answers.find((answer) =>
+      TopTasksFieldIds.blocker.includes(
+        answer.fieldId as (typeof TopTasksFieldIds.blocker)[number],
+      ),
     );
     const blocker =
       blockerAnswer?.fieldType === "TEXT" && blockerAnswer.value.text
         ? blockerAnswer.value.text
         : null;
 
-    if (!taskMap.has(task)) {
-      taskMap.set(task, {
+    if (!taskMap.has(taskId)) {
+      taskMap.set(taskId, {
+        taskId,
         task,
         totalCount: 0,
         successCount: 0,
@@ -79,16 +87,24 @@ export function getMockTopTasksStats(
         totalDurationMs: 0,
         durationCount: 0,
         blockerTexts: [],
+        latestSubmittedAt: item.submittedAt,
       });
     }
 
-    const stats = taskMap.get(task);
+    const stats = taskMap.get(taskId);
     if (stats) {
+      if (
+        new Date(item.submittedAt).getTime() >=
+        new Date(stats.latestSubmittedAt).getTime()
+      ) {
+        stats.task = task;
+        stats.latestSubmittedAt = item.submittedAt;
+      }
       stats.totalCount++;
 
-      if (successValue === "Ja") stats.successCount++;
-      else if (successValue === "Delvis") stats.partialCount++;
-      else if (successValue === "Nei") stats.failureCount++;
+      if (successValue === "yes") stats.successCount++;
+      else if (successValue === "partial") stats.partialCount++;
+      else if (successValue === "no") stats.failureCount++;
 
       if (blocker) {
         stats.blockerCounts[blocker] = (stats.blockerCounts[blocker] || 0) + 1;
@@ -108,7 +124,7 @@ export function getMockTopTasksStats(
       dailyStats[date] = { total: 0, success: 0 };
     }
     dailyStats[date].total++;
-    if (successValue === "Ja") {
+    if (successValue === "yes") {
       dailyStats[date].success++;
     }
   }
@@ -211,6 +227,7 @@ export function getMockTopTasksStats(
       totalDurationMs: _,
       durationCount: __,
       blockerTexts: ___,
+      latestSubmittedAt: ____,
       ...rest
     } = stats;
 
@@ -263,7 +280,11 @@ export function getMockTopTasksStats(
     dailyStats,
     questionText: filtered
       .find((i) => i.surveyType === "topTasks")
-      ?.answers.find((a) => a.fieldId === "task")?.question.label,
+      ?.answers.find((answer) =>
+        TopTasksFieldIds.task.includes(
+          answer.fieldId as (typeof TopTasksFieldIds.task)[number],
+        ),
+      )?.question.label,
     overallTpi,
     avgCompletionTimeMs,
     otherTasksPercentage,

--- a/apps/lumi-dashboard/app/mock/utils/extractors.ts
+++ b/apps/lumi-dashboard/app/mock/utils/extractors.ts
@@ -5,21 +5,47 @@
  * extract structured data from FeedbackDto items.
  */
 
+import {
+  LEGACY_SPECIALIZED_SURVEY_FIELD_IDS,
+  SPECIALIZED_SURVEY_FIELD_IDS,
+} from "@navikt/lumi-survey";
 import type { FeedbackDto } from "~/types/api";
 
 // ============================================
-// Field ID Constants (mirrors backend TopTasksFieldIds)
+// Top Tasks answer fields used by the mock analytics.
 // ============================================
 
 /**
  * Known field IDs for Top Tasks survey answers.
- * Matches the backend TopTasksFieldIds object in Models.kt.
+ * The analysis fields come from the package contract. Duration is an older,
+ * optional answer field still understood by the mock extractor.
  */
 export const TopTasksFieldIds = {
-  task: ["task", "category"] as const,
-  success: ["taskSuccess", "success"] as const,
-  blocker: ["blocker", "hindring"] as const,
+  task: [SPECIALIZED_SURVEY_FIELD_IDS.task] as const,
+  success: [
+    SPECIALIZED_SURVEY_FIELD_IDS.success,
+    LEGACY_SPECIALIZED_SURVEY_FIELD_IDS.success,
+  ] as const,
+  blocker: [SPECIALIZED_SURVEY_FIELD_IDS.blocker] as const,
   duration: ["duration", "tid"] as const,
+} as const;
+
+export const DiscoveryFieldIds = {
+  task: [
+    SPECIALIZED_SURVEY_FIELD_IDS.task,
+    LEGACY_SPECIALIZED_SURVEY_FIELD_IDS.discoveryTask,
+  ] as const,
+  success: [
+    SPECIALIZED_SURVEY_FIELD_IDS.success,
+    LEGACY_SPECIALIZED_SURVEY_FIELD_IDS.success,
+  ] as const,
+} as const;
+
+export const TaskPriorityFieldIds = {
+  priority: [
+    SPECIALIZED_SURVEY_FIELD_IDS.priority,
+    LEGACY_SPECIALIZED_SURVEY_FIELD_IDS.priority,
+  ] as const,
 } as const;
 
 /**
@@ -53,6 +79,19 @@ export function getTaskNameFromFeedback(item: FeedbackDto): string | null {
   const option = taskAnswer.question.options?.find((o) => o.id === selectedId);
 
   return option?.label ?? selectedId ?? null;
+}
+
+/** Stable option identity used by filters and aggregation. */
+export function getTaskIdFromFeedback(item: FeedbackDto): string | null {
+  if (item.surveyType !== "topTasks") return null;
+  const taskAnswer = item.answers.find((answer) =>
+    TopTasksFieldIds.task.includes(
+      answer.fieldId as (typeof TopTasksFieldIds.task)[number],
+    ),
+  );
+  return taskAnswer?.fieldType === "SINGLE_CHOICE"
+    ? taskAnswer.value.selectedOptionId
+    : null;
 }
 
 /**

--- a/apps/lumi-dashboard/app/mock/utils/filters.ts
+++ b/apps/lumi-dashboard/app/mock/utils/filters.ts
@@ -7,7 +7,7 @@ import { parseChoiceParam } from "~/utils/choiceFilterUtils";
 import { parsePhraseParam } from "~/utils/phraseFilterUtils";
 import { parseRatingParam } from "~/utils/ratingFilterUtils";
 import { mockThemes } from "../themes";
-import { getTaskNameFromFeedback } from "./extractors";
+import { getTaskIdFromFeedback } from "./extractors";
 import { matchesThemeKeywords } from "./textAnalysis";
 
 export interface FilterParams {
@@ -75,7 +75,7 @@ export function applyFeedbackFilters(
 
   if (filters.task) {
     filtered = filtered.filter(
-      (item) => getTaskNameFromFeedback(item) === filters.task,
+      (item) => getTaskIdFromFeedback(item) === filters.task,
     );
   }
 

--- a/apps/lumi-dashboard/app/mock/utils/index.ts
+++ b/apps/lumi-dashboard/app/mock/utils/index.ts
@@ -12,6 +12,7 @@ export {
   getDurationFromFeedback,
   getRatingFromFeedback,
   getSuccessStatusFromFeedback,
+  getTaskIdFromFeedback,
   getTaskNameFromFeedback,
   RatingFieldIds,
   TopTasksFieldIds,

--- a/apps/lumi-dashboard/app/routes/surveyverksted.$projectId.tsx
+++ b/apps/lumi-dashboard/app/routes/surveyverksted.$projectId.tsx
@@ -4,7 +4,10 @@ import type {
   SurveyPageV1,
   SurveyQuestionV1,
 } from "@navikt/lumi-survey";
-import { validateSurveyDocumentV1 } from "@navikt/lumi-survey";
+import {
+  getSpecializedSurveyContractIssues,
+  validateSurveyDocumentV1,
+} from "@navikt/lumi-survey";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { createFileRoute, useBlocker } from "@tanstack/react-router";
 import { zodValidator } from "@tanstack/zod-adapter";
@@ -48,12 +51,14 @@ import {
   addPage,
   addQuestion,
   changeQuestionType,
+  commitOptionLabel,
   conditionValueSuggestions,
   duplicatePage,
   duplicateQuestion,
   findHandoffIssues,
   insertPageAt,
   insertQuestionAt,
+  isRequiredSpecializedQuestion,
   listReferenceableQuestions,
   locateQuestion,
   type MoveDirection,
@@ -66,6 +71,7 @@ import {
   removeOption,
   removePage,
   removeQuestion,
+  repairSpecializedSurveyDocument,
   setQuestionVisibleIf,
   setSurveyIntro,
   setSurveySuccess,
@@ -174,6 +180,8 @@ function SurveyWorkshopEditor({
   const [undo, setUndo] = useState<UndoState | null>(null);
   const [settingsOpen, setSettingsOpen] = useState(false);
   const [shareOpen, setShareOpen] = useState(false);
+  const [repairNoticeVisible, setRepairNoticeVisible] = useState(false);
+  const repairNoticeRef = useRef<HTMLDivElement>(null);
 
   const revisionsQuery = useQuery({
     queryKey: ["survey-authoring-revisions", project.team, project.id],
@@ -393,6 +401,19 @@ function SurveyWorkshopEditor({
   const selectedPage =
     pages.find((page) => page.id === selectedPageId) ?? pages[0];
   const selectedPageNumber = pages.indexOf(selectedPage) + 1;
+  const protectedPageIds = useMemo(
+    () =>
+      new Set(
+        draft.document.pages
+          .filter((page) =>
+            page.questions.some((question) =>
+              isRequiredSpecializedQuestion(draft.document.type, question.id),
+            ),
+          )
+          .map((page) => page.id),
+      ),
+    [draft.document],
+  );
   const isDirty = fingerprint !== savedFingerprint;
   const totalQuestions = pages.reduce(
     (sum, page) => sum + page.questions.length,
@@ -406,6 +427,14 @@ function SurveyWorkshopEditor({
       return error instanceof Error ? error.message : "Dokumentet er ugyldig";
     }
   }, [draft.document]);
+  const specializedContractIssues = useMemo(
+    () =>
+      getSpecializedSurveyContractIssues(
+        draft.document.type ?? "custom",
+        draft.document.pages.flatMap((page) => page.questions),
+      ),
+    [draft.document],
+  );
 
   // Refs keep option handlers stable without stale closures.
   const draftRef = useRef(draft);
@@ -427,8 +456,18 @@ function SurveyWorkshopEditor({
   }, [selectedPageId]);
 
   const updateDocument = useCallback((document: SurveyDocumentV1) => {
+    setRepairNoticeVisible(false);
     setDraft((current) => ({ ...current, document }));
   }, []);
+
+  useEffect(() => {
+    if (repairNoticeVisible) repairNoticeRef.current?.focus();
+  }, [repairNoticeVisible]);
+
+  const handleRepairSpecializedSurvey = useCallback(() => {
+    updateDocument(repairSpecializedSurveyDocument(draftRef.current.document));
+    setRepairNoticeVisible(true);
+  }, [updateDocument]);
 
   const clearUndo = useCallback(() => setUndo(null), []);
 
@@ -763,6 +802,16 @@ function SurveyWorkshopEditor({
             label,
           ),
         ),
+      onCommitLabel: (index: number, label: string) =>
+        updateDocument(
+          commitOptionLabel(
+            draftRef.current.document,
+            selectedPageRef.current,
+            questionId,
+            index,
+            label,
+          ),
+        ),
       onUpdateValue: (index: number, value: string) =>
         updateDocument(
           updateOptionValue(
@@ -928,11 +977,40 @@ function SurveyWorkshopEditor({
         </Alert>
       ) : null}
 
+      {specializedContractIssues.length > 0 ? (
+        <Alert variant="warning" className={styles.saveAlert}>
+          <HStack gap="space-12" align="center" justify="space-between" wrap>
+            <span>
+              Analyseoppsettet mangler noe som trengs for å kunne dele surveyen.
+              Du kan gjenopprette feltene uten å miste andre spørsmål.
+            </span>
+            <Button
+              type="button"
+              variant="secondary-neutral"
+              size="small"
+              onClick={handleRepairSpecializedSurvey}
+            >
+              Gjenopprett analyseoppsettet
+            </Button>
+          </HStack>
+        </Alert>
+      ) : null}
+
+      {repairNoticeVisible && specializedContractIssues.length === 0 ? (
+        <div ref={repairNoticeRef} tabIndex={-1}>
+          <Alert variant="success" className={styles.saveAlert}>
+            Analyseoppsettet er gjenopprettet. Se gjennom feltene før du deler
+            surveyen.
+          </Alert>
+        </div>
+      ) : null}
+
       <div className={styles.editorGrid}>
         <aside className={styles.outline}>
           <PageRail
             pages={pages}
             selectedPageId={selectedPage.id}
+            protectedPageIds={protectedPageIds}
             onSelect={handleSelectPage}
             onAdd={handleAddPage}
             onMove={handleMovePage}
@@ -950,6 +1028,7 @@ function SurveyWorkshopEditor({
             page={selectedPage}
             pageNumber={selectedPageNumber}
             totalPages={pages.length}
+            surveyType={draft.document.type}
             expandedIds={expandedIds}
             intro={draft.document.intro}
             success={draft.document.success}

--- a/apps/lumi-dashboard/app/routes/surveyverksted.index.tsx
+++ b/apps/lumi-dashboard/app/routes/surveyverksted.index.tsx
@@ -14,7 +14,12 @@ import {
   TextField,
   VStack,
 } from "@navikt/ds-react";
-import type { SurveyDocumentV1 } from "@navikt/lumi-survey";
+import {
+  createDiscoverySurveyDocument,
+  createTaskPrioritySurveyDocument,
+  createTopTasksSurveyDocument,
+  type SurveyDocumentV1,
+} from "@navikt/lumi-survey";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { createFileRoute, Link } from "@tanstack/react-router";
 import { zodValidator } from "@tanstack/zod-adapter";
@@ -28,7 +33,11 @@ import {
   fetchTeamsServerFn,
 } from "~/server/actions";
 import type { SurveyAuthoringRevisionDetail } from "~/types/surveyAuthoring";
-import { suggestSurveyId } from "~/utils/surveyDocument";
+import {
+  SURVEY_TEMPLATE_PLACEHOLDER_LABELS,
+  SURVEY_TEMPLATE_PLACEHOLDER_OPTION_VALUE,
+  suggestSurveyId,
+} from "~/utils/surveyDocument";
 import styles from "./surveyverksted.module.css";
 
 const searchSchema = z.object({ team: z.string().optional() });
@@ -42,38 +51,113 @@ function formatProjectDate(value: string): string {
 }
 
 /*
- * The seeded draft is the pattern most authors ship, so it teaches the shape
- * we want: one question carries the panel, the follow-up waits until the
- * rating is answered, and no page title competes with the question beneath
- * it. A title is for pages that genuinely group several questions.
+ * Templates teach the supported analysis shapes without exposing field IDs
+ * or transport details in the creation flow.
  */
-const initialDocument: SurveyDocumentV1 = {
-  authoringSchemaVersion: 1,
-  type: "rating",
-  pages: [
-    {
-      id: "opplevelse",
-      questions: [
+type SurveyTemplateId =
+  | "rating"
+  | "discovery"
+  | "topTasks"
+  | "taskPriority"
+  | "custom";
+
+const surveyTemplates: Record<
+  SurveyTemplateId,
+  { label: string; description: string; create: () => SurveyDocumentV1 }
+> = {
+  rating: {
+    label: "Hvordan opplevde brukeren tjenesten?",
+    description:
+      "Starter med en vurdering og et valgfritt oppfølgingsspørsmål.",
+    create: () => ({
+      authoringSchemaVersion: 1,
+      type: "rating",
+      pages: [
         {
-          id: "rating",
-          type: "rating",
-          prompt: "Hvordan opplevde du tjenesten?",
-          required: true,
-        },
-        {
-          id: "kommentar",
-          type: "text",
-          prompt: "Hva kan vi gjøre bedre?",
-          required: false,
-          maxLength: 1000,
-          minRows: 4,
-          // Same shape the condition builder emits, so a seeded draft and a
-          // hand-built one stay byte-identical.
-          visibleIf: { questionId: "rating", operator: "EXISTS" },
+          id: "opplevelse",
+          questions: [
+            {
+              id: "rating",
+              type: "rating",
+              prompt: "Hvordan opplevde du tjenesten?",
+              required: true,
+            },
+            {
+              id: "kommentar",
+              type: "text",
+              prompt: "Hva kan vi gjøre bedre?",
+              required: false,
+              maxLength: 1000,
+              minRows: 4,
+              visibleIf: { questionId: "rating", operator: "EXISTS" },
+            },
+          ],
         },
       ],
-    },
-  ],
+    }),
+  },
+  discovery: {
+    label: "Hva kom brukeren for å gjøre?",
+    description:
+      "Finner oppgaven, om brukeren lyktes og hva som eventuelt hindret hen.",
+    create: () => createDiscoverySurveyDocument(),
+  },
+  topTasks: {
+    label: "Lyktes brukeren med en kjent oppgave?",
+    description:
+      "Måler resultatet for en liste med oppgaver dere kjenner på forhånd.",
+    create: () =>
+      createTopTasksSurveyDocument({
+        tasks: [
+          {
+            value: SURVEY_TEMPLATE_PLACEHOLDER_OPTION_VALUE,
+            label: SURVEY_TEMPLATE_PLACEHOLDER_LABELS[0],
+          },
+        ],
+        includeOtherTask: true,
+      }),
+  },
+  taskPriority: {
+    label: "Hvilke oppgaver er viktigst?",
+    description:
+      "Lar brukerne velge de viktigste oppgavene fra en liste dere lager.",
+    create: () =>
+      createTaskPrioritySurveyDocument({
+        tasks: [
+          {
+            value: `${SURVEY_TEMPLATE_PLACEHOLDER_OPTION_VALUE}-1`,
+            label: SURVEY_TEMPLATE_PLACEHOLDER_LABELS[1],
+          },
+          {
+            value: `${SURVEY_TEMPLATE_PLACEHOLDER_OPTION_VALUE}-2`,
+            label: SURVEY_TEMPLATE_PLACEHOLDER_LABELS[2],
+          },
+        ],
+      }),
+  },
+  custom: {
+    label: "Noe annet",
+    description: "Starter med ett åpent spørsmål uten en fast analyse.",
+    create: () => ({
+      authoringSchemaVersion: 1,
+      type: "custom",
+      pages: [
+        {
+          id: "sporsmal",
+          questions: [
+            {
+              id: "sporsmal",
+              type: "text",
+              prompt: "Hva vil dere spørre om?",
+              required: true,
+              maxLength: 1000,
+              minRows: 4,
+            },
+          ],
+        },
+      ],
+    }),
+  },
 };
 
 export const Route = createFileRoute("/surveyverksted/")({
@@ -88,6 +172,7 @@ function SurveyWorkshopIndex() {
   const [name, setName] = useState("");
   const [surveyId, setSurveyId] = useState("");
   const [surveyIdTouched, setSurveyIdTouched] = useState(false);
+  const [templateId, setTemplateId] = useState<SurveyTemplateId>("rating");
 
   const teamsQuery = useQuery({
     queryKey: ["teams"],
@@ -121,7 +206,7 @@ function SurveyWorkshopIndex() {
           team: selectedTeam,
           name,
           surveyId,
-          document: initialDocument,
+          document: surveyTemplates[templateId].create(),
         },
       });
     },
@@ -240,8 +325,8 @@ function SurveyWorkshopIndex() {
                     Start et utkast
                   </Heading>
                   <BodyShort textColor="subtle">
-                    Du starter med én side, et vurderingsspørsmål og et åpent
-                    oppfølgingsspørsmål.
+                    Velg det dere vil finne ut. Dere kan tilpasse sider,
+                    spørsmål og tekst etterpå.
                   </BodyShort>
                 </div>
                 <Select
@@ -257,6 +342,20 @@ function SurveyWorkshopIndex() {
                   {availableTeams.map((team) => (
                     <option key={team} value={team}>
                       {team}
+                    </option>
+                  ))}
+                </Select>
+                <Select
+                  label="Hva vil dere finne ut?"
+                  description={surveyTemplates[templateId].description}
+                  value={templateId}
+                  onChange={(event) =>
+                    setTemplateId(event.target.value as SurveyTemplateId)
+                  }
+                >
+                  {Object.entries(surveyTemplates).map(([value, template]) => (
+                    <option key={value} value={value}>
+                      {template.label}
                     </option>
                   ))}
                 </Select>

--- a/apps/lumi-dashboard/app/server/actions/__tests__/fetchTaskPriority.contract.test.ts
+++ b/apps/lumi-dashboard/app/server/actions/__tests__/fetchTaskPriority.contract.test.ts
@@ -7,11 +7,31 @@ describe("fetchTaskPriority contract", () => {
     const payload = {
       totalSubmissions: 200,
       tasks: [
-        { task: "Søke om sykepenger", votes: 85, percentage: 42.5 },
-        { task: "Melde fra om endringer", votes: 45, percentage: 22.5 },
-        { task: "Finne informasjon", votes: 30, percentage: 15.0 },
-        { task: "Sjekke utbetalinger", votes: 25, percentage: 12.5 },
-        { task: "Annet", votes: 15, percentage: 7.5 },
+        {
+          taskId: "apply",
+          task: "Søke om sykepenger",
+          votes: 85,
+          percentage: 42.5,
+        },
+        {
+          taskId: "change",
+          task: "Melde fra om endringer",
+          votes: 45,
+          percentage: 22.5,
+        },
+        {
+          taskId: "info",
+          task: "Finne informasjon",
+          votes: 30,
+          percentage: 15.0,
+        },
+        {
+          taskId: "payment",
+          task: "Sjekke utbetalinger",
+          votes: 25,
+          percentage: 12.5,
+        },
+        { taskId: "other", task: "Annet", votes: 15, percentage: 7.5 },
       ],
       longNeckCutoff: 2, // First 2 tasks = 65% (before 80% threshold)
       cumulativePercentageAt5: 100.0,
@@ -25,10 +45,20 @@ describe("fetchTaskPriority contract", () => {
     const payload = {
       totalSubmissions: 100,
       tasks: [
-        { task: "Main Task", votes: 60, percentage: 60.0 },
-        { task: "Secondary Task", votes: 25, percentage: 25.0 },
-        { task: "Tertiary Task", votes: 10, percentage: 10.0 },
-        { task: "Minor Task", votes: 5, percentage: 5.0 },
+        { taskId: "main", task: "Main Task", votes: 60, percentage: 60.0 },
+        {
+          taskId: "secondary",
+          task: "Secondary Task",
+          votes: 25,
+          percentage: 25.0,
+        },
+        {
+          taskId: "tertiary",
+          task: "Tertiary Task",
+          votes: 10,
+          percentage: 10.0,
+        },
+        { taskId: "minor", task: "Minor Task", votes: 5, percentage: 5.0 },
       ],
       longNeckCutoff: 2, // First 2 tasks = 85% (> 80%)
       cumulativePercentageAt5: 100.0,
@@ -40,7 +70,7 @@ describe("fetchTaskPriority contract", () => {
   it("rejects response with missing required fields", () => {
     const invalidPayload = {
       totalSubmissions: 50,
-      tasks: [{ task: "Test", votes: 50, percentage: 100 }],
+      tasks: [{ taskId: "test", task: "Test", votes: 50, percentage: 100 }],
       // missing longNeckCutoff and cumulativePercentageAt5
     };
 
@@ -52,6 +82,7 @@ describe("fetchTaskPriority contract", () => {
       totalSubmissions: 100,
       tasks: [
         {
+          taskId: "test",
           task: "Test",
           votes: "not-a-number", // should be number
           percentage: 100,
@@ -67,7 +98,9 @@ describe("fetchTaskPriority contract", () => {
   it("validates minimal response with single task", () => {
     const minimalPayload = {
       totalSubmissions: 1,
-      tasks: [{ task: "Only Task", votes: 1, percentage: 100.0 }],
+      tasks: [
+        { taskId: "only", task: "Only Task", votes: 1, percentage: 100.0 },
+      ],
       longNeckCutoff: 1,
       cumulativePercentageAt5: 100.0,
     };

--- a/apps/lumi-dashboard/app/server/actions/__tests__/fetchTopTasks.contract.test.ts
+++ b/apps/lumi-dashboard/app/server/actions/__tests__/fetchTopTasks.contract.test.ts
@@ -8,6 +8,7 @@ describe("fetchTopTasks contract", () => {
       totalSubmissions: 150,
       tasks: [
         {
+          taskId: "apply",
           task: "Søke om sykepenger",
           totalCount: 45,
           successCount: 32,
@@ -21,6 +22,7 @@ describe("fetchTopTasks contract", () => {
           },
         },
         {
+          taskId: "parental-benefit",
           task: "Finne informasjon om foreldrepenger",
           totalCount: 30,
           successCount: 25,
@@ -76,6 +78,7 @@ describe("fetchTopTasks contract", () => {
       totalSubmissions: 100,
       tasks: [
         {
+          taskId: "main-task",
           task: "Hovedoppgave",
           totalCount: 100,
           successCount: 80,

--- a/apps/lumi-dashboard/app/types/__tests__/submission.contract.test.ts
+++ b/apps/lumi-dashboard/app/types/__tests__/submission.contract.test.ts
@@ -228,6 +228,66 @@ describe("submission contract", () => {
     ).toThrow(/optionIds must be unique/);
   });
 
+  it("enforces multi-choice maxSelections in the shared v2 contract", () => {
+    const payload = {
+      schemaVersion: 2,
+      surveyId: "survey-priority",
+      surveyType: "custom",
+      submittedAt: "2026-01-21T12:00:00.000Z",
+      deduplicationKey: "retryable-submit:survey-priority",
+      definition: {
+        surveyType: "custom",
+        fields: [
+          {
+            fieldId: "priority",
+            fieldType: "MULTI_CHOICE",
+            optionIds: ["apply", "status"],
+            maxSelections: 1,
+          },
+        ],
+      },
+      answers: [
+        {
+          fieldId: "priority",
+          fieldType: "MULTI_CHOICE",
+          question: {
+            label: "Velg viktigste oppgave",
+            options: [
+              { id: "apply", label: "Søke" },
+              { id: "status", label: "Sjekke status" },
+            ],
+          },
+          value: { type: "multiChoice", selectedOptionIds: ["apply"] },
+        },
+      ],
+    };
+
+    expect(() => FeedbackSubmissionV2Schema.parse(payload)).not.toThrow();
+    expect(() =>
+      FeedbackSubmissionV2Schema.parse({
+        ...payload,
+        definition: {
+          ...payload.definition,
+          fields: [{ ...payload.definition.fields[0], maxSelections: 3 }],
+        },
+      }),
+    ).toThrow(/must not exceed/i);
+    expect(() =>
+      FeedbackSubmissionV2Schema.parse({
+        ...payload,
+        answers: [
+          {
+            ...payload.answers[0],
+            value: {
+              type: "multiChoice",
+              selectedOptionIds: ["apply", "status"],
+            },
+          },
+        ],
+      }),
+    ).toThrow(/exceeds maxSelections=1/i);
+  });
+
   it("rejects invalid v2 deduplication keys", () => {
     const invalidPayload = {
       schemaVersion: 2,

--- a/apps/lumi-dashboard/app/utils/surveyDocument.test.ts
+++ b/apps/lumi-dashboard/app/utils/surveyDocument.test.ts
@@ -1,4 +1,10 @@
-import type { SurveyDocumentV1 } from "@navikt/lumi-survey";
+import {
+  createDiscoverySurveyDocument,
+  createTaskPrioritySurveyDocument,
+  createTopTasksSurveyDocument,
+  type SurveyDocumentV1,
+  validateSurveyDocumentV1,
+} from "@navikt/lumi-survey";
 import { describe, expect, it } from "vitest";
 import {
   addOption,
@@ -7,6 +13,7 @@ import {
   allowedConditionOperators,
   buildVisibleIf,
   changeQuestionType,
+  commitOptionLabel,
   conditionCombinator,
   conditionValueSuggestions,
   createQuestion,
@@ -16,6 +23,8 @@ import {
   findHandoffIssues,
   insertPageAt,
   insertQuestionAt,
+  isRequiredSpecializedQuestion,
+  isSpecializedQuestionContractValid,
   listReferenceableQuestions,
   locateQuestion,
   moveOption,
@@ -27,6 +36,8 @@ import {
   removeOption,
   removePage,
   removeQuestion,
+  repairSpecializedSurveyDocument,
+  SURVEY_TEMPLATE_PLACEHOLDER_OPTION_VALUE,
   setQuestionVisibleIf,
   setSurveyIntro,
   setSurveySuccess,
@@ -529,6 +540,80 @@ describe("option mutations", () => {
     expect(question.options[0]).toEqual({ value: "soke", label: "Søknad" });
   });
 
+  it("replaces a template placeholder once and then keeps the value stable", () => {
+    const document = createTopTasksSurveyDocument({
+      tasks: [
+        {
+          value: SURVEY_TEMPLATE_PLACEHOLDER_OPTION_VALUE,
+          label: "Bytt ut",
+        },
+      ],
+    });
+    const committed = commitOptionLabel(
+      updateOptionLabel(document, "task", "task", 0, "Sende søknad"),
+      "task",
+      "task",
+      0,
+      "Sende søknad",
+    );
+    const renamed = commitOptionLabel(
+      updateOptionLabel(committed, "task", "task", 0, "Søke digitalt"),
+      "task",
+      "task",
+      0,
+      "Søke digitalt",
+    );
+    const first = committed.pages[0].questions[0];
+    const second = renamed.pages[0].questions[0];
+    if (first.type !== "singleChoice" || second.type !== "singleChoice") {
+      throw new Error("wrong type");
+    }
+    expect(first.options[0].value).toBe("sende-soknad");
+    expect(second.options[0].value).toBe("sende-soknad");
+  });
+
+  it("does not accept the template instruction itself as a real task", () => {
+    const document = createTopTasksSurveyDocument({
+      tasks: [
+        {
+          value: SURVEY_TEMPLATE_PLACEHOLDER_OPTION_VALUE,
+          label: "Bytt ut med en oppgave dere vil måle",
+        },
+      ],
+    });
+
+    expect(
+      commitOptionLabel(
+        document,
+        "task",
+        "task",
+        0,
+        "Bytt ut med en oppgave dere vil måle",
+      ),
+    ).toBe(document);
+  });
+
+  it("accepts a real task whose wording starts with 'Bytt ut'", () => {
+    const document = createTopTasksSurveyDocument({
+      tasks: [
+        {
+          value: SURVEY_TEMPLATE_PLACEHOLDER_OPTION_VALUE,
+          label: "Bytt ut med en oppgave dere vil måle",
+        },
+      ],
+    });
+    const committed = commitOptionLabel(
+      updateOptionLabel(document, "task", "task", 0, "Bytt ut passord"),
+      "task",
+      "task",
+      0,
+      "Bytt ut passord",
+    );
+    const task = committed.pages[0].questions[0];
+    if (task.type !== "singleChoice") throw new Error("wrong type");
+    expect(task.options[0].value).toBe("bytt-ut-passord");
+  });
+
   it("updateOptionValue sets the value", () => {
     const document = makeDocument();
     const next = updateOptionValue(
@@ -640,6 +725,279 @@ describe("findHandoffIssues", () => {
     expect(
       issues.some((issue) => /alternativ 1 mangler verdi/i.test(issue.message)),
     ).toBe(true);
+  });
+
+  it.each([
+    createDiscoverySurveyDocument(),
+    createTopTasksSurveyDocument({
+      tasks: [{ value: "apply", label: "Søke" }],
+    }),
+    createTaskPrioritySurveyDocument({
+      tasks: [
+        { value: "apply", label: "Søke" },
+        { value: "status", label: "Sjekke status" },
+      ],
+    }),
+  ])("accepts a complete specialized survey contract", (document) => {
+    expect(findHandoffIssues(document)).toEqual([]);
+  });
+
+  it("flags a specialized survey when a contract field is removed", () => {
+    const document = createDiscoverySurveyDocument();
+    document.pages = document.pages.filter(
+      (page) => page.id !== "success",
+    ) as SurveyDocumentV1["pages"];
+
+    expect(findHandoffIssues(document)).toContainEqual({
+      questionId: null,
+      message:
+        "Oppsettet «Hva kom brukeren for å gjøre?» trenger spørsmålet «success».",
+    });
+  });
+
+  it("flags a specialized outcome field with incompatible choices", () => {
+    const document = createTopTasksSurveyDocument({
+      tasks: [{ value: "apply", label: "Søke" }],
+    });
+    const success = document.pages
+      .flatMap((page) => page.questions)
+      .find((question) => question.id === "success");
+    if (!success || success.type !== "singleChoice") {
+      throw new Error("missing success question");
+    }
+    success.options = [{ value: "done", label: "Ferdig" }];
+
+    expect(findHandoffIssues(document)).toContainEqual({
+      questionId: "success",
+      message:
+        "Spørsmålet «success» må ha nøyaktig svarene Ja, Delvis og Nei for oppsettet «Lyktes brukeren med en kjent oppgave?».",
+    });
+  });
+
+  it("flags extra outcome choices and a repurposed blocker field", () => {
+    const document = createTopTasksSurveyDocument({
+      tasks: [{ value: "apply", label: "Søke" }],
+    });
+    const questions = document.pages.flatMap((page) => page.questions);
+    const success = questions.find((question) => question.id === "success");
+    const blocker = questions.find((question) => question.id === "blocker");
+    if (!success || success.type !== "singleChoice" || !blocker) {
+      throw new Error("missing contract questions");
+    }
+    success.options.push({ value: "unknown", label: "Vet ikke" });
+    Object.assign(blocker, {
+      type: "singleChoice",
+      options: [{ value: "other", label: "Annet" }],
+    });
+
+    expect(findHandoffIssues(document)).toEqual(
+      expect.arrayContaining([
+        {
+          questionId: "success",
+          message:
+            "Spørsmålet «success» må ha nøyaktig svarene Ja, Delvis og Nei for oppsettet «Lyktes brukeren med en kjent oppgave?».",
+        },
+        {
+          questionId: "blocker",
+          message:
+            "Spørsmålet «blocker» har feil type for oppsettet «Lyktes brukeren med en kjent oppgave?».",
+        },
+      ]),
+    );
+  });
+
+  it("keeps example tasks accessible while blocking handoff", () => {
+    const document = createTopTasksSurveyDocument({
+      tasks: [
+        {
+          value: SURVEY_TEMPLATE_PLACEHOLDER_OPTION_VALUE,
+          label: "Bytt ut med en oppgave dere vil måle",
+        },
+      ],
+    });
+
+    expect(findHandoffIssues(document)).toContainEqual({
+      questionId: "task",
+      message:
+        "Bytt ut eksempeloppgaven i alternativ 1 med en oppgave dere vil måle.",
+    });
+  });
+
+  it("still blocks the template instruction if its technical value changed", () => {
+    const document = createTopTasksSurveyDocument({
+      tasks: [
+        {
+          value: "manually-changed",
+          label: "Bytt ut med en oppgave dere vil måle",
+        },
+      ],
+    });
+    expect(findHandoffIssues(document)).toContainEqual({
+      questionId: "task",
+      message:
+        "Bytt ut eksempeloppgaven i alternativ 1 med en oppgave dere vil måle.",
+    });
+  });
+
+  it("identifies only the fixed fields used by specialized analytics", () => {
+    expect(isRequiredSpecializedQuestion("discovery", "task")).toBe(true);
+    expect(isRequiredSpecializedQuestion("topTasks", "success")).toBe(true);
+    expect(isRequiredSpecializedQuestion("taskPriority", "priority")).toBe(
+      true,
+    );
+    expect(isRequiredSpecializedQuestion("topTasks", "blocker")).toBe(false);
+    expect(isRequiredSpecializedQuestion("rating", "rating")).toBe(false);
+  });
+
+  it("unlocks an invalid analysis field and repairs it without removing other questions", () => {
+    const document = createDiscoverySurveyDocument();
+    const task = document.pages[0].questions[0];
+    Object.assign(task, {
+      type: "singleChoice",
+      options: [{ value: "wrong", label: "Feil" }],
+      required: false,
+      visibleIf: { questionId: "success", operator: "EXISTS" },
+    });
+    document.pages[0].questions.push({
+      id: "extra",
+      type: "text",
+      prompt: "Eget spørsmål",
+    });
+
+    expect(isSpecializedQuestionContractValid("discovery", task)).toBe(false);
+    const repaired = repairSpecializedSurveyDocument(document);
+    expect(findHandoffIssues(repaired)).toEqual([]);
+    expect(locateQuestion(repaired, "extra")).not.toBeNull();
+    const repairedTask = repaired.pages
+      .flatMap((page) => page.questions)
+      .find((question) => question.id === "task");
+    expect(repairedTask?.type).toBe("text");
+    expect(repairedTask?.required).toBe(true);
+    expect(repairedTask?.visibleIf).toBeUndefined();
+  });
+
+  it("restores a missing fixed field for a specialized analysis", () => {
+    const document = createDiscoverySurveyDocument();
+    document.pages = document.pages.filter(
+      (page) => !page.questions.some((question) => question.id === "success"),
+    ) as SurveyDocumentV1["pages"];
+    const repaired = repairSpecializedSurveyDocument(document);
+    expect(
+      repaired.pages
+        .flatMap((page) => page.questions)
+        .find((question) => question.id === "success"),
+    ).toMatchObject({ type: "singleChoice", required: true });
+    expect(
+      repaired.pages.flatMap((page) => page.questions).map(({ id }) => id),
+    ).toEqual(["task", "success", "blocker"]);
+    expect(findHandoffIssues(repaired)).toEqual([]);
+  });
+
+  it("preserves authored success option text while repairing its contract", () => {
+    const document = createDiscoverySurveyDocument();
+    const success = document.pages
+      .flatMap((page) => page.questions)
+      .find((question) => question.id === "success");
+    if (!success || success.type !== "singleChoice") {
+      throw new Error("missing success question");
+    }
+    success.required = false;
+    success.options[0] = {
+      ...success.options[0],
+      label: "Ja, helt",
+      description: "Jeg fikk gjort alt",
+    };
+
+    const repaired = repairSpecializedSurveyDocument(document);
+    const repairedSuccess = repaired.pages
+      .flatMap((page) => page.questions)
+      .find((question) => question.id === "success");
+    if (!repairedSuccess || repairedSuccess.type !== "singleChoice") {
+      throw new Error("missing repaired success question");
+    }
+    expect(repairedSuccess.required).toBe(true);
+    expect(
+      repairedSuccess.options.find((option) => option.value === "yes"),
+    ).toEqual({
+      value: "yes",
+      label: "Ja, helt",
+      description: "Jeg fikk gjort alt",
+    });
+  });
+
+  it("uses a unique page id and keeps existing page order while repairing", () => {
+    const document = createDiscoverySurveyDocument();
+    const taskPage = document.pages.find((page) => page.id === "task");
+    const blockerPage = document.pages.find((page) => page.id === "blocker");
+    if (!taskPage || !blockerPage) throw new Error("missing template pages");
+    document.pages = [
+      taskPage,
+      {
+        id: "success",
+        questions: [
+          {
+            id: "extra-before-blocker",
+            type: "text",
+            prompt: "Eget spørsmål",
+            visibleIf: { questionId: "task", operator: "EXISTS" },
+          },
+        ],
+      },
+      blockerPage,
+    ];
+
+    const repaired = repairSpecializedSurveyDocument(document);
+    expect(repaired.pages.map((page) => page.id)).toEqual([
+      "task",
+      "success",
+      "success-2",
+      "blocker",
+    ]);
+    expect(repaired.pages[1].questions[0].id).toBe("extra-before-blocker");
+    expect(() => validateSurveyDocumentV1(repaired)).not.toThrow();
+  });
+
+  it("preserves a real priority task and only fills the missing minimum", () => {
+    const document = createTaskPrioritySurveyDocument({
+      tasks: [
+        { value: "apply", label: "Søke" },
+        { value: "status", label: "Sjekke status" },
+      ],
+      maxSelections: 2,
+    });
+    const priority = document.pages[0].questions[0];
+    if (priority.type !== "multiChoice") throw new Error("missing priority");
+    priority.options = [priority.options[0]];
+
+    const repaired = repairSpecializedSurveyDocument(document);
+    const repairedPriority = repaired.pages[0].questions[0];
+    expect(repairedPriority.type).toBe("multiChoice");
+    if (repairedPriority.type !== "multiChoice") return;
+    expect(repairedPriority.options[0]).toEqual({
+      value: "apply",
+      label: "Søke",
+    });
+    expect(repairedPriority.options).toHaveLength(2);
+    expect(() => validateSurveyDocumentV1(repaired)).not.toThrow();
+  });
+
+  it("requires a real known task when Top Tasks only has the other choice", () => {
+    const document = createTopTasksSurveyDocument({
+      tasks: [{ value: "known", label: "Kjent oppgave" }],
+      includeOtherTask: true,
+    });
+    const task = document.pages
+      .flatMap((page) => page.questions)
+      .find((question) => question.id === "task");
+    if (!task || task.type !== "singleChoice") {
+      throw new Error("missing task question");
+    }
+    task.options = [{ value: "other", label: "Noe annet" }];
+
+    expect(findHandoffIssues(document)).toContainEqual({
+      questionId: "task",
+      message: "Legg til minst én kjent oppgave som brukeren kan velge mellom.",
+    });
   });
 });
 

--- a/apps/lumi-dashboard/app/utils/surveyDocument.ts
+++ b/apps/lumi-dashboard/app/utils/surveyDocument.ts
@@ -1,14 +1,275 @@
-import type {
-  SurveyDocumentV1,
-  SurveyIntroV1,
-  SurveyPageV1,
-  SurveyQuestionV1,
-  SurveySuccessV1,
+import {
+  createDiscoverySurveyDocument,
+  createTaskPrioritySurveyDocument,
+  createTopTasksSurveyDocument,
+  getSpecializedSurveyContractIssues,
+  SPECIALIZED_SURVEY_FIELD_IDS,
+  type SurveyDocumentV1,
+  type SurveyIntroV1,
+  type SurveyPageV1,
+  type SurveyQuestionV1,
+  type SurveySuccessV1,
 } from "@navikt/lumi-survey";
 
 export type QuestionTypeId = "rating" | "text" | "singleChoice" | "multiChoice";
 export type MoveDirection = "up" | "down";
 export type IdFactory = () => string;
+
+export const SURVEY_TEMPLATE_PLACEHOLDER_OPTION_VALUE = "__lumi_example_task__";
+export const SURVEY_TEMPLATE_PLACEHOLDER_LABELS = [
+  "Bytt ut med en oppgave dere vil måle",
+  "Bytt ut med den første oppgaven",
+  "Bytt ut med den andre oppgaven",
+] as const;
+
+export function isSurveyTemplatePlaceholderValue(value: string): boolean {
+  return value.startsWith(SURVEY_TEMPLATE_PLACEHOLDER_OPTION_VALUE);
+}
+
+export function isSurveyTemplatePlaceholderLabel(label: string): boolean {
+  const normalized = label.trim();
+  return SURVEY_TEMPLATE_PLACEHOLDER_LABELS.some(
+    (placeholder) => placeholder === normalized,
+  );
+}
+
+export function isRequiredSpecializedQuestion(
+  surveyType: SurveyDocumentV1["type"],
+  questionId: string,
+): boolean {
+  if (surveyType === "discovery" || surveyType === "topTasks") {
+    return (
+      questionId === SPECIALIZED_SURVEY_FIELD_IDS.task ||
+      questionId === SPECIALIZED_SURVEY_FIELD_IDS.success
+    );
+  }
+  return (
+    surveyType === "taskPriority" &&
+    questionId === SPECIALIZED_SURVEY_FIELD_IDS.priority
+  );
+}
+
+export function isSpecializedQuestionContractValid(
+  surveyType: SurveyDocumentV1["type"],
+  question: SurveyQuestionV1,
+): boolean {
+  if (!isRequiredSpecializedQuestion(surveyType, question.id)) return false;
+  if (question.required !== true || question.visibleIf !== undefined)
+    return false;
+  if (surveyType === "discovery" && question.id === "task") {
+    return question.type === "text";
+  }
+  if (surveyType === "topTasks" && question.id === "task") {
+    return question.type === "singleChoice";
+  }
+  if (question.id === "success") {
+    return (
+      question.type === "singleChoice" &&
+      question.options.length === 3 &&
+      new Set(question.options.map((option) => option.value)).size === 3 &&
+      question.options.every((option) =>
+        ["yes", "partial", "no"].includes(option.value),
+      )
+    );
+  }
+  return surveyType === "taskPriority" && question.type === "multiChoice";
+}
+
+/** Restores only the technical fields a specialized analysis needs. */
+export function repairSpecializedSurveyDocument(
+  document: SurveyDocumentV1,
+): SurveyDocumentV1 {
+  const template = (() => {
+    if (document.type === "discovery") return createDiscoverySurveyDocument();
+    if (document.type === "topTasks") {
+      return createTopTasksSurveyDocument({
+        tasks: [
+          {
+            value: SURVEY_TEMPLATE_PLACEHOLDER_OPTION_VALUE,
+            label: SURVEY_TEMPLATE_PLACEHOLDER_LABELS[0],
+          },
+        ],
+        includeOtherTask: true,
+      });
+    }
+    if (document.type === "taskPriority") {
+      return createTaskPrioritySurveyDocument({
+        tasks: [
+          {
+            value: `${SURVEY_TEMPLATE_PLACEHOLDER_OPTION_VALUE}-1`,
+            label: SURVEY_TEMPLATE_PLACEHOLDER_LABELS[1],
+          },
+          {
+            value: `${SURVEY_TEMPLATE_PLACEHOLDER_OPTION_VALUE}-2`,
+            label: SURVEY_TEMPLATE_PLACEHOLDER_LABELS[2],
+          },
+        ],
+      });
+    }
+    return null;
+  })();
+  if (!template) return document;
+
+  const templateQuestions = new Map(
+    template.pages.flatMap((page) =>
+      page.questions.map((question) => [question.id, question] as const),
+    ),
+  );
+  const requiredIds = new Set(
+    [...templateQuestions.keys()].filter((id) =>
+      isRequiredSpecializedQuestion(document.type, id),
+    ),
+  );
+  const seen = new Set<string>();
+  const repairQuestion = (current: SurveyQuestionV1): SurveyQuestionV1 => {
+    const fallback = templateQuestions.get(current.id);
+    if (!fallback) return current;
+    const common = {
+      ...fallback,
+      prompt: current.prompt.trim() ? current.prompt : fallback.prompt,
+      description: current.description,
+      analyticsId: current.analyticsId,
+    };
+    if (
+      current.id === SPECIALIZED_SURVEY_FIELD_IDS.task &&
+      document.type === "topTasks" &&
+      current.type === "singleChoice"
+    ) {
+      const options = current.options.some((option) => option.value !== "other")
+        ? current.options
+        : [
+            ...current.options,
+            {
+              value: SURVEY_TEMPLATE_PLACEHOLDER_OPTION_VALUE,
+              label: SURVEY_TEMPLATE_PLACEHOLDER_LABELS[0],
+            },
+          ];
+      return {
+        ...current,
+        options,
+        required: true,
+        visibleIf: undefined,
+      };
+    }
+    if (
+      current.id === SPECIALIZED_SURVEY_FIELD_IDS.priority &&
+      current.type === "multiChoice"
+    ) {
+      const fallbackOptions =
+        fallback.type === "multiChoice" ? fallback.options : [];
+      const options = [...current.options];
+      for (const option of fallbackOptions) {
+        if (options.length >= 2) break;
+        if (!options.some((candidate) => candidate.value === option.value)) {
+          options.push(option);
+        }
+      }
+      return {
+        ...current,
+        options,
+        required: true,
+        visibleIf: undefined,
+        maxSelections:
+          current.maxSelections && current.maxSelections <= options.length
+            ? current.maxSelections
+            : Math.min(5, options.length),
+      };
+    }
+    if (current.id === SPECIALIZED_SURVEY_FIELD_IDS.success) {
+      const currentOptions =
+        current.type === "singleChoice"
+          ? new Map(current.options.map((option) => [option.value, option]))
+          : new Map<string, never>();
+      if (fallback.type !== "singleChoice") return common;
+      return {
+        ...fallback,
+        prompt: current.prompt.trim() ? current.prompt : fallback.prompt,
+        description: current.description,
+        analyticsId: current.analyticsId,
+        randomize:
+          current.type === "singleChoice" ? current.randomize : undefined,
+        options: fallback.options.map((option) => ({
+          ...option,
+          ...currentOptions.get(option.value),
+          value: option.value,
+          label: currentOptions.get(option.value)?.label.trim() || option.label,
+        })),
+        required: true,
+        visibleIf: undefined,
+      };
+    }
+    return { ...common, required: true, visibleIf: undefined };
+  };
+
+  const pages = document.pages
+    .map((page) => ({
+      ...page,
+      questions: page.questions.flatMap((question) => {
+        if (!templateQuestions.has(question.id)) return [question];
+        if (seen.has(question.id)) return [];
+        seen.add(question.id);
+        return [repairQuestion(question)];
+      }) as SurveyPageV1["questions"],
+    }))
+    .filter((page) => page.questions.length > 0);
+
+  const uniquePageId = (preferred: string) => {
+    const existing = new Set(pages.map((page) => page.id));
+    if (!existing.has(preferred)) return preferred;
+    let suffix = 2;
+    while (existing.has(`${preferred}-${suffix}`)) suffix += 1;
+    return `${preferred}-${suffix}`;
+  };
+  const referencesQuestion = (
+    question: SurveyQuestionV1,
+    referencedId: string,
+  ) => {
+    const condition = question.visibleIf;
+    if (!condition) return false;
+    if ("questionId" in condition) return condition.questionId === referencedId;
+    if (!("all" in condition) && !("any" in condition)) return false;
+    const leaves = "all" in condition ? condition.all : condition.any;
+    return leaves.some(
+      (leaf) => "questionId" in leaf && leaf.questionId === referencedId,
+    );
+  };
+  const insertionIndexFor = (questionId: string) => {
+    if (
+      questionId === SPECIALIZED_SURVEY_FIELD_IDS.task ||
+      questionId === SPECIALIZED_SURVEY_FIELD_IDS.priority
+    ) {
+      return 0;
+    }
+    if (questionId === SPECIALIZED_SURVEY_FIELD_IDS.success) {
+      const dependentPageIndex = pages.findIndex((page) =>
+        page.questions.some(
+          (question) =>
+            question.id === SPECIALIZED_SURVEY_FIELD_IDS.blocker ||
+            referencesQuestion(question, questionId),
+        ),
+      );
+      if (dependentPageIndex >= 0) return dependentPageIndex;
+    }
+    return pages.length;
+  };
+
+  for (const templatePage of template.pages) {
+    for (const question of templatePage.questions) {
+      if (!requiredIds.has(question.id) || seen.has(question.id)) continue;
+      const pageId = uniquePageId(templatePage.id);
+      pages.splice(insertionIndexFor(question.id), 0, {
+        ...templatePage,
+        id: pageId,
+        questions: [question],
+      });
+      seen.add(question.id);
+    }
+  }
+  return {
+    ...document,
+    pages: pages as SurveyDocumentV1["pages"],
+  };
+}
 
 type PageList = SurveyDocumentV1["pages"];
 type QuestionList = SurveyPageV1["questions"];
@@ -442,6 +703,40 @@ export function updateOptionLabel(
   });
 }
 
+/**
+ * Replaces a template-only option identity after the designer has supplied a
+ * real label. Later label edits keep the generated identity stable.
+ */
+export function commitOptionLabel(
+  document: SurveyDocumentV1,
+  pageId: string,
+  questionId: string,
+  optionIndex: number,
+  label: string,
+): SurveyDocumentV1 {
+  return updateChoiceOptions(document, pageId, questionId, (options) => {
+    const option = options[optionIndex];
+    if (
+      !option ||
+      !label.trim() ||
+      isSurveyTemplatePlaceholderLabel(label) ||
+      !isSurveyTemplatePlaceholderValue(option.value)
+    ) {
+      return null;
+    }
+    const existingValues = options
+      .filter((_, index) => index !== optionIndex)
+      .map((candidate) => candidate.value);
+    const next = [...options];
+    next[optionIndex] = {
+      ...option,
+      label,
+      value: slugifyOptionValue(label, existingValues),
+    };
+    return next;
+  });
+}
+
 export function updateOptionValue(
   document: SurveyDocumentV1,
   pageId: string,
@@ -579,7 +874,7 @@ export interface HandoffIssue {
  * Release-gate validation for freezing a revision. The runtime validator
  * only checks types (an empty prompt is a valid string), so the workshop
  * adds the semantic bar a handoff deserves. Deliberately NOT part of the
- * widget package — production consumers stay untouched.
+ * widget's structural validator, so drafts remain editable until handoff.
  */
 function leafConditionIssues(
   question: SurveyQuestionV1,
@@ -691,6 +986,17 @@ export function findHandoffIssues(document: SurveyDocumentV1): HandoffIssue[] {
       questionById.set(question.id, question);
     }
   }
+  for (const contractIssue of getSpecializedSurveyContractIssues(
+    document.type ?? "custom",
+    [...questionById.values()],
+  )) {
+    issues.push({
+      questionId: questionById.has(contractIssue.fieldId)
+        ? contractIssue.fieldId
+        : null,
+      message: contractIssue.message,
+    });
+  }
   for (const page of document.pages) {
     for (const question of page.questions) {
       issues.push(...leafConditionIssues(question, questionById));
@@ -701,7 +1007,35 @@ export function findHandoffIssues(document: SurveyDocumentV1): HandoffIssue[] {
         });
       }
       if (question.type === "singleChoice" || question.type === "multiChoice") {
+        if (question.options.length === 0) {
+          issues.push({
+            questionId: question.id,
+            message: "Spørsmålet må ha minst ett svaralternativ.",
+          });
+        }
+        if (
+          document.type === "topTasks" &&
+          question.id === "task" &&
+          question.options.every((option) => option.value === "other")
+        ) {
+          issues.push({
+            questionId: question.id,
+            message:
+              "Legg til minst én kjent oppgave som brukeren kan velge mellom.",
+          });
+        }
         question.options.forEach((option, index) => {
+          if (
+            isSurveyTemplatePlaceholderValue(option.value) ||
+            isSurveyTemplatePlaceholderLabel(option.label)
+          ) {
+            issues.push({
+              questionId: question.id,
+              message: `Bytt ut eksempeloppgaven i alternativ ${index + 1} med en oppgave dere vil ${
+                document.type === "taskPriority" ? "prioritere" : "måle"
+              }.`,
+            });
+          }
           if (!option.label.trim()) {
             issues.push({
               questionId: question.id,

--- a/apps/lumi-dashboard/e2e/survey-workshop.spec.ts
+++ b/apps/lumi-dashboard/e2e/survey-workshop.spec.ts
@@ -164,6 +164,141 @@ test("creates, edits, previews and shares a survey draft", async ({ page }) => {
   await expectNoAxeViolations(page);
 });
 
+test("starts a verified specialized survey from plain-language choices", async ({
+  page,
+}) => {
+  await page.goto("/surveyverksted");
+
+  const template = page.getByLabel("Hva vil dere finne ut?");
+  await template.selectOption("discovery");
+  await expect(
+    page.getByText(
+      "Finner oppgaven, om brukeren lyktes og hva som eventuelt hindret hen.",
+    ),
+  ).toBeVisible();
+
+  await page.getByLabel("Navn på utkastet").fill("E2E discoverymal");
+  await page.getByRole("button", { name: "Opprett utkast" }).click();
+  await page.waitForURL(/\/surveyverksted\/[0-9a-f-]+/);
+
+  await expect(draftField(page)).toHaveValue(
+    "Hva kom du hit for å gjøre i dag?",
+  );
+  await page.getByRole("button", { name: "Del med utvikler" }).click();
+  await expect(page.getByText("Klar til å dele versjon 1")).toBeVisible();
+  await expectNoAxeViolations(page);
+  await page.getByRole("button", { name: "Del versjon 1" }).click();
+  await expect(page).toHaveURL(/\/surveyverksted\/revisions\/[0-9a-f-]+/);
+  await expect(
+    page.getByRole("heading", { name: "Klar til bruk" }),
+  ).toBeVisible();
+});
+
+test("turns a Top Tasks example into a protected, shareable analysis", async ({
+  page,
+}, testInfo) => {
+  await page.goto("/surveyverksted");
+  await page.getByLabel("Hva vil dere finne ut?").selectOption("topTasks");
+  await page
+    .getByLabel("Navn på utkastet")
+    .fill(`E2E top tasks ${testInfo.workerIndex}-${Date.now()}`);
+  await page.getByRole("button", { name: "Opprett utkast" }).click();
+  await page.waitForURL(/\/surveyverksted\/[0-9a-f-]+/);
+
+  const firstTask = page.getByRole("textbox", {
+    name: "Alternativ 1",
+    exact: true,
+  });
+  await firstTask.fill("Sende søknad");
+  await firstTask.press("Tab");
+  await expect(
+    page.getByRole("button", { name: /endre verdi for alternativ 1/i }),
+  ).toHaveText("sende-soknad");
+  await expect(
+    page.getByRole("checkbox", { name: "Må besvares" }),
+  ).toBeDisabled();
+  await expect(
+    page.getByRole("button", { name: "Slett spørsmålet" }),
+  ).toBeDisabled();
+
+  await page.getByRole("button", { name: "Handlinger for side 1" }).click();
+  await expect(
+    page.getByRole("menuitem", {
+      name: /kan ikke slettes.*brukes i analysen/i,
+    }),
+  ).toHaveAttribute("aria-disabled", "true");
+  await page.keyboard.press("Escape");
+
+  await page.getByRole("button", { name: "Del med utvikler" }).click();
+  await expect(page.getByText("Klar til å dele versjon 1")).toBeVisible();
+  await expectNoAxeViolations(page);
+  await page.getByRole("button", { name: "Del versjon 1" }).click();
+  await expect(page).toHaveURL(/\/surveyverksted\/revisions\/[0-9a-f-]+/);
+  await expect(
+    page.getByRole("heading", { name: "Klar til bruk" }),
+  ).toBeVisible();
+});
+
+test("replaces both Task Priority examples before sharing", async ({
+  page,
+}, testInfo) => {
+  await page.goto("/surveyverksted");
+  await page.getByLabel("Hva vil dere finne ut?").selectOption("taskPriority");
+  await page
+    .getByLabel("Navn på utkastet")
+    .fill(`E2E priority ${testInfo.workerIndex}-${Date.now()}`);
+  await page.getByRole("button", { name: "Opprett utkast" }).click();
+  await page.waitForURL(/\/surveyverksted\/[0-9a-f-]+/);
+
+  await page.getByRole("button", { name: "Del med utvikler" }).click();
+  await expect(page.getByText(/bytt ut eksempeloppgaven/i)).toBeVisible();
+  await page.keyboard.press("Escape");
+
+  const first = page.getByRole("textbox", {
+    name: "Alternativ 1",
+    exact: true,
+  });
+  const second = page.getByRole("textbox", {
+    name: "Alternativ 2",
+    exact: true,
+  });
+  await first.fill("Søke om støtte");
+  await second.fill("Sjekke status");
+  await second.press("Tab");
+  await expect(
+    page.getByRole("button", { name: /endre verdi for alternativ 1/i }),
+  ).toHaveText("soke-om-stotte");
+  await expect(
+    page.getByRole("button", { name: /endre verdi for alternativ 2/i }),
+  ).toHaveText("sjekke-status");
+  const maxSelections = page.getByLabel(
+    "Maks antall alternativer brukeren kan velge",
+  );
+  await expect(maxSelections).toHaveValue("2");
+
+  // Repair remains announced and focused on repeated use, not only the first.
+  for (let attempt = 0; attempt < 2; attempt += 1) {
+    await maxSelections.fill("");
+    await page
+      .getByRole("button", { name: "Gjenopprett analyseoppsettet" })
+      .click();
+    const repairNotice = page
+      .locator('div[tabindex="-1"]')
+      .filter({ hasText: "Analyseoppsettet er gjenopprettet" });
+    await expect(repairNotice).toBeFocused();
+    await expect(maxSelections).toHaveValue("2");
+  }
+
+  await page.getByRole("button", { name: "Del med utvikler" }).click();
+  await expect(page.getByText("Klar til å dele versjon 1")).toBeVisible();
+  await expectNoAxeViolations(page);
+  await page.getByRole("button", { name: "Del versjon 1" }).click();
+  await expect(page).toHaveURL(/\/surveyverksted\/revisions\/[0-9a-f-]+/);
+  await expect(
+    page.getByRole("heading", { name: "Klar til bruk" }),
+  ).toBeVisible();
+});
+
 test("authors intro and confirmation screens that render in the real widget", async ({
   page,
 }) => {

--- a/apps/lumi-local-demo/src/scenarios.ts
+++ b/apps/lumi-local-demo/src/scenarios.ts
@@ -1,12 +1,11 @@
 import {
-  createTaskPrioritySurvey,
-  createTopTasksSurvey,
-  DEFAULT_SURVEY_DISCOVERY,
-  DEFAULT_SURVEY_NPS,
-  DEFAULT_SURVEY_RATING,
-  DEFAULT_SURVEY_STARS,
-  DEFAULT_SURVEY_THUMBS,
+  createTaskPrioritySurveyDocument,
+  createTopTasksSurveyDocument,
+  DEFAULT_DISCOVERY_SURVEY_DOCUMENT,
+  DEFAULT_RATING_SURVEY_DOCUMENT,
   type LumiSurveyDefinition,
+  type SurveyDocumentV1,
+  type SurveyQuestionV1,
 } from "@navikt/lumi-survey";
 
 export interface DemoScenario {
@@ -26,48 +25,114 @@ const tasks = [
   { value: "change", label: "Melde fra om en endring" },
 ];
 
+function ratingDocument(
+  id: string,
+  firstQuestion: SurveyQuestionV1,
+  ...followUps: SurveyQuestionV1[]
+): SurveyDocumentV1 {
+  return {
+    authoringSchemaVersion: 1,
+    type: "rating",
+    pages: [{ id, questions: [firstQuestion, ...followUps] }],
+  };
+}
+
 export const demoScenarios: DemoScenario[] = [
   {
     id: "rating-emoji",
     title: "Rating · emoji",
     summary: "Standard 1–5-opplevelse med progressiv fritekst.",
     coverage: ["rating", "emoji", "text", "visibleIf"],
-    survey: DEFAULT_SURVEY_RATING,
+    survey: DEFAULT_RATING_SURVEY_DOCUMENT,
   },
   {
     id: "rating-thumbs",
     title: "Rating · tommel",
     summary: "Binært hjelpsomhetsspørsmål med oppfølging.",
     coverage: ["rating", "thumbs", "text"],
-    survey: DEFAULT_SURVEY_THUMBS,
+    survey: ratingDocument(
+      "helpful",
+      {
+        id: "helpful",
+        type: "rating",
+        variant: "thumbs",
+        prompt: "Var dette til hjelp?",
+        required: true,
+      },
+      {
+        id: "feedback",
+        type: "text",
+        prompt: "Har du forslag til forbedringer?",
+        required: false,
+        maxLength: 500,
+        visibleIf: { questionId: "helpful", operator: "EXISTS" },
+      },
+    ),
   },
   {
     id: "rating-stars",
     title: "Rating · stjerner",
     summary: "Fem stjerner og valgfri begrunnelse.",
     coverage: ["rating", "stars", "text"],
-    survey: DEFAULT_SURVEY_STARS,
+    survey: ratingDocument(
+      "stars",
+      {
+        id: "stars",
+        type: "rating",
+        variant: "stars",
+        prompt: "Hvordan opplevde du å bruke tjenesten?",
+        required: true,
+      },
+      {
+        id: "feedback",
+        type: "text",
+        prompt: "Legg gjerne til en begrunnelse",
+        required: false,
+        maxLength: 1000,
+        visibleIf: { questionId: "stars", operator: "EXISTS" },
+      },
+    ),
   },
   {
     id: "rating-nps",
     title: "Rating · NPS",
     summary: "0–10-skala med endeetiketter.",
     coverage: ["rating", "nps", "text"],
-    survey: DEFAULT_SURVEY_NPS,
+    survey: ratingDocument(
+      "nps",
+      {
+        id: "nps",
+        type: "rating",
+        variant: "nps",
+        prompt:
+          "Hvor sannsynlig er det at du vil anbefale denne tjenesten til en venn eller kollega?",
+        lowLabel: "Lite sannsynlig",
+        highLabel: "Svært sannsynlig",
+        required: true,
+      },
+      {
+        id: "reason",
+        type: "text",
+        prompt: "Legg gjerne til en begrunnelse",
+        required: false,
+        maxLength: 500,
+        visibleIf: { questionId: "nps", operator: "EXISTS" },
+      },
+    ),
   },
   {
     id: "discovery",
     title: "Discovery",
     summary: "Oppgave i fritekst, gjennomføring og eventuell hindring.",
     coverage: ["discovery", "text", "singleChoice"],
-    survey: DEFAULT_SURVEY_DISCOVERY,
+    survey: DEFAULT_DISCOVERY_SURVEY_DOCUMENT,
   },
   {
     id: "top-tasks",
     title: "Top Tasks",
-    summary: "Forgrenet oppgavevalg med annet-felt og tidlig submit.",
-    coverage: ["topTasks", "singleChoice", "logic", "text"],
-    survey: createTopTasksSurvey({
+    summary: "Sidebasert oppgavevalg med annet-felt og relevante oppfølginger.",
+    coverage: ["topTasks", "singleChoice", "visibleIf", "pages", "text"],
+    survey: createTopTasksSurveyDocument({
       tasks,
       includeOtherTask: true,
       includeBlockerQuestion: true,
@@ -78,7 +143,7 @@ export const demoScenarios: DemoScenario[] = [
     title: "Task Priority · avkryssing",
     summary: "Flervalg i kompakt checkbox-variant.",
     coverage: ["taskPriority", "multiChoice", "checkbox"],
-    survey: createTaskPrioritySurvey({
+    survey: createTaskPrioritySurveyDocument({
       tasks,
       maxSelections: 3,
       randomize: false,
@@ -90,7 +155,7 @@ export const demoScenarios: DemoScenario[] = [
     title: "Task Priority · komboboks",
     summary: "Søkbar flervalgsliste med chips.",
     coverage: ["taskPriority", "multiChoice", "combobox"],
-    survey: createTaskPrioritySurvey({
+    survey: createTaskPrioritySurveyDocument({
       tasks,
       maxSelections: 3,
       randomize: false,
@@ -103,38 +168,44 @@ export const demoScenarios: DemoScenario[] = [
     summary: "Alle generiske felttyper i én eksplisitt stegflyt.",
     coverage: ["custom", "text", "singleChoice", "multiChoice"],
     survey: {
+      authoringSchemaVersion: 1,
       type: "custom",
-      questions: [
+      pages: [
         {
-          id: "customText",
-          type: "text",
-          prompt: "Hva vil du teste i dag?",
-          placeholder: "Skriv en kort testmerknad",
-          maxLength: 300,
-          required: true,
-        },
-        {
-          id: "customSingle",
-          type: "singleChoice",
-          prompt: "Velg én kanal",
-          options: [
-            { value: "web", label: "Web" },
-            { value: "phone", label: "Telefon" },
-            { value: "office", label: "Kontor" },
+          id: "field-matrix",
+          questions: [
+            {
+              id: "customText",
+              type: "text",
+              prompt: "Hva vil du teste i dag?",
+              placeholder: "Skriv en kort testmerknad",
+              maxLength: 300,
+              required: true,
+            },
+            {
+              id: "customSingle",
+              type: "singleChoice",
+              prompt: "Velg én kanal",
+              options: [
+                { value: "web", label: "Web" },
+                { value: "phone", label: "Telefon" },
+                { value: "office", label: "Kontor" },
+              ],
+              required: true,
+            },
+            {
+              id: "customMulti",
+              type: "multiChoice",
+              variant: "checkbox",
+              prompt: "Velg én eller flere egenskaper",
+              options: [
+                { value: "clear", label: "Tydelig" },
+                { value: "fast", label: "Rask" },
+                { value: "safe", label: "Trygg" },
+              ],
+              required: true,
+            },
           ],
-          required: true,
-        },
-        {
-          id: "customMulti",
-          type: "multiChoice",
-          variant: "checkbox",
-          prompt: "Velg én eller flere egenskaper",
-          options: [
-            { value: "clear", label: "Tydelig" },
-            { value: "fast", label: "Rask" },
-            { value: "safe", label: "Trygg" },
-          ],
-          required: true,
         },
       ],
     },

--- a/docs/dashboard/filtrering.md
+++ b/docs/dashboard/filtrering.md
@@ -60,7 +60,7 @@ Filtrer ned til en spesifikk survey ved å velge survey-ID.
 
 ### Top Tasks drill-down
 
-For Top Tasks-surveys kan du filtrere på en spesifikk oppgave (task) for å se detaljstatistikk.
+For Top Tasks-surveys kan du filtrere på en spesifikk oppgave for å se detaljstatistikk. URL-en lagrer den stabile svarverdien (`taskId`), mens dashboardet viser teksten designeren har gitt oppgaven. Dermed fortsetter filteret å virke hvis teksten forbedres senere.
 
 ## Sortering og paginering
 

--- a/docs/guider/context-og-tags.md
+++ b/docs/guider/context-og-tags.md
@@ -107,7 +107,7 @@ Debug-verdier vises kun i detaljvisningen for enkeltinnsendinger. De brukes *ikk
 ```tsx
 <LumiSurveyDock
   surveyId="dine-sykmeldte-tilbakemelding"
-  survey={DEFAULT_SURVEY_RATING}
+  survey={survey}
   transport={transport}
   behavior={{ collectLocation: false }}
   context={{

--- a/docs/guider/presets-og-builders.md
+++ b/docs/guider/presets-og-builders.md
@@ -5,6 +5,6 @@ search: false
 
 # Eldre presets og builders
 
-Pakkens presets og builder-funksjoner lager den eldre, flate `LumiSurveyConfig`. De fortsetter å virke i 2.x, men skal ikke brukes til nye surveyer.
+De eldre presetene og builder-funksjonene lager en flat `LumiSurveyConfig`. De fortsetter å virke i 2.x, men skal ikke brukes til nye surveyer. De anbefalte builderne ender på `SurveyDocument` og er dokumentert under [Velg hva dere vil måle](/guider/surveytyper).
 
 Lag nye surveyer i [Surveyverksted](/kom-i-gang/lag-survey) eller som `SurveyDocumentV1` i kode. Se [Migrer en eldre survey](/referanse/migrer-eldre-survey) hvis du vedlikeholder et eksisterende oppsett.

--- a/docs/guider/sporsmalstyper.md
+++ b/docs/guider/sporsmalstyper.md
@@ -161,19 +161,20 @@ For mange alternativer (f.eks. Task Priority-surveyer) er combobox-varianten bed
 
 ```tsx
 {
-  id: "priorities",
+  id: "priority",
   type: "multiChoice",
   variant: "combobox",
-  prompt: "Velg de 5 viktigste oppgavene for deg",
-  maxSelections: 5,
+  prompt: "Hvilke oppgaver er viktigst for deg?",
+  maxSelections: 2,
   randomize: true,
   options: [
     { value: "apply", label: "Søke om sykepenger" },
     { value: "status", label: "Sjekke status" },
-    // ... flere alternativer
   ],
 }
 ```
+
+`maxSelections` må være minst 1 og kan ikke være høyere enn antallet alternativer.
 
 ### Felt for valgspørsmål
 

--- a/docs/guider/surveytyper.md
+++ b/docs/guider/surveytyper.md
@@ -4,15 +4,18 @@ title: Velg hva dere vil måle
 
 # Velg hva dere vil måle
 
-Feltet `type` forteller Lumi hvilken analyse surveyen tilhører. For nye surveyer i Surveyverksted eller `SurveyDocumentV1` bruker du vanligvis `rating` eller `custom`.
+Feltet `type` forteller Lumi hvilken analyse surveyen tilhører. Start med det dere vil finne ut — Surveyverkstedet og de ferdige kodemalene setter riktig type og struktur for dere.
 
 `type` bestemmer ikke hvilke sider eller spørsmål dokumentet kan ha. Spørsmålene og ID-ene avgjør hvilke data dashboardet faktisk kan vise.
 
-## Anbefalt for nye surveyer
+## Velg et oppsett
 
 | Type | Bruk når | Hva dashboardet viser |
 | :--- | :--- | :--- |
 | `rating` | Dere vil måle opplevelsen etter en konkret oppgave | Utvikling i vurderinger over tid og fritekstsvar |
+| `discovery` | Dere vil forstå hva brukeren kom for å gjøre | Oppgaver i fritekst, om brukeren lyktes og hindringer |
+| `topTasks` | Dere kjenner oppgavene og vil måle om brukeren lyktes | Resultat og hindringer per oppgave |
+| `taskPriority` | Dere vil prioritere mellom en liste med oppgaver | Hvilke oppgaver som får flest stemmer |
 | `custom` | Dere trenger spørsmål eller analyse som ikke passer i rating | Generell oversikt over svarene |
 
 ### `rating`
@@ -20,45 +23,78 @@ Feltet `type` forteller Lumi hvilken analyse surveyen tilhører. For nye surveye
 Bruk `rating` til en kort måling etter at brukeren har gjort noe konkret. Start med ett vurderingsspørsmål. Legg til et oppfølgingsspørsmål bare når dere vet hvordan svaret skal brukes.
 
 ```typescript
-import type { SurveyDocumentV1 } from "@navikt/lumi-survey";
+import { createRatingSurveyDocument } from "@navikt/lumi-survey";
 
-const survey = {
-  authoringSchemaVersion: 1,
-  type: "rating",
-  pages: [
-    {
-      id: "vurdering",
-      questions: [
-        {
-          id: "opplevelse",
-          type: "rating",
-          variant: "emoji",
-          prompt: "Hvordan var det å sende inn søknaden?",
-          required: true,
-        },
-      ],
-    },
-  ],
-} satisfies SurveyDocumentV1;
+const survey = createRatingSurveyDocument({
+  ratingPrompt: "Hvordan var det å sende inn søknaden?",
+  variant: "emoji",
+});
 ```
+
+Velg `variant: "emoji"`, `"thumbs"`, `"stars"` eller `"nps"`. For NPS kan dere også sette `lowLabel` og `highLabel`, for eksempel «Lite sannsynlig» og «Svært sannsynlig».
 
 ### `custom`
 
 Bruk `custom` når ingen av de spesialiserte analysetypene passer. Du kan bruke alle spørsmålstyper, sider og `visibleIf`.
 
-Velg `custom` hvis dere ikke bruker et ferdig og verifisert oppsett for en spesialisert analyse. Typeverdien alene gjør ikke et vilkårlig dokument om til en discovery-, top tasks- eller prioriteringsanalyse.
+Velg `custom` hvis ingen av de ferdige oppsettene passer. Typeverdien alene gjør ikke et vilkårlig dokument om til en discovery-, top tasks- eller prioriteringsanalyse.
 
-## Spesialiserte typer for eksisterende oppsett
+## Ferdige oppsett for oppgaver
 
-Pakken støtter også `discovery`, `topTasks` og `taskPriority`. Disse analysene forventer bestemte spørsmåls-ID-er og svarformer. Dagens ferdige oppsett bruker den eldre, flate konfigurasjonsmodellen, og kontraktene er ennå ikke tilgjengelige som verifiserte `SurveyDocumentV1`-maler.
+Dokumentbyggerne på denne siden krever `@navikt/lumi-survey` 2.1.0 eller nyere.
 
-Ikke velg disse typene manuelt i en ny survey. Ta kontakt i [#lumi på Slack](https://nav-it.slack.com/archives/C0AG2FKSSMD) hvis dere vil sette opp en slik analyse. Eksisterende surveyer fortsetter å virke.
+Velg samme oppsett i Surveyverkstedet, eller bruk en av funksjonene under i kode. Funksjonene returnerer ferdige `SurveyDocumentV1`-dokumenter med sidene og spørsmåls-ID-ene analysen trenger.
 
-| Type | Formål |
-| :--- | :--- |
-| `discovery` | Forstå hva brukeren kom for å gjøre, om hen fikk gjort det og hva som hindret hen |
-| `topTasks` | Måle resultatet for en kjent liste med kjerneoppgaver |
-| `taskPriority` | La brukerne velge hvilke oppgaver som er viktigst |
+### Forstå hva brukeren kom for å gjøre
+
+```typescript
+import { createDiscoverySurveyDocument } from "@navikt/lumi-survey";
+
+const survey = createDiscoverySurveyDocument();
+```
+
+Bruk discovery når dere ikke vil gi brukeren en oppgaveliste. Brukeren beskriver oppgaven med egne ord og svarer deretter på om hen lyktes. Spørsmålet om hindringer vises bare ved «Delvis» eller «Nei».
+
+### Måle om brukeren lyktes med en kjent oppgave
+
+```typescript
+import { createTopTasksSurveyDocument } from "@navikt/lumi-survey";
+
+const survey = createTopTasksSurveyDocument({
+  tasks: [
+    { value: "soke", label: "Søke om sykepenger" },
+    { value: "status", label: "Sjekke status på søknaden" },
+  ],
+  includeOtherTask: true,
+});
+```
+
+Bruk top tasks når dere allerede kjenner de viktigste oppgavene. Hold listen kort nok til at brukeren raskt finner riktig oppgave.
+
+`value` er oppgavens stabile ID (`taskId`) i analyse, filtre og delbare lenker. Behold den når dere bare retter teksten. `label` er teksten brukeren ser, og kan endres uten at historikken splittes. Se [survey-identitet](/guider/survey-identitet) før dere endrer en publisert oppgaveliste.
+
+### Prioritere mellom oppgaver
+
+```typescript
+import { createTaskPrioritySurveyDocument } from "@navikt/lumi-survey";
+
+const survey = createTaskPrioritySurveyDocument({
+  tasks: [
+    { value: "soke", label: "Søke om sykepenger" },
+    { value: "status", label: "Sjekke status på søknaden" },
+    { value: "ettersende", label: "Ettersende dokumentasjon" },
+  ],
+  maxSelections: 2,
+});
+```
+
+Bruk oppgaveprioritering når dere skal velge hva dere bør forbedre eller bygge først. En reell undersøkelse trenger vanligvis en større og gjennomarbeidet oppgaveliste enn det korte kodeeksemplet.
+
+Også her er `value` den stabile oppgave-ID-en, mens `label` er teksten som kan forbedres senere.
+
+::: warning Behold feltene analysen trenger
+Dere kan endre teksten og legge til egne spørsmål. Analysefeltene må være obligatoriske og alltid synlige. Ikke slett dem, bytt spørsmålstype eller endre svarverdiene som malen beskytter. Surveyverkstedet forklarer begrensningene i redigeringen og sjekker oppsettet før overlevering. Widgeten og API-et avviser også et ugyldig oppsett.
+:::
 
 ## Videre lesing
 

--- a/docs/kom-i-gang/konfigurer-survey.md
+++ b/docs/kom-i-gang/konfigurer-survey.md
@@ -31,7 +31,7 @@ import { survey } from "./survey";
 
 Eksporten inneholder `satisfies SurveyDocumentV1`, slik at appens TypeScript-oppsett sjekker dokumentet. Appen eier filen og ruller den ut på vanlig måte.
 
-Kontroller også `type` før utrulling. Nye utkast fra Surveyverksted starter som `rating`. Bytt til `custom` hvis surveyen ikke lenger er en vurderingssurvey. De andre analysetypene krever bestemte spørsmåls-ID-er og svarformer; se [Velg hva dere vil måle](/guider/surveytyper).
+Surveyverksted setter `type` og analysefeltene fra oppsettet dere valgte da utkastet ble opprettet. Ikke endre disse for hånd i den eksporterte koden. Skal surveyen måle noe annet, lag et nytt utkast med riktig oppsett. Se [Velg hva dere vil måle](/guider/surveytyper).
 
 Skriver du surveyen direkte i kode, kan du starte med eksempelet under.
 

--- a/docs/kom-i-gang/lag-survey.md
+++ b/docs/kom-i-gang/lag-survey.md
@@ -11,15 +11,15 @@ Du kan også skrive `SurveyDocumentV1` direkte i kode. Begge veier gir det samme
 ## Lag et utkast i Surveyverksted
 
 1. Åpne [Surveyverksted i produksjon](https://lumi-dashboard.ansatt.nav.no/surveyverksted).
-2. Velg team og gi utkastet et navn.
-3. Legg til sider og spørsmål.
+2. Velg team, gi utkastet et navn og velg hva dere vil finne ut.
+3. Tilpass spørsmålene og oppgavelisten i oppsettet dere valgte.
 4. Bruk forhåndsvisningen mens du jobber. Velg **Prøv i egen fane** for å gå gjennom surveyen slik brukeren gjør.
 5. Legg til en velkomstside eller tilpass bekreftelsen etter innsending når det gir brukeren nødvendig informasjon.
 
 Utkast lagres automatisk for teamet. Det er fortsatt et arbeidsdokument og påvirker ingen survey som allerede er i produksjon.
 
-::: info Sjekk analysetypen før utrulling
-Nye utkast starter som `type: "rating"`. Surveyverksted har foreløpig ikke et eget valg for analysetype. Hvis dere erstatter vurderingsspørsmålet med andre spørsmål, skal utvikleren kontrollere det eksporterte dokumentet og vanligvis endre `type` til `"custom"` før utrulling. Se [Velg hva dere vil måle](/guider/surveytyper).
+::: info Oppsettet følger det dere vil finne ut
+Valget ved opprettelse setter riktig analysetype og feltene analysen trenger. Surveyverksted beskytter disse feltene mot endringer som ville gjort svarene ubrukelige. Er ingen av de ferdige oppsettene riktig, velger dere **Noe annet**.
 :::
 
 ## Del en versjon

--- a/docs/referanse/datakontrakt.md
+++ b/docs/referanse/datakontrakt.md
@@ -116,6 +116,21 @@ Backend mapper `surveyType`-strenger til enums:
 | `"taskPriority"` | `SurveyType.TASK_PRIORITY` |
 | Alt annet | `SurveyType.CUSTOM` |
 
+### Faste felt i spesialiserte analyser
+
+Bruk de ferdige oppsettene i Surveyverkstedet eller funksjonene som er beskrevet under [Velg hva dere vil måle](/guider/surveytyper). API-et avviser en spesialisert survey som mangler feltene analysen trenger.
+
+| Type | Felt | Spørsmålstype | Svar som har fast betydning |
+| :--- | :--- | :--- | :--- |
+| `discovery` | `task` | Fritekst | — |
+| `discovery` | `success` | Enkeltvalg | `yes`, `partial`, `no` |
+| `topTasks` | `task` | Enkeltvalg | ID-ene til oppgavene dere oppgir |
+| `topTasks` | `success` | Enkeltvalg | `yes`, `partial`, `no` |
+| `taskPriority` | `priority` | Flervalg | ID-ene til oppgavene dere oppgir |
+
+`blocker` er et valgfritt fritekstfelt i discovery og top tasks. Dere kan legge til egne spørsmål utenom feltene i tabellen.
+`success` skal ha nøyaktig de tre svarverdiene i tabellen; ekstra utfall kan ikke klassifiseres av analysen og blir avvist.
+
 ## Komplett eksempel
 
 ```json

--- a/packages/lumi-survey/CHANGELOG.md
+++ b/packages/lumi-survey/CHANGELOG.md
@@ -6,10 +6,24 @@ This project follows SemVer.
 
 ## [Unreleased]
 
-## [2.0.2] - 2026-08-20
+## [2.1.0] - 2026-08-20
+
+### Added
+
+- `createRatingSurveyDocument` and `DEFAULT_RATING_SURVEY_DOCUMENT` make the page-based model the recommended starting point for rating surveys too.
+- `createDiscoverySurveyDocument`, `createTopTasksSurveyDocument` and `createTaskPrioritySurveyDocument` provide verified, page-based `SurveyDocumentV1` templates for Lumi's specialized analytics.
+- Specialized survey contracts are checked by the widget before transport so invalid field IDs or answer shapes cannot silently produce empty analytics.
+
+### Fixed
+
+- Specialized fields must now be required and always visible, Task Priority enforces a usable selection limit, optional answers are validated when supplied, and checkbox choices enforce `maxSelections` in the UI as well as at submission.
+- Submission setup errors now settle the widget in its error state and call `onSubmitError` instead of leaving the UI in a permanent submitting state.
+- The new Discovery, Top Tasks and Task Priority document builders use one canonical field vocabulary: `task`, `success`, `blocker` and `priority`. The widget and API continue to accept the field IDs emitted by the deprecated 2.0.1 builders. Specialized analytics require an explicit `type`, so ordinary surveys with similarly named fields are never misclassified.
+- Multi-choice `maxSelections` is now part of the V2 definition contract and is enforced by the API. Existing definitions without the field are enriched once on their first compatible submission; later limit changes are rejected as structural changes.
 
 ### Documentation
 
+- The legacy flat `LumiSurveyConfig`, rating presets and builders are marked deprecated in TypeScript while remaining runtime-compatible in 2.x.
 - The package README now teaches `SurveyDocumentV1` as the only model for new surveys and links to the page, visibility and migration guides. Legacy flat configs, presets, builders and `logic` remain supported in 2.x but are documented only as compatibility APIs.
 - The `LumiSurveyDock` example now uses a consumer-defined `survey` variable instead of the nonexistent `NAV_STANDARD_RATING` symbol.
 

--- a/packages/lumi-survey/README.md
+++ b/packages/lumi-survey/README.md
@@ -102,6 +102,8 @@ export function FeedbackWidget() {
 
 Hver side blir et steg når dokumentet har flere sider. Legg flere spørsmål på samme side når de skal vises og valideres sammen. Bruk `visibleIf` for å vise bare relevante oppfølgingsspørsmål.
 
+Bruk de sidebaserte malene når dere vil starte fra et kontrollert oppsett: `createRatingSurveyDocument`, `createDiscoverySurveyDocument`, `createTopTasksSurveyDocument` og `createTaskPrioritySurveyDocument`. Se [Velg hva dere vil måle](https://navikt.github.io/lumi/guider/surveytyper) for eksempler og valg av metode.
+
 ## Koble til Lumi
 
 `transport.submit` skal sende `submission.transportPayload` til appens eget endepunkt. Endepunktet gjør token exchange og videresender til Lumi API.
@@ -123,4 +125,4 @@ Se [Koble til backend](https://navikt.github.io/lumi/kom-i-gang/koble-til-backen
 
 ## Eldre surveyer
 
-Flat `LumiSurveyConfig`, presets, builder-funksjoner og `logic` fortsetter å virke i 2.x. Ikke bruk dem i nye surveyer. Se [migreringsguiden](https://navikt.github.io/lumi/referanse/migrer-eldre-survey) når du skal endre en eksisterende survey.
+Flat `LumiSurveyConfig`, eldre presets, eldre builder-funksjoner og `logic` fortsetter å virke i 2.x. Ikke bruk dem i nye surveyer. Funksjonene som ender på `SurveyDocument` er de anbefalte, sidebaserte malene. Se [migreringsguiden](https://navikt.github.io/lumi/referanse/migrer-eldre-survey) når du skal endre en eksisterende survey.

--- a/packages/lumi-survey/package.json
+++ b/packages/lumi-survey/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@navikt/lumi-survey",
-  "version": "2.0.2",
+  "version": "2.1.0",
   "private": false,
   "description": "Aksel-based React widget for configurable NAV Lumi surveys.",
   "type": "module",

--- a/packages/lumi-survey/src/components/LumiSurveyDock/__tests__/LumiSurveyDock.test.tsx
+++ b/packages/lumi-survey/src/components/LumiSurveyDock/__tests__/LumiSurveyDock.test.tsx
@@ -943,7 +943,7 @@ describe("LumiSurveyDock", () => {
     ).toBeGreaterThan(0);
   });
 
-  it("submits from taskSuccess when the blocker becomes hidden (top tasks)", async () => {
+  it("submits from success when the blocker becomes hidden (top tasks)", async () => {
     const transportSubmit = vi.fn().mockResolvedValue(undefined);
     const user = userEvent.setup();
 
@@ -963,7 +963,7 @@ describe("LumiSurveyDock", () => {
     await user.click(screen.getByRole("radio", { name: /oppgave 1/i }));
     await user.click(screen.getByRole("button", { name: /neste/i }));
 
-    // Step 2: taskSuccess
+    // Step 2: success
     await waitFor(() => {
       expect(screen.getByRole("radio", { name: /^ja$/i })).toBeInTheDocument();
     });

--- a/packages/lumi-survey/src/components/LumiSurveyDock/propTypes.ts
+++ b/packages/lumi-survey/src/components/LumiSurveyDock/propTypes.ts
@@ -73,8 +73,9 @@ export type StorageStrategy = "consent" | "localStorage" | "none";
  * - "auto": authored pages become steps; legacy surveys use step mode only
  *   when branching logic exists (default)
  * - "singlePage": show all visible authored pages/questions on one surface
- * - "steps": authored pages become steps; legacy surveys show one question
- *   per step
+ * - "steps": compatibility override for flat legacy surveys. New surveys
+ *   should express grouping and steps with `SurveyDocumentV1.pages` and leave
+ *   this setting as "auto"
  */
 export type QuestionLayout = "auto" | "singlePage" | "steps";
 

--- a/packages/lumi-survey/src/components/questions/DefaultQuestionRenderer/__tests__/DefaultQuestionRenderer.test.tsx
+++ b/packages/lumi-survey/src/components/questions/DefaultQuestionRenderer/__tests__/DefaultQuestionRenderer.test.tsx
@@ -550,6 +550,50 @@ describe("DefaultQuestionRenderer", () => {
     expect(handleChange.mock.calls[0][0]).toHaveLength(2);
   });
 
+  it("enforces maxSelections for checkbox multi-choice questions", () => {
+    const handleChange = vi.fn();
+    const question = {
+      id: "multi-limited",
+      type: "multiChoice" as const,
+      prompt: "Velg opptil to",
+      maxSelections: 2,
+      options: [
+        { value: "a", label: "A" },
+        { value: "b", label: "B" },
+        { value: "c", label: "C" },
+      ],
+    };
+
+    const { rerender } = render(
+      <DefaultQuestionRenderer
+        question={question}
+        value={["a", "b"]}
+        onChange={handleChange}
+        validationErrorMessage="Velg opptil to"
+        isMissing={false}
+        disabled={false}
+      />,
+    );
+    expect(screen.getByRole("checkbox", { name: "C" })).toBeDisabled();
+    expect(screen.getByRole("checkbox", { name: "A" })).toBeEnabled();
+    fireEvent.click(screen.getByRole("checkbox", { name: "C" }));
+    expect(handleChange).not.toHaveBeenCalled();
+
+    rerender(
+      <DefaultQuestionRenderer
+        question={question}
+        value={["a"]}
+        onChange={handleChange}
+        validationErrorMessage="Velg opptil to"
+        isMissing={false}
+        disabled={false}
+      />,
+    );
+    expect(screen.getByRole("checkbox", { name: "C" })).toBeEnabled();
+    fireEvent.click(screen.getByRole("checkbox", { name: "C" }));
+    expect(handleChange).toHaveBeenCalledWith(["a", "c"]);
+  });
+
   it("returns null for unsupported question types", () => {
     const question: LumiSurveyQuestion = {
       id: "unknown",

--- a/packages/lumi-survey/src/components/questions/choice/MultiChoiceField.tsx
+++ b/packages/lumi-survey/src/components/questions/choice/MultiChoiceField.tsx
@@ -28,14 +28,26 @@ export const MultiChoiceField = ({
 }: MultiChoiceFieldProps) => {
   const options = useChoiceOptions(question);
   const selected = Array.isArray(value) ? value : [];
+  const maxSelections = question.maxSelections;
+  const selectionLimitReached =
+    maxSelections !== undefined && selected.length >= maxSelections;
+  const description = [
+    question.description,
+    maxSelections ? `Velg opptil ${maxSelections}` : undefined,
+  ]
+    .filter(Boolean)
+    .join(" • ");
 
   return (
     <CheckboxGroup
       legend={formatQuestionPrompt(question)}
       hideLegend={hideLabel}
-      description={question.description}
+      description={description || undefined}
       value={selected}
-      onChange={(nextValues: string[]) => onChange(nextValues)}
+      onChange={(nextValues: string[]) => {
+        if (maxSelections && nextValues.length > maxSelections) return;
+        onChange(nextValues);
+      }}
       disabled={disabled}
       error={isMissing ? validationErrorMessage : undefined}
     >
@@ -44,6 +56,10 @@ export const MultiChoiceField = ({
           key={option.value}
           value={option.value}
           description={option.description}
+          disabled={
+            disabled ||
+            (selectionLimitReached && !selected.includes(option.value))
+          }
         >
           {option.label}
         </Checkbox>

--- a/packages/lumi-survey/src/components/shared/__tests__/canonicalSurvey.test.ts
+++ b/packages/lumi-survey/src/components/shared/__tests__/canonicalSurvey.test.ts
@@ -265,6 +265,27 @@ describe("buildCanonicalSurvey", () => {
         ],
       }),
     ).toThrowError(/invalid maxSelections/i);
+
+    expect(() =>
+      validateSurveyDocumentV1({
+        authoringSchemaVersion: 1,
+        type: "custom",
+        pages: [
+          {
+            id: "choices",
+            questions: [
+              {
+                id: "topics",
+                type: "multiChoice",
+                prompt: "Velg tema",
+                options: [{ value: "one", label: "Ett" }],
+                maxSelections: 2,
+              },
+            ],
+          },
+        ],
+      }),
+    ).toThrowError(/invalid maxSelections/i);
   });
 
   it("sets survey type if provided", () => {

--- a/packages/lumi-survey/src/components/shared/canonicalSurvey.ts
+++ b/packages/lumi-survey/src/components/shared/canonicalSurvey.ts
@@ -540,7 +540,8 @@ function validateDocumentQuestion(
       candidate.maxSelections !== undefined &&
       (typeof candidate.maxSelections !== "number" ||
         !Number.isInteger(candidate.maxSelections) ||
-        candidate.maxSelections <= 0)
+        candidate.maxSelections <= 0 ||
+        candidate.maxSelections > candidate.options.length)
     ) {
       throw new Error(
         `Lumi: Choice question "${candidate.id}" has an invalid maxSelections`,

--- a/packages/lumi-survey/src/components/surveyTypes.ts
+++ b/packages/lumi-survey/src/components/surveyTypes.ts
@@ -10,6 +10,9 @@ export type { SurveyType };
  * Configuration for a Lumi survey.
  * Questions are displayed in array order.
  * Use `visibleIf` on individual questions for progressive disclosure.
+ *
+ * @deprecated Use `SurveyDocumentV1`. The flat shape remains supported for
+ * existing integrations, but new surveys should describe explicit pages.
  */
 export interface LumiSurveyConfig {
   /** Versioned documents use `SurveyDocumentV1` instead. */

--- a/packages/lumi-survey/src/contracts/lumiApi.ts
+++ b/packages/lumi-survey/src/contracts/lumiApi.ts
@@ -162,6 +162,7 @@ export interface MultiChoiceSubmissionFieldDefinition
   extends SubmissionFieldDefinitionBase {
   fieldType: "MULTI_CHOICE";
   optionIds: string[];
+  maxSelections?: number;
 }
 
 export interface DateSubmissionFieldDefinition

--- a/packages/lumi-survey/src/core/__tests__/definitionBlock.test.ts
+++ b/packages/lumi-survey/src/core/__tests__/definitionBlock.test.ts
@@ -24,6 +24,7 @@ describe("buildDefinitionBlock", () => {
           { value: "ui", label: "UI" },
           { value: "perf", label: "Performance" },
         ],
+        maxSelections: 1,
       },
     ];
 
@@ -54,6 +55,7 @@ describe("buildDefinitionBlock", () => {
       fieldId: "tags",
       fieldType: "MULTI_CHOICE",
       optionIds: ["ui", "perf"],
+      maxSelections: 1,
     });
   });
 

--- a/packages/lumi-survey/src/core/__tests__/useLumiSurvey.test.ts
+++ b/packages/lumi-survey/src/core/__tests__/useLumiSurvey.test.ts
@@ -201,7 +201,7 @@ describe("useLumiSurvey", () => {
         surveyId: SURVEY_ID,
         questions: requiredQuestions,
         transport,
-        surveyType: "topTasks",
+        surveyType: "custom",
       }),
     );
 
@@ -215,7 +215,7 @@ describe("useLumiSurvey", () => {
     });
 
     const payload = submitMock.mock.calls[0][0];
-    expect(payload.transportPayload.definition.surveyType).toBe("topTasks");
+    expect(payload.transportPayload.definition.surveyType).toBe("custom");
   });
 
   it("submits answers when validation passes", async () => {
@@ -475,6 +475,55 @@ describe("useLumiSurvey", () => {
     expect(events.onValidationFailed).not.toHaveBeenCalled();
     expect(events.onAnswer).toHaveBeenCalledWith("rating", 3);
     expect(events.onAnswer).toHaveBeenCalledWith("feedback", "Hei");
+  });
+
+  it("turns payload contract errors into a settled transport error", async () => {
+    const transport: LumiSurveyTransport = { submit: vi.fn() };
+    const events = createEventSpies();
+    const questions: LumiSurveyQuestion[] = [
+      {
+        id: "task",
+        type: "text",
+        prompt: "Oppgave",
+        required: true,
+      },
+      {
+        id: "success",
+        type: "singleChoice",
+        prompt: "Resultat",
+        required: false,
+        options: [
+          { value: "yes", label: "Ja" },
+          { value: "partial", label: "Delvis" },
+          { value: "no", label: "Nei" },
+        ],
+      },
+    ];
+    const { result } = renderHook(() =>
+      useLumiSurvey({
+        surveyId: SURVEY_ID,
+        questions,
+        surveyType: "discovery",
+        transport,
+        events,
+      }),
+    );
+    await act(() => {
+      result.current.setAnswer("task", "Søke");
+      result.current.setAnswer("success", "yes");
+    });
+
+    let submission: LumiSurveySubmitResult | undefined;
+    await act(async () => {
+      submission = await result.current.submit();
+    });
+
+    expect(submission?.ok).toBe(false);
+    expect(result.current.status).toBe("error");
+    expect(result.current.error?.type).toBe("transport");
+    expect(transport.submit).not.toHaveBeenCalled();
+    expect(events.onSubmitStart).not.toHaveBeenCalled();
+    expect(events.onSubmitError).toHaveBeenCalledWith(expect.any(Error));
   });
 
   it("resets answers to the initial snapshot and refreshes startedAt", async () => {

--- a/packages/lumi-survey/src/core/__tests__/validation.test.ts
+++ b/packages/lumi-survey/src/core/__tests__/validation.test.ts
@@ -61,4 +61,43 @@ describe("validateAnswers", () => {
       "rating",
     ]);
   });
+
+  it("validates optional answers when a value is present", () => {
+    const question: LumiSurveyQuestion = {
+      id: "choice",
+      type: "singleChoice",
+      prompt: "Velg",
+      required: false,
+      options: [{ value: "known", label: "Kjent" }],
+    };
+
+    expect(validateAnswers([question], {})).toEqual([]);
+    expect(validateAnswers([question], { choice: "unknown" })).toEqual([
+      "choice",
+    ]);
+  });
+
+  it("enforces unique multi-choice values and maxSelections", () => {
+    const question: LumiSurveyQuestion = {
+      id: "priority",
+      type: "multiChoice",
+      prompt: "Velg",
+      maxSelections: 2,
+      options: [
+        { value: "one", label: "Én" },
+        { value: "two", label: "To" },
+        { value: "three", label: "Tre" },
+      ],
+    };
+
+    expect(validateAnswers([question], { priority: ["one", "two"] })).toEqual(
+      [],
+    );
+    expect(validateAnswers([question], { priority: ["one", "one"] })).toEqual([
+      "priority",
+    ]);
+    expect(
+      validateAnswers([question], { priority: ["one", "two", "three"] }),
+    ).toEqual(["priority"]);
+  });
 });

--- a/packages/lumi-survey/src/core/definitionBlock.ts
+++ b/packages/lumi-survey/src/core/definitionBlock.ts
@@ -38,6 +38,18 @@ export function buildDefinitionBlock(
           fieldId: question.id,
           fieldType: "MULTI_CHOICE" as const,
           optionIds: question.options.map((o) => o.value),
+          ...(question.maxSelections === undefined
+            ? {}
+            : {
+                // Flat 2.0.x configs could declare a limit above their option
+                // count. Its effective limit was still the option count; keep
+                // that runtime behavior when serializing the stricter V2
+                // definition. V1 documents reject this shape during validation.
+                maxSelections: Math.min(
+                  question.maxSelections,
+                  question.options.length,
+                ),
+              }),
         };
       default:
         return {

--- a/packages/lumi-survey/src/core/index.ts
+++ b/packages/lumi-survey/src/core/index.ts
@@ -23,5 +23,6 @@ export {
   shouldShowSubmitButton,
 } from "./evaluateVisibility";
 export * from "./ratingLabels";
+export * from "./specializedSurveyContract.js";
 export * from "./types";
 export * from "./useLumiSurvey";

--- a/packages/lumi-survey/src/core/specializedSurveyContract.ts
+++ b/packages/lumi-survey/src/core/specializedSurveyContract.ts
@@ -1,0 +1,278 @@
+import type { LumiSurveyQuestionType, SurveyType } from "./types";
+
+export interface SpecializedSurveyContractIssue {
+  fieldId: string;
+  message: string;
+}
+
+export const SPECIALIZED_SURVEY_FIELD_IDS = {
+  task: "task",
+  success: "success",
+  blocker: "blocker",
+  priority: "priority",
+} as const;
+
+/** Field IDs emitted by the deprecated flat builders through version 2.0.1. */
+export const LEGACY_SPECIALIZED_SURVEY_FIELD_IDS = {
+  discoveryTask: "discoveredTask",
+  success: "taskSuccess",
+  priority: "priorities",
+} as const;
+
+interface RequiredField {
+  id: string;
+  type: LumiSurveyQuestionType;
+  optional?: boolean;
+  optionIds?: readonly string[];
+}
+
+interface SurveyContractQuestion {
+  id: string;
+  type: LumiSurveyQuestionType;
+  required?: boolean;
+  options?: readonly { value: string }[];
+  visibleIf?: unknown;
+  maxSelections?: number;
+}
+
+const outcomeOptionIds = ["yes", "partial", "no"] as const;
+
+const contractNames = {
+  discovery: "Hva kom brukeren for å gjøre?",
+  topTasks: "Lyktes brukeren med en kjent oppgave?",
+  taskPriority: "Hvilke oppgaver er viktigst?",
+} as const;
+
+const contracts: Partial<Record<SurveyType, readonly RequiredField[]>> = {
+  discovery: [
+    { id: SPECIALIZED_SURVEY_FIELD_IDS.task, type: "text" },
+    {
+      id: SPECIALIZED_SURVEY_FIELD_IDS.success,
+      type: "singleChoice",
+      optionIds: outcomeOptionIds,
+    },
+    {
+      id: SPECIALIZED_SURVEY_FIELD_IDS.blocker,
+      type: "text",
+      optional: true,
+    },
+  ],
+  topTasks: [
+    { id: SPECIALIZED_SURVEY_FIELD_IDS.task, type: "singleChoice" },
+    {
+      id: SPECIALIZED_SURVEY_FIELD_IDS.success,
+      type: "singleChoice",
+      optionIds: outcomeOptionIds,
+    },
+    {
+      id: SPECIALIZED_SURVEY_FIELD_IDS.blocker,
+      type: "text",
+      optional: true,
+    },
+  ],
+  taskPriority: [
+    { id: SPECIALIZED_SURVEY_FIELD_IDS.priority, type: "multiChoice" },
+  ],
+};
+
+const legacyContracts: Partial<Record<SurveyType, readonly RequiredField[]>> = {
+  discovery: [
+    { id: LEGACY_SPECIALIZED_SURVEY_FIELD_IDS.discoveryTask, type: "text" },
+    {
+      id: LEGACY_SPECIALIZED_SURVEY_FIELD_IDS.success,
+      type: "singleChoice",
+      optionIds: outcomeOptionIds,
+    },
+    {
+      id: SPECIALIZED_SURVEY_FIELD_IDS.blocker,
+      type: "text",
+      optional: true,
+    },
+  ],
+  topTasks: [
+    { id: SPECIALIZED_SURVEY_FIELD_IDS.task, type: "singleChoice" },
+    {
+      id: LEGACY_SPECIALIZED_SURVEY_FIELD_IDS.success,
+      type: "singleChoice",
+      optionIds: outcomeOptionIds,
+    },
+    {
+      id: SPECIALIZED_SURVEY_FIELD_IDS.blocker,
+      type: "text",
+      optional: true,
+    },
+  ],
+  taskPriority: [
+    {
+      id: LEGACY_SPECIALIZED_SURVEY_FIELD_IDS.priority,
+      type: "multiChoice",
+    },
+  ],
+};
+
+/**
+ * Checks the fixed fields that Lumi's specialized dashboards read.
+ * Extra questions are allowed; missing or repurposed contract fields are not.
+ */
+export function getSpecializedSurveyContractIssues(
+  surveyType: SurveyType,
+  questions: readonly SurveyContractQuestion[],
+  options: { allowLegacyFieldIds?: boolean } = {},
+): SpecializedSurveyContractIssue[] {
+  const canonicalContract = contracts[surveyType];
+  if (!canonicalContract) return [];
+  const contractName = contractNames[surveyType as keyof typeof contractNames];
+
+  const questionsById = new Map(
+    questions.map((question) => [question.id, question]),
+  );
+  if (options.allowLegacyFieldIds) {
+    const aliasPairs: Array<readonly [string, string]> = [];
+    if (surveyType === "discovery") {
+      aliasPairs.push([
+        SPECIALIZED_SURVEY_FIELD_IDS.task,
+        LEGACY_SPECIALIZED_SURVEY_FIELD_IDS.discoveryTask,
+      ]);
+    }
+    if (surveyType === "discovery" || surveyType === "topTasks") {
+      aliasPairs.push([
+        SPECIALIZED_SURVEY_FIELD_IDS.success,
+        LEGACY_SPECIALIZED_SURVEY_FIELD_IDS.success,
+      ]);
+    }
+    if (surveyType === "taskPriority") {
+      aliasPairs.push([
+        SPECIALIZED_SURVEY_FIELD_IDS.priority,
+        LEGACY_SPECIALIZED_SURVEY_FIELD_IDS.priority,
+      ]);
+    }
+    const duplicateAlias = aliasPairs.find(
+      ([canonical, legacy]) =>
+        questionsById.has(canonical) && questionsById.has(legacy),
+    );
+    if (duplicateAlias) {
+      return [
+        {
+          fieldId: duplicateAlias[0],
+          message: `Oppsettet kan ikke inneholde både «${duplicateAlias[0]}» og den eldre ID-en «${duplicateAlias[1]}».`,
+        },
+      ];
+    }
+  }
+  const legacyContract = legacyContracts[surveyType];
+  const hasEveryRequiredField = (candidate: readonly RequiredField[]) =>
+    candidate.every(
+      (required) => required.optional || questionsById.has(required.id),
+    );
+  const contract =
+    options.allowLegacyFieldIds &&
+    legacyContract &&
+    !hasEveryRequiredField(canonicalContract) &&
+    hasEveryRequiredField(legacyContract)
+      ? legacyContract
+      : canonicalContract;
+  const usesLegacyContract = contract === legacyContract;
+
+  const issues = contract.flatMap((required) => {
+    const question = questionsById.get(required.id);
+    if (!question) {
+      if (required.optional) return [];
+      return [
+        {
+          fieldId: required.id,
+          message: `Oppsettet «${contractName}» trenger spørsmålet «${required.id}».`,
+        },
+      ];
+    }
+    if (question.type !== required.type) {
+      return [
+        {
+          fieldId: required.id,
+          message: `Spørsmålet «${required.id}» har feil type for oppsettet «${contractName}».`,
+        },
+      ];
+    }
+    if (required.optionIds) {
+      const actualOptionIds =
+        question.options?.map((option) => option.value) ?? [];
+      const expectedOptionIds = new Set(required.optionIds);
+      const actualOptionIdSet = new Set(actualOptionIds);
+      if (
+        actualOptionIds.length !== expectedOptionIds.size ||
+        actualOptionIdSet.size !== expectedOptionIds.size ||
+        actualOptionIds.some((optionId) => !expectedOptionIds.has(optionId))
+      ) {
+        return [
+          {
+            fieldId: required.id,
+            message: `Spørsmålet «${required.id}» må ha nøyaktig svarene Ja, Delvis og Nei for oppsettet «${contractName}».`,
+          },
+        ];
+      }
+    }
+    if (!required.optional && question.required !== true) {
+      return [
+        {
+          fieldId: required.id,
+          message: `Spørsmålet «${required.id}» må være merket «Må besvares» for oppsettet «${contractName}».`,
+        },
+      ];
+    }
+    if (!required.optional && question.visibleIf !== undefined) {
+      return [
+        {
+          fieldId: required.id,
+          message: `Spørsmålet «${required.id}» må alltid vises i oppsettet «${contractName}».`,
+        },
+      ];
+    }
+    return [];
+  });
+
+  if (surveyType === "taskPriority" && !usesLegacyContract) {
+    const priorityFieldId = contract.find(
+      (field) => field.type === "multiChoice" && !field.optional,
+    )?.id;
+    const priority = priorityFieldId
+      ? questionsById.get(priorityFieldId)
+      : undefined;
+    if (priority?.type === "multiChoice") {
+      const optionCount = priority.options?.length ?? 0;
+      if (optionCount < 2) {
+        issues.push({
+          fieldId: priority.id,
+          message:
+            "Oppsettet «Hvilke oppgaver er viktigst?» trenger minst to oppgaver å velge mellom.",
+        });
+      }
+      if (
+        !Number.isInteger(priority.maxSelections) ||
+        (priority.maxSelections ?? 0) < 1 ||
+        (priority.maxSelections ?? 0) > optionCount
+      ) {
+        issues.push({
+          fieldId: priority.id,
+          message:
+            "Antallet brukeren kan velge må være mellom 1 og antallet oppgaver i listen.",
+        });
+      }
+    }
+  }
+
+  return issues;
+}
+
+export function assertSpecializedSurveyContract(
+  surveyType: SurveyType,
+  questions: readonly SurveyContractQuestion[],
+  options: { allowLegacyFieldIds?: boolean } = {},
+): void {
+  const [firstIssue] = getSpecializedSurveyContractIssues(
+    surveyType,
+    questions,
+    options,
+  );
+  if (firstIssue) {
+    throw new Error(`Lumi: ${firstIssue.message}`);
+  }
+}

--- a/packages/lumi-survey/src/core/transportPayload.ts
+++ b/packages/lumi-survey/src/core/transportPayload.ts
@@ -1,4 +1,5 @@
 import { buildDefinitionBlock } from "./definitionBlock.js";
+import { assertSpecializedSurveyContract } from "./specializedSurveyContract.js";
 import type {
   ChoiceOption,
   LumiSurveyAnswerValue,
@@ -17,28 +18,8 @@ import { RATING_SCALES } from "./types";
  * This ensures analytics always gets a valid surveyType even if not explicitly set.
  */
 export function inferSurveyType(questions: LumiSurveyQuestion[]): SurveyType {
-  // Check for Discovery pattern: has "discoveredTask" text field
-  const hasDiscoveredTask = questions.some(
-    (q) => q.id === "discoveredTask" && q.type === "text",
-  );
-  if (hasDiscoveredTask) return "discovery";
-
-  // Check for TopTasks pattern: has "task" single choice + "taskSuccess"
-  const hasTask = questions.some(
-    (q) => q.id === "task" && q.type === "singleChoice",
-  );
-  const hasTaskSuccess = questions.some(
-    (q) => q.id === "taskSuccess" && q.type === "singleChoice",
-  );
-  if (hasTask && hasTaskSuccess) return "topTasks";
-
-  // Check for TaskPriority pattern: has "priorities" multi choice
-  const hasPriorities = questions.some(
-    (q) => q.id === "priorities" && q.type === "multiChoice",
-  );
-  if (hasPriorities) return "taskPriority";
-
-  // Check for Rating pattern: has a rating question
+  // Specialized analytics require an explicit type. Their field IDs are
+  // ordinary words that custom surveys may legitimately use.
   const hasRating = questions.some((q) => q.type === "rating");
   if (hasRating) return "rating";
 
@@ -62,6 +43,9 @@ export function buildTransportPayload(
 
   // Add survey type - use provided or infer from questions
   const resolvedSurveyType = surveyType ?? inferSurveyType(questions);
+  assertSpecializedSurveyContract(resolvedSurveyType, questions, {
+    allowLegacyFieldIds: true,
+  });
 
   const definition = buildDefinitionBlock(questions, resolvedSurveyType);
 
@@ -157,6 +141,13 @@ export function buildTransportPayload(
       value: answerValue,
     });
   }
+
+  const answeredFieldIds = new Set(answersList.map((answer) => answer.fieldId));
+  assertSpecializedSurveyContract(
+    resolvedSurveyType,
+    questions.filter((question) => answeredFieldIds.has(question.id)),
+    { allowLegacyFieldIds: true },
+  );
 
   payload.answers = answersList;
 

--- a/packages/lumi-survey/src/core/types.ts
+++ b/packages/lumi-survey/src/core/types.ts
@@ -71,12 +71,18 @@ export type VisibleIfCondition = LogicLeafCondition | LogicConditionGroup;
  * - "JUMP_TO": Jump to a specific question by ID
  * - "SKIP": Skip the next question (go to currentIndex + 2)
  * - "SUBMIT": Submit the survey immediately
+ *
+ * @deprecated Compatibility type for legacy flat surveys. New surveys should
+ * use `SurveyDocumentV1` pages and `visibleIf` instead of imperative logic.
  */
 export type LogicActionType = "JUMP_TO" | "SKIP" | "SUBMIT";
 
 /**
  * Action to perform when a logic condition is met.
  * Uses discriminated unions to ensure targetId is provided for JUMP_TO.
+ *
+ * @deprecated Compatibility type for legacy flat surveys. New surveys should
+ * use `SurveyDocumentV1` pages and `visibleIf`.
  */
 export type LogicAction =
   | {
@@ -97,6 +103,9 @@ export type LogicAction =
 /**
  * A branching rule that controls survey navigation.
  * Rules are evaluated in order; first matching rule wins.
+ *
+ * @deprecated Compatibility type for legacy flat surveys. New surveys should
+ * model the flow with `SurveyDocumentV1` pages and `visibleIf`.
  */
 export interface LogicRule {
   /** Condition to evaluate (leaf only — `logic` does not support any/all groups) */
@@ -120,6 +129,9 @@ export interface LumiSurveyQuestionBase<TType extends LumiSurveyQuestionType> {
    * Optional branching rules evaluated after this question is answered.
    * Rules are evaluated in order; first matching rule determines navigation.
    * If no rules match (or logic is undefined), proceeds to next question.
+   *
+   * @deprecated Supported for existing flat surveys only. New surveys should
+   * use `SurveyDocumentV1` pages and `visibleIf`.
    */
   logic?: LogicRule[];
   /**
@@ -266,7 +278,7 @@ export type LumiSurveyAnswerValue = string | number | string[];
  * - "rating": Classic 1-5 scale with optional text (current default behavior)
  * - "topTasks": Task selection + success measurement for conversion tracking
  * - "discovery": Free-text task discovery to identify what users are trying to do
- * - "taskPriority": Users select their top 5 most important tasks from a list
+ * - "taskPriority": Users select a configured number of important tasks from a list
  * - "custom": Any other question combination
  */
 export type SurveyType =
@@ -310,7 +322,12 @@ export type TransportFieldDefinition =
     }
   | { fieldId: string; fieldType: "TEXT" }
   | { fieldId: string; fieldType: "SINGLE_CHOICE"; optionIds: string[] }
-  | { fieldId: string; fieldType: "MULTI_CHOICE"; optionIds: string[] };
+  | {
+      fieldId: string;
+      fieldType: "MULTI_CHOICE";
+      optionIds: string[];
+      maxSelections?: number;
+    };
 
 /**
  * V2 submission definition block containing survey structure.

--- a/packages/lumi-survey/src/core/useLumiSurvey.ts
+++ b/packages/lumi-survey/src/core/useLumiSurvey.ts
@@ -100,35 +100,34 @@ export function useLumiSurvey(
       setStatus("submitting");
       setError(null);
 
-      const answerSnapshot = cloneAnswers(answers);
-      const submittedAnswers = getVisibleAnswers(
-        questions,
-        answerSnapshot,
-        getVisibilityMetadata(context),
-      );
-      const submittedAtTimestamp = new Date().toISOString();
-      const deduplicationKey = getDeduplicationKey();
-      const submission: LumiSurveySubmission = {
-        surveyId,
-        answers: submittedAnswers,
-        startedAt: startedAtRef.current,
-        submittedAt: submittedAtTimestamp,
-        context: context ? { ...context } : undefined,
-        transportPayload: buildTransportPayload(
-          surveyId,
-          submittedAnswers,
-          questions,
-          deduplicationKey,
-          surveyType,
-          context,
-          startedAtRef.current,
-          submittedAtTimestamp,
-        ),
-      };
-
-      events?.onSubmitStart?.(submission);
-
       try {
+        const answerSnapshot = cloneAnswers(answers);
+        const submittedAnswers = getVisibleAnswers(
+          questions,
+          answerSnapshot,
+          getVisibilityMetadata(context),
+        );
+        const submittedAtTimestamp = new Date().toISOString();
+        const deduplicationKey = getDeduplicationKey();
+        const submission: LumiSurveySubmission = {
+          surveyId,
+          answers: submittedAnswers,
+          startedAt: startedAtRef.current,
+          submittedAt: submittedAtTimestamp,
+          context: context ? { ...context } : undefined,
+          transportPayload: buildTransportPayload(
+            surveyId,
+            submittedAnswers,
+            questions,
+            deduplicationKey,
+            surveyType,
+            context,
+            startedAtRef.current,
+            submittedAtTimestamp,
+          ),
+        };
+
+        events?.onSubmitStart?.(submission);
         await transport.submit(submission);
         setStatus("success");
         setError(null);

--- a/packages/lumi-survey/src/core/validation.ts
+++ b/packages/lumi-survey/src/core/validation.ts
@@ -13,14 +13,10 @@ export function validateAnswers(
   const missingIds: string[] = [];
 
   for (const question of questions) {
-    if (!question.required) {
-      continue;
-    }
-
     const answer = answers[question.id];
 
     if (!isAnswerPresent(answer)) {
-      missingIds.push(question.id);
+      if (question.required) missingIds.push(question.id);
       continue;
     }
 
@@ -123,6 +119,13 @@ function isValidMultiChoiceAnswer(
   const optionValues = new Set(
     question.options.map(({ value }: ChoiceOption) => value),
   );
+  if (new Set(rawAnswer).size !== rawAnswer.length) return false;
+  if (
+    question.maxSelections !== undefined &&
+    rawAnswer.length > question.maxSelections
+  ) {
+    return false;
+  }
   return rawAnswer.every(
     (value) => typeof value === "string" && optionValues.has(value),
   );

--- a/packages/lumi-survey/src/index.ts
+++ b/packages/lumi-survey/src/index.ts
@@ -25,10 +25,16 @@ export type {
 export * from "./core/index.js";
 export {
   createDiscoverySurvey,
+  createDiscoverySurveyDocument,
   // Builder functions
   createRatingSurvey,
+  createRatingSurveyDocument,
   createTaskPrioritySurvey,
+  createTaskPrioritySurveyDocument,
   createTopTasksSurvey,
+  createTopTasksSurveyDocument,
+  DEFAULT_DISCOVERY_SURVEY_DOCUMENT,
+  DEFAULT_RATING_SURVEY_DOCUMENT,
   DEFAULT_SURVEY_DISCOVERY,
   DEFAULT_SURVEY_NPS,
   // Default presets
@@ -36,4 +42,9 @@ export {
   DEFAULT_SURVEY_SERVICE_FEEDBACK,
   DEFAULT_SURVEY_STARS,
   DEFAULT_SURVEY_THUMBS,
+  type DiscoverySurveyOptions,
+  type RatingSurveyDocumentOptions,
+  type RatingSurveyOptions,
+  type TaskPrioritySurveyOptions,
+  type TopTasksSurveyOptions,
 } from "./presets/index.js";

--- a/packages/lumi-survey/src/presets/__tests__/specializedSurveyDocuments.test.ts
+++ b/packages/lumi-survey/src/presets/__tests__/specializedSurveyDocuments.test.ts
@@ -1,0 +1,410 @@
+import { describe, expect, it } from "vitest";
+import { validateSurveyDocumentV1 } from "../../components/shared/canonicalSurvey";
+import {
+  buildTransportPayload,
+  inferSurveyType,
+} from "../../core/transportPayload";
+import type { LumiSurveyQuestion } from "../../core/types";
+import type { RatingSurveyDocumentOptions } from "../../index";
+import {
+  createDiscoverySurvey,
+  createDiscoverySurveyDocument,
+  createRatingSurveyDocument,
+  createTaskPrioritySurvey,
+  createTaskPrioritySurveyDocument,
+  createTopTasksSurvey,
+  createTopTasksSurveyDocument,
+} from "../index";
+
+const tasks = [
+  { value: "apply", label: "Søke" },
+  { value: "status", label: "Sjekke status" },
+];
+
+function questionsFromPages(
+  pages: ReturnType<typeof createDiscoverySurveyDocument>["pages"],
+): LumiSurveyQuestion[] {
+  return pages.flatMap((page) => page.questions) as LumiSurveyQuestion[];
+}
+
+describe("specialized survey contracts", () => {
+  it("exports the recommended rating options from the package root", () => {
+    const options = {
+      ratingPrompt: "Hvordan gikk det?",
+      variant: "thumbs",
+    } satisfies RatingSurveyDocumentOptions;
+    expect(
+      createRatingSurveyDocument(options).pages[0].questions[0],
+    ).toMatchObject({ variant: "thumbs" });
+  });
+  it("creates a page-based rating document with progressive follow-ups", () => {
+    const document = createRatingSurveyDocument({
+      ratingPrompt: "Hvordan gikk det?",
+      followUpQuestions: [
+        {
+          id: "reason",
+          type: "text",
+          prompt: "Fortell mer",
+        },
+      ],
+    });
+
+    expect(document.pages).toHaveLength(1);
+    expect(document.pages[0].questions[1]).toMatchObject({
+      id: "reason",
+      visibleIf: {
+        questionId: "rating",
+        operator: "EXISTS",
+      },
+    });
+    expect(validateSurveyDocumentV1(document)).toBe(document);
+  });
+
+  it.each([
+    "emoji",
+    "thumbs",
+    "stars",
+  ] as const)("creates a %s rating document", (variant) => {
+    const document = createRatingSurveyDocument({
+      ratingPrompt: "Hvordan gikk det?",
+      variant,
+    });
+    expect(document.pages[0].questions[0]).toMatchObject({ variant });
+    expect(validateSurveyDocumentV1(document)).toBe(document);
+  });
+
+  it("creates an NPS document with endpoint labels", () => {
+    const document = createRatingSurveyDocument({
+      ratingPrompt: "Hvor sannsynlig er det at du anbefaler oss?",
+      variant: "nps",
+      lowLabel: "Lite sannsynlig",
+      highLabel: "Svært sannsynlig",
+    });
+    expect(document.pages[0].questions[0]).toMatchObject({
+      variant: "nps",
+      lowLabel: "Lite sannsynlig",
+      highLabel: "Svært sannsynlig",
+    });
+  });
+
+  it.each([
+    {
+      name: "discovery",
+      document: createDiscoverySurveyDocument(),
+      expectedIds: ["task", "success", "blocker"],
+    },
+    {
+      name: "top tasks",
+      document: createTopTasksSurveyDocument({ tasks }),
+      expectedIds: ["task", "success", "blocker"],
+    },
+    {
+      name: "task priority",
+      document: createTaskPrioritySurveyDocument({ tasks }),
+      expectedIds: ["priority"],
+    },
+  ])("creates a valid page-based $name document", ({
+    document,
+    expectedIds,
+  }) => {
+    expect(validateSurveyDocumentV1(document)).toBe(document);
+    expect(document.pages.map((page) => page.id)).toEqual(expectedIds);
+    expect(
+      questionsFromPages(document.pages).map((question) => question.id),
+    ).toEqual(expectedIds);
+  });
+
+  it.each([
+    [createDiscoverySurvey(), ["discoveredTask", "taskSuccess", "blocker"]],
+    [createTopTasksSurvey({ tasks }), ["task", "taskSuccess", "blocker"]],
+    [createTaskPrioritySurvey({ tasks }), ["priorities"]],
+  ])("preserves the 2.0.1 field IDs from a deprecated builder", (survey, ids) => {
+    expect(survey.questions.map((question) => question.id)).toEqual(ids);
+  });
+
+  it("still transports a deprecated Discovery config", () => {
+    const survey = createDiscoverySurvey();
+    expect(() =>
+      buildTransportPayload(
+        "legacy-discovery",
+        {
+          discoveredTask: "Søke om sykepenger",
+          taskSuccess: "yes",
+        },
+        survey.questions,
+        "1234567890abcdef",
+        survey.type,
+        undefined,
+        undefined,
+        "2026-08-20T12:00:00Z",
+      ),
+    ).not.toThrow();
+  });
+
+  it("keeps a one-option deprecated Task Priority survey transport-compatible", () => {
+    const survey = createTaskPrioritySurvey({
+      tasks: [{ value: "apply", label: "Søke" }],
+      maxSelections: 5,
+    });
+    const payload = buildTransportPayload(
+      "legacy-priority",
+      { priorities: ["apply"] },
+      survey.questions,
+      "1234567890abcdef",
+      survey.type,
+      undefined,
+      undefined,
+      "2026-08-20T12:00:00Z",
+    );
+    expect(payload.definition.fields[0]).toMatchObject({ maxSelections: 1 });
+  });
+
+  it("never infers specialized analytics from ordinary custom field names", () => {
+    expect(
+      inferSurveyType([
+        {
+          id: "task",
+          type: "text",
+          prompt: "Oppgave",
+          required: true,
+        },
+        {
+          id: "success",
+          type: "singleChoice",
+          prompt: "Resultat",
+          required: true,
+          options: [{ value: "done", label: "Ferdig" }],
+        },
+      ]),
+    ).toBe("custom");
+    expect(
+      inferSurveyType([
+        {
+          id: "priority",
+          type: "multiChoice",
+          prompt: "Prioritet",
+          options: [{ value: "one", label: "Én" }],
+        },
+      ]),
+    ).toBe("custom");
+  });
+
+  it("rejects empty, blank and duplicate task lists at the builder boundary", () => {
+    expect(() => createTopTasksSurveyDocument({ tasks: [] })).toThrow(
+      "Top Tasks needs at least one task",
+    );
+    expect(() =>
+      createTaskPrioritySurveyDocument({
+        tasks: [{ value: " ", label: "Oppgave" }],
+      }),
+    ).toThrow("tasks need a non-blank value and label");
+    expect(() =>
+      createTopTasksSurveyDocument({
+        tasks: [
+          { value: "same", label: "Første" },
+          { value: "same", label: "Andre" },
+        ],
+      }),
+    ).toThrow("task values must be unique");
+    expect(() =>
+      createTopTasksSurveyDocument({
+        tasks: [{ value: "other", label: "Noe annet" }],
+        includeOtherTask: true,
+      }),
+    ).toThrow('reserves the task value "other"');
+    expect(() =>
+      createTaskPrioritySurveyDocument({ tasks, maxSelections: 0 }),
+    ).toThrow("maxSelections must be a positive integer");
+    expect(() =>
+      createTaskPrioritySurveyDocument({
+        tasks: [{ value: "one", label: "Én oppgave" }],
+      }),
+    ).toThrow("requires at least two tasks");
+    expect(() =>
+      createTaskPrioritySurveyDocument({ tasks, maxSelections: 3 }),
+    ).toThrow("maxSelections cannot exceed the number of tasks");
+  });
+
+  it("uses a neutral Task Priority prompt and a truthful limit", () => {
+    const document = createTaskPrioritySurveyDocument({ tasks });
+    const [question] = questionsFromPages(document.pages);
+
+    expect(question.prompt).toBe("Hvilke oppgaver er viktigst for deg?");
+    expect(question).toMatchObject({ maxSelections: 2 });
+  });
+
+  it("rejects an unusable Task Priority selection rule", () => {
+    const document = createTaskPrioritySurveyDocument({ tasks });
+    const questions = questionsFromPages(document.pages);
+    const priority = questions[0];
+    if (priority.type !== "multiChoice") {
+      throw new Error("missing priority question");
+    }
+
+    priority.maxSelections = 3;
+    expect(() =>
+      buildTransportPayload(
+        "priority-test",
+        { priority: ["apply"] },
+        questions,
+        "1234567890abcdef",
+        document.type,
+        undefined,
+        undefined,
+        "2026-08-20T12:00:00Z",
+      ),
+    ).toThrow("må være mellom 1 og antallet oppgaver");
+  });
+
+  it("builds the exact Discovery payload consumed by analytics", () => {
+    const document = createDiscoverySurveyDocument();
+    const questions = questionsFromPages(document.pages);
+    const payload = buildTransportPayload(
+      "discovery-test",
+      {
+        task: "Søke om sykepenger",
+        success: "partial",
+        blocker: "Fant ikke riktig skjema",
+      },
+      questions,
+      "1234567890abcdef",
+      document.type,
+      undefined,
+      undefined,
+      "2026-08-20T12:00:00Z",
+    );
+
+    expect(payload.surveyType).toBe("discovery");
+    expect(
+      payload.answers.map((answer) => [answer.fieldId, answer.fieldType]),
+    ).toEqual([
+      ["task", "TEXT"],
+      ["success", "SINGLE_CHOICE"],
+      ["blocker", "TEXT"],
+    ]);
+    expect(payload.definition.fields.map((field) => field.fieldId)).toEqual([
+      "task",
+      "success",
+      "blocker",
+    ]);
+  });
+
+  it("refuses transport when a required analytics answer is missing", () => {
+    const document = createDiscoverySurveyDocument();
+    const questions = questionsFromPages(document.pages);
+
+    expect(() =>
+      buildTransportPayload(
+        "discovery-test",
+        { task: "Søke om sykepenger" },
+        questions,
+        "1234567890abcdef",
+        document.type,
+        undefined,
+        undefined,
+        "2026-08-20T12:00:00Z",
+      ),
+    ).toThrow(
+      "Lumi: Oppsettet «Hva kom brukeren for å gjøre?» trenger spørsmålet «success».",
+    );
+  });
+
+  it("refuses an extra outcome and a repurposed blocker field", () => {
+    const document = createTopTasksSurveyDocument({ tasks });
+    const questions = questionsFromPages(document.pages);
+    const success = questions.find((question) => question.id === "success");
+    const blocker = questions.find((question) => question.id === "blocker");
+    if (!success || success.type !== "singleChoice" || !blocker) {
+      throw new Error("missing contract questions");
+    }
+    success.options.push({ value: "unknown", label: "Vet ikke" });
+
+    expect(() =>
+      buildTransportPayload(
+        "top-tasks-test",
+        { task: "apply", success: "yes" },
+        questions,
+        "1234567890abcdef",
+        document.type,
+        undefined,
+        undefined,
+        "2026-08-20T12:00:00Z",
+      ),
+    ).toThrow("må ha nøyaktig svarene Ja, Delvis og Nei");
+
+    success.options.pop();
+    Object.assign(blocker, {
+      type: "singleChoice",
+      options: [{ value: "other", label: "Annet" }],
+    });
+    expect(() =>
+      buildTransportPayload(
+        "top-tasks-test",
+        { task: "apply", success: "yes" },
+        questions,
+        "1234567890abcdef",
+        document.type,
+        undefined,
+        undefined,
+        "2026-08-20T12:00:00Z",
+      ),
+    ).toThrow("Spørsmålet «blocker» har feil type");
+  });
+
+  it("requires contract questions to be mandatory, unconditional and unique", () => {
+    const document = createDiscoverySurveyDocument();
+    const questions = questionsFromPages(document.pages);
+    const success = questions.find((question) => question.id === "success");
+    if (!success || success.type !== "singleChoice") {
+      throw new Error("missing success question");
+    }
+
+    success.required = false;
+    expect(() =>
+      buildTransportPayload(
+        "discovery-test",
+        { task: "Søke", success: "yes" },
+        questions,
+        "1234567890abcdef",
+        document.type,
+        undefined,
+        undefined,
+        "2026-08-20T12:00:00Z",
+      ),
+    ).toThrow("må være merket «Må besvares»");
+
+    success.required = true;
+    success.visibleIf = { questionId: "task", operator: "EXISTS" };
+    expect(() =>
+      buildTransportPayload(
+        "discovery-test",
+        { task: "Søke", success: "yes" },
+        questions,
+        "1234567890abcdef",
+        document.type,
+        undefined,
+        undefined,
+        "2026-08-20T12:00:00Z",
+      ),
+    ).toThrow("må alltid vises");
+
+    delete success.visibleIf;
+    success.options = [
+      { value: "yes", label: "Ja" },
+      { value: "yes", label: "Ja igjen" },
+      { value: "partial", label: "Delvis" },
+    ];
+    expect(() =>
+      buildTransportPayload(
+        "discovery-test",
+        { task: "Søke", success: "yes" },
+        questions,
+        "1234567890abcdef",
+        document.type,
+        undefined,
+        undefined,
+        "2026-08-20T12:00:00Z",
+      ),
+    ).toThrow("må ha nøyaktig svarene");
+  });
+});

--- a/packages/lumi-survey/src/presets/__tests__/topTasksSurvey.test.ts
+++ b/packages/lumi-survey/src/presets/__tests__/topTasksSurvey.test.ts
@@ -1,60 +1,69 @@
 import { describe, expect, it } from "vitest";
 import { evaluateVisibility } from "../../core/evaluateVisibility";
-import { createTopTasksSurvey } from "../index";
+import type { VisibleIfCondition } from "../../core/types";
+import { createTopTasksSurveyDocument } from "../index";
 
-describe("createTopTasksSurvey", () => {
+describe("createTopTasksSurveyDocument", () => {
   it("uses visibleIf to show otherTask only when task is 'other'", () => {
-    const survey = createTopTasksSurvey({
+    const survey = createTopTasksSurveyDocument({
       tasks: [{ value: "t1", label: "Oppgave 1" }],
       includeOtherTask: true,
       includeBlockerQuestion: true,
     });
 
-    const [taskQuestion, otherTaskQuestion, taskSuccessQuestion] =
-      survey.questions;
+    const questions = survey.pages.flatMap((page) => page.questions);
+    const [taskQuestion, otherTaskQuestion, successQuestion] = questions;
 
     expect(taskQuestion.id).toBe("task");
     expect(otherTaskQuestion.id).toBe("otherTask");
-    expect(taskSuccessQuestion.id).toBe("taskSuccess");
+    expect(successQuestion.id).toBe("success");
 
-    expect(survey.questions.every((question) => !question.logic)).toBe(true);
+    expect(questions.every((question) => !("logic" in question))).toBe(true);
     expect(otherTaskQuestion.visibleIf).toEqual({
       questionId: "task",
       operator: "EQ",
       value: "other",
     });
     expect(
-      evaluateVisibility(otherTaskQuestion.visibleIf, { task: "t1" }),
+      evaluateVisibility(otherTaskQuestion.visibleIf as VisibleIfCondition, {
+        task: "t1",
+      }),
     ).toBe(false);
     expect(
-      evaluateVisibility(otherTaskQuestion.visibleIf, { task: "other" }),
+      evaluateVisibility(otherTaskQuestion.visibleIf as VisibleIfCondition, {
+        task: "other",
+      }),
     ).toBe(true);
   });
 
-  it("guards blocker visibility until taskSuccess exists and is not 'yes'", () => {
-    const survey = createTopTasksSurvey({
+  it("guards blocker visibility until success exists and is not 'yes'", () => {
+    const survey = createTopTasksSurveyDocument({
       tasks: [{ value: "t1", label: "Oppgave 1" }],
       includeOtherTask: true,
       includeBlockerQuestion: true,
     });
 
-    const blockerQuestion = survey.questions.find(
-      (question) => question.id === "blocker",
-    );
+    const blockerQuestion = survey.pages
+      .flatMap((page) => page.questions)
+      .find((question) => question.id === "blocker");
 
     expect(blockerQuestion?.visibleIf).toEqual({
       all: [
-        { questionId: "taskSuccess", operator: "EXISTS" },
-        { questionId: "taskSuccess", operator: "NEQ", value: "yes" },
+        { questionId: "success", operator: "EXISTS" },
+        { questionId: "success", operator: "NEQ", value: "yes" },
       ],
     });
-    expect(evaluateVisibility(blockerQuestion?.visibleIf, {})).toBe(false);
     expect(
-      evaluateVisibility(blockerQuestion?.visibleIf, { taskSuccess: "yes" }),
+      evaluateVisibility(blockerQuestion?.visibleIf as VisibleIfCondition, {}),
     ).toBe(false);
     expect(
-      evaluateVisibility(blockerQuestion?.visibleIf, {
-        taskSuccess: "partial",
+      evaluateVisibility(blockerQuestion?.visibleIf as VisibleIfCondition, {
+        success: "yes",
+      }),
+    ).toBe(false);
+    expect(
+      evaluateVisibility(blockerQuestion?.visibleIf as VisibleIfCondition, {
+        success: "partial",
       }),
     ).toBe(true);
   });

--- a/packages/lumi-survey/src/presets/index.ts
+++ b/packages/lumi-survey/src/presets/index.ts
@@ -1,8 +1,14 @@
-import type { LumiSurveyConfig } from "../components/surveyTypes.js";
+import type {
+  LumiSurveyConfig,
+  SurveyDocumentV1,
+  SurveyQuestionV1,
+} from "../components/surveyTypes.js";
+import { SPECIALIZED_SURVEY_FIELD_IDS } from "../core/specializedSurveyContract.js";
 import type {
   EmojiRatingQuestion,
   LumiSurveyQuestion,
   NpsRatingQuestion,
+  RatingScaleLabel,
   StarRatingQuestion,
   TextQuestion,
   ThumbsRatingQuestion,
@@ -14,6 +20,8 @@ import type {
 
 /**
  * Default rating survey: 5-point emoji rating with optional text follow-up.
+ *
+ * @deprecated Use `DEFAULT_RATING_SURVEY_DOCUMENT` for new surveys.
  *
  * @example
  * ```tsx
@@ -34,8 +42,7 @@ export const DEFAULT_SURVEY_RATING: LumiSurveyConfig = {
       type: "rating",
       variant: "emoji",
       prompt: "Hvordan var opplevelsen din?",
-      description:
-        "Svarene du sender inn er anonyme, og blir brukt til videreutvikling av tjenesten",
+      description: "Svarene brukes til å videreutvikle tjenesten",
       required: true,
     } as EmojiRatingQuestion,
     {
@@ -53,7 +60,10 @@ export const DEFAULT_SURVEY_RATING: LumiSurveyConfig = {
 
 /**
  * Service-oriented rating survey with improved messaging.
- * Emphasizes that feedback is anonymous and used for service development.
+ * Emphasizes that feedback is used for service development.
+ *
+ * @deprecated Use a `SurveyDocumentV1`, for example from
+ * `createRatingSurveyDocument`.
  */
 export const DEFAULT_SURVEY_SERVICE_FEEDBACK: LumiSurveyConfig = {
   type: "rating",
@@ -63,8 +73,7 @@ export const DEFAULT_SURVEY_SERVICE_FEEDBACK: LumiSurveyConfig = {
       type: "rating",
       variant: "emoji",
       prompt: "Hvordan opplevde du å svare på spørsmålene?",
-      description:
-        "Svarene du sender inn er anonyme, og blir brukt til videreutvikling av tjenesten",
+      description: "Svarene brukes til å videreutvikle tjenesten",
       required: true,
     } as EmojiRatingQuestion,
     {
@@ -87,6 +96,9 @@ export const DEFAULT_SURVEY_SERVICE_FEEDBACK: LumiSurveyConfig = {
 /**
  * Quick thumbs up/down survey: 2-point binary rating.
  * Perfect for "Was this helpful?" type questions.
+ *
+ * @deprecated Use a `SurveyDocumentV1`, for example from
+ * `createRatingSurveyDocument`.
  *
  * @example
  * ```tsx
@@ -122,6 +134,9 @@ export const DEFAULT_SURVEY_THUMBS: LumiSurveyConfig = {
  * Star rating survey: 5-point star rating.
  * Common UX pattern for quality ratings.
  *
+ * @deprecated Use a `SurveyDocumentV1`, for example from
+ * `createRatingSurveyDocument`.
+ *
  * @example
  * ```tsx
  * <LumiSurveyDock
@@ -139,8 +154,7 @@ export const DEFAULT_SURVEY_STARS: LumiSurveyConfig = {
       type: "rating",
       variant: "stars",
       prompt: "Hvordan opplevde du å bruke tjenesten?",
-      description:
-        "Svarene du sender inn er anonyme, og blir brukt til videreutvikling av tjenesten",
+      description: "Svarene brukes til å videreutvikle tjenesten",
       required: true,
     } as StarRatingQuestion,
     {
@@ -158,6 +172,9 @@ export const DEFAULT_SURVEY_STARS: LumiSurveyConfig = {
 /**
  * NPS (Net Promoter Score) survey: 0-10 scale.
  * Standard methodology for measuring customer loyalty.
+ *
+ * @deprecated Use a `SurveyDocumentV1`, for example from
+ * `createRatingSurveyDocument`.
  * @example
  * ```tsx
  * <LumiSurveyDock
@@ -196,6 +213,8 @@ export const DEFAULT_SURVEY_NPS: LumiSurveyConfig = {
  * Default discovery survey: Free-text task identification with success question.
  * Use this to discover what tasks users come to your site for.
  *
+ * @deprecated Use `DEFAULT_DISCOVERY_SURVEY_DOCUMENT` for new surveys.
+ *
  * @example
  * ```tsx
  * import { LumiSurveyDock, DEFAULT_SURVEY_DISCOVERY } from "@navikt/lumi-survey";
@@ -209,50 +228,43 @@ export const DEFAULT_SURVEY_NPS: LumiSurveyConfig = {
  */
 export const DEFAULT_SURVEY_DISCOVERY: LumiSurveyConfig = {
   type: "discovery",
-  questions: [
-    {
-      id: "discoveredTask",
-      type: "text",
-      prompt: "Hva kom du hit for å gjøre i dag?",
-      placeholder: "Beskriv med dine egne ord...",
-      required: true,
-      minRows: 2,
-      maxLength: 500,
-    } as LumiSurveyQuestion,
-    {
-      id: "taskSuccess",
-      type: "singleChoice",
-      prompt: "Fikk du gjort det?",
-      options: [
-        { value: "yes", label: "Ja" },
-        { value: "partial", label: "Delvis" },
-        { value: "no", label: "Nei" },
-      ],
-      required: true,
-    } as LumiSurveyQuestion,
-    {
-      id: "blocker",
-      type: "text",
-      prompt: "Hva hindret deg?",
-      required: false,
-      maxLength: 500,
-    } as LumiSurveyQuestion,
-  ],
+  questions: createLegacyDiscoveryQuestions(),
 };
 
 // ============================================
 // Survey Builder Functions
 // ============================================
 
-/**
- * Creates a rating survey with customizable prompts.
- * Follow-up questions are automatically hidden until the rating is answered.
- */
-export function createRatingSurvey(options: {
+/** @deprecated Use `RatingSurveyDocumentOptions` with `createRatingSurveyDocument`. */
+export interface RatingSurveyOptions {
   ratingPrompt: string;
   ratingDescription?: string;
   followUpQuestions?: LumiSurveyQuestion[];
-}): LumiSurveyConfig {
+}
+
+type RatingSurveyDocumentPresentation =
+  | {
+      variant?: "emoji" | "thumbs" | "stars";
+      labels?: RatingScaleLabel[];
+      lowLabel?: never;
+      highLabel?: never;
+    }
+  | {
+      variant: "nps";
+      labels?: RatingScaleLabel[];
+      lowLabel?: string;
+      highLabel?: string;
+    };
+
+export type RatingSurveyDocumentOptions = {
+  ratingPrompt: string;
+  ratingDescription?: string;
+  followUpQuestions?: SurveyQuestionV1[];
+} & RatingSurveyDocumentPresentation;
+
+function createLegacyRatingQuestions(
+  options: RatingSurveyOptions,
+): LumiSurveyQuestion[] {
   const questions: LumiSurveyQuestion[] = [
     {
       id: "rating",
@@ -276,23 +288,110 @@ export function createRatingSurvey(options: {
     questions.push(...followUpsWithVisibility);
   }
 
-  return {
-    type: "rating",
-    questions,
+  return questions;
+}
+
+function createRatingDocumentQuestions(
+  options: RatingSurveyDocumentOptions,
+): [SurveyQuestionV1, ...SurveyQuestionV1[]] {
+  const commonRating = {
+    id: "rating",
+    type: "rating" as const,
+    prompt: options.ratingPrompt,
+    description: options.ratingDescription,
+    required: true,
+    labels: options.labels,
   };
+  const rating: SurveyQuestionV1 =
+    options.variant === "nps"
+      ? {
+          ...commonRating,
+          variant: "nps",
+          lowLabel: options.lowLabel,
+          highLabel: options.highLabel,
+        }
+      : { ...commonRating, variant: options.variant ?? "emoji" };
+  const followUps = (options.followUpQuestions ?? []).map((question) => ({
+    ...question,
+    visibleIf: question.visibleIf ?? {
+      questionId: "rating",
+      operator: "EXISTS" as const,
+    },
+  }));
+  return [rating, ...followUps];
 }
 
 /**
- * Creates a Discovery survey for free-text task identification.
- * Use this to discover what tasks users come to your site for.
+ * Creates a legacy flat rating survey.
+ *
+ * @deprecated Use `createRatingSurveyDocument` for new surveys.
  */
-export function createDiscoverySurvey(options?: {
+export function createRatingSurvey(
+  options: RatingSurveyOptions,
+): LumiSurveyConfig {
+  return { type: "rating", questions: createLegacyRatingQuestions(options) };
+}
+
+/**
+ * Creates the recommended page-based rating survey. The rating and its
+ * progressively disclosed follow-up fields share one explicit page.
+ */
+export function createRatingSurveyDocument(
+  options: RatingSurveyDocumentOptions,
+): SurveyDocumentV1 {
+  return {
+    authoringSchemaVersion: 1,
+    type: "rating",
+    pages: [
+      {
+        id: "rating",
+        questions: createRatingDocumentQuestions(options),
+      },
+    ],
+  };
+}
+
+/** Recommended rating document with a progressively disclosed comment. */
+export const DEFAULT_RATING_SURVEY_DOCUMENT = createRatingSurveyDocument({
+  ratingPrompt: "Hvordan var opplevelsen din?",
+  followUpQuestions: [
+    {
+      id: "feedback",
+      type: "text",
+      prompt: "Har du andre tilbakemeldinger?",
+      required: false,
+      maxLength: 1000,
+    },
+  ],
+});
+
+/** Options shared by the legacy and page-based Discovery builders. */
+export interface DiscoverySurveyOptions {
   taskPrompt?: string;
   taskPlaceholder?: string;
   successPrompt?: string;
   blockerPrompt?: string;
   includeBlockerQuestion?: boolean;
-}): LumiSurveyConfig {
+}
+
+/**
+ * Creates a Discovery survey for free-text task identification.
+ * Use this to discover what tasks users come to your site for.
+ *
+ * @deprecated Use `createDiscoverySurveyDocument` for new surveys.
+ */
+export function createDiscoverySurvey(
+  options?: DiscoverySurveyOptions,
+): LumiSurveyConfig {
+  return {
+    type: "discovery",
+    questions: createLegacyDiscoveryQuestions(options),
+  };
+}
+
+function createLegacyDiscoveryQuestions(
+  options?: DiscoverySurveyOptions,
+): LumiSurveyQuestion[] {
   const questions: LumiSurveyQuestion[] = [
     {
       id: "discoveredTask",
@@ -315,7 +414,6 @@ export function createDiscoverySurvey(options?: {
       required: true,
     },
   ];
-
   if (options?.includeBlockerQuestion !== false) {
     questions.push({
       id: "blocker",
@@ -325,15 +423,97 @@ export function createDiscoverySurvey(options?: {
       maxLength: 500,
     });
   }
+  return questions;
+}
 
-  return {
-    type: "discovery",
-    questions,
-  };
+function createDiscoveryDocumentQuestions(
+  options?: DiscoverySurveyOptions,
+): LumiSurveyQuestion[] {
+  const questions: LumiSurveyQuestion[] = [
+    {
+      id: SPECIALIZED_SURVEY_FIELD_IDS.task,
+      type: "text",
+      prompt: options?.taskPrompt ?? "Hva kom du hit for å gjøre i dag?",
+      placeholder: options?.taskPlaceholder ?? "Beskriv med dine egne ord...",
+      required: true,
+      minRows: 2,
+      maxLength: 500,
+    },
+    {
+      id: SPECIALIZED_SURVEY_FIELD_IDS.success,
+      type: "singleChoice",
+      prompt: options?.successPrompt ?? "Fikk du gjort det?",
+      options: [
+        { value: "yes", label: "Ja" },
+        { value: "partial", label: "Delvis" },
+        { value: "no", label: "Nei" },
+      ],
+      required: true,
+    },
+  ];
+
+  if (options?.includeBlockerQuestion !== false) {
+    questions.push({
+      id: SPECIALIZED_SURVEY_FIELD_IDS.blocker,
+      type: "text",
+      prompt: options?.blockerPrompt ?? "Hva hindret deg?",
+      required: false,
+      maxLength: 500,
+      visibleIf: {
+        all: [
+          {
+            questionId: SPECIALIZED_SURVEY_FIELD_IDS.success,
+            operator: "EXISTS",
+          },
+          {
+            questionId: SPECIALIZED_SURVEY_FIELD_IDS.success,
+            operator: "NEQ",
+            value: "yes",
+          },
+        ],
+      },
+    });
+  }
+
+  return questions;
+}
+
+/** Options shared by the legacy and page-based Top Tasks builders. */
+export interface TopTasksSurveyOptions {
+  taskPrompt?: string;
+  tasks: Array<{ value: string; label: string }>;
+  successPrompt?: string;
+  blockerPrompt?: string;
+  includeBlockerQuestion?: boolean;
+  includeOtherTask?: boolean;
+  otherTaskPrompt?: string;
+}
+
+function assertTaskOptions(
+  tasks: readonly { value: string; label: string }[],
+  templateName: string,
+): void {
+  if (tasks.length === 0) {
+    throw new Error(`Lumi: ${templateName} needs at least one task`);
+  }
+  const values = new Set<string>();
+  for (const task of tasks) {
+    if (!task.value.trim() || !task.label.trim()) {
+      throw new Error(
+        `Lumi: ${templateName} tasks need a non-blank value and label`,
+      );
+    }
+    if (values.has(task.value)) {
+      throw new Error(`Lumi: ${templateName} task values must be unique`);
+    }
+    values.add(task.value);
+  }
 }
 
 /**
  * Creates a Top Tasks survey for measuring task completion success.
+ *
+ * @deprecated Use `createTopTasksSurveyDocument` for new surveys.
  *
  * Note: Tasks must be provided as they are domain-specific.
  * There is no DEFAULT_SURVEY_TOP_TASKS since tasks vary per application.
@@ -348,19 +528,21 @@ export function createDiscoverySurvey(options?: {
  * });
  * ```
  */
-export function createTopTasksSurvey(options: {
-  taskPrompt?: string;
-  tasks: Array<{ value: string; label: string }>;
-  successPrompt?: string;
-  blockerPrompt?: string;
-  includeBlockerQuestion?: boolean;
-  includeOtherTask?: boolean;
-  otherTaskPrompt?: string;
-}): LumiSurveyConfig {
+export function createTopTasksSurvey(
+  options: TopTasksSurveyOptions,
+): LumiSurveyConfig {
+  return {
+    type: "topTasks",
+    questions: createLegacyTopTasksQuestions(options),
+  };
+}
+
+function createLegacyTopTasksQuestions(
+  options: TopTasksSurveyOptions,
+): LumiSurveyQuestion[] {
   const taskOptions = options.includeOtherTask
     ? [...options.tasks, { value: "other", label: "Noe annet" }]
     : options.tasks;
-
   const questions: LumiSurveyQuestion[] = [
     {
       id: "task",
@@ -370,8 +552,6 @@ export function createTopTasksSurvey(options: {
       required: true,
     },
   ];
-
-  // otherTask comes BEFORE taskSuccess (shown only when task === "other")
   if (options.includeOtherTask) {
     questions.push({
       id: "otherTask",
@@ -379,15 +559,9 @@ export function createTopTasksSurvey(options: {
       prompt: options.otherTaskPrompt ?? "Beskriv hva du prøvde å gjøre",
       required: false,
       maxLength: 500,
-      visibleIf: {
-        questionId: "task",
-        operator: "EQ",
-        value: "other",
-      },
+      visibleIf: { questionId: "task", operator: "EQ", value: "other" },
     });
   }
-
-  // taskSuccess with branching to skip blocker if "yes"
   questions.push({
     id: "taskSuccess",
     type: "singleChoice",
@@ -399,8 +573,6 @@ export function createTopTasksSurvey(options: {
     ],
     required: true,
   });
-
-  // blocker (shown only when taskSuccess !== "yes")
   if (options.includeBlockerQuestion !== false) {
     questions.push({
       id: "blocker",
@@ -416,16 +588,113 @@ export function createTopTasksSurvey(options: {
       },
     });
   }
+  return questions;
+}
 
-  return {
-    type: "topTasks",
-    questions,
-  };
+function createTopTasksDocumentQuestions(
+  options: TopTasksSurveyOptions,
+): LumiSurveyQuestion[] {
+  assertTaskOptions(options.tasks, "Top Tasks");
+  if (
+    options.includeOtherTask &&
+    options.tasks.some((task) => task.value === "other")
+  ) {
+    throw new Error(
+      'Lumi: Top Tasks reserves the task value "other" when includeOtherTask is enabled',
+    );
+  }
+  const taskOptions = options.includeOtherTask
+    ? [...options.tasks, { value: "other", label: "Noe annet" }]
+    : options.tasks;
+
+  const questions: LumiSurveyQuestion[] = [
+    {
+      id: SPECIALIZED_SURVEY_FIELD_IDS.task,
+      type: "singleChoice",
+      prompt: options.taskPrompt ?? "Hva prøvde du å gjøre i dag?",
+      options: taskOptions,
+      required: true,
+    },
+  ];
+
+  // otherTask comes before success (shown only when task === "other")
+  if (options.includeOtherTask) {
+    questions.push({
+      id: "otherTask",
+      type: "text",
+      prompt: options.otherTaskPrompt ?? "Beskriv hva du prøvde å gjøre",
+      required: false,
+      maxLength: 500,
+      visibleIf: {
+        questionId: SPECIALIZED_SURVEY_FIELD_IDS.task,
+        operator: "EQ",
+        value: "other",
+      },
+    });
+  }
+
+  // success with branching to skip blocker if "yes"
+  questions.push({
+    id: SPECIALIZED_SURVEY_FIELD_IDS.success,
+    type: "singleChoice",
+    prompt: options.successPrompt ?? "Klarte du det?",
+    options: [
+      { value: "yes", label: "Ja" },
+      { value: "partial", label: "Delvis" },
+      { value: "no", label: "Nei" },
+    ],
+    required: true,
+  });
+
+  // blocker (shown only when success !== "yes")
+  if (options.includeBlockerQuestion !== false) {
+    questions.push({
+      id: SPECIALIZED_SURVEY_FIELD_IDS.blocker,
+      type: "text",
+      prompt: options.blockerPrompt ?? "Hva hindret deg?",
+      required: false,
+      maxLength: 500,
+      visibleIf: {
+        all: [
+          {
+            questionId: SPECIALIZED_SURVEY_FIELD_IDS.success,
+            operator: "EXISTS",
+          },
+          {
+            questionId: SPECIALIZED_SURVEY_FIELD_IDS.success,
+            operator: "NEQ",
+            value: "yes",
+          },
+        ],
+      },
+    });
+  }
+
+  return questions;
+}
+
+/** Options shared by the legacy and page-based Task Priority builders. */
+export interface TaskPrioritySurveyOptions {
+  prompt?: string;
+  /** Stable task identities (`value`) and their user-facing wording (`label`). At least two are required by the document builder. */
+  tasks: Array<{ value: string; label: string }>;
+  /** Number of tasks a user may select. Defaults to `min(5, tasks.length)` and must be between 1 and the task count. */
+  maxSelections?: number;
+  /** Randomizes the displayed order. Defaults to true. */
+  randomize?: boolean;
+  /**
+   * Display variant for the task selection.
+   * - "combobox": Searchable dropdown with chips (default, recommended for 10+ tasks)
+   * - "checkbox": Traditional checkbox list
+   */
+  variant?: "checkbox" | "combobox";
 }
 
 /**
  * Creates a Task Priority survey for ranking which tasks matter most.
  * Classic McGovern methodology: users select their top N tasks from a list.
+ *
+ * @deprecated Use `createTaskPrioritySurveyDocument` for new surveys.
  *
  * Note: Tasks must be provided as they are domain-specific.
  * There is no DEFAULT_SURVEY_TASK_PRIORITY since tasks vary per application.
@@ -445,23 +714,21 @@ export function createTopTasksSurvey(options: {
  * });
  * ```
  */
-export function createTaskPrioritySurvey(options: {
-  prompt?: string;
-  tasks: Array<{ value: string; label: string }>;
-  maxSelections?: number;
-  randomize?: boolean;
-  /**
-   * Display variant for the task selection.
-   * - "combobox": Searchable dropdown with chips (default, recommended for 10+ tasks)
-   * - "checkbox": Traditional checkbox list
-   */
-  variant?: "checkbox" | "combobox";
-}): LumiSurveyConfig {
-  const maxSelections = options.maxSelections ?? 5;
-  // Default to combobox for Task Priority (typically has many options)
-  const variant = options.variant ?? "combobox";
+export function createTaskPrioritySurvey(
+  options: TaskPrioritySurveyOptions,
+): LumiSurveyConfig {
+  return {
+    type: "taskPriority",
+    questions: createLegacyTaskPriorityQuestions(options),
+  };
+}
 
-  const questions: LumiSurveyQuestion[] = [
+function createLegacyTaskPriorityQuestions(
+  options: TaskPrioritySurveyOptions,
+): LumiSurveyQuestion[] {
+  const maxSelections =
+    options.maxSelections ?? Math.min(5, options.tasks.length);
+  return [
     {
       id: "priorities",
       type: "multiChoice",
@@ -471,13 +738,113 @@ export function createTaskPrioritySurvey(options: {
       options: options.tasks,
       required: true,
       randomize: options.randomize ?? true,
+      variant: options.variant ?? "combobox",
+      maxSelections,
+    },
+  ];
+}
+
+function createTaskPriorityDocumentQuestions(
+  options: TaskPrioritySurveyOptions,
+): LumiSurveyQuestion[] {
+  assertTaskOptions(options.tasks, "Task Priority");
+  if (options.tasks.length < 2) {
+    throw new Error("Lumi: Task Priority requires at least two tasks");
+  }
+  const maxSelections =
+    options.maxSelections ?? Math.min(5, options.tasks.length);
+  if (!Number.isInteger(maxSelections) || maxSelections <= 0) {
+    throw new Error(
+      "Lumi: Task Priority maxSelections must be a positive integer",
+    );
+  }
+  if (maxSelections > options.tasks.length) {
+    throw new Error(
+      "Lumi: Task Priority maxSelections cannot exceed the number of tasks",
+    );
+  }
+  // Default to combobox for Task Priority (typically has many options)
+  const variant = options.variant ?? "combobox";
+
+  const questions: LumiSurveyQuestion[] = [
+    {
+      id: SPECIALIZED_SURVEY_FIELD_IDS.priority,
+      type: "multiChoice",
+      prompt: options.prompt ?? "Hvilke oppgaver er viktigst for deg?",
+      options: options.tasks,
+      required: true,
+      randomize: options.randomize ?? true,
       variant,
       maxSelections,
     },
   ];
 
+  return questions;
+}
+
+function createSurveyDocument(
+  type: NonNullable<SurveyDocumentV1["type"]>,
+  questions: LumiSurveyQuestion[],
+): SurveyDocumentV1 {
+  const [firstQuestion, ...remainingQuestions] = questions;
+  if (!firstQuestion) {
+    throw new Error("Lumi: A survey template must contain a question");
+  }
+  const toPage = (question: LumiSurveyQuestion) => ({
+    id: question.id,
+    questions: [question] as [LumiSurveyQuestion],
+  });
   return {
-    type: "taskPriority",
-    questions,
+    authoringSchemaVersion: 1,
+    type,
+    pages: [
+      toPage(firstQuestion),
+      ...remainingQuestions.map(toPage),
+    ] as SurveyDocumentV1["pages"],
   };
+}
+
+/**
+ * Creates the recommended page-based Discovery survey document.
+ * The fixed field IDs form the contract used by Lumi's Discovery analysis.
+ */
+export function createDiscoverySurveyDocument(
+  options?: DiscoverySurveyOptions,
+): SurveyDocumentV1 {
+  return createSurveyDocument(
+    "discovery",
+    createDiscoveryDocumentQuestions(options),
+  );
+}
+
+/** Recommended page-based Discovery survey with Lumi's default wording. */
+export const DEFAULT_DISCOVERY_SURVEY_DOCUMENT =
+  createDiscoverySurveyDocument();
+
+/**
+ * Creates the recommended page-based Top Tasks survey document.
+ * Task choices are domain-specific and must be supplied by the consumer.
+ */
+export function createTopTasksSurveyDocument(
+  options: TopTasksSurveyOptions,
+): SurveyDocumentV1 {
+  return createSurveyDocument(
+    "topTasks",
+    createTopTasksDocumentQuestions(options),
+  );
+}
+
+/**
+ * Creates the recommended page-based Task Priority survey document.
+ * Task choices are domain-specific and must be supplied by the consumer.
+ * Provide at least two tasks. `maxSelections` defaults to the smaller of five
+ * and the number of tasks, and must stay between one and the task count.
+ */
+export function createTaskPrioritySurveyDocument(
+  options: TaskPrioritySurveyOptions,
+): SurveyDocumentV1 {
+  return createSurveyDocument(
+    "taskPriority",
+    createTaskPriorityDocumentQuestions(options),
+  );
 }

--- a/packages/lumi-survey/src/stories/LumiSurveyDock.tasks.stories.tsx
+++ b/packages/lumi-survey/src/stories/LumiSurveyDock.tasks.stories.tsx
@@ -1,9 +1,9 @@
 import type { Meta, StoryObj } from "@storybook/react-vite";
 import { LumiSurveyDock } from "../components/LumiSurveyDock";
 import {
-  createTaskPrioritySurvey,
-  createTopTasksSurvey,
-  DEFAULT_SURVEY_DISCOVERY,
+  createTaskPrioritySurveyDocument,
+  createTopTasksSurveyDocument,
+  DEFAULT_DISCOVERY_SURVEY_DOCUMENT,
   DEFAULT_SURVEY_RATING,
 } from "../presets/index.js";
 import { ExamplePage, SUCCESS_TRANSPORT } from "./LumiSurveyDockExamplePage";
@@ -44,13 +44,13 @@ const TASK_PRIORITY_TASKS = [
   { value: "cv-registrering", label: "Registrere CV" },
 ];
 
-const TOP_TASKS_SURVEY = createTopTasksSurvey({
+const TOP_TASKS_SURVEY = createTopTasksSurveyDocument({
   tasks: TOP_TASKS,
   includeBlockerQuestion: true,
   includeOtherTask: true,
 });
 
-const TASK_PRIORITY_SURVEY = createTaskPrioritySurvey({
+const TASK_PRIORITY_SURVEY = createTaskPrioritySurveyDocument({
   tasks: TASK_PRIORITY_TASKS,
   maxSelections: 5,
 });
@@ -88,16 +88,13 @@ export const Discovery: Story = {
   render: (args) => <ExamplePage {...args} />,
   args: {
     surveyId: "nav-no-forside-discovery",
-    survey: DEFAULT_SURVEY_DISCOVERY,
-    behavior: {
-      questionLayout: "steps",
-    },
+    survey: DEFAULT_DISCOVERY_SURVEY_DOCUMENT,
   },
   parameters: {
     docs: {
       description: {
         story:
-          "Discovery-undersøkelse med `DEFAULT_SURVEY_DISCOVERY` preset og `questionLayout: 'steps'`. Viser ett spørsmål om gangen med Neste/Tilbake-knapper.",
+          "Sidebasert discovery-undersøkelse med `DEFAULT_DISCOVERY_SURVEY_DOCUMENT`. Viser ett spørsmål om gangen med Neste/Tilbake-knapper.",
       },
     },
   },
@@ -113,7 +110,7 @@ export const TaskPriority: Story = {
     docs: {
       description: {
         story:
-          "McGovern Task Priority-undersøkelse. Brukere velger sine viktigste oppgaver. Bruker `createTaskPrioritySurvey`.",
+          "McGovern Task Priority-undersøkelse. Brukere velger sine viktigste oppgaver. Bruker `createTaskPrioritySurveyDocument`.",
       },
     },
   },
@@ -129,7 +126,7 @@ export const TopTasks: Story = {
     docs: {
       description: {
         story:
-          "Top Tasks-undersøkelse for å måle suksessrate på oppgaver. Bruker `createTopTasksSurvey` med oppgaveliste.",
+          "Top Tasks-undersøkelse for å måle suksessrate på oppgaver. Bruker `createTopTasksSurveyDocument` med oppgaveliste.",
       },
     },
   },

--- a/packages/lumi-types/src/api.ts
+++ b/packages/lumi-types/src/api.ts
@@ -67,6 +67,7 @@ export interface MultiChoiceSubmissionFieldDefinition
   extends SubmissionFieldDefinitionBase {
   fieldType: "MULTI_CHOICE";
   optionIds: string[];
+  maxSelections?: number;
 }
 
 export interface DateSubmissionFieldDefinition
@@ -327,6 +328,9 @@ export interface TeamsAndApps {
 // ============================================
 
 export interface TopTaskStats {
+  /** Stable option value used for filtering and aggregation. */
+  taskId: string;
+  /** Display label captured from the newest matching response. */
   task: string;
   totalCount: number;
   successCount: number;
@@ -510,6 +514,7 @@ export interface UpdateThemeInput {
 // ============================================
 
 export interface TaskVote {
+  taskId: string;
   task: string;
   votes: number;
   percentage: number;

--- a/packages/lumi-types/src/schemas.ts
+++ b/packages/lumi-types/src/schemas.ts
@@ -679,6 +679,7 @@ const SubmissionMultiChoiceFieldDefinitionSchema =
   SubmissionFieldDefinitionBaseSchema.extend({
     fieldType: z.literal("MULTI_CHOICE"),
     optionIds: SubmissionOptionIdsSchema,
+    maxSelections: z.number().int().positive().optional(),
   }).strict();
 
 const SubmissionDateFieldDefinitionSchema =
@@ -739,6 +740,18 @@ export const SubmissionDefinitionSchema = z
             path: ["fields", i, "ratingScale"],
           });
         }
+      }
+      if (
+        field.fieldType === "MULTI_CHOICE" &&
+        field.maxSelections !== undefined &&
+        field.maxSelections > field.optionIds.length
+      ) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          message:
+            "maxSelections must not exceed the number of multi-choice options",
+          path: ["fields", i, "maxSelections"],
+        });
       }
     }
   });
@@ -867,6 +880,16 @@ function validateAnswerValueAgainstDefinition(
       ctx.addIssue({
         code: z.ZodIssueCode.custom,
         message: `selectedOptionIds=${invalidIds.join(",")} are not valid for fieldId=${answer.fieldId}`,
+        path: ["answers", answerIndex, "value", "selectedOptionIds"],
+      });
+    }
+    if (
+      field.maxSelections !== undefined &&
+      answer.value.selectedOptionIds.length > field.maxSelections
+    ) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: `selectedOptionIds exceeds maxSelections=${field.maxSelections} for fieldId=${answer.fieldId}`,
         path: ["answers", answerIndex, "value", "selectedOptionIds"],
       });
     }
@@ -1083,6 +1106,7 @@ export const TeamsAndAppsSchema = z.object({
 
 // Top Tasks schemas
 const TopTaskStatsSchema = z.object({
+  taskId: z.string(),
   task: z.string(),
   totalCount: z.number(),
   successCount: z.number(),
@@ -1197,6 +1221,7 @@ export const BlockerResponseSchema = z.object({
 
 // Task Priority schemas
 const TaskVoteSchema = z.object({
+  taskId: z.string(),
   task: z.string(),
   votes: z.number(),
   percentage: z.number(),


### PR DESCRIPTION
## Beskrivelse

Gjør Discovery, Top Tasks og oppgaveprioritering til komplette, støttede surveytyper i den sidebaserte modellen. Verkstedet, widgeten, API-et og analysesidene bruker nå samme kontrakt, slik at et utkast som er klart til deling også kan sendes inn og analyseres uten skjulte krav.

PR-en klargjør samtidig `@navikt/lumi-survey` 2.1.0. Den eldre, flate modellen beholdes for eksisterende integrasjoner, men nye integrasjoner ledes til `SurveyDocumentV1`.

## Endringer

- legger til verifiserte `SurveyDocumentV1`-byggere for rating, Discovery, Top Tasks og oppgaveprioritering
- håndhever felt-ID-er, svarformer, obligatoriske felt og valggrenser gjennom widget, API og Verksted
- gjør analyseoppsett reparerbare i Verkstedet og beskytter feltene analysen er avhengig av
- lar API-et kontrollere `maxSelections` og berike eldre, kompatible definisjoner én gang
- bruker stabile oppgave-ID-er og nyeste oppgavetekst i Top Tasks og oppgaveprioritering
- holder mockdata og eldre feltaliaser kompatible med produksjons-API-et
- oppdaterer guider, pakkedokumentasjon og maskinveiledning til den nye modellen
- klargjør pakkerelease `2.1.0` med changelog og release-vern

## Bakoverkompatibilitet og utrulling

- eksisterende flate konfigurasjoner og 2.0.1-feltaliaser støttes fortsatt i 2.x
- API og dashboard rulles ut fra `main` før widgeten publiseres
- widgeten publiseres separat som `@navikt/lumi-survey@2.1.0` etter merge

## Issue

Ingen egen issue – samlet oppfølging av den nye survey- og dokumentasjonsmodellen.

## Verifisering

- widgetpakke: 432/432 tester
- dashboard: 499/499 tester
- API: full Testcontainers-suite
- Playwright: 46 bestått, 1 eksisterende hoppet over
- lint, typekontroll, produksjonsbygg og dokumentasjonsbygg
- release-vern: 15/15 og verifisert pakkedrift fra 2.0.1 til 2.1.0
- to iterative, uavhengige reviewrunder uten gjenværende funn

## Sjekkliste

- [x] Koden kompilerer og linter uten feil
- [x] Endringene er testet automatisk og i nettleser
- [x] Ingen sensitiv data eksponert
