### PR TITLE
Velg automatisk svarperiode for surveys i dashboardet

### DIFF
--- a/apps/lumi-dashboard/app/components/dashboard/PeriodSelector/PeriodSelector.test.tsx
+++ b/apps/lumi-dashboard/app/components/dashboard/PeriodSelector/PeriodSelector.test.tsx
@@ -1,0 +1,209 @@
+import {
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+  within,
+} from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { PeriodSelector } from ".";
+
+const { mockParams, mockSetParams } = vi.hoisted(() => ({
+  mockParams: {
+    dateMode: undefined as "auto" | "fixed" | undefined,
+    surveyId: undefined as string | undefined,
+    fromDate: undefined as string | undefined,
+    toDate: undefined as string | undefined,
+  },
+  mockSetParams: vi.fn(),
+}));
+
+vi.mock("~/hooks/useSearchParams", () => ({
+  useSearchParams: () => ({
+    params: mockParams,
+    setParams: mockSetParams,
+  }),
+}));
+
+vi.mock("~/hooks/useBreakpoint", () => ({
+  useBreakpoint: () => ({ isMobile: false }),
+}));
+
+describe("PeriodSelector", () => {
+  beforeEach(() => {
+    mockParams.dateMode = undefined;
+    mockParams.surveyId = undefined;
+    mockParams.fromDate = undefined;
+    mockParams.toDate = undefined;
+    mockSetParams.mockClear();
+  });
+
+  it("lets a fixed survey period return to automatic mode without clearing the survey", async () => {
+    const user = userEvent.setup();
+    mockParams.dateMode = "fixed";
+    mockParams.surveyId = "survey-historisk";
+    mockParams.fromDate = "2024-02-01";
+    mockParams.toDate = "2024-02-18";
+    render(<PeriodSelector />);
+
+    await user.click(
+      screen.getByRole("button", {
+        name: "Periode: 01.02.2024 - 18.02.2024",
+      }),
+    );
+    await user.click(
+      screen.getByRole("button", { name: "Automatisk periode" }),
+    );
+
+    expect(mockSetParams).toHaveBeenCalledWith({
+      dateMode: "auto",
+      page: "1",
+    });
+    await waitFor(() =>
+      expect(
+        screen.getByRole("button", {
+          name: "Periode: 01.02.2024 - 18.02.2024",
+        }),
+      ).toHaveFocus(),
+    );
+  });
+
+  it("labels a partial fixed period that only has a start date", () => {
+    mockParams.dateMode = "fixed";
+    mockParams.fromDate = "2024-02-01";
+
+    render(<PeriodSelector />);
+
+    expect(
+      screen.getByRole("button", { name: "Periode: Fra 01.02.2024" }),
+    ).toBeInTheDocument();
+  });
+
+  it("labels a partial fixed period that only has an end date", () => {
+    mockParams.dateMode = "fixed";
+    mockParams.toDate = "2024-02-18";
+
+    render(<PeriodSelector />);
+
+    expect(
+      screen.getByRole("button", { name: "Periode: Til 18.02.2024" }),
+    ).toBeInTheDocument();
+  });
+
+  it("marks a manually selected preset as fixed", async () => {
+    const user = userEvent.setup();
+    render(<PeriodSelector />);
+
+    await user.click(
+      screen.getByRole("button", { name: "Periode: Velg periode" }),
+    );
+    await user.click(screen.getByRole("button", { name: "Siste 7 dager" }));
+
+    expect(mockSetParams).toHaveBeenCalledWith(
+      expect.objectContaining({ dateMode: "fixed", page: "1" }),
+    );
+  });
+
+  it("marks a custom date range as fixed", async () => {
+    const user = userEvent.setup();
+    render(<PeriodSelector />);
+
+    await user.click(
+      screen.getByRole("button", { name: "Periode: Velg periode" }),
+    );
+    await user.type(
+      screen.getAllByRole("textbox", { name: "Fra" })[0],
+      "01.02.2024",
+    );
+    await user.type(
+      screen.getAllByRole("textbox", { name: "Til" })[0],
+      "18.02.2024",
+    );
+
+    const applyButton = within(
+      screen.getByRole("dialog", { name: "Velg periode" }),
+    )
+      .getAllByRole("button", { name: "Velg periode" })
+      .find((button) => !button.hasAttribute("disabled"));
+
+    expect(applyButton).toBeDefined();
+    await user.click(applyButton as HTMLButtonElement);
+
+    expect(mockSetParams).toHaveBeenCalledWith({
+      dateMode: "fixed",
+      fromDate: "2024-02-01",
+      toDate: "2024-02-18",
+      page: "1",
+    });
+  });
+
+  it("exposes dialog state and restores focus after Escape", async () => {
+    const user = userEvent.setup();
+    render(<PeriodSelector />);
+
+    const trigger = screen.getByRole("button", {
+      name: "Periode: Velg periode",
+    });
+    expect(trigger).toHaveAttribute("aria-expanded", "false");
+    expect(trigger).toHaveAttribute("aria-haspopup", "dialog");
+
+    await user.click(trigger);
+
+    const dialog = screen.getByRole("dialog", { name: "Velg periode" });
+    expect(trigger).toHaveAttribute("aria-expanded", "true");
+    expect(trigger).toHaveAttribute("aria-controls", dialog.id);
+
+    screen.getByRole("button", { name: "Siste 7 dager" }).focus();
+    fireEvent.keyDown(dialog, { key: "Escape" });
+
+    await waitFor(() => expect(trigger).toHaveFocus());
+    expect(trigger).toHaveAttribute("aria-expanded", "false");
+  });
+
+  it("leaves the period selector open when Escape comes from a nested dialog", async () => {
+    const user = userEvent.setup();
+    render(<PeriodSelector />);
+
+    const trigger = screen.getByRole("button", {
+      name: "Periode: Velg periode",
+    });
+    await user.click(trigger);
+
+    const dialog = screen.getByRole("dialog", { name: "Velg periode" });
+    await user.click(screen.getAllByTitle("Åpne datovelger")[0]);
+    const nestedDialog = screen
+      .getAllByRole("dialog")
+      .find((candidate) => candidate !== dialog);
+    expect(nestedDialog).toBeDefined();
+
+    within(nestedDialog as HTMLElement)
+      .getByRole("button", { name: "Lukk" })
+      .focus();
+    await user.keyboard("{Escape}");
+
+    expect(trigger).toHaveAttribute("aria-expanded", "true");
+    expect(dialog).toBeInTheDocument();
+  });
+
+  it("does not steal focus when an outside click closes the popover", async () => {
+    const user = userEvent.setup();
+    render(
+      <>
+        <PeriodSelector />
+        <button type="button">Utenfor</button>
+      </>,
+    );
+
+    const trigger = screen.getByRole("button", {
+      name: "Periode: Velg periode",
+    });
+    const outsideButton = screen.getByRole("button", { name: "Utenfor" });
+
+    await user.click(trigger);
+    await user.click(outsideButton);
+
+    expect(outsideButton).toHaveFocus();
+    expect(trigger).toHaveAttribute("aria-expanded", "false");
+  });
+});

--- a/apps/lumi-dashboard/app/components/dashboard/PeriodSelector/index.tsx
+++ b/apps/lumi-dashboard/app/components/dashboard/PeriodSelector/index.tsx
@@ -15,7 +15,7 @@ import {
   VStack,
 } from "@navikt/ds-react";
 import dayjs from "dayjs";
-import { useRef, useState } from "react";
+import { useId, useRef, useState } from "react";
 import { useBreakpoint } from "~/hooks/useBreakpoint";
 import { useSearchParams } from "~/hooks/useSearchParams";
 import styles from "./PeriodSelector.module.css";
@@ -70,19 +70,26 @@ export function PeriodSelector() {
   const { params, setParams } = useSearchParams();
   const [open, setOpen] = useState(false);
   const buttonRef = useRef<HTMLButtonElement>(null);
+  const popoverId = useId();
   const { isMobile } = useBreakpoint();
 
   // Parse current params
   const currentFrom = params.fromDate ? dayjs(params.fromDate) : undefined;
   const currentTo = params.toDate ? dayjs(params.toDate) : undefined;
 
+  const closeAndRestoreFocus = () => {
+    setOpen(false);
+    window.requestAnimationFrame(() => buttonRef.current?.focus());
+  };
+
   const handleApply = (from: Date, to: Date) => {
     setParams({
+      dateMode: "fixed",
       fromDate: dayjs(from).format("YYYY-MM-DD"),
       toDate: dayjs(to).format("YYYY-MM-DD"),
       page: "1",
     });
-    setOpen(false);
+    closeAndRestoreFocus();
   };
 
   const handlePreset = (days: number | "year" | "today") => {
@@ -98,15 +105,27 @@ export function PeriodSelector() {
     }
 
     setParams({
+      dateMode: "fixed",
       fromDate: start.format("YYYY-MM-DD"),
       toDate: end.format("YYYY-MM-DD"),
       page: "1",
     });
-    setOpen(false);
+    closeAndRestoreFocus();
+  };
+
+  const handleAutomaticPeriod = () => {
+    setParams({ dateMode: "auto", page: "1" });
+    closeAndRestoreFocus();
   };
 
   // Determine label text
   const getLabel = () => {
+    if (currentFrom && !currentTo) {
+      return `Fra ${currentFrom.format(isMobile ? "DD.MM" : "DD.MM.YYYY")}`;
+    }
+    if (!currentFrom && currentTo) {
+      return `Til ${currentTo.format(isMobile ? "DD.MM" : "DD.MM.YYYY")}`;
+    }
     if (!currentFrom || !currentTo) return "Velg periode";
 
     const end = currentTo;
@@ -133,6 +152,8 @@ export function PeriodSelector() {
     return `${start.format("DD.MM.YYYY")} - ${end.format("DD.MM.YYYY")}`;
   };
 
+  const periodLabel = getLabel();
+
   return (
     <>
       <Button
@@ -143,20 +164,51 @@ export function PeriodSelector() {
         icon={<CalendarIcon aria-hidden />}
         iconPosition="left"
         className={styles.triggerButton}
+        aria-label={`Periode: ${periodLabel}`}
+        aria-expanded={open}
+        aria-haspopup="dialog"
+        aria-controls={popoverId}
       >
-        {getLabel()}
+        {periodLabel}
         {open ? <ChevronUpIcon aria-hidden /> : <ChevronDownIcon aria-hidden />}
       </Button>
 
       <Popover
+        id={popoverId}
+        role="dialog"
+        aria-label="Velg periode"
         open={open}
         onClose={() => setOpen(false)}
         anchorEl={buttonRef.current}
         placement={isMobile ? "bottom" : "bottom-start"}
+        onKeyDown={(event) => {
+          if (event.key !== "Escape") return;
+
+          const sourceDialog =
+            event.target instanceof Element
+              ? event.target.closest('[role="dialog"]')
+              : null;
+          if (sourceDialog !== event.currentTarget) return;
+
+          event.preventDefault();
+          event.stopPropagation();
+          closeAndRestoreFocus();
+        }}
       >
         <Popover.Content className={styles.popoverContent}>
           {open && (
-            <>
+            <VStack gap="space-16">
+              {params.dateMode === "fixed" && (
+                <Button
+                  type="button"
+                  variant="secondary"
+                  size="small"
+                  onClick={handleAutomaticPeriod}
+                >
+                  Automatisk periode
+                </Button>
+              )}
+
               {/* Desktop: Side by side */}
               <Show above="md">
                 <HStack gap="space-16" align="start">
@@ -187,7 +239,7 @@ export function PeriodSelector() {
                   <CustomPeriodInputs onApply={handleApply} />
                 </VStack>
               </Hide>
-            </>
+            </VStack>
           )}
         </Popover.Content>
       </Popover>

--- a/apps/lumi-dashboard/app/components/shared/Charts/RatingTrendChart.tsx
+++ b/apps/lumi-dashboard/app/components/shared/Charts/RatingTrendChart.tsx
@@ -135,8 +135,10 @@ export function RatingTrendChart({ markers = [] }: RatingTrendChartProps) {
             to: "/feedback",
             search: {
               ...params,
+              dateMode: "fixed",
               fromDate: clickData.date,
               toDate: clickData.date,
+              page: "1",
               lowRating: clickData.average < 3 ? "true" : undefined,
             },
           });

--- a/apps/lumi-dashboard/app/components/shared/Charts/TimelineChart.tsx
+++ b/apps/lumi-dashboard/app/components/shared/Charts/TimelineChart.tsx
@@ -109,8 +109,10 @@ export function TimelineChart() {
             to: "/feedback",
             search: {
               ...params,
+              dateMode: "fixed",
               fromDate: date,
               toDate: date,
+              page: "1",
             },
           });
         }}

--- a/apps/lumi-dashboard/app/components/shared/Charts/__tests__/ChartDrilldown.test.tsx
+++ b/apps/lumi-dashboard/app/components/shared/Charts/__tests__/ChartDrilldown.test.tsx
@@ -1,0 +1,130 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import type { ReactNode } from "react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { RatingTrendChart } from "../RatingTrendChart";
+import { TimelineChart } from "../TimelineChart";
+
+const { mockNavigate, mockStats, mockParams } = vi.hoisted(() => ({
+  mockNavigate: vi.fn(),
+  mockStats: { data: undefined as unknown },
+  mockParams: {
+    surveyId: "survey-historisk",
+    dateMode: "auto" as "auto" | "fixed",
+    page: "7",
+  },
+}));
+
+vi.mock("@tanstack/react-router", () => ({
+  useNavigate: () => mockNavigate,
+}));
+
+vi.mock("~/hooks/useStats", () => ({
+  useStats: () => ({ data: mockStats.data, isPending: false }),
+}));
+
+vi.mock("~/hooks/useSearchParams", () => ({
+  useSearchParams: () => ({ params: mockParams }),
+}));
+
+vi.mock("~/hooks/useBreakpoint", () => ({
+  useBreakpoint: () => ({ isMobile: false }),
+}));
+
+vi.mock("~/context/ThemeContext", () => ({
+  useTheme: () => ({ theme: "light" }),
+}));
+
+vi.mock(
+  "~/components/shared/Charts/ResponsiveContainerWithInitialSize",
+  () => ({
+    ResponsiveContainerWithInitialSize: ({
+      children,
+    }: {
+      children: ReactNode;
+    }) => <>{children}</>,
+  }),
+);
+
+vi.mock("recharts", () => ({
+  BarChart: ({
+    onClick,
+  }: {
+    onClick: (state: { activeIndex: number }) => void;
+  }) => (
+    <button type="button" onClick={() => onClick({ activeIndex: 0 })}>
+      Åpne tidslinjedag
+    </button>
+  ),
+  Bar: () => null,
+  CartesianGrid: () => null,
+  LineChart: ({
+    onClick,
+  }: {
+    onClick: (state: { activeIndex: number }) => void;
+  }) => (
+    <button type="button" onClick={() => onClick({ activeIndex: 0 })}>
+      Åpne vurderingsdag
+    </button>
+  ),
+  Line: () => null,
+  ReferenceLine: () => null,
+  Tooltip: () => null,
+  XAxis: () => null,
+  YAxis: () => null,
+}));
+
+describe("chart drilldown", () => {
+  beforeEach(() => {
+    mockNavigate.mockClear();
+    mockStats.data = undefined;
+    mockParams.dateMode = "auto";
+    mockParams.page = "7";
+  });
+
+  it("opens a timeline day as a fixed period on the first feedback page", async () => {
+    const user = userEvent.setup();
+    mockStats.data = { byDate: { "2024-02-18": 3 } };
+
+    render(<TimelineChart />);
+    await user.click(screen.getByRole("button", { name: "Åpne tidslinjedag" }));
+
+    expect(mockNavigate).toHaveBeenCalledWith({
+      to: "/feedback",
+      search: {
+        surveyId: "survey-historisk",
+        dateMode: "fixed",
+        page: "1",
+        fromDate: "2024-02-18",
+        toDate: "2024-02-18",
+      },
+    });
+  });
+
+  it("opens a rating day as a fixed period on the first feedback page", async () => {
+    const user = userEvent.setup();
+    mockStats.data = {
+      ratingByDate: {
+        "2024-02-18": { average: 2.5, count: 4 },
+      },
+      averageRating: 2.5,
+    };
+
+    render(<RatingTrendChart />);
+    await user.click(
+      screen.getByRole("button", { name: "Åpne vurderingsdag" }),
+    );
+
+    expect(mockNavigate).toHaveBeenCalledWith({
+      to: "/feedback",
+      search: {
+        surveyId: "survey-historisk",
+        dateMode: "fixed",
+        page: "1",
+        fromDate: "2024-02-18",
+        toDate: "2024-02-18",
+        lowRating: "true",
+      },
+    });
+  });
+});

--- a/apps/lumi-dashboard/app/components/shared/FilterBar/__tests__/FilterBar.archive.test.tsx
+++ b/apps/lumi-dashboard/app/components/shared/FilterBar/__tests__/FilterBar.archive.test.tsx
@@ -1,27 +1,34 @@
 import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import { resolveDashboardPeriod } from "~/utils/dashboardPeriod";
 import { FilterBar } from "../index";
 
-const { mockParams, mockSetParams, mockBootstrap } = vi.hoisted(() => ({
-  mockParams: {
-    team: "team-test",
-    app: undefined as string | undefined,
-    surveyId: "survey-archived" as string | undefined,
-    showArchived: undefined as string | undefined,
-  },
-  mockSetParams: vi.fn(),
-  mockBootstrap: {
-    data: undefined as unknown,
-    isPending: false,
-  },
-}));
+const { mockParams, mockSetParams, mockResetParams, mockBootstrap } =
+  vi.hoisted(() => ({
+    mockParams: {
+      team: "team-test",
+      app: undefined as string | undefined,
+      surveyId: "survey-archived" as string | undefined,
+      showArchived: undefined as string | undefined,
+      dateMode: "auto" as "auto" | "fixed" | undefined,
+      fromDate: "2026-07-23" as string | undefined,
+      toDate: "2026-08-21" as string | undefined,
+      query: undefined as string | undefined,
+    },
+    mockSetParams: vi.fn(),
+    mockResetParams: vi.fn(),
+    mockBootstrap: {
+      data: undefined as unknown,
+      isPending: false,
+    },
+  }));
 
 vi.mock("~/hooks/useSearchParams", () => ({
   useSearchParams: () => ({
     params: mockParams,
     setParam: vi.fn(),
     setParams: mockSetParams,
-    resetParams: vi.fn(),
+    resetParams: mockResetParams,
   }),
 }));
 
@@ -40,8 +47,47 @@ function loadedBootstrapData() {
     },
     tags: [],
     surveyMeta: {
+      "survey-active": {
+        archivedAt: null,
+        firstSubmissionAt: "2024-01-01T12:00:00Z",
+        lastSubmissionAt: "2024-02-18T12:00:00Z",
+      },
       "survey-archived": { archivedAt: "2026-08-01T10:00:00Z" },
       "survey-only-archived": { archivedAt: "2026-08-02T10:00:00Z" },
+    },
+  };
+}
+
+function sharedSurveyBootstrapData() {
+  return {
+    ...loadedBootstrapData(),
+    apps: ["app-a", "app-b"],
+    surveysByApp: {
+      "app-a": ["shared-survey"],
+      "app-b": ["shared-survey"],
+    },
+    surveyMeta: {
+      "shared-survey": {
+        archivedAt: null,
+        firstSubmissionAt: "2024-05-01T12:00:00Z",
+        lastSubmissionAt: "2024-05-30T12:00:00Z",
+      },
+    },
+    surveyMetaByApp: {
+      "app-a": {
+        "shared-survey": {
+          archivedAt: null,
+          firstSubmissionAt: "2024-01-01T12:00:00Z",
+          lastSubmissionAt: "2024-02-18T12:00:00Z",
+        },
+      },
+      "app-b": {
+        "shared-survey": {
+          archivedAt: null,
+          firstSubmissionAt: "2024-05-01T12:00:00Z",
+          lastSubmissionAt: "2024-05-30T12:00:00Z",
+        },
+      },
     },
   };
 }
@@ -59,9 +105,14 @@ describe("FilterBar archive state", () => {
     mockParams.app = undefined;
     mockParams.surveyId = "survey-archived";
     mockParams.showArchived = undefined;
+    mockParams.dateMode = "auto";
+    mockParams.fromDate = "2026-07-23";
+    mockParams.toDate = "2026-08-21";
+    mockParams.query = undefined;
     mockBootstrap.data = loadedBootstrapData();
     mockBootstrap.isPending = false;
     mockSetParams.mockClear();
+    mockResetParams.mockClear();
   });
 
   it("does not clear an app filter while bootstrap is still loading", () => {
@@ -76,6 +127,7 @@ describe("FilterBar archive state", () => {
   });
 
   it("hides and clears a selected archived survey while the toggle is off", async () => {
+    const automaticPeriod = resolveDashboardPeriod({ dateMode: "auto" });
     render(<FilterBar />);
 
     expect(
@@ -87,6 +139,9 @@ describe("FilterBar archive state", () => {
         choice: undefined,
         rating: undefined,
         phrase: undefined,
+        dateMode: "auto",
+        fromDate: automaticPeriod.fromDate,
+        toDate: automaticPeriod.toDate,
         page: "1",
       }),
     );
@@ -125,7 +180,86 @@ describe("FilterBar archive state", () => {
     expect(mockSetParams).toHaveBeenCalledWith({ showArchived: "true" });
   });
 
+  it("moves an automatic period to the selected survey's newest responses", () => {
+    mockParams.surveyId = undefined;
+    render(<FilterBar />);
+
+    fireEvent.change(screen.getAllByRole("combobox", { name: "Survey" })[0], {
+      target: { value: "survey-active" },
+    });
+
+    expect(mockSetParams).toHaveBeenCalledWith({
+      surveyId: "survey-active",
+      choice: undefined,
+      rating: undefined,
+      phrase: undefined,
+      dateMode: "auto",
+      fromDate: "2024-01-20",
+      toDate: "2024-02-18",
+      page: "1",
+    });
+  });
+
+  it("preserves a fixed period when switching survey", () => {
+    mockParams.surveyId = undefined;
+    mockParams.dateMode = "fixed";
+    render(<FilterBar />);
+
+    fireEvent.change(screen.getAllByRole("combobox", { name: "Survey" })[0], {
+      target: { value: "survey-active" },
+    });
+
+    expect(mockSetParams).toHaveBeenCalledWith({
+      surveyId: "survey-active",
+      choice: undefined,
+      rating: undefined,
+      phrase: undefined,
+      page: "1",
+    });
+  });
+
+  it("offers the survey response period when a fixed period does not overlap", () => {
+    mockParams.surveyId = "survey-active";
+    mockParams.dateMode = "fixed";
+    mockParams.fromDate = "2026-08-01";
+    mockParams.toDate = "2026-08-21";
+
+    render(<FilterBar />);
+
+    expect(
+      screen.getByText(
+        "Surveyen har registrerte svar fra 01.01.2024 til 18.02.2024.",
+      ),
+    ).toBeInTheDocument();
+
+    fireEvent.click(
+      screen.getByRole("button", { name: "Vis hele svarperioden" }),
+    );
+
+    expect(mockSetParams).toHaveBeenCalledWith({
+      dateMode: "fixed",
+      fromDate: "2024-01-01",
+      toDate: "2024-02-18",
+      page: "1",
+    });
+  });
+
+  it("resolves an automatic period for a survey opened from a direct URL", async () => {
+    mockParams.surveyId = "survey-active";
+    render(<FilterBar />);
+
+    await waitFor(() =>
+      expect(mockSetParams).toHaveBeenCalledWith({
+        dateMode: "auto",
+        fromDate: "2024-01-20",
+        toDate: "2024-02-18",
+        page: "1",
+      }),
+    );
+  });
+
   it("clears the app when its final visible survey is archived", async () => {
+    const automaticPeriod = resolveDashboardPeriod({ dateMode: "auto" });
     mockParams.app = "app-archived";
     mockParams.surveyId = "survey-only-archived";
     render(<FilterBar />);
@@ -137,6 +271,223 @@ describe("FilterBar archive state", () => {
         choice: undefined,
         rating: undefined,
         phrase: undefined,
+        dateMode: "auto",
+        fromDate: automaticPeriod.fromDate,
+        toDate: automaticPeriod.toDate,
+        page: "1",
+      }),
+    );
+  });
+
+  it("returns to a rolling automatic period when an app change clears the survey", () => {
+    const automaticPeriod = resolveDashboardPeriod({ dateMode: "auto" });
+    mockParams.app = "app-test";
+    mockParams.surveyId = "survey-active";
+    mockBootstrap.data = {
+      ...loadedBootstrapData(),
+      apps: ["app-test", "app-other"],
+      surveysByApp: {
+        ...loadedBootstrapData().surveysByApp,
+        "app-other": ["survey-other"],
+      },
+      surveyMeta: {
+        ...loadedBootstrapData().surveyMeta,
+        "survey-other": { archivedAt: null },
+      },
+    };
+
+    render(<FilterBar />);
+    mockSetParams.mockClear();
+
+    fireEvent.change(screen.getAllByRole("combobox", { name: "App" })[0], {
+      target: { value: "app-other" },
+    });
+
+    expect(mockSetParams).toHaveBeenCalledWith(
+      expect.objectContaining({
+        app: "app-other",
+        surveyId: undefined,
+        dateMode: "auto",
+        fromDate: automaticPeriod.fromDate,
+        toDate: automaticPeriod.toDate,
+      }),
+    );
+  });
+
+  it("returns to a rolling automatic period when a team change clears the survey", () => {
+    const automaticPeriod = resolveDashboardPeriod({ dateMode: "auto" });
+    mockParams.surveyId = "survey-active";
+    mockBootstrap.data = {
+      ...loadedBootstrapData(),
+      availableTeams: ["team-test", "team-other"],
+    };
+
+    render(<FilterBar />);
+    mockSetParams.mockClear();
+
+    fireEvent.change(screen.getAllByRole("combobox", { name: "Team" })[0], {
+      target: { value: "team-other" },
+    });
+
+    expect(mockSetParams).toHaveBeenCalledWith(
+      expect.objectContaining({
+        team: "team-other",
+        surveyId: undefined,
+        dateMode: "auto",
+        fromDate: automaticPeriod.fromDate,
+        toDate: automaticPeriod.toDate,
+      }),
+    );
+  });
+
+  it("resets all filters in one navigation to a bounded automatic period", () => {
+    const automaticPeriod = resolveDashboardPeriod({ dateMode: "auto" });
+    mockParams.surveyId = undefined;
+    mockParams.query = "søketekst";
+
+    render(<FilterBar />);
+
+    fireEvent.click(
+      screen.getAllByRole("button", {
+        name: "Nullstill alle filtre til standard (siste 30 dager)",
+      })[0],
+    );
+
+    expect(mockResetParams).toHaveBeenCalledWith({
+      team: "team-test",
+      dateMode: "auto",
+      fromDate: automaticPeriod.fromDate,
+      toDate: automaticPeriod.toDate,
+      page: "1",
+    });
+    expect(mockSetParams).not.toHaveBeenCalled();
+  });
+
+  it("offers reset when the only active filter is a fixed period", () => {
+    mockParams.surveyId = undefined;
+    mockParams.dateMode = "fixed";
+    mockParams.fromDate = "2024-02-01";
+    mockParams.toDate = "2024-02-18";
+
+    render(<FilterBar />);
+
+    expect(
+      screen.getAllByRole("button", {
+        name: "Nullstill alle filtre til standard (siste 30 dager)",
+      }),
+    ).toHaveLength(2);
+  });
+
+  it("anchors a shared survey to the selected app's response period", async () => {
+    mockParams.app = "app-a";
+    mockParams.surveyId = "shared-survey";
+    mockBootstrap.data = sharedSurveyBootstrapData();
+
+    render(<FilterBar />);
+
+    await waitFor(() =>
+      expect(mockSetParams).toHaveBeenCalledWith({
+        dateMode: "auto",
+        fromDate: "2024-01-20",
+        toDate: "2024-02-18",
+        page: "1",
+      }),
+    );
+  });
+
+  it("shows the selected app's response period for a fixed shared survey", () => {
+    mockParams.app = "app-a";
+    mockParams.surveyId = "shared-survey";
+    mockParams.dateMode = "fixed";
+    mockParams.fromDate = "2026-08-01";
+    mockParams.toDate = "2026-08-21";
+    mockBootstrap.data = sharedSurveyBootstrapData();
+
+    render(<FilterBar />);
+
+    expect(
+      screen.getByText(
+        "Surveyen har registrerte svar fra 01.01.2024 til 18.02.2024.",
+      ),
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByText(
+        "Surveyen har registrerte svar fra 01.05.2024 til 30.05.2024.",
+      ),
+    ).not.toBeInTheDocument();
+  });
+
+  it("falls back to global survey metadata for an older bootstrap response", async () => {
+    mockParams.app = "app-test";
+    mockParams.surveyId = "survey-active";
+    mockBootstrap.data = loadedBootstrapData();
+
+    render(<FilterBar />);
+
+    await waitFor(() =>
+      expect(mockSetParams).toHaveBeenCalledWith({
+        dateMode: "auto",
+        fromDate: "2024-01-20",
+        toDate: "2024-02-18",
+        page: "1",
+      }),
+    );
+  });
+
+  it("falls back to global metadata when the selected app has no survey entry", async () => {
+    const bootstrap = sharedSurveyBootstrapData();
+    mockParams.app = "app-a";
+    mockParams.surveyId = "shared-survey";
+    mockBootstrap.data = {
+      ...bootstrap,
+      surveyMetaByApp: {
+        ...bootstrap.surveyMetaByApp,
+        "app-a": {},
+      },
+    };
+
+    render(<FilterBar />);
+
+    await waitFor(() =>
+      expect(mockSetParams).toHaveBeenCalledWith({
+        dateMode: "auto",
+        fromDate: "2024-05-01",
+        toDate: "2024-05-30",
+        page: "1",
+      }),
+    );
+  });
+
+  it("reanchors a shared survey when switching to another app", async () => {
+    mockParams.app = "app-a";
+    mockParams.surveyId = "shared-survey";
+    mockParams.fromDate = "2024-01-20";
+    mockParams.toDate = "2024-02-18";
+    mockBootstrap.data = sharedSurveyBootstrapData();
+
+    const { rerender } = render(<FilterBar />);
+    expect(mockSetParams).not.toHaveBeenCalled();
+
+    fireEvent.change(screen.getAllByRole("combobox", { name: "App" })[0], {
+      target: { value: "app-b" },
+    });
+    expect(mockSetParams).toHaveBeenCalledWith({
+      app: "app-b",
+      page: "1",
+      phrase: undefined,
+      choice: undefined,
+      rating: undefined,
+    });
+
+    mockSetParams.mockClear();
+    mockParams.app = "app-b";
+    rerender(<FilterBar />);
+
+    await waitFor(() =>
+      expect(mockSetParams).toHaveBeenCalledWith({
+        dateMode: "auto",
+        fromDate: "2024-05-01",
+        toDate: "2024-05-30",
         page: "1",
       }),
     );

--- a/apps/lumi-dashboard/app/components/shared/FilterBar/index.tsx
+++ b/apps/lumi-dashboard/app/components/shared/FilterBar/index.tsx
@@ -1,5 +1,7 @@
 import { XMarkIcon } from "@navikt/aksel-icons";
 import {
+  Alert,
+  BodyShort,
   Box,
   Button,
   Hide,
@@ -19,6 +21,10 @@ import { useFilterBootstrap } from "~/hooks/useFilterBootstrap";
 import { useSearchParams } from "~/hooks/useSearchParams";
 import { useStats } from "~/hooks/useStats";
 import { useThemes } from "~/hooks/useThemes";
+import {
+  resolveDashboardPeriod,
+  type SurveyPeriodMetadata,
+} from "~/utils/dashboardPeriod";
 import { getFilterLabels } from "~/utils/filterLabels";
 import {
   isSurveyArchived,
@@ -45,6 +51,12 @@ export function FilterBar({ showDetails = false }: FilterBarProps) {
     stats,
     themes,
   });
+  const currentPeriod = resolveDashboardPeriod({
+    dateMode: params.dateMode,
+    fromDate: params.fromDate,
+    toDate: params.toDate,
+  });
+  const rollingAutomaticPeriod = resolveDashboardPeriod({ dateMode: "auto" });
 
   const selectedTags = params.tag
     ? params.tag
@@ -61,6 +73,12 @@ export function FilterBar({ showDetails = false }: FilterBarProps) {
   const surveysByApp = bootstrap?.surveysByApp ?? {};
   const allTags = bootstrap?.tags ?? [];
   const showArchived = params.showArchived === "true";
+  const getSurveyPeriodMetadata = (
+    surveyId: string,
+  ): SurveyPeriodMetadata | undefined =>
+    (params.app
+      ? bootstrap?.surveyMetaByApp?.[params.app]?.[surveyId]
+      : undefined) ?? bootstrap?.surveyMeta?.[surveyId];
 
   const allAvailableSurveys = Array.from(
     new Set(Object.values(surveysByApp).flat()),
@@ -165,16 +183,36 @@ export function FilterBar({ showDetails = false }: FilterBarProps) {
       rating: undefined,
       ...(shouldClearSurvey && {
         surveyId: undefined,
+        ...(currentPeriod.dateMode === "auto" && {
+          dateMode: "auto" as const,
+          fromDate: rollingAutomaticPeriod.fromDate,
+          toDate: rollingAutomaticPeriod.toDate,
+        }),
       }),
     });
   };
 
   const handleSurveyChange = (newSurveyId: string | undefined) => {
+    const selectedSurveyMeta = newSurveyId
+      ? getSurveyPeriodMetadata(newSurveyId)
+      : undefined;
+    const period = resolveDashboardPeriod({
+      dateMode: params.dateMode,
+      fromDate: params.fromDate,
+      toDate: params.toDate,
+      surveyMeta: selectedSurveyMeta,
+    });
+
     setParams({
       surveyId: newSurveyId,
       choice: undefined,
       rating: undefined,
       phrase: undefined,
+      ...(period.dateMode === "auto" && {
+        dateMode: "auto",
+        fromDate: period.fromDate,
+        toDate: period.toDate,
+      }),
       page: "1",
     });
   };
@@ -182,6 +220,15 @@ export function FilterBar({ showDetails = false }: FilterBarProps) {
   const selectedSurveyIsArchived =
     !!params.surveyId &&
     isSurveyArchived(params.surveyId, bootstrap?.surveyMeta);
+  const selectedSurveyMeta = params.surveyId
+    ? getSurveyPeriodMetadata(params.surveyId)
+    : undefined;
+  const selectedSurveyPeriod = resolveDashboardPeriod({
+    dateMode: params.dateMode,
+    fromDate: params.fromDate,
+    toDate: params.toDate,
+    surveyMeta: selectedSurveyMeta,
+  });
   // Guarded on loaded bootstrap: while data is pending visibleApps is empty,
   // and an unguarded check would wipe the app filter from bookmarked URLs.
   const selectedAppIsHidden =
@@ -198,6 +245,11 @@ export function FilterBar({ showDetails = false }: FilterBarProps) {
         choice: undefined,
         rating: undefined,
         phrase: undefined,
+        ...(currentPeriod.dateMode === "auto" && {
+          dateMode: "auto" as const,
+          fromDate: rollingAutomaticPeriod.fromDate,
+          toDate: rollingAutomaticPeriod.toDate,
+        }),
         page: "1",
       });
     } else if (!showArchived && selectedSurveyIsArchived) {
@@ -206,24 +258,67 @@ export function FilterBar({ showDetails = false }: FilterBarProps) {
         choice: undefined,
         rating: undefined,
         phrase: undefined,
+        ...(currentPeriod.dateMode === "auto" && {
+          dateMode: "auto" as const,
+          fromDate: rollingAutomaticPeriod.fromDate,
+          toDate: rollingAutomaticPeriod.toDate,
+        }),
         page: "1",
       });
     }
-  }, [showArchived, selectedAppIsHidden, selectedSurveyIsArchived, setParams]);
+  }, [
+    currentPeriod.dateMode,
+    rollingAutomaticPeriod.fromDate,
+    rollingAutomaticPeriod.toDate,
+    selectedAppIsHidden,
+    selectedSurveyIsArchived,
+    setParams,
+    showArchived,
+  ]);
+
+  useEffect(() => {
+    if (
+      !bootstrap ||
+      !params.surveyId ||
+      selectedAppIsHidden ||
+      (!showArchived && selectedSurveyIsArchived) ||
+      selectedSurveyPeriod.dateMode !== "auto" ||
+      (params.dateMode === "auto" &&
+        params.fromDate === selectedSurveyPeriod.fromDate &&
+        params.toDate === selectedSurveyPeriod.toDate)
+    ) {
+      return;
+    }
+
+    setParams({
+      dateMode: "auto",
+      fromDate: selectedSurveyPeriod.fromDate,
+      toDate: selectedSurveyPeriod.toDate,
+      page: "1",
+    });
+  }, [
+    bootstrap,
+    params.dateMode,
+    params.fromDate,
+    params.surveyId,
+    params.toDate,
+    selectedAppIsHidden,
+    selectedSurveyIsArchived,
+    selectedSurveyPeriod.dateMode,
+    selectedSurveyPeriod.fromDate,
+    selectedSurveyPeriod.toDate,
+    setParams,
+    showArchived,
+  ]);
 
   const handleReset = () => {
-    const team = params.team;
-    resetParams();
-    const end = dayjs();
-    const start = dayjs().subtract(29, "day");
-
-    setTimeout(() => {
-      setParams({
-        team,
-        fromDate: start.format("YYYY-MM-DD"),
-        toDate: end.format("YYYY-MM-DD"),
-      });
-    }, 0);
+    resetParams({
+      team: params.team,
+      dateMode: "auto",
+      fromDate: rollingAutomaticPeriod.fromDate,
+      toDate: rollingAutomaticPeriod.toDate,
+      page: "1",
+    });
   };
 
   const handleTeamChange = (newTeam: string) => {
@@ -231,6 +326,11 @@ export function FilterBar({ showDetails = false }: FilterBarProps) {
       team: newTeam,
       fromDate: params.fromDate,
       toDate: params.toDate,
+      ...(currentPeriod.dateMode === "auto" && {
+        dateMode: "auto",
+        fromDate: rollingAutomaticPeriod.fromDate,
+        toDate: rollingAutomaticPeriod.toDate,
+      }),
       app: undefined,
       surveyId: undefined,
       query: undefined,
@@ -250,6 +350,7 @@ export function FilterBar({ showDetails = false }: FilterBarProps) {
   };
 
   const hasActiveFilters =
+    params.dateMode === "fixed" ||
     params.query ||
     params.surveyId ||
     params.app ||
@@ -492,6 +593,41 @@ export function FilterBar({ showDetails = false }: FilterBarProps) {
           </VStack>
         </Hide>
       </Box>
+
+      {selectedSurveyPeriod.dateMode === "fixed" &&
+        selectedSurveyPeriod.isOutsideSurveyPeriod &&
+        selectedSurveyPeriod.surveyPeriod && (
+          <Alert variant="info" size="small">
+            <VStack gap="space-8" align="start">
+              <BodyShort size="small">
+                Surveyen har registrerte svar fra{" "}
+                {dayjs(selectedSurveyPeriod.surveyPeriod.fromDate).format(
+                  "DD.MM.YYYY",
+                )}{" "}
+                til{" "}
+                {dayjs(selectedSurveyPeriod.surveyPeriod.toDate).format(
+                  "DD.MM.YYYY",
+                )}
+                .
+              </BodyShort>
+              <Button
+                type="button"
+                variant="tertiary"
+                size="small"
+                onClick={() =>
+                  setParams({
+                    dateMode: "fixed",
+                    fromDate: selectedSurveyPeriod.surveyPeriod?.fromDate,
+                    toDate: selectedSurveyPeriod.surveyPeriod?.toDate,
+                    page: "1",
+                  })
+                }
+              >
+                Vis hele svarperioden
+              </Button>
+            </VStack>
+          </Alert>
+        )}
     </VStack>
   );
 }

--- a/apps/lumi-dashboard/app/hooks/__tests__/useSearchParams.test.ts
+++ b/apps/lumi-dashboard/app/hooks/__tests__/useSearchParams.test.ts
@@ -69,6 +69,16 @@ describe("useSearchParams", () => {
     expect(getResult().params.app).toBe("spinnsyn");
   });
 
+  it("parses the dashboard date mode from the URL", async () => {
+    expect(searchSchema.parse({ dateMode: "auto" })).toMatchObject({
+      dateMode: "auto",
+    });
+
+    const { getResult } = await setup(["/?dateMode=auto"]);
+
+    expect(getResult().params.dateMode).toBe("auto");
+  });
+
   it("setParam adds a new parameter", async () => {
     const { router, getResult } = await setup();
 
@@ -193,6 +203,32 @@ describe("useSearchParams", () => {
     await waitFor(() => {
       expect(router.state.location.searchStr).toBe("");
       expect(getResult().params).toEqual({});
+    });
+  });
+
+  it("resetParams can replace all parameters with bounded defaults atomically", async () => {
+    const { router, getResult } = await setup([
+      "/?team=flex&app=spinnsyn&query=tekst",
+    ]);
+
+    await act(async () => {
+      getResult().resetParams({
+        team: "flex",
+        dateMode: "auto",
+        fromDate: "2026-05-05",
+        toDate: "2026-06-03",
+        page: "1",
+      });
+    });
+
+    await waitFor(() => {
+      expect(router.state.location.search).toEqual({
+        team: "flex",
+        dateMode: "auto",
+        fromDate: "2026-05-05",
+        toDate: "2026-06-03",
+        page: "1",
+      });
     });
   });
 

--- a/apps/lumi-dashboard/app/hooks/useSearchParams.ts
+++ b/apps/lumi-dashboard/app/hooks/useSearchParams.ts
@@ -48,13 +48,16 @@ export function useSearchParams() {
     [navigate],
   );
 
-  const resetParams = useCallback(() => {
-    void navigate({
-      // @ts-expect-error -- shared hook used across routes; strict typing not feasible
-      search: {},
-      replace: true,
-    });
-  }, [navigate]);
+  const resetParams = useCallback(
+    (nextParams: Partial<SearchParams> = {}) => {
+      void navigate({
+        // @ts-expect-error -- shared hook used across routes; strict typing not feasible
+        search: nextParams,
+        replace: true,
+      });
+    },
+    [navigate],
+  );
 
   return { params, setParam, setParams, resetParams };
 }

--- a/apps/lumi-dashboard/app/mock/mockData.ts
+++ b/apps/lumi-dashboard/app/mock/mockData.ts
@@ -109,6 +109,92 @@ function generateFieldStatsOrderingSurveyData(count: number): FeedbackDto[] {
   return items;
 }
 
+/**
+ * A deterministic survey whose complete response period is well outside the
+ * dashboard's rolling 30-day default. This keeps the historical-period E2E
+ * coverage stable regardless of when the test suite runs.
+ */
+function generateHistoricalSurveyData(): FeedbackDto[] {
+  const submissions = [
+    ["2024-02-10T09:00:00.000Z", 2],
+    ["2024-02-11T09:00:00.000Z", 3],
+    ["2024-02-13T09:00:00.000Z", 4],
+    ["2024-02-15T09:00:00.000Z", 5],
+    ["2024-02-17T09:00:00.000Z", 4],
+    ["2024-02-18T09:00:00.000Z", 5],
+  ] as const;
+
+  return submissions.map(([submittedAt, rating], index) => ({
+    id: `historical-${index + 1}`,
+    submittedAt,
+    app: "syfo-oppfolgingsplan-frontend",
+    surveyId: "survey-historical",
+    surveyType: "rating",
+    context: createContext("/syk/historisk", "desktop"),
+    answers: [
+      createRatingAnswer(
+        "historical-rating",
+        "Hvor nyttig var den historiske tjenesten?",
+        rating,
+      ),
+    ],
+    sensitiveDataRedacted: false,
+  }));
+}
+
+/**
+ * The same survey ID used by two apps at different times. The older app is
+ * deliberately far away from the global latest response so an app-scoped
+ * period lookup cannot accidentally pass by using global survey metadata.
+ */
+function generateSharedSurveyData(): FeedbackDto[] {
+  const appPeriods = [
+    {
+      app: "dialogmote-frontend",
+      pathname: "/dialogmote/historisk",
+      dates: [
+        "2021-04-01T09:00:00.000Z",
+        "2021-04-02T09:00:00.000Z",
+        "2021-04-03T09:00:00.000Z",
+        "2021-04-04T09:00:00.000Z",
+        "2021-04-05T09:00:00.000Z",
+        "2021-04-06T09:00:00.000Z",
+      ],
+    },
+    {
+      app: "syfo-oppfolgingsplan-frontend",
+      pathname: "/syk/delt-survey",
+      dates: [
+        "2025-11-10T09:00:00.000Z",
+        "2025-11-11T09:00:00.000Z",
+        "2025-11-12T09:00:00.000Z",
+        "2025-11-13T09:00:00.000Z",
+        "2025-11-14T09:00:00.000Z",
+        "2025-11-15T09:00:00.000Z",
+      ],
+    },
+  ] as const;
+
+  return appPeriods.flatMap(({ app, pathname, dates }) =>
+    dates.map((submittedAt, index) => ({
+      id: `shared-${app}-${index + 1}`,
+      submittedAt,
+      app,
+      surveyId: "survey-shared-apps",
+      surveyType: "rating",
+      context: createContext(pathname, "desktop"),
+      answers: [
+        createRatingAnswer(
+          "shared-rating",
+          "Hvor nyttig var den delte surveyen?",
+          1 + (index % 5),
+        ),
+      ],
+      sensitiveDataRedacted: false,
+    })),
+  );
+}
+
 export const mockFeedbackItems: FeedbackDto[] = [
   // ===========================================
   // 1. RATING SURVEY (type: "rating")
@@ -176,6 +262,18 @@ export const mockFeedbackItems: FeedbackDto[] = [
   // 0-10 Net Promoter Score
   // ===========================================
   ...generateNpsSurveyData(60),
+
+  // ===========================================
+  // 10. HISTORICAL RATING SURVEY
+  // Stable old responses used to verify automatic response-period selection
+  // ===========================================
+  ...generateHistoricalSurveyData(),
+
+  // ===========================================
+  // 11. SHARED SURVEY ID ACROSS TWO APPS
+  // Stable periods used to verify app-scoped survey metadata
+  // ===========================================
+  ...generateSharedSurveyData(),
 ];
 
 export * from "./helpers"; // export helpers if needed by tests
@@ -552,6 +650,12 @@ export function unarchiveMockSurvey(surveyId: string): void {
   }
 }
 
+interface MockSurveyMetaEntry {
+  archivedAt: string | null;
+  firstSubmissionAt?: string;
+  lastSubmissionAt?: string;
+}
+
 export function getMockFilterBootstrap(team?: string): {
   generatedAt: string;
   selectedTeam: string;
@@ -560,10 +664,8 @@ export function getMockFilterBootstrap(team?: string): {
   apps: string[];
   surveysByApp: Record<string, string[]>;
   tags: string[];
-  surveyMeta: Record<
-    string,
-    { archivedAt: string | null; lastSubmissionAt?: string }
-  >;
+  surveyMeta: Record<string, MockSurveyMetaEntry>;
+  surveyMetaByApp?: Record<string, Record<string, MockSurveyMetaEntry>>;
 } {
   void team;
   const availableTeams = ["team-esyfo"];
@@ -573,30 +675,75 @@ export function getMockFilterBootstrap(team?: string): {
   const apps = Object.keys(surveysByApp).sort();
   const tags = getMockTags(selectedTeam);
 
-  // Mirrors the backend's MAX(opprettet)-per-survey aggregation
+  // Mirrors the backend's MIN/MAX(opprettet)-per-survey aggregation.
+  const firstSubmissionBySurvey: Record<string, string> = {};
   const lastSubmissionBySurvey: Record<string, string> = {};
+  const submissionBoundsByApp: Record<
+    string,
+    Record<string, { firstSubmissionAt: string; lastSubmissionAt: string }>
+  > = {};
   for (const item of getMockItemsForTeam(selectedTeam)) {
     if (!item.surveyId) continue;
-    const current = lastSubmissionBySurvey[item.surveyId];
-    if (!current || item.submittedAt > current) {
+    const currentFirst = firstSubmissionBySurvey[item.surveyId];
+    const currentLast = lastSubmissionBySurvey[item.surveyId];
+    if (!currentFirst || item.submittedAt < currentFirst) {
+      firstSubmissionBySurvey[item.surveyId] = item.submittedAt;
+    }
+    if (!currentLast || item.submittedAt > currentLast) {
       lastSubmissionBySurvey[item.surveyId] = item.submittedAt;
+    }
+
+    const app = item.app || "unknown";
+    if (!submissionBoundsByApp[app]) {
+      submissionBoundsByApp[app] = {};
+    }
+    const boundsBySurvey = submissionBoundsByApp[app];
+    const currentBounds = boundsBySurvey[item.surveyId];
+    if (!currentBounds) {
+      boundsBySurvey[item.surveyId] = {
+        firstSubmissionAt: item.submittedAt,
+        lastSubmissionAt: item.submittedAt,
+      };
+    } else {
+      if (item.submittedAt < currentBounds.firstSubmissionAt) {
+        currentBounds.firstSubmissionAt = item.submittedAt;
+      }
+      if (item.submittedAt > currentBounds.lastSubmissionAt) {
+        currentBounds.lastSubmissionAt = item.submittedAt;
+      }
     }
   }
 
-  const surveyMeta: Record<
-    string,
-    { archivedAt: string | null; lastSubmissionAt?: string }
-  > = {};
+  const surveyMeta: Record<string, MockSurveyMetaEntry> = {};
   for (const [surveyId, lastSubmissionAt] of Object.entries(
     lastSubmissionBySurvey,
   )) {
-    surveyMeta[surveyId] = { archivedAt: null, lastSubmissionAt };
+    surveyMeta[surveyId] = {
+      archivedAt: null,
+      firstSubmissionAt: firstSubmissionBySurvey[surveyId],
+      lastSubmissionAt,
+    };
   }
   for (const [surveyId, meta] of Object.entries(mockSurveyMeta)) {
     surveyMeta[surveyId] = {
       ...(surveyMeta[surveyId] ?? {}),
       archivedAt: meta.archivedAt,
     };
+  }
+
+  const surveyMetaByApp: Record<
+    string,
+    Record<string, MockSurveyMetaEntry>
+  > = {};
+  for (const [app, boundsBySurvey] of Object.entries(submissionBoundsByApp)) {
+    surveyMetaByApp[app] = {};
+    for (const [surveyId, bounds] of Object.entries(boundsBySurvey)) {
+      surveyMetaByApp[app][surveyId] = {
+        archivedAt: mockSurveyMeta[surveyId]?.archivedAt ?? null,
+        firstSubmissionAt: bounds.firstSubmissionAt,
+        lastSubmissionAt: bounds.lastSubmissionAt,
+      };
+    }
   }
 
   return {
@@ -608,6 +755,7 @@ export function getMockFilterBootstrap(team?: string): {
     surveysByApp,
     tags,
     surveyMeta,
+    surveyMetaByApp,
   };
 }
 

--- a/apps/lumi-dashboard/app/routes/export.tsx
+++ b/apps/lumi-dashboard/app/routes/export.tsx
@@ -1,13 +1,27 @@
 import { Alert, Box, Heading, VStack } from "@navikt/ds-react";
-import { createFileRoute } from "@tanstack/react-router";
+import { createFileRoute, redirect } from "@tanstack/react-router";
 import { zodValidator } from "@tanstack/zod-adapter";
 import { ExportPanel } from "~/components/export/Panel";
 import { FilterBar } from "~/components/shared/FilterBar";
 import { Header } from "~/components/shared/Header";
 import { searchSchema } from "~/schemas/searchSchema";
+import { applyDashboardSearchDefaults } from "~/utils/dashboardSearchDefaults";
 
 export const Route = createFileRoute("/export")({
   validateSearch: zodValidator(searchSchema),
+  beforeLoad: async ({ location }) => {
+    const defaults = applyDashboardSearchDefaults(
+      location.search as Record<string, unknown> | undefined,
+    );
+
+    if (defaults.changed) {
+      throw redirect({
+        to: "/export",
+        search: defaults.search,
+        replace: true,
+      });
+    }
+  },
   component: ExportPage,
 });
 

--- a/apps/lumi-dashboard/app/routes/feedback.tsx
+++ b/apps/lumi-dashboard/app/routes/feedback.tsx
@@ -1,14 +1,28 @@
 import { Box, Heading, VStack } from "@navikt/ds-react";
-import { createFileRoute } from "@tanstack/react-router";
+import { createFileRoute, redirect } from "@tanstack/react-router";
 import { zodValidator } from "@tanstack/zod-adapter";
 import { FeedbackTable } from "~/components/feedback/FeedbackTable";
 import { ActiveFiltersChips } from "~/components/shared/ActiveFiltersChips";
 import { FilterBar } from "~/components/shared/FilterBar";
 import { Header } from "~/components/shared/Header";
 import { searchSchema } from "~/schemas/searchSchema";
+import { applyDashboardSearchDefaults } from "~/utils/dashboardSearchDefaults";
 
 export const Route = createFileRoute("/feedback")({
   validateSearch: zodValidator(searchSchema),
+  beforeLoad: async ({ location }) => {
+    const defaults = applyDashboardSearchDefaults(
+      location.search as Record<string, unknown> | undefined,
+    );
+
+    if (defaults.changed) {
+      throw redirect({
+        to: "/feedback",
+        search: defaults.search,
+        replace: true,
+      });
+    }
+  },
   component: FeedbackPage,
 });
 

--- a/apps/lumi-dashboard/app/schemas/searchSchema.ts
+++ b/apps/lumi-dashboard/app/schemas/searchSchema.ts
@@ -4,6 +4,10 @@ import { z } from "zod";
 const optionalStringParam = fallback(z.string().optional(), undefined).catch(
   undefined,
 );
+const optionalDateModeParam = fallback(
+  z.enum(["auto", "fixed"]).optional(),
+  undefined,
+).catch(undefined);
 
 export const searchSchema = z
   .object({
@@ -11,6 +15,7 @@ export const searchSchema = z
     app: optionalStringParam,
     page: optionalStringParam,
     size: optionalStringParam,
+    dateMode: optionalDateModeParam,
     fromDate: optionalStringParam,
     toDate: optionalStringParam,
     hasText: optionalStringParam,

--- a/apps/lumi-dashboard/app/utils/__tests__/dashboardPeriod.test.ts
+++ b/apps/lumi-dashboard/app/utils/__tests__/dashboardPeriod.test.ts
@@ -1,0 +1,100 @@
+import { describe, expect, it } from "vitest";
+import { resolveDashboardPeriod } from "../dashboardPeriod";
+
+describe("resolveDashboardPeriod", () => {
+  it("uses a rolling 30-day period in auto mode when no survey is selected", () => {
+    expect(
+      resolveDashboardPeriod({
+        now: new Date("2026-08-21T10:00:00Z"),
+      }),
+    ).toMatchObject({
+      dateMode: "auto",
+      fromDate: "2026-07-23",
+      toDate: "2026-08-21",
+    });
+  });
+
+  it("treats legacy URLs with explicit dates as fixed periods", () => {
+    expect(
+      resolveDashboardPeriod({
+        fromDate: "2024-02-01",
+        toDate: "2024-02-18",
+        now: new Date("2026-08-21T10:00:00Z"),
+      }),
+    ).toMatchObject({
+      dateMode: "fixed",
+      fromDate: "2024-02-01",
+      toDate: "2024-02-18",
+    });
+  });
+
+  it("falls back to a bounded automatic period when fixed mode has no dates", () => {
+    expect(
+      resolveDashboardPeriod({
+        dateMode: "fixed",
+        now: new Date("2026-08-21T10:00:00Z"),
+      }),
+    ).toMatchObject({
+      dateMode: "auto",
+      fromDate: "2026-07-23",
+      toDate: "2026-08-21",
+    });
+  });
+
+  it("anchors an automatic survey period on its newest response", () => {
+    expect(
+      resolveDashboardPeriod({
+        dateMode: "auto",
+        fromDate: "2026-07-23",
+        toDate: "2026-08-21",
+        surveyMeta: {
+          firstSubmissionAt: "2024-01-01T12:00:00Z",
+          lastSubmissionAt: "2024-02-18T12:00:00Z",
+        },
+        now: new Date("2026-08-21T10:00:00Z"),
+      }),
+    ).toMatchObject({
+      dateMode: "auto",
+      fromDate: "2024-01-20",
+      toDate: "2024-02-18",
+    });
+  });
+
+  it("does not start an automatic period before the survey's first response", () => {
+    expect(
+      resolveDashboardPeriod({
+        dateMode: "auto",
+        surveyMeta: {
+          firstSubmissionAt: "2024-02-10T23:30:00Z",
+          lastSubmissionAt: "2024-02-18T12:00:00Z",
+        },
+      }),
+    ).toMatchObject({
+      fromDate: "2024-02-11",
+      toDate: "2024-02-18",
+    });
+  });
+
+  it("preserves a fixed period and reports when it misses the survey's response period", () => {
+    expect(
+      resolveDashboardPeriod({
+        dateMode: "fixed",
+        fromDate: "2026-08-01",
+        toDate: "2026-08-21",
+        surveyMeta: {
+          firstSubmissionAt: "2024-02-10T12:00:00Z",
+          lastSubmissionAt: "2024-02-18T12:00:00Z",
+        },
+      }),
+    ).toEqual({
+      dateMode: "fixed",
+      fromDate: "2026-08-01",
+      toDate: "2026-08-21",
+      surveyPeriod: {
+        fromDate: "2024-02-10",
+        toDate: "2024-02-18",
+      },
+      isOutsideSurveyPeriod: true,
+    });
+  });
+});

--- a/apps/lumi-dashboard/app/utils/__tests__/dashboardSearchDefaults.test.ts
+++ b/apps/lumi-dashboard/app/utils/__tests__/dashboardSearchDefaults.test.ts
@@ -12,13 +12,14 @@ describe("applyDashboardSearchDefaults", () => {
 
     expect(result.changed).toBe(true);
     expect(result.search).toEqual({
+      dateMode: "auto",
       fromDate: "2026-05-05",
       toDate: "2026-06-03",
       page: "1",
     });
   });
 
-  it("keeps explicit date filters for deep links", () => {
+  it("marks legacy deep links with explicit dates as fixed", () => {
     const result = applyDashboardSearchDefaults(
       {
         team: "flex",
@@ -27,9 +28,10 @@ describe("applyDashboardSearchDefaults", () => {
       { now },
     );
 
-    expect(result.changed).toBe(false);
+    expect(result.changed).toBe(true);
     expect(result.search).toEqual({
       team: "flex",
+      dateMode: "fixed",
       fromDate: "2026-01-01",
     });
   });
@@ -47,6 +49,86 @@ describe("applyDashboardSearchDefaults", () => {
     expect(result.search).toEqual({
       team: "team-esyfo",
       app: "lumi",
+      dateMode: "auto",
+      fromDate: "2026-05-05",
+      toDate: "2026-06-03",
+      page: "1",
+    });
+  });
+
+  it("replaces a partial automatic range with two bounded dates", () => {
+    const result = applyDashboardSearchDefaults(
+      {
+        dateMode: "auto",
+        fromDate: "2024-01-01",
+      },
+      { now },
+    );
+
+    expect(result.changed).toBe(true);
+    expect(result.search).toEqual({
+      dateMode: "auto",
+      fromDate: "2026-05-05",
+      toDate: "2026-06-03",
+      page: "1",
+    });
+  });
+
+  it("refreshes a stale automatic range when no survey is selected", () => {
+    const result = applyDashboardSearchDefaults(
+      {
+        dateMode: "auto",
+        fromDate: "2024-01-01",
+        toDate: "2024-01-30",
+      },
+      { now },
+    );
+
+    expect(result.changed).toBe(true);
+    expect(result.search).toEqual({
+      dateMode: "auto",
+      fromDate: "2026-05-05",
+      toDate: "2026-06-03",
+      page: "1",
+    });
+  });
+
+  it("keeps today's automatic range stable", () => {
+    const result = applyDashboardSearchDefaults(
+      {
+        dateMode: "auto",
+        fromDate: "2026-05-05",
+        toDate: "2026-06-03",
+      },
+      { now },
+    );
+
+    expect(result.changed).toBe(false);
+  });
+
+  it("leaves a complete automatic survey range for bootstrap metadata to resolve", () => {
+    const search = {
+      surveyId: "historisk-survey",
+      dateMode: "auto",
+      fromDate: "2024-01-20",
+      toDate: "2024-02-18",
+    };
+
+    const result = applyDashboardSearchDefaults(search, { now });
+
+    expect(result).toEqual({ search, changed: false });
+  });
+
+  it("normalizes fixed mode without dates to a bounded automatic range", () => {
+    const result = applyDashboardSearchDefaults(
+      {
+        dateMode: "fixed",
+      },
+      { now },
+    );
+
+    expect(result.search).toEqual({
+      dateMode: "auto",
       fromDate: "2026-05-05",
       toDate: "2026-06-03",
       page: "1",

--- a/apps/lumi-dashboard/app/utils/dashboardPeriod.ts
+++ b/apps/lumi-dashboard/app/utils/dashboardPeriod.ts
@@ -1,0 +1,100 @@
+import dayjs from "dayjs";
+import timezone from "dayjs/plugin/timezone";
+import utc from "dayjs/plugin/utc";
+
+dayjs.extend(utc);
+dayjs.extend(timezone);
+
+const OSLO_TIME_ZONE = "Europe/Oslo";
+
+export type DashboardDateMode = "auto" | "fixed";
+
+export interface DashboardPeriod {
+  dateMode: DashboardDateMode;
+  fromDate?: string;
+  toDate?: string;
+  surveyPeriod?: {
+    fromDate: string;
+    toDate: string;
+  };
+  isOutsideSurveyPeriod?: boolean;
+}
+
+export interface SurveyPeriodMetadata {
+  firstSubmissionAt?: string | null;
+  lastSubmissionAt?: string | null;
+}
+
+interface ResolveDashboardPeriodInput {
+  dateMode?: DashboardDateMode;
+  fromDate?: string;
+  toDate?: string;
+  surveyMeta?: SurveyPeriodMetadata;
+  now?: Date;
+}
+
+function toOsloDate(timestamp: string | null | undefined) {
+  if (!timestamp) return undefined;
+  const date = dayjs(timestamp).tz(OSLO_TIME_ZONE);
+  return date.isValid() ? date : undefined;
+}
+
+function getSurveyPeriod(surveyMeta: SurveyPeriodMetadata | undefined) {
+  const first = toOsloDate(surveyMeta?.firstSubmissionAt);
+  const last = toOsloDate(surveyMeta?.lastSubmissionAt);
+  if (!first || !last || first.isAfter(last, "day")) return undefined;
+
+  return {
+    fromDate: first.format("YYYY-MM-DD"),
+    toDate: last.format("YYYY-MM-DD"),
+  };
+}
+
+export function resolveDashboardPeriod({
+  dateMode,
+  fromDate,
+  toDate,
+  surveyMeta,
+  now = new Date(),
+}: ResolveDashboardPeriodInput = {}): DashboardPeriod {
+  const hasExplicitDate = Boolean(fromDate || toDate);
+  const resolvedMode =
+    hasExplicitDate && (dateMode === "fixed" || !dateMode) ? "fixed" : "auto";
+
+  const surveyPeriod = getSurveyPeriod(surveyMeta);
+
+  if (resolvedMode === "fixed") {
+    const isOutsideSurveyPeriod = surveyPeriod
+      ? Boolean(
+          (toDate && toDate < surveyPeriod.fromDate) ||
+            (fromDate && fromDate > surveyPeriod.toDate),
+        )
+      : undefined;
+
+    return {
+      dateMode: resolvedMode,
+      fromDate,
+      toDate,
+      ...(surveyPeriod && { surveyPeriod, isOutsideSurveyPeriod }),
+    };
+  }
+
+  const latestSubmission = toOsloDate(surveyMeta?.lastSubmissionAt);
+  const end = latestSubmission?.isValid()
+    ? latestSubmission
+    : dayjs(now).tz(OSLO_TIME_ZONE);
+  const defaultStart = end.subtract(29, "day");
+  const firstSubmission = toOsloDate(surveyMeta?.firstSubmissionAt);
+  const start =
+    firstSubmission?.isValid() &&
+    !firstSubmission.isAfter(end, "day") &&
+    firstSubmission.isAfter(defaultStart, "day")
+      ? firstSubmission
+      : defaultStart;
+
+  return {
+    dateMode: "auto",
+    fromDate: start.format("YYYY-MM-DD"),
+    toDate: end.format("YYYY-MM-DD"),
+  };
+}

--- a/apps/lumi-dashboard/app/utils/dashboardSearchDefaults.ts
+++ b/apps/lumi-dashboard/app/utils/dashboardSearchDefaults.ts
@@ -31,14 +31,36 @@ export function applyDashboardSearchDefaults(
 
   const hasFromDate = hasSearchValue(nextSearch.fromDate);
   const hasToDate = hasSearchValue(nextSearch.toDate);
-  if (!hasFromDate && !hasToDate) {
+  const hasDateMode =
+    nextSearch.dateMode === "auto" || nextSearch.dateMode === "fixed";
+
+  if ((hasFromDate || hasToDate) && !hasDateMode) {
+    nextSearch.dateMode = "fixed";
+    changed = true;
+  }
+
+  const needsAutomaticRange =
+    (!hasFromDate && !hasToDate) ||
+    (nextSearch.dateMode === "auto" &&
+      (!hasFromDate || !hasToDate || !hasSearchValue(nextSearch.surveyId)));
+
+  if (needsAutomaticRange) {
     const end = (options.now ?? dayjs()).tz(OSLO_TIME_ZONE);
     const start = end.subtract(29, "day");
+    const resolvedFromDate = start.format("YYYY-MM-DD");
+    const resolvedToDate = end.format("YYYY-MM-DD");
 
-    nextSearch.fromDate = start.format("YYYY-MM-DD");
-    nextSearch.toDate = end.format("YYYY-MM-DD");
-    nextSearch.page = "1";
-    changed = true;
+    if (
+      nextSearch.dateMode !== "auto" ||
+      nextSearch.fromDate !== resolvedFromDate ||
+      nextSearch.toDate !== resolvedToDate
+    ) {
+      nextSearch.dateMode = "auto";
+      nextSearch.fromDate = resolvedFromDate;
+      nextSearch.toDate = resolvedToDate;
+      nextSearch.page = "1";
+      changed = true;
+    }
   }
 
   return { search: nextSearch, changed };

--- a/apps/lumi-dashboard/e2e/dashboard-period.spec.ts
+++ b/apps/lumi-dashboard/e2e/dashboard-period.spec.ts
@@ -1,0 +1,138 @@
+import { expect, type Page, test } from "@playwright/test";
+
+const HISTORICAL_SURVEY_ID = "survey-historical";
+const HISTORICAL_FROM_DATE = "2024-02-10";
+const HISTORICAL_TO_DATE = "2024-02-18";
+const SHARED_SURVEY_ID = "survey-shared-apps";
+const OLDER_APP = "dialogmote-frontend";
+const OLDER_APP_FROM_DATE = "2021-04-01";
+const OLDER_APP_TO_DATE = "2021-04-06";
+
+async function expectSearchParams(
+  page: Page,
+  expected: Record<string, string>,
+) {
+  await expect
+    .poll(() => {
+      const search = new URL(page.url()).searchParams;
+      return Object.fromEntries(
+        Object.keys(expected).map((key) => [key, search.get(key)]),
+      );
+    })
+    .toEqual(expected);
+}
+
+test.describe("Dashboard response period", () => {
+  test("selecting an old survey finds its responses and keeps the automatic period across routes", async ({
+    page,
+  }) => {
+    await page.goto("/");
+
+    await page
+      .getByRole("combobox", { name: "Survey" })
+      .selectOption(HISTORICAL_SURVEY_ID);
+
+    const automaticPeriod = {
+      surveyId: HISTORICAL_SURVEY_ID,
+      dateMode: "auto",
+      fromDate: HISTORICAL_FROM_DATE,
+      toDate: HISTORICAL_TO_DATE,
+      page: "1",
+    };
+    await expectSearchParams(page, automaticPeriod);
+
+    await expect(
+      page.getByRole("img", {
+        name: /Stolpediagram som viser \d+ dager med tilbakemeldinger/,
+      }),
+    ).toBeVisible();
+    await expect(page.getByText("Ingen data for valgt periode")).toHaveCount(0);
+
+    await page.getByRole("link", { name: "Tilbakemeldinger" }).click();
+    await expect(page).toHaveURL(/\/feedback/);
+    await expectSearchParams(page, automaticPeriod);
+    await expect(
+      page
+        .getByRole("table")
+        .getByText(HISTORICAL_SURVEY_ID, { exact: true })
+        .first(),
+    ).toBeVisible();
+    await expect(page.getByText("Ingen tilbakemeldinger funnet")).toHaveCount(
+      0,
+    );
+
+    await page.getByRole("link", { name: "Eksporter" }).click();
+    await expect(page).toHaveURL(/\/export/);
+    await expectSearchParams(page, automaticPeriod);
+    await expect(
+      page.getByRole("heading", { name: "Aktive filtre" }),
+    ).toBeVisible();
+    await expect(page.getByText(/Fra:\s*10\.02\.2024/)).toBeVisible();
+    await expect(page.getByText(/Til:\s*18\.02\.2024/)).toBeVisible();
+  });
+
+  test("a legacy fixed bookmark offers the full response period without returning to auto mode", async ({
+    page,
+  }) => {
+    await page.goto(
+      `/?surveyId=${HISTORICAL_SURVEY_ID}&fromDate=2035-01-01&toDate=2035-01-30&page=7`,
+    );
+
+    await expectSearchParams(page, {
+      surveyId: HISTORICAL_SURVEY_ID,
+      dateMode: "fixed",
+      fromDate: "2035-01-01",
+      toDate: "2035-01-30",
+      page: "7",
+    });
+    await expect(page.getByText("Ingen data for valgt periode")).toBeVisible();
+
+    const showFullResponsePeriod = page.getByRole("button", {
+      name: "Vis hele svarperioden",
+    });
+    await expect(showFullResponsePeriod).toBeVisible();
+    await showFullResponsePeriod.click();
+
+    await expectSearchParams(page, {
+      surveyId: HISTORICAL_SURVEY_ID,
+      dateMode: "fixed",
+      fromDate: HISTORICAL_FROM_DATE,
+      toDate: HISTORICAL_TO_DATE,
+      page: "1",
+    });
+    await expect(
+      page.getByRole("img", {
+        name: /Stolpediagram som viser \d+ dager med tilbakemeldinger/,
+      }),
+    ).toBeVisible();
+    await expect(page.getByText("Ingen data for valgt periode")).toHaveCount(0);
+  });
+
+  test("a shared survey ID uses the selected app's older response period", async ({
+    page,
+  }) => {
+    await page.goto("/");
+
+    await page.getByRole("combobox", { name: "App" }).selectOption(OLDER_APP);
+    const surveySelect = page.getByRole("combobox", { name: "Survey" });
+    await expect(
+      surveySelect.locator(`option[value="${SHARED_SURVEY_ID}"]`),
+    ).toHaveCount(1);
+    await surveySelect.selectOption(SHARED_SURVEY_ID);
+
+    await expectSearchParams(page, {
+      app: OLDER_APP,
+      surveyId: SHARED_SURVEY_ID,
+      dateMode: "auto",
+      fromDate: OLDER_APP_FROM_DATE,
+      toDate: OLDER_APP_TO_DATE,
+      page: "1",
+    });
+    await expect(
+      page.getByRole("img", {
+        name: /Stolpediagram som viser \d+ dager med tilbakemeldinger/,
+      }),
+    ).toBeVisible();
+    await expect(page.getByText("Ingen data for valgt periode")).toHaveCount(0);
+  });
+});


### PR DESCRIPTION
## Beskrivelse

Lar dashboardet finne hele svarperioden automatisk når en survey velges. Historiske surveys blir dermed synlige uten at brukeren må gjette når de kjørte, samtidig som eksisterende lenker med et eksplisitt datointervall beholder intervallet.

## Endringer

- Innfører URL-styrt automatisk og fast periodemodus.
- Forankrer automatisk periode i surveyens første og siste svar, per valgt app.
- Bevarer faste perioder og tilbyr et tydelig valg tilbake til automatisk periode.
- Bruker samme periode på dashboard-, feedback- og eksportsidene.
- Nullstiller side ved endret periode og låser chart-drilldown til første side.
- Forbedrer periodevelgerens dialogsemantikk, fokus og Escape-håndtering.
- Legger til historiske mockdata, enhets- og ende-til-ende-tester.

## Issue

Ingen.

## Verifisering

- pnpm run lint
- pnpm run typecheck
- pnpm test
- pnpm run e2e

## Sjekkliste

- [x] Koden kompilerer og linter uten feil
- [x] Endringene er testet automatisk
- [x] Ingen sensitiv data eksponert (tokens, credentials, PII)