### PR TITLE
Surveyverksted: legg til spørsmålsdetaljer

### DIFF
--- a/apps/lumi-api/src/main/kotlin/no/nav/lumi/validation/SpecializedSurveyContractValidator.kt
+++ b/apps/lumi-api/src/main/kotlin/no/nav/lumi/validation/SpecializedSurveyContractValidator.kt
@@ -22,6 +22,7 @@ object SpecializedSurveyContractValidator {
         val required: Boolean = false,
         val conditionallyVisible: Boolean = false,
         val maxSelections: Int? = null,
+        val randomize: Boolean = false,
     )
 
     private data class RequiredField(
@@ -155,6 +156,7 @@ object SpecializedSurveyContractValidator {
                     required = field.required,
                     conditionallyVisible = field.conditionallyVisible,
                     maxSelections = field.maxSelections,
+                    randomize = field.randomize,
                 )
             },
             source = "document",
@@ -172,6 +174,7 @@ object SpecializedSurveyContractValidator {
         val required: Boolean = false,
         val conditionallyVisible: Boolean = false,
         val maxSelections: Int? = null,
+        val randomize: Boolean = false,
     )
 
     private fun validateFields(
@@ -229,6 +232,9 @@ object SpecializedSurveyContractValidator {
             }
             if (enforceAuthoringSemantics && !required.optional && actual.conditionallyVisible) {
                 invalid(surveyType, "$source field '${required.id}' must always be visible")
+            }
+            if (enforceAuthoringSemantics && required.optionIds.isNotEmpty() && actual.randomize) {
+                invalid(surveyType, "$source field '${required.id}' must keep its option order")
             }
         }
         val usesLegacyContract = contract === legacyContracts[surveyType]

--- a/apps/lumi-api/src/main/kotlin/no/nav/lumi/validation/SurveyAuthoringDocumentValidator.kt
+++ b/apps/lumi-api/src/main/kotlin/no/nav/lumi/validation/SurveyAuthoringDocumentValidator.kt
@@ -144,6 +144,15 @@ object SurveyAuthoringDocumentValidator {
                     required = required,
                     conditionallyVisible = question.containsKey("visibleIf"),
                     maxSelections = (question["maxSelections"] as? JsonPrimitive)?.intOrNull,
+                    randomize = if (type == "singleChoice" || type == "multiChoice") {
+                        optionalBoolean(
+                            question,
+                            "randomize",
+                            "Choice question '$questionId'",
+                        ) ?: false
+                    } else {
+                        false
+                    },
                 )
                 conditionTargets[questionId] = when (type) {
                     "rating" -> {

--- a/apps/lumi-api/src/test/kotlin/no/nav/lumi/validation/SurveyAuthoringDocumentValidatorTest.kt
+++ b/apps/lumi-api/src/test/kotlin/no/nav/lumi/validation/SurveyAuthoringDocumentValidatorTest.kt
@@ -5,7 +5,9 @@ import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.collections.shouldContainExactly
 import io.kotest.matchers.shouldBe
 import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonArray
 import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.jsonArray
 import kotlinx.serialization.json.jsonObject
 import no.nav.lumi.config.exception.ApiErrorException
 import no.nav.lumi.domain.FieldType
@@ -128,6 +130,31 @@ class SurveyAuthoringDocumentValidatorTest : FunSpec({
         shouldThrow<ApiErrorException.BadRequestException> {
             SurveyAuthoringDocumentValidator.validate(blankPrompt, "survey-v1", releaseGate = true)
         }.errorMessage shouldBe "Question 'rating' needs a prompt before it can be shared"
+    }
+
+    test("unrelated randomize metadata stays lenient on non-choice questions") {
+        val document = JsonObject(
+            validDocument().toMutableMap().also { root ->
+                val pages = root.getValue("pages").jsonArray
+                val page = pages.first().jsonObject
+                val questions = page.getValue("questions").jsonArray
+                val rating = JsonObject(
+                    questions.first().jsonObject.toMutableMap().also { question ->
+                        question["randomize"] = Json.parseToJsonElement("\"legacy-value\"")
+                    },
+                )
+                root["pages"] = JsonArray(
+                    listOf(
+                        JsonObject(
+                            page.toMutableMap().also { it["questions"] = JsonArray(listOf(rating)) },
+                        ),
+                    ),
+                )
+            },
+        )
+
+        SurveyAuthoringDocumentValidator.validate(document, "survey-v1")
+        SurveyAuthoringDocumentValidator.validate(document, "survey-v1", releaseGate = true)
     }
 
     test("release gate rejects blank option labels and values") {
@@ -331,6 +358,10 @@ class SurveyAuthoringDocumentValidatorTest : FunSpec({
                 "\"required\":true,\"visibleIf\":{\"questionId\":\"task\",\"operator\":\"EXISTS\"}," +
                     "\"options\":[{\"value\":\"yes\"",
             ) to "Invalid topTasks survey contract: document field 'success' must always be visible",
+            valid.toString().replace(
+                "\"required\":true,\"options\":[{\"value\":\"yes\"",
+                "\"required\":true,\"randomize\":true,\"options\":[{\"value\":\"yes\"",
+            ) to "Invalid topTasks survey contract: document field 'success' must keep its option order",
         )
 
         cases.forEach { (json, expectedMessage) ->

--- a/apps/lumi-dashboard/app/components/surveyverksted/QuestionCard.tsx
+++ b/apps/lumi-dashboard/app/components/surveyverksted/QuestionCard.tsx
@@ -12,9 +12,10 @@ import {
   Button,
   Detail,
   HStack,
+  Radio,
+  RadioGroup,
   Switch,
   TextField,
-  ToggleGroup,
   Tooltip,
   VStack,
 } from "@navikt/ds-react";
@@ -278,44 +279,11 @@ export const QuestionCard = memo(function QuestionCard({
           />
         ) : null}
 
-        {question.type === "multiChoice" ? (
-          <TextField
-            type="number"
-            label="Maks antall alternativer brukeren kan velge"
-            description={
-              contractLocked
-                ? `Velg et tall mellom 1 og ${question.options.length}.`
-                : `Velg et tall mellom 1 og ${question.options.length}, eller la feltet stå tomt uten en grense.`
-            }
-            min={1}
-            max={question.options.length}
-            value={
-              question.maxSelections === undefined
-                ? ""
-                : String(question.maxSelections)
-            }
-            error={
-              question.maxSelections === undefined && contractLocked
-                ? "Velg hvor mange oppgaver brukeren kan krysse av."
-                : question.maxSelections !== undefined &&
-                    question.maxSelections > question.options.length
-                  ? `Tallet kan ikke være høyere enn ${question.options.length}.`
-                  : undefined
-            }
-            onChange={(event) => {
-              const value = Number(event.target.value);
-              onChange((current) =>
-                current.type === "multiChoice"
-                  ? {
-                      ...current,
-                      maxSelections:
-                        Number.isInteger(value) && value > 0
-                          ? value
-                          : undefined,
-                    }
-                  : current,
-              );
-            }}
+        {question.type === "singleChoice" || question.type === "multiChoice" ? (
+          <ChoiceSettings
+            question={question}
+            contractLocked={contractLocked}
+            onChange={onChange}
           />
         ) : null}
 
@@ -413,8 +381,8 @@ function RatingSettings({
   const variant = question.variant ?? "emoji";
   return (
     <VStack gap="space-16">
-      <ToggleGroup
-        label="Skala"
+      <RadioGroup
+        legend="Skala"
         size="small"
         value={variant}
         onChange={(next) =>
@@ -426,14 +394,14 @@ function RatingSettings({
         }
       >
         {RATING_VARIANTS.map((candidate) => (
-          <ToggleGroup.Item
-            key={candidate.id}
-            value={candidate.id}
-            icon={<candidate.Icon aria-hidden />}
-            label={candidate.label}
-          />
+          <Radio key={candidate.id} value={candidate.id}>
+            <HStack as="span" gap="space-4" align="center">
+              <candidate.Icon aria-hidden />
+              {candidate.label}
+            </HStack>
+          </Radio>
         ))}
-      </ToggleGroup>
+      </RadioGroup>
       {question.variant === "nps" ? (
         <HStack gap="space-16" wrap>
           <TextField
@@ -508,5 +476,111 @@ function TextSettings({
         }}
       />
     </HStack>
+  );
+}
+
+function ChoiceSettings({
+  question,
+  contractLocked,
+  onChange,
+}: {
+  question:
+    | Extract<SurveyQuestionV1, { type: "singleChoice" }>
+    | Extract<SurveyQuestionV1, { type: "multiChoice" }>;
+  contractLocked: boolean;
+  onChange: QuestionCardProps["onChange"];
+}) {
+  const orderLocked =
+    contractLocked && question.id === SPECIALIZED_SURVEY_FIELD_IDS.success;
+
+  return (
+    <VStack gap="space-16">
+      {!orderLocked ? (
+        <Switch
+          size="small"
+          checked={question.randomize ?? false}
+          description="Reduserer sjansen for at alternativene øverst får flere svar."
+          onChange={(event) => {
+            const randomize = event.target.checked;
+            onChange((current) => {
+              if (
+                current.type !== "singleChoice" &&
+                current.type !== "multiChoice"
+              ) {
+                return current;
+              }
+              if (randomize) return { ...current, randomize: true };
+              const { randomize: _randomize, ...withoutRandomize } = current;
+              return withoutRandomize;
+            });
+          }}
+        >
+          Bland rekkefølgen
+        </Switch>
+      ) : null}
+
+      {question.type === "multiChoice" ? (
+        <>
+          <RadioGroup
+            legend="Slik vises svaralternativene"
+            description="Avkryssing passer best med opptil 6 alternativer. Velg søkbart felt når listen er lengre."
+            size="small"
+            value={question.variant ?? "checkbox"}
+            onChange={(next) =>
+              onChange((current) => {
+                if (current.type !== "multiChoice") return current;
+                if (next === "combobox") {
+                  return { ...current, variant: "combobox" };
+                }
+                const { variant: _variant, ...withoutVariant } = current;
+                return withoutVariant;
+              })
+            }
+          >
+            <Radio value="checkbox">Avkryssing</Radio>
+            <Radio value="combobox">Søkbart felt</Radio>
+          </RadioGroup>
+
+          <TextField
+            type="number"
+            label="Maks antall alternativer brukeren kan velge"
+            description={
+              contractLocked
+                ? `Velg et tall mellom 1 og ${question.options.length}.`
+                : `Velg et tall mellom 1 og ${question.options.length}, eller la feltet stå tomt uten en grense.`
+            }
+            min={1}
+            max={question.options.length}
+            value={
+              question.maxSelections === undefined
+                ? ""
+                : String(question.maxSelections)
+            }
+            error={
+              question.maxSelections === undefined && contractLocked
+                ? "Velg hvor mange oppgaver brukeren kan krysse av."
+                : question.maxSelections !== undefined &&
+                    question.maxSelections > question.options.length
+                  ? `Tallet kan ikke være høyere enn ${question.options.length}.`
+                  : undefined
+            }
+            onChange={(event) => {
+              const value = Number(event.target.value);
+              onChange((current) =>
+                current.type === "multiChoice"
+                  ? {
+                      ...current,
+                      maxSelections:
+                        Number.isInteger(value) && value > 0
+                          ? value
+                          : undefined,
+                    }
+                  : current,
+              );
+            }}
+          />
+        </>
+      ) : null}
+    </VStack>
   );
 }

--- a/apps/lumi-dashboard/app/components/surveyverksted/QuestionMiniPreview.tsx
+++ b/apps/lumi-dashboard/app/components/surveyverksted/QuestionMiniPreview.tsx
@@ -1,6 +1,11 @@
 import { BodyShort } from "@navikt/ds-react";
-import type { LumiSurveyQuestion, SurveyQuestionV1 } from "@navikt/lumi-survey";
+import type {
+  ChoiceQuestion,
+  LumiSurveyQuestion,
+  SurveyQuestionV1,
+} from "@navikt/lumi-survey";
 import {
+  DefaultQuestionRenderer,
   MultiChoiceField,
   RatingQuestionField,
   SingleChoiceField,
@@ -11,6 +16,29 @@ import styles from "./verksted.module.css";
 const noop = () => {};
 
 const MAX_VISIBLE_OPTIONS = 4;
+
+function stablePreviewOptions(question: ChoiceQuestion) {
+  const options = [...question.options];
+  if (!question.randomize) return options.slice(0, MAX_VISIBLE_OPTIONS);
+
+  // A compact preview should not jump on every editor render, but it must
+  // sample the complete option list when the real widget will randomize it.
+  const hash = (value: string) => {
+    let result = 2166136261;
+    for (const character of value) {
+      result ^= character.charCodeAt(0);
+      result = Math.imul(result, 16777619);
+    }
+    return result >>> 0;
+  };
+  return options
+    .sort(
+      (left, right) =>
+        hash(`${question.id}:${left.value}`) -
+        hash(`${question.id}:${right.value}`),
+    )
+    .slice(0, MAX_VISIBLE_OPTIONS);
+}
 
 /**
  * The V1 authoring question narrows `visibleIf`/`logic`; the field
@@ -77,13 +105,23 @@ function MiniField({ question }: { question: SurveyQuestionV1 }) {
       );
     case "singleChoice":
     case "multiChoice": {
-      const visible = core.options.slice(0, MAX_VISIBLE_OPTIONS);
+      const visible = stablePreviewOptions(core);
       const hidden = core.options.length - visible.length;
       return (
         <>
           {core.type === "singleChoice" ? (
             <SingleChoiceField
-              question={{ ...core, options: visible }}
+              question={{ ...core, options: visible, randomize: false }}
+              value={undefined}
+              onChange={noop}
+              validationErrorMessage=""
+              isMissing={false}
+              disabled={false}
+              hideLabel
+            />
+          ) : core.variant === "combobox" ? (
+            <DefaultQuestionRenderer
+              question={{ ...core, options: visible, randomize: false }}
               value={undefined}
               onChange={noop}
               validationErrorMessage=""
@@ -93,7 +131,7 @@ function MiniField({ question }: { question: SurveyQuestionV1 }) {
             />
           ) : (
             <MultiChoiceField
-              question={{ ...core, options: visible }}
+              question={{ ...core, options: visible, randomize: false }}
               value={undefined}
               onChange={noop}
               validationErrorMessage=""

--- a/apps/lumi-dashboard/app/components/surveyverksted/__tests__/QuestionCard.test.tsx
+++ b/apps/lumi-dashboard/app/components/surveyverksted/__tests__/QuestionCard.test.tsx
@@ -1,4 +1,7 @@
-import type { SurveyQuestionV1 } from "@navikt/lumi-survey";
+import {
+  SPECIALIZED_SURVEY_FIELD_IDS,
+  type SurveyQuestionV1,
+} from "@navikt/lumi-survey";
 import { render, screen, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { describe, expect, it, vi } from "vitest";
@@ -17,6 +20,10 @@ function renderCard(options?: {
   question?: SurveyQuestionV1;
   onExpand?: () => void;
   onCollapse?: () => void;
+  contractLocked?: boolean;
+  onChange?: (
+    updater: (question: SurveyQuestionV1) => SurveyQuestionV1,
+  ) => void;
 }) {
   const noop = () => {};
   return render(
@@ -27,9 +34,10 @@ function renderCard(options?: {
       canDelete
       canMoveUp={false}
       canMoveDown
+      contractLocked={options?.contractLocked}
       onExpand={options?.onExpand ?? noop}
       onCollapse={options?.onCollapse ?? noop}
-      onChange={noop}
+      onChange={options?.onChange ?? noop}
       onChangeType={noop}
       onDuplicate={noop}
       onDelete={noop}
@@ -54,6 +62,30 @@ describe("QuestionCard collapsed", () => {
     );
     expect(preview).not.toBeNull();
     expect(preview).toHaveAttribute("aria-hidden", "true");
+  });
+
+  it("summarizes a searchable multi-choice field when collapsed", () => {
+    renderCard({
+      question: {
+        id: "choice-1",
+        type: "multiChoice",
+        prompt: "Hva er viktigst?",
+        variant: "combobox",
+        options: [
+          { value: "one", label: "Første valg" },
+          { value: "two", label: "Andre valg" },
+        ],
+      },
+    });
+
+    expect(
+      screen.getByText("Flervalg · Søkbart felt · 2 alternativer"),
+    ).toBeVisible();
+    const preview = document.querySelector<HTMLElement>("[data-mini-preview]");
+    expect(preview).not.toBeNull();
+    expect(
+      within(preview as HTMLElement).getByRole("combobox", { hidden: true }),
+    ).toBeInTheDocument();
   });
 
   it("expands when the card button is clicked", async () => {
@@ -156,5 +188,143 @@ describe("QuestionCard expanded", () => {
     expect(
       screen.getByRole("button", { name: /lukk redigering/i }),
     ).toHaveAttribute("aria-expanded", "true");
+  });
+
+  it("uses form radios to change the rating scale", async () => {
+    const onChange = vi.fn();
+    renderCard({ expanded: true, onChange });
+
+    expect(screen.getByRole("group", { name: "Skala" })).toBeInTheDocument();
+    await userEvent.click(screen.getByRole("radio", { name: "NPS" }));
+
+    const updater = onChange.mock.calls[0]?.[0];
+    expect(updater).toBeTypeOf("function");
+    expect(updater(ratingQuestion)).toMatchObject({ variant: "nps" });
+  });
+
+  it("lets authors randomize choice options in plain language", async () => {
+    const question: SurveyQuestionV1 = {
+      id: "choice-1",
+      type: "singleChoice",
+      prompt: "Hva vil du gjøre?",
+      options: [
+        { value: "one", label: "Første valg" },
+        { value: "two", label: "Andre valg" },
+      ],
+    };
+    const onChange = vi.fn();
+    renderCard({ expanded: true, question, onChange });
+
+    await userEvent.click(
+      screen.getByRole("checkbox", { name: /^Bland rekkefølgen/ }),
+    );
+
+    const updater = onChange.mock.calls[0]?.[0];
+    expect(updater).toBeTypeOf("function");
+    expect(updater(question)).toMatchObject({ randomize: true });
+    expect(
+      screen.getByRole("checkbox", { name: /^Bland rekkefølgen/ }),
+    ).toHaveAccessibleName(/alternativene øverst får flere svar/i);
+  });
+
+  it.each([
+    "singleChoice",
+    "multiChoice",
+  ] as const)("removes randomization from a %s question when switched off", async (type) => {
+    const question: SurveyQuestionV1 = {
+      id: "choice-1",
+      type,
+      prompt: "Hva vil du gjøre?",
+      randomize: true,
+      options: [
+        { value: "one", label: "Første valg" },
+        { value: "two", label: "Andre valg" },
+      ],
+    };
+    const onChange = vi.fn();
+    renderCard({ expanded: true, question, onChange });
+
+    await userEvent.click(
+      screen.getByRole("checkbox", { name: /^Bland rekkefølgen/ }),
+    );
+
+    const updater = onChange.mock.calls[0]?.[0];
+    expect(updater).toBeTypeOf("function");
+    expect(updater(question)).not.toHaveProperty("randomize");
+  });
+
+  it("keeps the ordered analysis outcome from being randomized", () => {
+    const question: SurveyQuestionV1 = {
+      id: SPECIALIZED_SURVEY_FIELD_IDS.success,
+      type: "singleChoice",
+      prompt: "Fikk du gjort det?",
+      required: true,
+      options: [
+        { value: "yes", label: "Ja" },
+        { value: "partial", label: "Delvis" },
+        { value: "no", label: "Nei" },
+      ],
+    };
+    renderCard({ expanded: true, question, contractLocked: true });
+
+    expect(
+      screen.queryByRole("checkbox", { name: /^Bland rekkefølgen/ }),
+    ).not.toBeInTheDocument();
+  });
+
+  it("lets authors choose a searchable field for multi-choice questions", async () => {
+    const question: SurveyQuestionV1 = {
+      id: "choice-1",
+      type: "multiChoice",
+      prompt: "Hva er viktigst?",
+      options: [
+        { value: "one", label: "Første valg" },
+        { value: "two", label: "Andre valg" },
+      ],
+    };
+    const onChange = vi.fn();
+    renderCard({ expanded: true, question, onChange });
+
+    await userEvent.click(screen.getByRole("radio", { name: "Søkbart felt" }));
+
+    const updater = onChange.mock.calls.at(-1)?.[0];
+    expect(updater).toBeTypeOf("function");
+    expect(updater(question)).toMatchObject({ variant: "combobox" });
+    expect(
+      screen.getByRole("group", {
+        name: /^Slik vises svaralternativene/,
+      }),
+    ).toHaveAccessibleName(/opptil 6 alternativer/i);
+  });
+
+  it("restores the default checkbox presentation without keeping stale data", async () => {
+    const question: SurveyQuestionV1 = {
+      id: "choice-1",
+      type: "multiChoice",
+      prompt: "Hva er viktigst?",
+      variant: "combobox",
+      options: [
+        { value: "one", label: "Første valg" },
+        { value: "two", label: "Andre valg" },
+      ],
+    };
+    const onChange = vi.fn();
+    renderCard({ expanded: true, question, onChange });
+
+    await userEvent.click(screen.getByRole("radio", { name: "Avkryssing" }));
+
+    const updater = onChange.mock.calls.at(-1)?.[0];
+    expect(updater).toBeTypeOf("function");
+    expect(updater(question)).not.toHaveProperty("variant");
+  });
+
+  it("does not show choice settings for rating questions", () => {
+    renderCard({ expanded: true });
+    expect(
+      screen.queryByRole("checkbox", { name: "Bland rekkefølgen" }),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByText("Slik vises svaralternativene"),
+    ).not.toBeInTheDocument();
   });
 });

--- a/apps/lumi-dashboard/app/components/surveyverksted/questionTypeMeta.tsx
+++ b/apps/lumi-dashboard/app/components/surveyverksted/questionTypeMeta.tsx
@@ -72,7 +72,17 @@ export function describeQuestion(question: SurveyQuestionV1): string {
     return `${questionTypeMeta("rating").label} · ${variant?.label ?? "Emoji"}`;
   }
   if (question.type === "singleChoice" || question.type === "multiChoice") {
-    return `${questionTypeMeta(question.type).label} · ${question.options.length} alternativer`;
+    const presentation =
+      question.type === "multiChoice" && question.variant === "combobox"
+        ? "Søkbart felt"
+        : undefined;
+    return [
+      questionTypeMeta(question.type).label,
+      presentation,
+      `${question.options.length} alternativer`,
+    ]
+      .filter(Boolean)
+      .join(" · ");
   }
   return questionTypeMeta(question.type).label;
 }

--- a/apps/lumi-dashboard/app/mock/__tests__/surveyAuthoring.test.ts
+++ b/apps/lumi-dashboard/app/mock/__tests__/surveyAuthoring.test.ts
@@ -123,4 +123,95 @@ describe("mock survey authoring store", () => {
     // Idempotent from the caller's view: the second delete reports missing.
     expect(store.deleteMockSurveyProject("team-a", created.id)).toBe(false);
   });
+
+  it("rejects a changed multi-choice limit after the first revision", async () => {
+    const store = await import("../surveyAuthoring");
+    const choiceDocument = (maxSelections: number): SurveyDocumentV1 => ({
+      authoringSchemaVersion: 1,
+      type: "custom",
+      pages: [
+        {
+          id: "page-1",
+          questions: [
+            {
+              id: "priorities",
+              type: "multiChoice",
+              prompt: "Hva er viktigst?",
+              options: [
+                { value: "a", label: "A" },
+                { value: "b", label: "B" },
+              ],
+              maxSelections,
+            },
+          ],
+        },
+      ],
+    });
+    const created = store.createMockSurveyProject({
+      team: "team-a",
+      name: "Valggrense",
+      surveyId: "valggrense",
+      document: choiceDocument(1),
+    });
+    await store.createMockSurveyRevision({
+      team: "team-a",
+      projectId: created.id,
+      expectedDraftVersion: 1,
+    });
+    const saved = store.saveMockSurveyProject({
+      team: "team-a",
+      projectId: created.id,
+      expectedVersion: 1,
+      name: created.name,
+      surveyId: created.surveyId,
+      document: choiceDocument(2),
+    });
+
+    await expect(
+      store.createMockSurveyRevision({
+        team: "team-a",
+        projectId: created.id,
+        expectedDraftVersion: saved.draftVersion,
+      }),
+    ).rejects.toThrow(/structure differs/i);
+  });
+
+  it("rejects a selection limit on a single-choice field", async () => {
+    const store = await import("../surveyAuthoring");
+    const invalidDocument: SurveyDocumentV1 = {
+      authoringSchemaVersion: 1,
+      type: "custom",
+      pages: [
+        {
+          id: "page-1",
+          questions: [
+            {
+              id: "choice",
+              type: "singleChoice",
+              prompt: "Velg én",
+              options: [
+                { value: "a", label: "A" },
+                { value: "b", label: "B" },
+              ],
+              maxSelections: 1,
+            },
+          ],
+        },
+      ],
+    };
+    const created = store.createMockSurveyProject({
+      team: "team-a",
+      name: "Ugyldig valggrense",
+      surveyId: "ugyldig-valggrense",
+      document: invalidDocument,
+    });
+
+    await expect(
+      store.createMockSurveyRevision({
+        team: "team-a",
+        projectId: created.id,
+        expectedDraftVersion: 1,
+      }),
+    ).rejects.toThrow(/bare brukes på flervalg/i);
+  });
 });

--- a/apps/lumi-dashboard/app/routes/surveyverksted.$projectId.tsx
+++ b/apps/lumi-dashboard/app/routes/surveyverksted.$projectId.tsx
@@ -4,10 +4,7 @@ import type {
   SurveyPageV1,
   SurveyQuestionV1,
 } from "@navikt/lumi-survey";
-import {
-  getSpecializedSurveyContractIssues,
-  validateSurveyDocumentV1,
-} from "@navikt/lumi-survey";
+import { validateSurveyDocumentV1 } from "@navikt/lumi-survey";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { createFileRoute, useBlocker } from "@tanstack/react-router";
 import { zodValidator } from "@tanstack/zod-adapter";
@@ -56,6 +53,7 @@ import {
   duplicatePage,
   duplicateQuestion,
   findHandoffIssues,
+  getSpecializedAuthoringContractIssues,
   insertPageAt,
   insertQuestionAt,
   isRequiredSpecializedQuestion,
@@ -428,11 +426,7 @@ function SurveyWorkshopEditor({
     }
   }, [draft.document]);
   const specializedContractIssues = useMemo(
-    () =>
-      getSpecializedSurveyContractIssues(
-        draft.document.type ?? "custom",
-        draft.document.pages.flatMap((page) => page.questions),
-      ),
+    () => getSpecializedAuthoringContractIssues(draft.document),
     [draft.document],
   );
 

--- a/apps/lumi-dashboard/app/utils/__tests__/surveyRevision.test.ts
+++ b/apps/lumi-dashboard/app/utils/__tests__/surveyRevision.test.ts
@@ -103,6 +103,57 @@ describe("survey revision exports", () => {
     expect(analyticalStructure(reordered)).toBe(analyticalStructure(document));
   });
 
+  it("treats the multi-choice limit as analysis structure", () => {
+    const withLimit = (maxSelections: number): SurveyDocumentV1 => ({
+      authoringSchemaVersion: 1,
+      type: "custom",
+      pages: [
+        {
+          id: "valg",
+          questions: [
+            {
+              id: "prioriteringer",
+              type: "multiChoice",
+              prompt: "Hva er viktigst?",
+              options: [
+                { value: "a", label: "A" },
+                { value: "b", label: "B" },
+              ],
+              maxSelections,
+            },
+          ],
+        },
+      ],
+    });
+
+    expect(analyticalStructure(withLimit(1))).not.toBe(
+      analyticalStructure(withLimit(2)),
+    );
+    const base = withLimit(1);
+    const baseQuestion = base.pages[0].questions[0];
+    if (baseQuestion.type !== "multiChoice") {
+      throw new Error("Testoppsettet må inneholde et flervalgsspørsmål");
+    }
+    const presentationChanged: SurveyDocumentV1 = {
+      ...base,
+      pages: [
+        {
+          ...base.pages[0],
+          questions: [
+            {
+              ...baseQuestion,
+              randomize: true,
+              variant: "combobox",
+            },
+          ],
+        },
+      ],
+    };
+    expect(analyticalStructure(presentationChanged)).toBe(
+      analyticalStructure(base),
+    );
+  });
+
   it("describes content changes without treating them as publication state", () => {
     const changed: SurveyDocumentV1 = {
       ...document,

--- a/apps/lumi-dashboard/app/utils/surveyDocument.test.ts
+++ b/apps/lumi-dashboard/app/utils/surveyDocument.test.ts
@@ -774,6 +774,44 @@ describe("findHandoffIssues", () => {
     });
   });
 
+  it("keeps the specialized outcome choices in their meaningful order", () => {
+    const document = createDiscoverySurveyDocument();
+    const success = document.pages
+      .flatMap((page) => page.questions)
+      .find((question) => question.id === "success");
+    if (!success || success.type !== "singleChoice") {
+      throw new Error("missing success question");
+    }
+    success.randomize = true;
+
+    expect(findHandoffIssues(document)).toContainEqual({
+      questionId: "success",
+      message:
+        "Svarene Ja, Delvis og Nei må vises i fast rekkefølge for dette analyseoppsettet.",
+    });
+    expect(isSpecializedQuestionContractValid("discovery", success)).toBe(
+      false,
+    );
+    const repaired = repairSpecializedSurveyDocument(document);
+    const repairedSuccess = repaired.pages
+      .flatMap((page) => page.questions)
+      .find((question) => question.id === "success");
+    expect(repairedSuccess).not.toHaveProperty("randomize");
+    expect(findHandoffIssues(repaired)).toEqual([]);
+  });
+
+  it("rejects a selection limit on single-choice questions before handoff", () => {
+    const document = makeDocument();
+    const question = document.pages[1].questions[0];
+    if (question.type !== "singleChoice") throw new Error("wrong type");
+    question.maxSelections = 1;
+
+    expect(findHandoffIssues(document)).toContainEqual({
+      questionId: question.id,
+      message: "Maks antall valg kan bare brukes på flervalgsspørsmål.",
+    });
+  });
+
   it("flags extra outcome choices and a repurposed blocker field", () => {
     const document = createTopTasksSurveyDocument({
       tasks: [{ value: "apply", label: "Søke" }],

--- a/apps/lumi-dashboard/app/utils/surveyDocument.ts
+++ b/apps/lumi-dashboard/app/utils/surveyDocument.ts
@@ -49,6 +49,32 @@ export function isRequiredSpecializedQuestion(
   );
 }
 
+export function getSpecializedAuthoringContractIssues(
+  document: SurveyDocumentV1,
+) {
+  const questions = document.pages.flatMap((page) => page.questions);
+  const issues = [
+    ...getSpecializedSurveyContractIssues(document.type ?? "custom", questions),
+  ];
+  if (document.type === "discovery" || document.type === "topTasks") {
+    const success = questions.find(
+      (question) => question.id === SPECIALIZED_SURVEY_FIELD_IDS.success,
+    );
+    if (
+      success?.type === "singleChoice" &&
+      success.randomize === true &&
+      !issues.some((issue) => issue.fieldId === success.id)
+    ) {
+      issues.push({
+        fieldId: success.id,
+        message:
+          "Svarene Ja, Delvis og Nei må vises i fast rekkefølge for dette analyseoppsettet.",
+      });
+    }
+  }
+  return issues;
+}
+
 export function isSpecializedQuestionContractValid(
   surveyType: SurveyDocumentV1["type"],
   question: SurveyQuestionV1,
@@ -65,6 +91,7 @@ export function isSpecializedQuestionContractValid(
   if (question.id === "success") {
     return (
       question.type === "singleChoice" &&
+      question.randomize !== true &&
       question.options.length === 3 &&
       new Set(question.options.map((option) => option.value)).size === 3 &&
       question.options.every((option) =>
@@ -186,8 +213,6 @@ export function repairSpecializedSurveyDocument(
         prompt: current.prompt.trim() ? current.prompt : fallback.prompt,
         description: current.description,
         analyticsId: current.analyticsId,
-        randomize:
-          current.type === "singleChoice" ? current.randomize : undefined,
         options: fallback.options.map((option) => ({
           ...option,
           ...currentOptions.get(option.value),
@@ -986,10 +1011,7 @@ export function findHandoffIssues(document: SurveyDocumentV1): HandoffIssue[] {
       questionById.set(question.id, question);
     }
   }
-  for (const contractIssue of getSpecializedSurveyContractIssues(
-    document.type ?? "custom",
-    [...questionById.values()],
-  )) {
+  for (const contractIssue of getSpecializedAuthoringContractIssues(document)) {
     issues.push({
       questionId: questionById.has(contractIssue.fieldId)
         ? contractIssue.fieldId
@@ -1007,6 +1029,15 @@ export function findHandoffIssues(document: SurveyDocumentV1): HandoffIssue[] {
         });
       }
       if (question.type === "singleChoice" || question.type === "multiChoice") {
+        if (
+          question.type === "singleChoice" &&
+          question.maxSelections !== undefined
+        ) {
+          issues.push({
+            questionId: question.id,
+            message: "Maks antall valg kan bare brukes på flervalgsspørsmål.",
+          });
+        }
         if (question.options.length === 0) {
           issues.push({
             questionId: question.id,

--- a/apps/lumi-dashboard/app/utils/surveyRevision.ts
+++ b/apps/lumi-dashboard/app/utils/surveyRevision.ts
@@ -222,6 +222,10 @@ export function analyticalStructure(document: SurveyDocumentV1): string {
             "options" in question
               ? question.options.map((option) => option.value)
               : undefined,
+          maxSelections:
+            question.type === "multiChoice"
+              ? question.maxSelections
+              : undefined,
         })),
       )
       .sort((left, right) =>

--- a/apps/lumi-dashboard/e2e/survey-workshop.spec.ts
+++ b/apps/lumi-dashboard/e2e/survey-workshop.spec.ts
@@ -749,6 +749,72 @@ test("a flush inherits a failed save instead of repeating it", async ({
   await page.unroute("**/*");
 });
 
+test("configures and previews a searchable multi-choice question", async ({
+  page,
+}, testInfo) => {
+  await page.goto("/surveyverksted");
+  await page
+    .getByLabel("Navn på utkastet")
+    .fill(`Søkbart flervalg ${testInfo.workerIndex}-${Date.now()}`);
+  await page.getByRole("button", { name: "Opprett utkast" }).click();
+  await page.waitForURL(/\/surveyverksted\/[0-9a-f-]+/);
+
+  await page.getByRole("button", { name: "Legg til spørsmål" }).click();
+  await page.getByRole("menuitem", { name: /Flervalg/ }).click();
+  const prompt = "Hvilke temaer er viktigst?";
+  await page
+    .getByRole("textbox", { name: "Spørsmålstekst" })
+    .last()
+    .fill(prompt);
+  for (let option = 3; option <= 7; option += 1) {
+    await page.getByRole("button", { name: "Legg til alternativ" }).click();
+  }
+  await page.getByRole("checkbox", { name: /^Bland rekkefølgen/ }).click();
+  await page.getByRole("radio", { name: "Søkbart felt" }).click();
+  await page
+    .getByLabel("Maks antall alternativer brukeren kan velge")
+    .fill("1");
+
+  const stage = page.getByRole("region", { name: "Forhåndsvisning" });
+  const combobox = stage.getByRole("combobox", { name: prompt });
+  await expect(combobox).toBeVisible();
+  await expect(page.locator('[data-state="saved"]')).toBeVisible();
+  await expectNoAxeViolations(page);
+
+  await combobox.click();
+  await page.getByRole("option", { name: "Alternativ 1" }).click();
+  await expect(stage.getByText("Maks 1 valgt")).toBeVisible();
+  await combobox.click();
+  await expect(
+    page.getByRole("option", { name: "Alternativ 2", exact: true }),
+  ).toBeDisabled();
+
+  // The choices are stored in the draft, not only held in the open editor.
+  await page.reload();
+  await expect(stage.getByRole("combobox", { name: prompt })).toBeVisible();
+  await page.getByRole("button", { name: new RegExp(prompt) }).click();
+  await expect(
+    page.getByRole("checkbox", { name: /^Bland rekkefølgen/ }),
+  ).toBeChecked();
+  await expect(page.getByRole("radio", { name: "Søkbart felt" })).toBeChecked();
+  await expect(
+    page.getByLabel("Maks antall alternativer brukeren kan velge"),
+  ).toHaveValue("1");
+
+  await page.setViewportSize({ width: 390, height: 844 });
+  await expect(
+    page.getByText("Slik vises svaralternativene", { exact: true }),
+  ).toBeVisible();
+  await expect
+    .poll(() =>
+      page.evaluate(
+        () => document.documentElement.scrollWidth <= window.innerWidth,
+      ),
+    )
+    .toBe(true);
+  await expectNoAxeViolations(page);
+});
+
 test("a visibility condition set in the editor gates the question live in the stage", async ({
   page,
 }) => {


### PR DESCRIPTION
## Beskrivelse

Gir designere kontroll over hvordan svaralternativer vises i Surveyverkstedet: de kan blande rekkefølgen og velge mellom avkryssing og søkbart flervalg. Innstillingene lagres i `SurveyDocumentV1` og vises i den ekte forhåndsvisningen.

## Endringer

- legger til Aksel-baserte innstillinger for tilfeldig rekkefølge og flervalgsvisning
- viser et stabilt, representativt miniforhåndsvisningsutvalg
- holder Ja/Delvis/Nei i fast rekkefølge for analyseoppsett
- gjør mock- og API-valideringen konsistent for valggrenser og analysekontrakter
- dekker lagring, ny innlasting, mobilvisning, tilgjengelighet og faktisk valggrense

## Issue

Closes #442

## Sjekkliste

- [x] Koden kompilerer og linter uten feil
- [x] Endringene er testet (manuelt eller automatisk)
- [x] Ingen sensitiv data eksponert (tokens, credentials, PII)
