### PR TITLE
Støtt automatiske perioder for historiske surveys i API-et

### DIFF
--- a/apps/lumi-api/src/main/kotlin/no/nav/lumi/repository/FeedbackContextTagsRepository.kt
+++ b/apps/lumi-api/src/main/kotlin/no/nav/lumi/repository/FeedbackContextTagsRepository.kt
@@ -13,12 +13,19 @@ import java.time.Instant
 
 data class SurveyOverview(
     val surveysByApp: Map<String, List<String>>,
+    val firstSubmissionBySurvey: Map<String, String>,
     val lastSubmissionBySurvey: Map<String, String>,
+    val submissionBoundsByApp: Map<String, Map<String, SurveySubmissionBounds>>,
+)
+
+data class SurveySubmissionBounds(
+    val firstSubmissionAt: String,
+    val lastSubmissionAt: String,
 )
 
 class FeedbackContextTagsRepository {
     /**
-     * Surveys grouped by app and their latest submission timestamps.
+     * Surveys grouped by app and their first/latest submission timestamps.
      * Both views are derived from the same result set so bootstrap cannot
      * cache a survey list and recency metadata from different DB snapshots.
      */
@@ -28,6 +35,7 @@ class FeedbackContextTagsRepository {
                 SELECT
                     app,
                     feedback_json::jsonb->>'surveyId' as survey_id,
+                    MIN(opprettet) as first_submission_at,
                     MAX(opprettet) as last_submission_at
                 FROM feedback
                 WHERE team = ?
@@ -38,14 +46,24 @@ class FeedbackContextTagsRepository {
             """.trimIndent()
 
             val surveysByApp = mutableMapOf<String, MutableList<String>>()
+            val firstSubmissionInstants = mutableMapOf<String, Instant>()
             val lastSubmissionInstants = mutableMapOf<String, Instant>()
+            val submissionBoundsByApp = mutableMapOf<String, MutableMap<String, SurveySubmissionBounds>>()
             val transaction = TransactionManager.current()
             transaction.exec(sql, listOf(VarCharColumnType() to team)) { rs ->
                 while (rs.next()) {
                     val app = rs.getString("app") ?: continue
                     val surveyId = rs.getString("survey_id") ?: continue
+                    val firstSubmissionAt = rs.getTimestamp("first_submission_at")?.toInstant() ?: continue
                     val lastSubmissionAt = rs.getTimestamp("last_submission_at")?.toInstant() ?: continue
                     surveysByApp.getOrPut(app) { mutableListOf() }.add(surveyId)
+                    submissionBoundsByApp.getOrPut(app) { mutableMapOf() }[surveyId] = SurveySubmissionBounds(
+                        firstSubmissionAt = firstSubmissionAt.toString(),
+                        lastSubmissionAt = lastSubmissionAt.toString(),
+                    )
+                    firstSubmissionInstants.merge(surveyId, firstSubmissionAt) { current, candidate ->
+                        minOf(current, candidate)
+                    }
                     lastSubmissionInstants.merge(surveyId, lastSubmissionAt) { current, candidate ->
                         maxOf(current, candidate)
                     }
@@ -53,7 +71,9 @@ class FeedbackContextTagsRepository {
             }
             SurveyOverview(
                 surveysByApp = surveysByApp,
+                firstSubmissionBySurvey = firstSubmissionInstants.mapValues { (_, instant) -> instant.toString() },
                 lastSubmissionBySurvey = lastSubmissionInstants.mapValues { (_, instant) -> instant.toString() },
+                submissionBoundsByApp = submissionBoundsByApp,
             )
         }
     }

--- a/apps/lumi-api/src/main/kotlin/no/nav/lumi/repository/FeedbackStatsRepository.kt
+++ b/apps/lumi-api/src/main/kotlin/no/nav/lumi/repository/FeedbackStatsRepository.kt
@@ -90,7 +90,9 @@ class FeedbackStatsRepository {
             val dateExpr = DateDate(FeedbackTable.opprettet)
             val dateQuery = FeedbackTable.select(dateExpr, FeedbackTable.id.count())
             applyStatsFilters(dateQuery, query)
-            dateQuery.andWhere { FeedbackTable.opprettet greaterEq Instant.now().minus(Duration.ofDays(30)) }
+            if (query.fromDate == null && query.toDate == null) {
+                dateQuery.andWhere { FeedbackTable.opprettet greaterEq Instant.now().minus(Duration.ofDays(30)) }
+            }
             val byDate = dateQuery
                  .groupBy(dateExpr)
                  .orderBy(dateExpr to SortOrder.ASC)

--- a/apps/lumi-api/src/main/kotlin/no/nav/lumi/repository/FeedbackTable.kt
+++ b/apps/lumi-api/src/main/kotlin/no/nav/lumi/repository/FeedbackTable.kt
@@ -105,6 +105,9 @@ class DateDate(val expr: Expression<Instant>) : Function<LocalDate>(JavaLocalDat
     override fun toQueryBuilder(queryBuilder: QueryBuilder) {
         queryBuilder.append("DATE(")
         expr.toQueryBuilder(queryBuilder)
+        // feedback.opprettet is timestamptz. Convert it explicitly so timeline
+        // buckets match the Europe/Oslo boundaries used by date filters.
+        queryBuilder.append(" AT TIME ZONE 'Europe/Oslo'")
         queryBuilder.append(")")
     }
 }

--- a/apps/lumi-api/src/main/kotlin/no/nav/lumi/routes/FilterRoutes.kt
+++ b/apps/lumi-api/src/main/kotlin/no/nav/lumi/routes/FilterRoutes.kt
@@ -34,17 +34,20 @@ data class FilterBootstrapResponse(
     val surveysByApp: Map<String, List<String>>,
     val tags: List<String>,
     val surveyMeta: Map<String, SurveyMetaEntry> = emptyMap(),
+    val surveyMetaByApp: Map<String, Map<String, SurveyMetaEntry>> = emptyMap(),
 )
 
 /**
  * Per-survey dashboard metadata. Surveys without an entry are active.
  * `archivedAt == null` means active (or restored after being archived).
+ * `firstSubmissionAt` identifies the beginning of the survey's response history.
  * `lastSubmissionAt` drives the recency signal and, for archived surveys,
  * the "still receiving submissions" badge (lastSubmissionAt > archivedAt).
  */
 @Serializable
 data class SurveyMetaEntry(
     val archivedAt: String?,
+    val firstSubmissionAt: String? = null,
     val lastSubmissionAt: String? = null,
 )
 
@@ -72,7 +75,9 @@ private fun bootstrapCacheGenerationKey(team: String) = "generation:team=${team.
  */
 internal fun bootstrapCacheKey(team: String, principal: no.nav.lumi.config.auth.BrukerPrincipal): String? {
     val userIdentity = stablePrincipalIdentity(principal) ?: return null
-    return "${bootstrapCacheTeamPrefix(team)}user=$userIdentity".lowercase()
+    // Version the response contract so rolling deploys cannot reuse bootstrap
+    // payloads that predate newly added metadata fields.
+    return "${bootstrapCacheTeamPrefix(team)}user=${userIdentity.lowercase()}&responseVersion=2"
 }
 
 internal fun stablePrincipalIdentity(principal: no.nav.lumi.config.auth.BrukerPrincipal): String? =
@@ -151,13 +156,26 @@ fun Route.filterRoutes(
         val surveyOverview = feedbackRepository.findSurveyOverview(team)
         val tags = feedbackRepository.findAllTags(team)
         val archiveStates = surveyMetadataRepository.findByTeam(team).associateBy { it.surveyId }
+        val firstSubmissionBySurvey = surveyOverview.firstSubmissionBySurvey
         val lastSubmissionBySurvey = surveyOverview.lastSubmissionBySurvey
-        val surveyMeta = (archiveStates.keys + lastSubmissionBySurvey.keys).associateWith { surveyId ->
+        val surveyMeta = (
+            archiveStates.keys + firstSubmissionBySurvey.keys + lastSubmissionBySurvey.keys
+        ).associateWith { surveyId ->
             SurveyMetaEntry(
                 archivedAt = archiveStates[surveyId]?.archivedAt,
+                firstSubmissionAt = firstSubmissionBySurvey[surveyId],
                 lastSubmissionAt = lastSubmissionBySurvey[surveyId],
             )
         }
+        val surveyMetaByApp = surveyOverview.submissionBoundsByApp.mapValues { (_, boundsBySurvey) ->
+            boundsBySurvey.mapValues { (surveyId, bounds) ->
+                SurveyMetaEntry(
+                    archivedAt = archiveStates[surveyId]?.archivedAt,
+                    firstSubmissionAt = bounds.firstSubmissionAt,
+                    lastSubmissionAt = bounds.lastSubmissionAt,
+                )
+            }.toSortedMap()
+        }.toSortedMap()
 
         val response = FilterBootstrapResponse(
             generatedAt = Instant.now().toString(),
@@ -167,6 +185,7 @@ fun Route.filterRoutes(
             surveysByApp = surveyOverview.surveysByApp.mapValues { it.value.sorted() }.toSortedMap(),
             tags = tags.sorted(),
             surveyMeta = surveyMeta,
+            surveyMetaByApp = surveyMetaByApp,
         )
 
         versionedBootstrapCache.set(

--- a/apps/lumi-api/src/main/kotlin/no/nav/lumi/routes/StatsRoutes.kt
+++ b/apps/lumi-api/src/main/kotlin/no/nav/lumi/routes/StatsRoutes.kt
@@ -20,13 +20,15 @@ internal fun ApiV1Intern.Stats.toStatsQuery(
     team: String,
     surveyIdOverride: String? = surveyId,
 ): StatsQuery {
-    validateDateRange(fromDate, toDate)
+    val normalizedFromDate = fromDate?.takeIf { it.isNotBlank() }
+    val normalizedToDate = toDate?.takeIf { it.isNotBlank() }
+    validateDateRange(normalizedFromDate, normalizedToDate)
     return StatsQuery(
     team = team,
     includeArchived = includeArchived ?: false,
     app = app?.takeIf { it != FILTER_ALL },
-    fromDate = fromDate,
-    toDate = toDate,
+    fromDate = normalizedFromDate,
+    toDate = normalizedToDate,
     surveyId = surveyIdOverride,
     deviceType = deviceType?.takeIf { it != FILTER_ALL },
     segments = parseSegments(segment),

--- a/apps/lumi-api/src/main/kotlin/no/nav/lumi/service/StatsService.kt
+++ b/apps/lumi-api/src/main/kotlin/no/nav/lumi/service/StatsService.kt
@@ -41,6 +41,9 @@ class StatsService(
     private val blockersCacheTtl: Duration = Duration.ofMinutes(3)
     private val taskPriorityCacheTtl: Duration = Duration.ofMinutes(3)
 
+    internal fun statsCacheKey(prefix: String, query: StatsQuery): String =
+        "$prefix:${query.toCacheKey()}"
+
     private fun StatsQuery.toCacheKey(): String {
         fun enc(value: String): String = URLEncoder.encode(value, StandardCharsets.UTF_8)
 
@@ -71,6 +74,9 @@ class StatsService(
             "task" to task,
             "choice" to choiceValue,
             "rating" to ratingValue,
+            // Bump when the cached response semantics change. This prevents a
+            // rolling deploy from serving values written by an older version.
+            "resultVersion" to "2",
         )
             .filter { (_, value) -> value != null }
             .map { (key, value) -> "${enc(key)}=${enc(value!!)}" }
@@ -84,7 +90,7 @@ class StatsService(
         ttl: Duration,
         crossinline compute: suspend () -> T
     ): T {
-        val cacheKey = "$prefix:${query.toCacheKey()}"
+        val cacheKey = statsCacheKey(prefix, query)
 
         statsCache.get(cacheKey)?.let { cached ->
             return try {
@@ -103,7 +109,7 @@ class StatsService(
      * Results are cached for 5 minutes.
      */
     suspend fun getDashboardStats(query: StatsQuery): FeedbackStats {
-        val cacheKey = "dashboard:${query.toCacheKey()}"
+        val cacheKey = statsCacheKey("dashboard", query)
         
         // Try cache first
         statsCache.get(cacheKey)?.let { cached ->

--- a/apps/lumi-api/src/test/kotlin/no/nav/lumi/TestDatabase.kt
+++ b/apps/lumi-api/src/test/kotlin/no/nav/lumi/TestDatabase.kt
@@ -48,6 +48,8 @@ object TestDatabase {
             isAutoCommit = false
             transactionIsolation = "TRANSACTION_READ_COMMITTED"
             poolName = "lumi-test-pool"
+            // Keep date bucketing tests independent of the developer machine's timezone.
+            connectionInitSql = "SET TIME ZONE 'UTC'"
         })
     }
     

--- a/apps/lumi-api/src/test/kotlin/no/nav/lumi/repository/FeedbackRepositoryTest.kt
+++ b/apps/lumi-api/src/test/kotlin/no/nav/lumi/repository/FeedbackRepositoryTest.kt
@@ -251,30 +251,53 @@ class FeedbackRepositoryTest : FunSpec({
     }
 
     context("findSurveyOverview") {
-        test("returns surveys by app and newest submission timestamps from one team-scoped aggregation") {
+        test("returns surveys by app and submission bounds from one team-scoped aggregation") {
+            val earliest = OffsetDateTime.parse("2025-05-01T10:00:00+02:00")
             val old = OffsetDateTime.parse("2026-06-01T10:00:00+02:00")
             val newer = OffsetDateTime.parse("2026-08-01T10:00:00+02:00")
+            val latest = OffsetDateTime.parse("2026-09-01T10:00:00+02:00")
             insertTestFeedback(id = "a1", team = "flex", app = "app-a", surveyId = "survey-a", opprettet = old)
             insertTestFeedback(id = "a2", team = "flex", app = "app-a", surveyId = "survey-a", opprettet = newer)
             insertTestFeedback(id = "b1", team = "flex", app = "app-b", surveyId = "survey-b", opprettet = old)
+            insertTestFeedback(id = "b2", team = "flex", app = "app-b", surveyId = "survey-a", opprettet = earliest)
+            insertTestFeedback(id = "b3", team = "flex", app = "app-b", surveyId = "survey-a", opprettet = old)
+            insertTestFeedback(id = "c1", team = "flex", app = "app-c", surveyId = "survey-a", opprettet = latest)
             insertTestFeedback(id = "other", team = "team-test", surveyId = "survey-a", opprettet = newer)
 
             val result = repository.findSurveyOverview("flex")
 
             result.surveysByApp shouldBe mapOf(
                 "app-a" to listOf("survey-a"),
-                "app-b" to listOf("survey-b"),
+                "app-b" to listOf("survey-a", "survey-b"),
+                "app-c" to listOf("survey-a"),
             )
+            result.firstSubmissionBySurvey.keys shouldBe setOf("survey-a", "survey-b")
+            java.time.Instant.parse(result.firstSubmissionBySurvey["survey-a"]) shouldBe earliest.toInstant()
+            java.time.Instant.parse(result.firstSubmissionBySurvey["survey-b"]) shouldBe old.toInstant()
             result.lastSubmissionBySurvey.keys shouldBe setOf("survey-a", "survey-b")
-            java.time.Instant.parse(result.lastSubmissionBySurvey["survey-a"]) shouldBe newer.toInstant()
+            java.time.Instant.parse(result.lastSubmissionBySurvey["survey-a"]) shouldBe latest.toInstant()
             java.time.Instant.parse(result.lastSubmissionBySurvey["survey-b"]) shouldBe old.toInstant()
+            result.submissionBoundsByApp shouldBe mapOf(
+                "app-a" to mapOf(
+                    "survey-a" to SurveySubmissionBounds(old.toInstant().toString(), newer.toInstant().toString()),
+                ),
+                "app-b" to mapOf(
+                    "survey-a" to SurveySubmissionBounds(earliest.toInstant().toString(), old.toInstant().toString()),
+                    "survey-b" to SurveySubmissionBounds(old.toInstant().toString(), old.toInstant().toString()),
+                ),
+                "app-c" to mapOf(
+                    "survey-a" to SurveySubmissionBounds(latest.toInstant().toString(), latest.toInstant().toString()),
+                ),
+            )
         }
 
         test("returns empty maps for a team without feedback") {
             val result = repository.findSurveyOverview("nonexistent")
 
             result.surveysByApp shouldBe emptyMap()
+            result.firstSubmissionBySurvey shouldBe emptyMap()
             result.lastSubmissionBySurvey shouldBe emptyMap()
+            result.submissionBoundsByApp shouldBe emptyMap()
         }
     }
 

--- a/apps/lumi-api/src/test/kotlin/no/nav/lumi/routes/FilterRoutesTest.kt
+++ b/apps/lumi-api/src/test/kotlin/no/nav/lumi/routes/FilterRoutesTest.kt
@@ -23,6 +23,7 @@ import no.nav.lumi.integrations.valkey.InMemoryStringCache
 import no.nav.lumi.repository.SurveyMetadataRepository
 import no.nav.lumi.testModule
 import java.time.Duration
+import java.time.OffsetDateTime
 
 class FilterRoutesTest : FunSpec({
     beforeSpec {
@@ -36,7 +37,7 @@ class FilterRoutesTest : FunSpec({
             email = "test@nav.no",
             clientId = null,
         )
-        bootstrapCacheKey("Team-Test", principal) shouldBe "team=team-test&user=a123456"
+        bootstrapCacheKey("Team-Test", principal) shouldBe "team=team-test&user=a123456&responseVersion=2"
     }
 
     test("bootstrapCacheKey falls back to email when navIdent is missing") {
@@ -46,7 +47,7 @@ class FilterRoutesTest : FunSpec({
             email = "Test.User@nav.no",
             clientId = null,
         )
-        bootstrapCacheKey("team-test", principal) shouldBe "team=team-test&user=test.user@nav.no"
+        bootstrapCacheKey("team-test", principal) shouldBe "team=team-test&user=test.user@nav.no&responseVersion=2"
     }
 
     test("bootstrapCacheKey falls back to email when navIdent is blank") {
@@ -56,7 +57,7 @@ class FilterRoutesTest : FunSpec({
             email = "Test.User@nav.no",
             clientId = null,
         )
-        bootstrapCacheKey("team-test", principal) shouldBe "team=team-test&user=test.user@nav.no"
+        bootstrapCacheKey("team-test", principal) shouldBe "team=team-test&user=test.user@nav.no&responseVersion=2"
     }
 
     test("bootstrapCacheKey returns null when navIdent and email are blank") {
@@ -158,6 +159,62 @@ class FilterRoutesTest : FunSpec({
             val archivedEntry = surveyMeta["survey-archived"]!!.jsonObject
             archivedEntry["archivedAt"] shouldNotBe JsonNull
             archivedEntry["lastSubmissionAt"] shouldNotBe JsonNull
+        }
+    }
+
+    test("bootstrap exposes app-specific submission bounds and consistent archive state") {
+        testApplication {
+            application { testModule() }
+            val surveyId = "survey-across-apps"
+            val first = OffsetDateTime.parse("2020-01-15T10:00:00+01:00")
+            val middle = OffsetDateTime.parse("2021-06-10T12:00:00+02:00")
+            val last = OffsetDateTime.parse("2022-09-20T14:00:00+02:00")
+
+            insertTestFeedback(
+                id = "first-app-a",
+                app = "app-a",
+                surveyId = surveyId,
+                opprettet = first,
+            )
+            insertTestFeedback(
+                id = "middle-app-b",
+                app = "app-b",
+                surveyId = surveyId,
+                opprettet = middle,
+            )
+            insertTestFeedback(
+                id = "last-app-b",
+                app = "app-b",
+                surveyId = surveyId,
+                opprettet = last,
+            )
+            val archiveState = SurveyMetadataRepository().archive(
+                team = "team-test",
+                surveyId = surveyId,
+                archivedBy = "A123456",
+            )
+
+            val response = createTestClient().get("/api/v1/intern/filters/bootstrap?team=team-test") {
+                header(HttpHeaders.Authorization, "Bearer test-token")
+            }
+
+            response.status shouldBe HttpStatusCode.OK
+            val body = Json.parseToJsonElement(response.bodyAsText()).jsonObject
+            val surveyMeta = body["surveyMeta"]!!.jsonObject[surveyId]!!.jsonObject
+            val surveyMetaByApp = body["surveyMetaByApp"]!!.jsonObject
+            val appAMeta = surveyMetaByApp["app-a"]!!.jsonObject[surveyId]!!.jsonObject
+            val appBMeta = surveyMetaByApp["app-b"]!!.jsonObject[surveyId]!!.jsonObject
+
+            surveyMeta["firstSubmissionAt"]?.jsonPrimitive?.content shouldBe first.toInstant().toString()
+            surveyMeta["lastSubmissionAt"]?.jsonPrimitive?.content shouldBe last.toInstant().toString()
+            surveyMeta["archivedAt"]?.jsonPrimitive?.content shouldBe archiveState.archivedAt
+            appAMeta["firstSubmissionAt"]?.jsonPrimitive?.content shouldBe first.toInstant().toString()
+            appAMeta["lastSubmissionAt"]?.jsonPrimitive?.content shouldBe first.toInstant().toString()
+            appAMeta["archivedAt"]?.jsonPrimitive?.content shouldBe archiveState.archivedAt
+            appBMeta["firstSubmissionAt"]?.jsonPrimitive?.content shouldBe middle.toInstant().toString()
+            appBMeta["lastSubmissionAt"]?.jsonPrimitive?.content shouldBe last.toInstant().toString()
+            appBMeta["archivedAt"]?.jsonPrimitive?.content shouldBe archiveState.archivedAt
+            body["surveysByApp"]!!.jsonObject.keys shouldBe setOf("app-a", "app-b")
         }
     }
 

--- a/apps/lumi-api/src/test/kotlin/no/nav/lumi/routes/QueryValidationTest.kt
+++ b/apps/lumi-api/src/test/kotlin/no/nav/lumi/routes/QueryValidationTest.kt
@@ -273,4 +273,16 @@ class QueryValidationTest : FunSpec({
             ex.message shouldContain "YYYY-MM-DD"
         }
     }
+
+    context("toStatsQuery") {
+        test("normalizes blank date parameters to a missing period") {
+            val query = ApiV1Intern.Stats(
+                fromDate = "",
+                toDate = "   ",
+            ).toStatsQuery(team = "flex")
+
+            query.fromDate shouldBe null
+            query.toDate shouldBe null
+        }
+    }
 })

--- a/apps/lumi-api/src/test/kotlin/no/nav/lumi/routes/StatsDashboardRoutesTest.kt
+++ b/apps/lumi-api/src/test/kotlin/no/nav/lumi/routes/StatsDashboardRoutesTest.kt
@@ -238,6 +238,138 @@ class StatsDashboardRoutesTest : FunSpec({
         }
     }
 
+    test("GET /api/v1/intern/stats/dashboard honors explicit historical date ranges in byDate") {
+        testApplication {
+            application { testModule() }
+
+            val team = "flex"
+            val app = "historical-period-app"
+            val surveyId = "historical-period-survey"
+            val historicalDay = OffsetDateTime.parse("2020-01-15T10:00:00+01:00")
+
+            repeat(5) { index ->
+                val submittedAt = historicalDay.plusMinutes(index.toLong())
+                insertTestFeedbackWithJson(
+                    team = team,
+                    app = app,
+                    feedbackJson = feedbackJson(
+                        surveyId = surveyId,
+                        pathname = "/historical-period",
+                        deviceType = "desktop",
+                        rating = 5,
+                        text = "historical-$index",
+                        startedAt = submittedAt.minusSeconds(30),
+                        submittedAt = submittedAt,
+                    ),
+                    opprettet = submittedAt,
+                )
+            }
+
+            val response = createTestClient().get(
+                "/api/v1/intern/stats/dashboard" +
+                    "?team=$team&app=$app&surveyId=$surveyId&fromDate=2020-01-15&toDate=2020-01-15"
+            ) {
+                header(HttpHeaders.Authorization, "Bearer test-token")
+            }
+
+            response.status shouldBe HttpStatusCode.OK
+            val stats = json.decodeFromString<FeedbackStats>(response.bodyAsText())
+
+            stats.totalCount shouldBe 5
+            stats.byDate shouldBe mapOf("2020-01-15" to 5)
+
+            val oneSidedResponse = createTestClient().get(
+                "/api/v1/intern/stats/dashboard" +
+                    "?team=$team&app=$app&surveyId=$surveyId&toDate=2020-01-15"
+            ) {
+                header(HttpHeaders.Authorization, "Bearer test-token")
+            }
+
+            oneSidedResponse.status shouldBe HttpStatusCode.OK
+            val oneSidedStats = json.decodeFromString<FeedbackStats>(oneSidedResponse.bodyAsText())
+            oneSidedStats.byDate shouldBe mapOf("2020-01-15" to 5)
+        }
+    }
+
+    test("GET /api/v1/intern/stats/dashboard groups timeline dates in Europe Oslo") {
+        testApplication {
+            application { testModule() }
+
+            val team = "flex"
+            val app = "oslo-date-bucket-app"
+            val surveyId = "oslo-date-bucket-survey"
+            val lateUtc = OffsetDateTime.parse("2024-02-10T23:30:00Z")
+
+            repeat(5) { index ->
+                val submittedAt = lateUtc.plusMinutes(index.toLong())
+                insertTestFeedbackWithJson(
+                    team = team,
+                    app = app,
+                    feedbackJson = feedbackJson(
+                        surveyId = surveyId,
+                        pathname = "/oslo-date-bucket",
+                        deviceType = "desktop",
+                        rating = 5,
+                        text = "oslo-date-$index",
+                        startedAt = submittedAt.minusSeconds(30),
+                        submittedAt = submittedAt,
+                    ),
+                    opprettet = submittedAt,
+                )
+            }
+
+            val response = createTestClient().get(
+                "/api/v1/intern/stats/dashboard" +
+                    "?team=$team&app=$app&surveyId=$surveyId&fromDate=2024-02-11&toDate=2024-02-11"
+            ) {
+                header(HttpHeaders.Authorization, "Bearer test-token")
+            }
+
+            response.status shouldBe HttpStatusCode.OK
+            val stats = json.decodeFromString<FeedbackStats>(response.bodyAsText())
+
+            stats.totalCount shouldBe 5
+            stats.byDate shouldBe mapOf("2024-02-11" to 5)
+            stats.ratingByDate.keys shouldBe setOf("2024-02-11")
+            stats.ratingByDate["2024-02-11"]?.count shouldBe 5
+        }
+    }
+
+    test("GET /api/v1/intern/stats/dashboard treats blank dates as a missing period") {
+        testApplication {
+            application { testModule() }
+
+            val submittedAt = OffsetDateTime.parse("2020-01-15T10:00:00+01:00")
+            insertTestFeedbackWithJson(
+                team = "flex",
+                app = "blank-period-app",
+                feedbackJson = feedbackJson(
+                    surveyId = "blank-period-survey",
+                    pathname = "/blank-period",
+                    deviceType = "desktop",
+                    rating = 5,
+                    text = "historical",
+                    startedAt = submittedAt.minusSeconds(30),
+                    submittedAt = submittedAt,
+                ),
+                opprettet = submittedAt,
+            )
+
+            val response = createTestClient().get(
+                "/api/v1/intern/stats/dashboard" +
+                    "?team=flex&app=blank-period-app&fromDate=&toDate="
+            ) {
+                header(HttpHeaders.Authorization, "Bearer test-token")
+            }
+
+            response.status shouldBe HttpStatusCode.OK
+            val stats = json.decodeFromString<FeedbackStats>(response.bodyAsText())
+
+            stats.totalCount shouldBe 1
+            stats.byDate shouldBe emptyMap()
+        }
+    }
+
     test("DELETE /api/v1/intern/feedback invalidates cached stats immediately") {
         testApplication {
             application { testModule() }

--- a/apps/lumi-api/src/test/kotlin/no/nav/lumi/service/StatsServiceTest.kt
+++ b/apps/lumi-api/src/test/kotlin/no/nav/lumi/service/StatsServiceTest.kt
@@ -1,11 +1,20 @@
 package no.nav.lumi.service
 
+import no.nav.lumi.domain.StatsQuery
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.Assertions.*
 
 class StatsServiceTest {
     
     private val service = StatsService()
+
+    @Test
+    fun `stats cache key includes the result contract version`() {
+        assertEquals(
+            "dashboard:team=flex&includeArchived=false&resultVersion=2",
+            service.statsCacheKey("dashboard", StatsQuery(team = "flex")),
+        )
+    }
     
     @Test
     fun `calculateAverageRating returns correct average`() {

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "verify:lumi-survey": "pnpm --filter @navikt/lumi-survey run build && node scripts/verify-lumi-survey-package.mjs",
     "check:lumi-survey-release-drift": "node scripts/check-lumi-survey-release-drift.mjs",
     "test:release-guards": "node --test scripts/check-lumi-survey-release-drift.test.mjs",
-    "test": "pnpm --filter lumi-dashboard run test",
+    "test": "pnpm --filter @navikt/lumi-types run test && pnpm --filter lumi-dashboard run test",
     "e2e": "pnpm --filter lumi-dashboard run e2e",
     "docs:dev": "pnpm --filter lumi-docs run dev",
     "docs:build": "pnpm --filter lumi-docs run build",

--- a/packages/lumi-types/package.json
+++ b/packages/lumi-types/package.json
@@ -29,6 +29,7 @@
   },
   "scripts": {
     "build": "tsup src/index.ts src/api.ts src/errors.ts src/schemas.ts --format esm --dts --clean --outDir dist",
+    "test": "node --test src/*.test.mjs",
     "typecheck": "tsc -p tsconfig.json --noEmit"
   },
   "dependencies": {

--- a/packages/lumi-types/src/schemas.test.mjs
+++ b/packages/lumi-types/src/schemas.test.mjs
@@ -1,0 +1,74 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import { FilterBootstrapResponseSchema } from "./schemas.ts";
+
+test("filter bootstrap preserves app-specific survey metadata", () => {
+  const archivedAt = "2023-01-01T00:00:00Z";
+  const parsed = FilterBootstrapResponseSchema.parse({
+    generatedAt: "2026-08-21T12:00:00Z",
+    selectedTeam: "team-test",
+    availableTeams: ["team-test"],
+    deviceTypes: ["desktop"],
+    apps: ["app-a", "app-b"],
+    surveysByApp: {
+      "app-a": ["shared-survey"],
+      "app-b": ["shared-survey"],
+    },
+    tags: [],
+    surveyMeta: {
+      "shared-survey": {
+        archivedAt,
+        firstSubmissionAt: "2020-01-15T09:00:00Z",
+        lastSubmissionAt: "2022-09-20T12:00:00Z",
+      },
+    },
+    surveyMetaByApp: {
+      "app-a": {
+        "shared-survey": {
+          archivedAt,
+          firstSubmissionAt: "2020-01-15T09:00:00Z",
+          lastSubmissionAt: "2020-01-15T09:00:00Z",
+        },
+      },
+      "app-b": {
+        "shared-survey": {
+          archivedAt,
+          firstSubmissionAt: "2021-06-10T10:00:00Z",
+          lastSubmissionAt: "2022-09-20T12:00:00Z",
+        },
+      },
+    },
+  });
+
+  assert.deepEqual(parsed.surveyMetaByApp, {
+    "app-a": {
+      "shared-survey": {
+        archivedAt,
+        firstSubmissionAt: "2020-01-15T09:00:00Z",
+        lastSubmissionAt: "2020-01-15T09:00:00Z",
+      },
+    },
+    "app-b": {
+      "shared-survey": {
+        archivedAt,
+        firstSubmissionAt: "2021-06-10T10:00:00Z",
+        lastSubmissionAt: "2022-09-20T12:00:00Z",
+      },
+    },
+  });
+});
+
+test("filter bootstrap remains compatible when app-specific metadata is absent", () => {
+  const parsed = FilterBootstrapResponseSchema.parse({
+    generatedAt: "2026-08-21T12:00:00Z",
+    selectedTeam: "team-test",
+    availableTeams: ["team-test"],
+    deviceTypes: ["desktop"],
+    apps: [],
+    surveysByApp: {},
+    tags: [],
+  });
+
+  assert.equal(parsed.surveyMetaByApp, undefined);
+});

--- a/packages/lumi-types/src/schemas.ts
+++ b/packages/lumi-types/src/schemas.ts
@@ -161,6 +161,8 @@ export type DeleteSurvey = z.infer<typeof DeleteSurveySchema>;
  */
 export const SurveyMetaEntrySchema = z.object({
   archivedAt: z.string().nullable(),
+  /** Oldest submission for the survey (ISO-8601). Absent for surveys without feedback. */
+  firstSubmissionAt: z.string().nullable().optional(),
   /** Newest submission for the survey (ISO-8601). Absent for surveys without feedback. */
   lastSubmissionAt: z.string().nullable().optional(),
 });
@@ -176,6 +178,10 @@ export const FilterBootstrapResponseSchema = z.object({
   surveysByApp: z.record(z.string(), z.array(z.string())),
   tags: z.array(z.string()),
   surveyMeta: z.record(z.string(), SurveyMetaEntrySchema).optional(),
+  /** Per-app survey periods; optional for backwards compatibility with older API responses. */
+  surveyMetaByApp: z
+    .record(z.string(), z.record(z.string(), SurveyMetaEntrySchema))
+    .optional(),
 });
 
 export type FilterBootstrapResponse = z.infer<


### PR DESCRIPTION
## Beskrivelse

Gjør dashboardets surveyperiode datadrevet, slik at en survey med eldre svar ikke skjules av API-ets implisitte 30-dagersvindu. API-et sender første og siste svartid både globalt og per app, og eksplisitte datogrenser respekteres.

## Endringer

- Utvider bootstrap-kontrakten med firstSubmissionAt og surveyMetaByApp.
- Beregner svargrenser per survey og app i Europe/Oslo.
- Bruker 30 dager bare når klienten ikke sender noen datogrense.
- Versjonerer bootstrap- og statistikkcache for trygg rullerende deploy.
- Legger til kontrakt-, repository- og ruteregresjonstester.

## Issue

Ingen.

## Verifisering

- pnpm run lint
- pnpm run typecheck
- pnpm test
- pnpm run api:test
- pnpm run e2e

## Sjekkliste

- [x] Koden kompilerer og linter uten feil
- [x] Endringene er testet automatisk
- [x] Ingen sensitiv data eksponert (tokens, credentials, PII)