### PR TITLE
Oppgrader Jedis til versjon 8

### DIFF
--- a/apps/lumi-api/build.gradle.kts
+++ b/apps/lumi-api/build.gradle.kts
@@ -91,7 +91,7 @@ dependencies {
     implementation("org.apache.poi:poi-ooxml:5.5.1")
     
     // Valkey/Redis cache
-    implementation("redis.clients:jedis:7.5.3")
+    implementation("redis.clients:jedis:8.0.0")
     
     // Testing
     testImplementation("io.ktor:ktor-server-test-host:$ktorVersion")

--- a/apps/lumi-api/src/main/kotlin/no/nav/lumi/integrations/valkey/JedisFactory.kt
+++ b/apps/lumi-api/src/main/kotlin/no/nav/lumi/integrations/valkey/JedisFactory.kt
@@ -4,8 +4,14 @@ import redis.clients.jedis.ConnectionPoolConfig
 import redis.clients.jedis.DefaultJedisClientConfig
 import redis.clients.jedis.HostAndPort
 import redis.clients.jedis.RedisClient
+import redis.clients.jedis.SslOptions
 import java.net.URI
 import java.time.Duration
+
+internal data class JedisConnectionConfig(
+    val hostAndPort: HostAndPort,
+    val clientConfig: DefaultJedisClientConfig,
+)
 
 internal object JedisFactory {
     private val defaultConnectionTimeout: Duration = Duration.ofSeconds(2)
@@ -16,6 +22,28 @@ internal object JedisFactory {
         username: String?,
         password: String?,
     ): RedisClient {
+        val connectionConfig = createConnectionConfig(uri, username, password)
+
+        val poolConfig = ConnectionPoolConfig().apply {
+            // Validate connections to avoid stale sockets ("Broken pipe") after idle.
+            testOnBorrow = true
+            testWhileIdle = true
+            timeBetweenEvictionRuns = Duration.ofMinutes(1)
+            minEvictableIdleDuration = Duration.ofMinutes(5)
+        }
+
+        return RedisClient.builder()
+            .hostAndPort(connectionConfig.hostAndPort)
+            .clientConfig(connectionConfig.clientConfig)
+            .poolConfig(poolConfig)
+            .build()
+    }
+
+    internal fun createConnectionConfig(
+        uri: String,
+        username: String?,
+        password: String?,
+    ): JedisConnectionConfig {
         val normalizedUri = uri
             .replace("valkey://", "redis://")
             .replace("valkeys://", "rediss://")
@@ -33,28 +61,16 @@ internal object JedisFactory {
             ?.toIntOrNull()
 
         val clientConfig = DefaultJedisClientConfig.builder()
-            .ssl(ssl)
             .connectionTimeoutMillis(defaultConnectionTimeout.toMillis().toInt())
             .socketTimeoutMillis(defaultSocketTimeout.toMillis().toInt())
             .apply {
+                if (ssl) sslOptions(SslOptions.defaults())
                 if (!username.isNullOrBlank()) user(username)
                 if (!password.isNullOrBlank()) password(password)
                 if (dbIndex != null) database(dbIndex)
             }
             .build()
 
-        val poolConfig = ConnectionPoolConfig().apply {
-            // Validate connections to avoid stale sockets ("Broken pipe") after idle.
-            testOnBorrow = true
-            testWhileIdle = true
-            timeBetweenEvictionRuns = Duration.ofMinutes(1)
-            minEvictableIdleDuration = Duration.ofMinutes(5)
-        }
-
-        return RedisClient.builder()
-            .hostAndPort(HostAndPort(host, port))
-            .clientConfig(clientConfig)
-            .poolConfig(poolConfig)
-            .build()
+        return JedisConnectionConfig(HostAndPort(host, port), clientConfig)
     }
 }

--- a/apps/lumi-api/src/main/kotlin/no/nav/lumi/integrations/valkey/StatsCache.kt
+++ b/apps/lumi-api/src/main/kotlin/no/nav/lumi/integrations/valkey/StatsCache.kt
@@ -9,6 +9,7 @@ import no.nav.lumi.config.appMicrometerRegistry
 import org.slf4j.LoggerFactory
 import redis.clients.jedis.RedisClient
 import redis.clients.jedis.exceptions.JedisConnectionException
+import redis.clients.jedis.params.SetParams
 import java.time.Duration
 import java.util.concurrent.ConcurrentHashMap
 
@@ -164,7 +165,7 @@ class ValkeyStatsCache private constructor(
         
         try {
             val startTime = System.nanoTime()
-            redisClient.setex(fullKey, ttl.seconds, jsonValue)
+            redisClient.set(fullKey, jsonValue, SetParams.setParams().ex(ttl.seconds))
             cacheOperationTimer.record(Duration.ofNanos(System.nanoTime() - startTime))
             
             log.debug("Cached stats for key: $key (TTL: ${ttl.seconds}s)")

--- a/apps/lumi-api/src/main/kotlin/no/nav/lumi/integrations/valkey/StringCache.kt
+++ b/apps/lumi-api/src/main/kotlin/no/nav/lumi/integrations/valkey/StringCache.kt
@@ -7,6 +7,7 @@ import no.nav.lumi.config.appMicrometerRegistry
 import org.slf4j.LoggerFactory
 import redis.clients.jedis.RedisClient
 import redis.clients.jedis.exceptions.JedisConnectionException
+import redis.clients.jedis.params.SetParams
 import java.time.Duration
 import java.util.concurrent.ConcurrentHashMap
 
@@ -123,7 +124,7 @@ class ValkeyStringCache private constructor(
 
         try {
             val startTime = System.nanoTime()
-            redisClient.setex(fullKey, ttl.seconds, value)
+            redisClient.set(fullKey, value, SetParams.setParams().ex(ttl.seconds))
             cacheOperationTimer.record(Duration.ofNanos(System.nanoTime() - startTime))
         } catch (e: JedisConnectionException) {
             cacheErrorCounter.increment()

--- a/apps/lumi-api/src/test/kotlin/no/nav/lumi/integrations/valkey/JedisFactoryTest.kt
+++ b/apps/lumi-api/src/test/kotlin/no/nav/lumi/integrations/valkey/JedisFactoryTest.kt
@@ -1,0 +1,39 @@
+package no.nav.lumi.integrations.valkey
+
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.nulls.shouldBeNull
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+import redis.clients.jedis.HostAndPort
+import redis.clients.jedis.SslVerifyMode
+
+class JedisFactoryTest : FunSpec({
+    test("configures Valkey TLS with hostname verification and URI database") {
+        val config = JedisFactory.createConnectionConfig(
+            uri = "valkeys://cache.example.nav:6380/2",
+            username = "cache-user",
+            password = "secret",
+        )
+
+        config.hostAndPort shouldBe HostAndPort("cache.example.nav", 6380)
+        config.clientConfig.database shouldBe 2
+        config.clientConfig.user shouldBe "cache-user"
+        config.clientConfig.password shouldBe "secret"
+        config.clientConfig.sslOptions shouldNotBe null
+        config.clientConfig.sslOptions.sslVerifyMode shouldBe SslVerifyMode.FULL
+        config.clientConfig.isAutoNegotiateProtocol shouldBe true
+        config.clientConfig.redisProtocol.shouldBeNull()
+    }
+
+    test("keeps plain Valkey connections non-TLS with the default port") {
+        val config = JedisFactory.createConnectionConfig(
+            uri = "valkey://localhost",
+            username = null,
+            password = null,
+        )
+
+        config.hostAndPort shouldBe HostAndPort("localhost", 6379)
+        config.clientConfig.sslOptions.shouldBeNull()
+        config.clientConfig.database shouldBe 0
+    }
+})


### PR DESCRIPTION
## Beskrivelse

Oppgraderer API-et fra Jedis 7.5.3 til 8.0.0 og tilpasser Valkey-integrasjonen til de anbefalte API-ene i Jedis 8.

Lumi bruker allerede `RedisClient.builder()`, så de fjernede legacy-klientene og konstruktørene berører oss ikke. Endringen beholder full TLS-vertsnavnkontroll mot Nais Valkey, bruker Jedis' standard auto-forhandling av RESP3 med RESP2-fallback og erstatter de deprekerte `ssl(Boolean)`- og `setex`-kallene.

## Endringer

- `build.gradle.kts`: Jedis 8.0.0
- `JedisFactory`: eksplisitt `SslOptions` og en testbar tilkoblingskonfigurasjon
- `StatsCache` og `StringCache`: moderne `SET ... EX` via `SetParams`
- regresjonstester for Valkey-URI, databasevalg, TLS-vertsnavnkontroll og protokollforhandling

## Issue

Erstatter Dependabot-PR #454.

## Sjekkliste

- [x] Koden kompilerer og linter uten feil
- [x] Endringene er testet automatisk
- [x] Ingen sensitiv data eksponert (tokens, credentials, PII)

Verifisert med full API-suite, `shadowJar`, rot-lint og alle TypeScript-sjekker. Runtime løser Jedis 8.0.0 og Commons Pool 2.13.1 uten avhengighetskonflikter.
