### PR TITLE
Gjør release-verifikasjon reproduserbar

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -233,6 +233,14 @@ jobs:
         run: pnpm run test:full-chain
         env:
           NPM_AUTH_TOKEN: ${{ github.token }}
+      - name: Upload full-chain evidence
+        if: always()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: full-chain-release-verification-${{ github.run_id }}
+          path: apps/lumi-dashboard/test-results/full-chain
+          if-no-files-found: warn
+          retention-days: 14
 
   docs:
     name: Build docs

--- a/apps/lumi-api/docs/runbooks/submission-health.md
+++ b/apps/lumi-api/docs/runbooks/submission-health.md
@@ -45,11 +45,15 @@ Ved `409 DefinitionConflict` følger du også
 ## Verifikasjon etter retting
 
 1. Kjør `pnpm test:full-chain` lokalt.
-2. Kjør den kontrollerte dev-verifikasjonen med en ny syntetisk survey-ID på
-   formen `lumi-release-verification-YYYYMMDD-<kort-id>`.
-3. Bekreft `created` i metrikken for riktig kanal.
-4. Bekreft at svaret er synlig i dev-dashboardet.
-5. Observer `failed` og `rejected` i minst 15 minutter før neste migrering.
+2. Kjør `/release-verification` i dev. Den oppretter en ny syntetisk survey-ID
+   på formen `lumi-release-verification-YYYYMMDD-<kort-id>`.
+3. Bekreft team-preflighten og send startproben. Dashboardet leser den eksakte
+   receipt-raden tilbake fra Postgres via analytics-API-et.
+4. Etter 15 minutter sender du sluttproben. Del rapportlenken eller last ned
+   JSON-beviset når den kontrollerte dev-kjeden er `passed`.
+5. Global feilrate og alarmer vurderes separat ved en faktisk hendelse. De er
+   ikke del av den databaseforankrede release-rapporten, som eksplisitt viser
+   `globalAzureHealth: not-assessed`.
 
 Syntetiske survey-ID-er skal aldri gjenbrukes med en annen struktur. Dataene
 kan arkiveres i dashboardet etter testen; de skal ikke slettes som del av

--- a/apps/lumi-dashboard/app/routes/release-verification.tsx
+++ b/apps/lumi-dashboard/app/routes/release-verification.tsx
@@ -1,3 +1,4 @@
+import { DownloadIcon, LinkIcon } from "@navikt/aksel-icons";
 import {
   Alert,
   BodyLong,
@@ -20,82 +21,178 @@ import {
 } from "@navikt/lumi-survey";
 import { useQuery } from "@tanstack/react-query";
 import { createFileRoute, Link } from "@tanstack/react-router";
+import { zodValidator } from "@tanstack/zod-adapter";
 import { useEffect, useMemo, useState } from "react";
+import { z } from "zod";
 import { Header } from "~/components/shared/Header";
 import {
   fetchReleaseVerificationConfigServerFn,
+  fetchReleaseVerificationRunServerFn,
   submitReleaseVerificationServerFn,
 } from "~/server/actions";
 import {
   canStartReleaseVerificationRun,
+  createReleaseVerificationControlCode,
+  createReleaseVerificationControlOptionId,
+  createReleaseVerificationReport,
   createReleaseVerificationSurveyId,
+  RELEASE_VERIFICATION_CONTROL_FIELD_ID,
+  RELEASE_VERIFICATION_SURVEY_ID_PATTERN,
+  type ReleaseVerificationCheckStatus,
+  type ReleaseVerificationPhase,
+  type ReleaseVerificationProbeEvidence,
+  type ReleaseVerificationReportV1,
 } from "~/utils/releaseVerification";
 
-const verificationSurvey: SurveyDocumentV1 = {
-  authoringSchemaVersion: 1,
-  type: "rating",
-  pages: [
-    {
-      id: "release-check",
-      questions: [
-        {
-          id: "rating",
-          type: "rating",
-          variant: "emoji",
-          prompt: "Hvordan oppleves denne verifikasjonskjøringen?",
-          required: true,
-        },
-        {
-          id: "trace",
-          type: "text",
-          prompt: "Legg inn en kort sporingsmerknad",
-          description: "Skriv noe du enkelt kjenner igjen i dashboardet.",
-          required: true,
-          maxLength: 160,
-        },
-      ],
-    },
-  ],
-  success: {
-    title: "Signal lagret",
-    body: "Kontroller nå at det samme svaret er synlig i dashboardet.",
-  },
-};
+const searchSchema = z.object({
+  surveyId: z.string().regex(RELEASE_VERIFICATION_SURVEY_ID_PATTERN).optional(),
+  initialReceiptId: z.string().uuid().optional(),
+  closingReceiptId: z.string().uuid().optional(),
+});
 
 type AttemptState =
   | { status: "idle" }
   | { status: "sending" }
-  | { status: "success"; id: string; duplicate: boolean }
   | { status: "error"; message: string };
 
 export const Route = createFileRoute("/release-verification")({
+  validateSearch: zodValidator(searchSchema),
   component: ReleaseVerificationPage,
 });
 
 function ReleaseVerificationPage() {
+  const search = Route.useSearch();
+  const navigate = Route.useNavigate();
   const configQuery = useQuery({
     queryKey: ["release-verification-config"],
     queryFn: () => fetchReleaseVerificationConfigServerFn(),
     staleTime: Number.POSITIVE_INFINITY,
+    refetchOnWindowFocus: false,
   });
-  const [surveyId, setSurveyId] = useState<string | null>(null);
   const [attempt, setAttempt] = useState<AttemptState>({ status: "idle" });
+  const [optimisticProbes, setOptimisticProbes] = useState<{
+    initial?: ReleaseVerificationProbeEvidence;
+    closing?: ReleaseVerificationProbeEvidence;
+  }>({});
+  const [openedAt] = useState(() => new Date().toISOString());
+  const [shareUrl, setShareUrl] = useState("");
+  const shareKey = `${search.surveyId ?? ""}:${search.initialReceiptId ?? ""}:${search.closingReceiptId ?? ""}`;
+
+  const config = configQuery.data;
+  const surveyId = search.surveyId ?? config?.surveyId ?? null;
+  const readbackInput =
+    surveyId && search.initialReceiptId
+      ? {
+          surveyId,
+          initialReceiptId: search.initialReceiptId,
+          closingReceiptId: search.closingReceiptId,
+        }
+      : null;
+  const runQuery = useQuery({
+    queryKey: ["release-verification-run", readbackInput],
+    queryFn: () => {
+      if (!readbackInput) throw new Error("Ingen kjøring å lese tilbake");
+      return fetchReleaseVerificationRunServerFn({ data: readbackInput });
+    },
+    enabled: Boolean(config?.enabled && readbackInput),
+    refetchInterval: (query) => {
+      const current = query.state.data;
+      const unavailable =
+        current?.initial?.status === "unavailable" ||
+        current?.closing?.status === "unavailable";
+      if (unavailable) return 5_000;
+      return readbackInput && !search.closingReceiptId ? 30_000 : false;
+    },
+    refetchOnWindowFocus: true,
+  });
 
   useEffect(() => {
-    if (configQuery.data?.surveyId && !surveyId) {
-      setSurveyId(configQuery.data.surveyId);
-    }
-  }, [configQuery.data?.surveyId, surveyId]);
+    if (!shareKey && !globalThis.location) return;
+    setShareUrl(globalThis.location?.href ?? "");
+  }, [shareKey]);
 
-  const transport = useMemo<LumiSurveyTransport>(
-    () => ({
+  useEffect(() => {
+    if (!config?.enabled || search.surveyId) return;
+    void navigate({
+      to: "/release-verification",
+      search: { surveyId: config.surveyId },
+      replace: true,
+    });
+  }, [config, navigate, search.surveyId]);
+
+  const initialProbe =
+    runQuery.data?.initial ?? optimisticProbes.initial ?? null;
+  const closingProbe =
+    runQuery.data?.closing ?? optimisticProbes.closing ?? null;
+  const trustedNow =
+    runQuery.data?.observedAt ?? initialProbe?.storedAt ?? openedAt;
+  const report =
+    config?.enabled && surveyId
+      ? createReleaseVerificationReport({
+          profile: config.profile,
+          environment: config.environment,
+          surveyId,
+          now: trustedNow,
+          holdDurationMs: config.holdDurationMs,
+          preflight: config.preflight,
+          initialProbe: initialProbe ?? undefined,
+          closingProbe: closingProbe ?? undefined,
+        })
+      : null;
+  const holdPassed =
+    report?.checks.find(({ id }) => id === "hold-window")?.status === "passed";
+  const closingStatus = report?.checks.find(
+    ({ id }) => id === "closing-round-trip",
+  )?.status;
+  const earlyClosingProbe =
+    closingProbe?.status === "verified" && closingStatus === "pending";
+  const readbackUnavailable =
+    initialProbe?.status === "unavailable" ||
+    closingProbe?.status === "unavailable";
+  const activePhase: ReleaseVerificationPhase | null =
+    config?.enabled && config.preflight.status === "passed"
+      ? !initialProbe
+        ? "initial"
+        : initialProbe.status === "verified" &&
+            holdPassed &&
+            closingStatus === "pending" &&
+            (!closingProbe || earlyClosingProbe) &&
+            report?.outcome !== "failed"
+          ? "closing"
+          : null
+      : null;
+
+  const survey = useMemo(
+    () => (surveyId ? createVerificationSurvey(surveyId) : null),
+    [surveyId],
+  );
+  const transport = useMemo<LumiSurveyTransport | null>(() => {
+    if (!activePhase || !surveyId) return null;
+    return {
       submit: async (submission) => {
         setAttempt({ status: "sending" });
         try {
-          const receipt = await submitReleaseVerificationServerFn({
+          const evidence = await submitReleaseVerificationServerFn({
             data: submission.transportPayload,
           });
-          setAttempt({ status: "success", ...receipt });
+          setOptimisticProbes((current) => ({
+            ...current,
+            [activePhase]: evidence,
+          }));
+          setAttempt({ status: "idle" });
+          await navigate({
+            to: "/release-verification",
+            search: {
+              surveyId,
+              initialReceiptId:
+                activePhase === "initial"
+                  ? evidence.receiptId
+                  : search.initialReceiptId,
+              closingReceiptId:
+                activePhase === "closing" ? evidence.receiptId : undefined,
+            },
+            replace: true,
+          });
         } catch (error) {
           setAttempt({
             status: "error",
@@ -107,14 +204,17 @@ function ReleaseVerificationPage() {
           throw error;
         }
       },
-    }),
-    [],
-  );
+    };
+  }, [activePhase, navigate, search.initialReceiptId, surveyId]);
 
-  const startNewRun = () => {
+  const startNewRun = async () => {
     if (!canStartReleaseVerificationRun(attempt.status)) return;
-    setSurveyId(createReleaseVerificationSurveyId());
     setAttempt({ status: "idle" });
+    setOptimisticProbes({});
+    await navigate({
+      to: "/release-verification",
+      search: { surveyId: createReleaseVerificationSurveyId() },
+    });
   };
 
   return (
@@ -131,57 +231,58 @@ function ReleaseVerificationPage() {
             <Tag variant="warning" size="small">
               Kun dev
             </Tag>
-            <Detail>Release flight check</Detail>
+            <Detail>Release flight recorder · rapportformat v1</Detail>
           </HStack>
 
           <VStack gap="space-8">
             <Heading size="xlarge">Bevis kjeden før utrulling</Heading>
             <BodyLong size="large">
-              Denne siden sender en ekte v2-innsending til Lumi API. I dev går
-              den gjennom dashboardets eksisterende Azure OBO-flyt; den lokale
-              fullkjedetesten bruker eksplisitt auth-bypass. Hver kjøring får en
-              ny, syntetisk survey-ID og påvirker ingen survey som er i bruk.
+              En kontrollert, syntetisk kjøring gjennom widget, innlogget
+              dashboard, Lumi API og Postgres. Resultatet bygges fra eksakt
+              readback av receipts og kan deles som lenke eller JSON.
             </BodyLong>
           </VStack>
 
           {configQuery.isPending ? (
-            <HStack gap="space-12" align="center">
-              <Loader size="medium" title="Sjekker miljø" />
-              <BodyShort>Sjekker om verifikasjonsriggen er aktiv …</BodyShort>
-            </HStack>
+            <LoadingState text="Kontrollerer miljø og teamtilgang …" />
           ) : configQuery.isError ? (
             <Alert variant="error">
-              Kunne ikke kontrollere miljøet. Last siden på nytt eller sjekk
-              dashboard-loggene.
+              Kunne ikke starte preflight. Last siden på nytt.
             </Alert>
-          ) : !configQuery.data.enabled ? (
+          ) : !config?.enabled ? (
             <Alert variant="info">
-              Verifikasjonsriggen er avslått her. Den er bare aktiv mot ekte
-              backend i dev-gcp eller i den eksplisitte lokale
-              fullkjede-konfigurasjonen.
+              Riggen er bare aktiv mot ekte backend i dev-gcp eller den
+              eksplisitte lokale fullkjede-konfigurasjonen.
             </Alert>
-          ) : surveyId ? (
+          ) : surveyId && report ? (
             <>
-              <HGrid columns={{ xs: 1, md: 3 }} gap="space-16">
-                <VerificationStage
-                  step="01"
-                  title="Widget"
-                  detail="SurveyDocumentV1 fra release-build"
-                />
-                <VerificationStage
-                  step="02"
-                  title="Identitet"
-                  detail={
-                    configQuery.data.authMode === "azure-obo"
-                      ? "Azure OBO som lumi-dashboard"
-                      : "Eksplisitt lokal auth-bypass"
-                  }
-                />
-                <VerificationStage
-                  step="03"
-                  title="Rundtur"
-                  detail="API → Postgres → dashboard"
-                />
+              <ReportHeader report={report} />
+
+              {config.preflight.status === "failed" ? (
+                <Alert variant="error">
+                  {config.preflight.message}. Ingen syntetiske data er sendt.
+                </Alert>
+              ) : config.preflight.status === "unavailable" ? (
+                <Alert variant="info">
+                  {config.preflight.message}. Ingen syntetiske data sendes før
+                  siden lastes på nytt og preflighten er bestått.
+                </Alert>
+              ) : (
+                <Alert variant="success">
+                  Teamtilgang er bekreftet før skrivetesten starter.
+                </Alert>
+              )}
+
+              <HGrid as="ol" columns={{ xs: 1, md: 4 }} gap="space-12">
+                {report.checks.map((check, index) => (
+                  <VerificationStage
+                    key={check.id}
+                    step={String(index + 1).padStart(2, "0")}
+                    title={checkTitle(check.id)}
+                    detail={check.detail}
+                    status={check.status}
+                  />
+                ))}
               </HGrid>
 
               <Box
@@ -192,13 +293,22 @@ function ReleaseVerificationPage() {
                 padding={{ xs: "space-16", md: "space-24" }}
               >
                 <VStack gap="space-16">
-                  <HStack justify="space-between" align="center" wrap>
+                  <HStack justify="space-between" align="start" wrap>
                     <VStack gap="space-4">
-                      <Detail>SYNTETISK SURVEY-ID</Detail>
+                      <Detail>SYNTETISK KJØRING</Detail>
                       <BodyShort weight="semibold">{surveyId}</BodyShort>
+                      <BodyShort size="small">
+                        Kontrollkode:{" "}
+                        {createReleaseVerificationControlCode(surveyId)}
+                      </BodyShort>
                     </VStack>
-                    <HStack gap="space-8">
-                      <CopyButton copyText={surveyId} size="small" />
+                    <HStack gap="space-8" wrap>
+                      <CopyButton
+                        copyText={surveyId}
+                        text="Kopier survey-ID"
+                        activeText="Survey-ID kopiert"
+                        size="small"
+                      />
                       <Button
                         type="button"
                         variant="secondary"
@@ -208,70 +318,106 @@ function ReleaseVerificationPage() {
                           !canStartReleaseVerificationRun(attempt.status)
                         }
                       >
-                        Ny test-ID
+                        Ny kjøring
                       </Button>
                     </HStack>
                   </HStack>
 
+                  {runQuery.isPending && readbackInput ? (
+                    <LoadingState text="Leser receipts fra databasen …" />
+                  ) : runQuery.isError ? (
+                    <Alert variant="error">
+                      Kunne ikke rekonstruere rapporten fra receipts.
+                    </Alert>
+                  ) : null}
+
                   {attempt.status === "sending" ? (
                     <Alert variant="info">
-                      Sender gjennom ekte dev-kjede …
-                    </Alert>
-                  ) : attempt.status === "success" ? (
-                    <Alert variant="success">
-                      API-et bekreftet{" "}
-                      {attempt.duplicate ? "en retry" : "ny lagring"}
-                      {` med id ${attempt.id}.`} Åpne dashboardet og finn
-                      sporingsmerknaden før testen godkjennes.
+                      Sender og leser tilbake eksakt receipt …
                     </Alert>
                   ) : attempt.status === "error" ? (
                     <Alert variant="error">
                       Innsendingen feilet: {attempt.message}
                     </Alert>
-                  ) : (
-                    <Alert variant="warning">
-                      Åpne widgeten nederst til høyre, fyll ut begge feltene og
-                      send inn.
-                    </Alert>
-                  )}
+                  ) : null}
 
-                  {attempt.status === "success" &&
-                  configQuery.data.dashboardTeam &&
-                  configQuery.data.dashboardApp ? (
-                    <Link
-                      to="/feedback"
-                      search={{
-                        team: configQuery.data.dashboardTeam,
-                        app: configQuery.data.dashboardApp,
-                        surveyId,
-                        dateMode: "auto",
+                  {readbackUnavailable ? (
+                    <Alert variant="info">
+                      <HStack gap="space-12" align="center" wrap>
+                        <BodyShort>
+                          Readback er midlertidig utilgjengelig. Siden prøver
+                          automatisk på nytt.
+                        </BodyShort>
+                        <Button
+                          type="button"
+                          variant="secondary"
+                          size="small"
+                          onClick={() => void runQuery.refetch()}
+                        >
+                          Prøv readback igjen
+                        </Button>
+                      </HStack>
+                    </Alert>
+                  ) : null}
+
+                  {activePhase === "initial" ? (
+                    <Alert variant="warning">
+                      Åpne widgeten, velg 4 «Bra» og den viste kontrollkoden.
+                      Startproben leses automatisk tilbake fra databasen.
+                    </Alert>
+                  ) : activePhase === "closing" ? (
+                    <Alert variant="warning">
+                      Holdetiden er ferdig. Send den avsluttende proben med de
+                      samme syntetiske valgene.
+                    </Alert>
+                  ) : report.outcome === "passed" ? (
+                    <Alert variant="success">
+                      Den kontrollerte dev-kjeden er bestått. Begge receipts er
+                      lest tilbake eksakt, og avslutningsproben ble lagret etter
+                      holdetiden.
+                    </Alert>
+                  ) : report.observeAfter &&
+                    initialProbe?.status === "verified" ? (
+                    <Alert variant="info">
+                      Startproben er bevist. Siden låser opp avslutningsproben
+                      etter {report.observeAfter}.
+                    </Alert>
+                  ) : report.outcome === "failed" ? (
+                    <Alert variant="error">
+                      Kjøringen er stoppet fordi et lagret bevis ikke matcher
+                      forventet receipt, survey, app, svar eller kontekst.
+                    </Alert>
+                  ) : null}
+
+                  {activePhase && survey && transport ? (
+                    <LumiSurveyDock
+                      key={`${surveyId}:${activePhase}:${closingProbe?.receiptId ?? "new"}`}
+                      surveyId={surveyId}
+                      survey={survey}
+                      transport={transport}
+                      context={{
+                        tags: {
+                          purpose: "release-verification",
+                          channel: config.authMode,
+                          phase: activePhase,
+                        },
                       }}
-                    >
-                      <Button variant="primary">
-                        Kontroller i dashboardet
-                      </Button>
-                    </Link>
+                      behavior={{
+                        initialOpen: true,
+                        hideAfterSubmit: false,
+                        storageStrategy: "none",
+                        showProgress: true,
+                      }}
+                    />
                   ) : null}
                 </VStack>
               </Box>
 
-              <LumiSurveyDock
-                key={surveyId}
-                surveyId={surveyId}
-                survey={verificationSurvey}
-                transport={transport}
-                context={{
-                  tags: {
-                    purpose: "release-verification",
-                    channel: configQuery.data.authMode ?? "unknown",
-                  },
-                }}
-                behavior={{
-                  initialOpen: true,
-                  hideAfterSubmit: false,
-                  storageStrategy: "none",
-                  showProgress: true,
-                }}
+              <ReportEvidence
+                report={report}
+                shareUrl={shareUrl}
+                dashboardTeam={config.dashboardTeam}
+                dashboardApp={config.dashboardApp}
               />
             </>
           ) : null}
@@ -281,25 +427,100 @@ function ReleaseVerificationPage() {
   );
 }
 
+function createVerificationSurvey(surveyId: string): SurveyDocumentV1 {
+  const code = createReleaseVerificationControlCode(surveyId);
+  return {
+    authoringSchemaVersion: 1,
+    type: "rating",
+    pages: [
+      {
+        id: "release-check",
+        questions: [
+          {
+            id: "rating",
+            type: "rating",
+            variant: "emoji",
+            prompt: "Hvordan oppleves denne verifikasjonskjøringen?",
+            required: true,
+          },
+          {
+            id: RELEASE_VERIFICATION_CONTROL_FIELD_ID,
+            type: "singleChoice",
+            prompt: `Velg kontrollkode ${code}`,
+            description:
+              "Valget er syntetisk og skal ikke inneholde persondata.",
+            required: true,
+            options: [
+              {
+                value: createReleaseVerificationControlOptionId(surveyId),
+                label: `Kontrollkode ${code}`,
+              },
+            ],
+          },
+        ],
+      },
+    ],
+    success: {
+      title: "Probe sendt",
+      body: "Dashboardet leser nå samme receipt tilbake fra databasen.",
+    },
+  };
+}
+
+function ReportHeader({ report }: { report: ReleaseVerificationReportV1 }) {
+  const labels = {
+    passed: "Kontrollert dev-kjede bestått",
+    pending: "Kjøringen pågår",
+    failed: "Kjøringen er stoppet",
+  } as const;
+  return (
+    <Box
+      background="raised"
+      role="status"
+      aria-live="polite"
+      borderWidth="2"
+      borderColor={report.outcome === "passed" ? "success" : "neutral-subtle"}
+      borderRadius="12"
+      padding={{ xs: "space-16", md: "space-24" }}
+    >
+      <HStack justify="space-between" align="center" wrap gap="space-12">
+        <VStack gap="space-4">
+          <Detail>STATUS FOR DENNE KJØRINGEN</Detail>
+          <Heading level="2" size="large">
+            {labels[report.outcome]}
+          </Heading>
+        </VStack>
+        <StatusTag status={report.outcome} />
+      </HStack>
+    </Box>
+  );
+}
+
 function VerificationStage({
   step,
   title,
   detail,
+  status,
 }: {
   step: string;
   title: string;
   detail: string;
+  status: ReleaseVerificationCheckStatus;
 }) {
   return (
     <Box
+      as="li"
       background="raised"
       borderWidth="1"
       borderColor="neutral-subtle"
       borderRadius="8"
       padding="space-16"
     >
-      <VStack gap="space-4">
-        <Detail>{step}</Detail>
+      <VStack gap="space-8">
+        <HStack justify="space-between" align="center">
+          <Detail>{step}</Detail>
+          <StatusTag status={status} size="small" />
+        </HStack>
         <Heading level="2" size="small">
           {title}
         </Heading>
@@ -307,4 +528,150 @@ function VerificationStage({
       </VStack>
     </Box>
   );
+}
+
+function ReportEvidence({
+  report,
+  shareUrl,
+  dashboardTeam,
+  dashboardApp,
+}: {
+  report: ReleaseVerificationReportV1;
+  shareUrl: string;
+  dashboardTeam: string;
+  dashboardApp: string;
+}) {
+  const reportJson = JSON.stringify(report, null, 2);
+  return (
+    <VStack gap="space-16">
+      <HStack justify="space-between" align="end" wrap gap="space-12">
+        <VStack gap="space-4">
+          <Heading level="2" size="medium">
+            Maskinlesbart bevis
+          </Heading>
+          <BodyShort>
+            Lenken rekonstruerer rapporten fra receipt-ID-ene. JSON-en
+            inneholder ikke token, NAV-ident, e-post eller fritekst.
+          </BodyShort>
+        </VStack>
+        <HStack gap="space-8" wrap>
+          {shareUrl ? (
+            <CopyButton
+              copyText={shareUrl}
+              text="Kopier rapportlenke"
+              activeText="Rapportlenke kopiert"
+              icon={<LinkIcon aria-hidden />}
+              size="small"
+            />
+          ) : null}
+          <CopyButton
+            copyText={reportJson}
+            text="Kopier JSON"
+            activeText="JSON kopiert"
+            size="small"
+          />
+          <Button
+            type="button"
+            variant="secondary"
+            size="small"
+            icon={<DownloadIcon aria-hidden />}
+            onClick={() => downloadReport(report)}
+          >
+            Last ned JSON
+          </Button>
+        </HStack>
+      </HStack>
+
+      <Box
+        as="pre"
+        background="neutral-soft"
+        borderWidth="1"
+        borderColor="neutral-subtle"
+        borderRadius="8"
+        padding="space-16"
+        overflow="auto"
+      >
+        <BodyShort as="code" size="small">
+          {reportJson}
+        </BodyShort>
+      </Box>
+
+      {report.probes.initial ? (
+        <Link
+          to="/feedback"
+          search={{
+            team: dashboardTeam,
+            app: dashboardApp,
+            surveyId: report.subject.surveyId,
+            dateMode: "auto",
+          }}
+        >
+          Vis de syntetiske radene i dashboardet
+        </Link>
+      ) : null}
+
+      <Alert variant="warning">
+        <Heading level="2" size="small" spacing>
+          Avgrensning
+        </Heading>
+        Denne rapporten tester ikke global Azure-feilrate eller
+        trygdeetaten-proxyen, og den godkjenner derfor ikke NAV-wide utrulling
+        alene. Første canary-app må fortsatt bevise proxy-integrasjonen.
+      </Alert>
+    </VStack>
+  );
+}
+
+function StatusTag({
+  status,
+  size = "medium",
+}: {
+  status: ReleaseVerificationCheckStatus;
+  size?: "small" | "medium";
+}) {
+  const labels = { passed: "Bestått", pending: "Venter", failed: "Feilet" };
+  const variants = {
+    passed: "success",
+    pending: "warning",
+    failed: "error",
+  } as const;
+  return (
+    <Tag variant={variants[status]} size={size}>
+      {labels[status]}
+    </Tag>
+  );
+}
+
+function LoadingState({ text }: { text: string }) {
+  return (
+    <HStack gap="space-12" align="center">
+      <Loader size="medium" title={text} />
+      <BodyShort>{text}</BodyShort>
+    </HStack>
+  );
+}
+
+function checkTitle(
+  id: ReleaseVerificationReportV1["checks"][number]["id"],
+): string {
+  return {
+    "team-preflight": "Teamtilgang",
+    "initial-round-trip": "Startprobe",
+    "hold-window": "15 minutters hold",
+    "closing-round-trip": "Sluttprobe",
+    "local-submission-proxy": "Lokal proxy",
+    "controlled-dashboard-round-trip": "Dashboard-rundtur",
+  }[id];
+}
+
+function downloadReport(report: ReleaseVerificationReportV1): void {
+  const blob = new Blob([JSON.stringify(report, null, 2)], {
+    type: "application/json",
+  });
+  const url = URL.createObjectURL(blob);
+  const anchor = document.createElement("a");
+  anchor.href = url;
+  anchor.download = `${report.runId}.json`;
+  anchor.click();
+  URL.revokeObjectURL(url);
 }

--- a/apps/lumi-dashboard/app/server/actions/index.ts
+++ b/apps/lumi-dashboard/app/server/actions/index.ts
@@ -43,6 +43,7 @@ export {
 // Release verification (dev only)
 export {
   fetchReleaseVerificationConfigServerFn,
+  fetchReleaseVerificationRunServerFn,
   submitReleaseVerificationServerFn,
 } from "./releaseVerification";
 // Survey authoring

--- a/apps/lumi-dashboard/app/server/actions/releaseVerification.ts
+++ b/apps/lumi-dashboard/app/server/actions/releaseVerification.ts
@@ -10,12 +10,22 @@ import {
 } from "~/server/utils";
 import { serverEnv } from "~/serverEnv";
 import {
+  createReleaseVerificationControlOptionId,
   createReleaseVerificationSurveyId,
   isReleaseVerificationEnabled,
+  RELEASE_VERIFICATION_CONTROL_FIELD_ID,
+  RELEASE_VERIFICATION_RATING,
+  RELEASE_VERIFICATION_SURVEY_ID_PATTERN,
   RELEASE_VERIFICATION_SURVEY_PREFIX,
+  type ReleaseVerificationPhase,
+  type ReleaseVerificationPreflightEvidence,
+  type ReleaseVerificationProbeEvidence,
+  type ReleaseVerificationProfile,
+  verifyReleaseVerificationReadback,
 } from "~/utils/releaseVerification";
 import { handleApiResponse } from "../fetchUtils";
 
+const DEV_HOLD_DURATION_MS = 15 * 60 * 1000;
 const surveyTypeSchema = z.enum([
   "rating",
   "discovery",
@@ -23,8 +33,8 @@ const surveyTypeSchema = z.enum([
   "taskPriority",
   "custom",
 ]);
-
 const ratingVariantSchema = z.enum(["emoji", "thumbs", "stars", "nps"]);
+const phaseSchema = z.enum(["initial", "closing"]);
 
 const transportPayloadSchema = z.object({
   schemaVersion: z.literal(2),
@@ -109,17 +119,71 @@ const submissionReceiptSchema = z.object({
   duplicate: z.boolean().optional(),
 });
 
-export interface ReleaseVerificationConfig {
-  enabled: boolean;
-  surveyId: string | null;
-  dashboardTeam: string | null;
-  dashboardApp: string | null;
-  authMode: "azure-obo" | "local-bypass" | null;
+const feedbackReadbackSchema = z.object({
+  id: z.string(),
+  submittedAt: z.string(),
+  app: z.string().nullable(),
+  surveyId: z.string(),
+  surveyType: z.string().optional(),
+  context: z
+    .object({ tags: z.record(z.string(), z.string()).optional() })
+    .optional(),
+  answers: z.array(
+    z.object({
+      fieldId: z.string(),
+      fieldType: z.string(),
+      value: z.object({
+        type: z.string(),
+        rating: z.number().optional(),
+        selectedOptionId: z.string().optional(),
+      }),
+    }),
+  ),
+});
+
+const readRunSchema = z.object({
+  surveyId: z.string().regex(RELEASE_VERIFICATION_SURVEY_ID_PATTERN),
+  initialReceiptId: z.string().uuid().optional(),
+  closingReceiptId: z.string().uuid().optional(),
+});
+
+export type ReleaseVerificationConfig =
+  | {
+      enabled: false;
+      surveyId: null;
+      dashboardTeam: null;
+      dashboardApp: null;
+      authMode: null;
+      profile: null;
+      environment: null;
+      holdDurationMs: null;
+      preflight: null;
+    }
+  | {
+      enabled: true;
+      surveyId: string;
+      dashboardTeam: string;
+      dashboardApp: string;
+      authMode: "azure-obo" | "local-bypass";
+      profile: ReleaseVerificationProfile;
+      environment: "dev-gcp" | "local";
+      holdDurationMs: number;
+      preflight: ReleaseVerificationPreflightEvidence;
+    };
+
+export interface ReleaseVerificationRunReadback {
+  observedAt: string;
+  initial: ReleaseVerificationProbeEvidence | null;
+  closing: ReleaseVerificationProbeEvidence | null;
 }
 
-export interface ReleaseVerificationReceipt {
-  id: string;
-  duplicate: boolean;
+interface ReleaseVerificationTarget {
+  team: string;
+  app: string;
+  channel: "azure-obo" | "local-bypass";
+  profile: ReleaseVerificationProfile;
+  environment: "dev-gcp" | "local";
+  holdDurationMs: number;
 }
 
 function releaseVerificationEnabled(): boolean {
@@ -130,30 +194,64 @@ function releaseVerificationEnabled(): boolean {
   });
 }
 
+function getTarget(): ReleaseVerificationTarget {
+  if (serverEnv.NAIS_CLUSTER_NAME === "dev-gcp") {
+    return {
+      team: "team-esyfo",
+      app: "lumi-dashboard",
+      channel: "azure-obo",
+      profile: "dev-authenticated-roundtrip",
+      environment: "dev-gcp",
+      holdDurationMs: DEV_HOLD_DURATION_MS,
+    };
+  }
+  return {
+    team: "local-dev",
+    app: "local-app",
+    channel: "local-bypass",
+    profile: "local-full-chain",
+    environment: "local",
+    holdDurationMs: 0,
+  };
+}
+
 export const fetchReleaseVerificationConfigServerFn = createServerFn({
   method: "GET",
 })
   .middleware([authMiddleware])
-  .handler(async (): Promise<ReleaseVerificationConfig> => {
+  .handler(async ({ context }): Promise<ReleaseVerificationConfig> => {
     const enabled = releaseVerificationEnabled();
+    if (!enabled) {
+      return {
+        enabled: false,
+        surveyId: null,
+        dashboardTeam: null,
+        dashboardApp: null,
+        authMode: null,
+        profile: null,
+        environment: null,
+        holdDurationMs: null,
+        preflight: null,
+      };
+    }
+
+    const target = getTarget();
+    const surveyId = createReleaseVerificationSurveyId();
+    const preflight = await runTeamPreflight(
+      context as AuthContext,
+      target,
+      surveyId,
+    );
     return {
-      enabled,
-      surveyId: enabled ? createReleaseVerificationSurveyId() : null,
-      dashboardTeam: enabled
-        ? serverEnv.NAIS_CLUSTER_NAME
-          ? "team-esyfo"
-          : "local-dev"
-        : null,
-      dashboardApp: enabled
-        ? serverEnv.NAIS_CLUSTER_NAME
-          ? "lumi-dashboard"
-          : "local-app"
-        : null,
-      authMode: enabled
-        ? serverEnv.NAIS_CLUSTER_NAME
-          ? "azure-obo"
-          : "local-bypass"
-        : null,
+      enabled: true,
+      surveyId,
+      dashboardTeam: target.team,
+      dashboardApp: target.app,
+      authMode: target.channel,
+      profile: target.profile,
+      environment: target.environment,
+      holdDurationMs: target.holdDurationMs,
+      preflight,
     };
   });
 
@@ -162,21 +260,270 @@ export const submitReleaseVerificationServerFn = createServerFn({
 })
   .middleware([authMiddleware])
   .inputValidator(zodValidator(transportPayloadSchema))
-  .handler(async ({ data, context }): Promise<ReleaseVerificationReceipt> => {
-    if (!releaseVerificationEnabled()) {
-      throw new Error("Release-verifikasjon er bare tilgjengelig i dev");
-    }
+  .handler(
+    async ({ data, context }): Promise<ReleaseVerificationProbeEvidence> => {
+      assertReleaseVerificationEnabled();
+      const target = getTarget();
+      const phase = assertExpectedSubmission(data, target);
+      const authContext = context as AuthContext;
+      const preflight = await runTeamPreflight(
+        authContext,
+        target,
+        data.surveyId,
+      );
+      if (preflight.status !== "passed") {
+        throw new Error(
+          preflight.message ?? "Teamtilgang kunne ikke bekreftes",
+        );
+      }
+      const response = await fetch(
+        buildUrl(authContext.backendUrl, "/api/azure/v1/feedback"),
+        {
+          method: "POST",
+          headers: getHeaders(authContext.oboToken),
+          body: JSON.stringify(data),
+        },
+      );
+      await handleApiResponse(response);
+      const receipt = submissionReceiptSchema.parse(await response.json());
+      return readExactProbe(authContext, target, {
+        phase,
+        surveyId: data.surveyId,
+        receiptId: receipt.id,
+        duplicate: receipt.duplicate === true,
+      });
+    },
+  );
 
-    const { backendUrl, oboToken } = context as AuthContext;
+export const fetchReleaseVerificationRunServerFn = createServerFn({
+  method: "GET",
+})
+  .middleware([authMiddleware])
+  .inputValidator(zodValidator(readRunSchema))
+  .handler(
+    async ({ data, context }): Promise<ReleaseVerificationRunReadback> => {
+      assertReleaseVerificationEnabled();
+      const target = getTarget();
+      const authContext = context as AuthContext;
+      const [initial, closing] = await Promise.all([
+        data.initialReceiptId
+          ? readExactProbe(authContext, target, {
+              phase: "initial",
+              surveyId: data.surveyId,
+              receiptId: data.initialReceiptId,
+              duplicate: null,
+            })
+          : null,
+        data.closingReceiptId
+          ? readExactProbe(authContext, target, {
+              phase: "closing",
+              surveyId: data.surveyId,
+              receiptId: data.closingReceiptId,
+              duplicate: null,
+            })
+          : null,
+      ]);
+      return { observedAt: new Date().toISOString(), initial, closing };
+    },
+  );
+
+async function runTeamPreflight(
+  { backendUrl, oboToken }: AuthContext,
+  target: ReleaseVerificationTarget,
+  surveyId: string,
+): Promise<ReleaseVerificationPreflightEvidence> {
+  const checkedAt = new Date().toISOString();
+  try {
     const response = await fetch(
-      buildUrl(backendUrl, "/api/azure/v1/feedback"),
-      {
-        method: "POST",
-        headers: getHeaders(oboToken),
-        body: JSON.stringify(data),
-      },
+      buildUrl(backendUrl, "/api/v1/intern/feedback", {
+        team: target.team,
+        app: target.app,
+        surveyId,
+        page: "0",
+        size: "1",
+      }),
+      { headers: getHeaders(oboToken) },
     );
-    await handleApiResponse(response);
-    const receipt = submissionReceiptSchema.parse(await response.json());
-    return { id: receipt.id, duplicate: receipt.duplicate === true };
-  });
+    if (!response.ok) {
+      if (response.status === 401 || response.status === 403) {
+        return {
+          status: "failed",
+          checkedAt,
+          team: target.team,
+          app: target.app,
+          message: `Mangler lesetilgang til ${target.team}/${target.app}`,
+        };
+      }
+      return {
+        status: "unavailable",
+        checkedAt,
+        team: target.team,
+        app: target.app,
+        message: "Team-preflight er midlertidig utilgjengelig",
+      };
+    }
+    return {
+      status: "passed",
+      checkedAt,
+      team: target.team,
+      app: target.app,
+    };
+  } catch {
+    return {
+      status: "unavailable",
+      checkedAt,
+      team: target.team,
+      app: target.app,
+      message: "Team-preflight er midlertidig utilgjengelig",
+    };
+  }
+}
+
+async function readExactProbe(
+  { backendUrl, oboToken }: AuthContext,
+  target: ReleaseVerificationTarget,
+  expected: {
+    phase: ReleaseVerificationPhase;
+    surveyId: string;
+    receiptId: string;
+    duplicate: boolean | null;
+  },
+): Promise<ReleaseVerificationProbeEvidence> {
+  const retryDelaysMs = [0, 100, 250, 500];
+  for (const [attempt, delayMs] of retryDelaysMs.entries()) {
+    if (delayMs > 0) await delay(delayMs);
+    try {
+      const response = await fetch(
+        buildUrl(
+          backendUrl,
+          `/api/v1/intern/feedback/${encodeURIComponent(expected.receiptId)}`,
+          { team: target.team },
+        ),
+        { headers: getHeaders(oboToken) },
+      );
+      if (response.status === 404) {
+        if (attempt < retryDelaysMs.length - 1) continue;
+        return verifyReleaseVerificationReadback(null, {
+          ...expected,
+          app: target.app,
+          channel: target.channel,
+        });
+      }
+      if (!response.ok) {
+        if (response.status >= 500 && attempt < retryDelaysMs.length - 1) {
+          continue;
+        }
+        return response.status >= 500
+          ? unavailableReadback(expected, `readback-http-${response.status}`)
+          : failedReadback(expected, `readback-http-${response.status}`);
+      }
+      const parsed = feedbackReadbackSchema.safeParse(await response.json());
+      if (!parsed.success) {
+        return failedReadback(expected, "readback-contract");
+      }
+      return verifyReleaseVerificationReadback(parsed.data, {
+        ...expected,
+        app: target.app,
+        channel: target.channel,
+      });
+    } catch {
+      if (attempt === retryDelaysMs.length - 1) {
+        return unavailableReadback(expected, "readback-request");
+      }
+    }
+  }
+  return unavailableReadback(expected, "readback-request");
+}
+
+function failedReadback(
+  expected: {
+    phase: ReleaseVerificationPhase;
+    receiptId: string;
+    duplicate: boolean | null;
+  },
+  mismatch: string,
+): ReleaseVerificationProbeEvidence {
+  return {
+    phase: expected.phase,
+    status: "mismatch",
+    receiptId: expected.receiptId,
+    duplicate: expected.duplicate,
+    storedAt: null,
+    mismatches: [mismatch],
+  };
+}
+
+function unavailableReadback(
+  expected: {
+    phase: ReleaseVerificationPhase;
+    receiptId: string;
+    duplicate: boolean | null;
+  },
+  mismatch: string,
+): ReleaseVerificationProbeEvidence {
+  return {
+    phase: expected.phase,
+    status: "unavailable",
+    receiptId: expected.receiptId,
+    duplicate: expected.duplicate,
+    storedAt: null,
+    mismatches: [mismatch],
+  };
+}
+
+function delay(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+function assertReleaseVerificationEnabled(): void {
+  if (!releaseVerificationEnabled()) {
+    throw new Error("Release-verifikasjon er bare tilgjengelig i dev");
+  }
+}
+
+function assertExpectedSubmission(
+  payload: z.infer<typeof transportPayloadSchema>,
+  target: ReleaseVerificationTarget,
+): ReleaseVerificationPhase {
+  const phase = phaseSchema.safeParse(payload.context?.tags?.phase);
+  const expectedControlOption = createReleaseVerificationControlOptionId(
+    payload.surveyId,
+  );
+  const ratingDefinition = payload.definition.fields.find(
+    ({ fieldId }) => fieldId === "rating",
+  );
+  const controlDefinition = payload.definition.fields.find(
+    ({ fieldId }) => fieldId === RELEASE_VERIFICATION_CONTROL_FIELD_ID,
+  );
+  const ratingAnswer = payload.answers.find(
+    ({ fieldId }) => fieldId === "rating",
+  );
+  const controlAnswer = payload.answers.find(
+    ({ fieldId }) => fieldId === RELEASE_VERIFICATION_CONTROL_FIELD_ID,
+  );
+
+  if (
+    payload.surveyType !== "rating" ||
+    payload.definition.surveyType !== "rating" ||
+    payload.definition.fields.length !== 2 ||
+    ratingDefinition?.fieldType !== "RATING" ||
+    ratingDefinition.ratingVariant !== "emoji" ||
+    ratingDefinition.ratingScale !== 5 ||
+    controlDefinition?.fieldType !== "SINGLE_CHOICE" ||
+    controlDefinition.optionIds.length !== 1 ||
+    controlDefinition.optionIds[0] !== expectedControlOption ||
+    payload.answers.length !== 2 ||
+    ratingAnswer?.fieldType !== "RATING" ||
+    ratingAnswer.value.type !== "rating" ||
+    ratingAnswer.value.rating !== RELEASE_VERIFICATION_RATING ||
+    controlAnswer?.fieldType !== "SINGLE_CHOICE" ||
+    controlAnswer.value.type !== "singleChoice" ||
+    controlAnswer.value.selectedOptionId !== expectedControlOption ||
+    payload.context?.tags?.purpose !== "release-verification" ||
+    payload.context?.tags?.channel !== target.channel ||
+    !phase.success
+  ) {
+    throw new Error("Uventet payload i release-verifikasjonen");
+  }
+  return phase.data;
+}

--- a/apps/lumi-dashboard/app/utils/__tests__/releaseVerification.test.ts
+++ b/apps/lumi-dashboard/app/utils/__tests__/releaseVerification.test.ts
@@ -1,9 +1,30 @@
 import { describe, expect, it } from "vitest";
 import {
   canStartReleaseVerificationRun,
+  createReleaseVerificationControlCode,
+  createReleaseVerificationReport,
   createReleaseVerificationSurveyId,
   isReleaseVerificationEnabled,
+  type ReleaseVerificationProbeEvidence,
+  verifyReleaseVerificationReadback,
 } from "~/utils/releaseVerification";
+
+const surveyId = "lumi-release-verification-20260822-8a0dc3b1";
+const initialStoredAt = "2026-08-22T08:49:47.000Z";
+
+function verifiedProbe(
+  phase: "initial" | "closing",
+  storedAt = initialStoredAt,
+): ReleaseVerificationProbeEvidence {
+  return {
+    phase,
+    status: "verified",
+    receiptId: `${phase}-receipt-id`,
+    duplicate: false,
+    storedAt,
+    mismatches: [],
+  };
+}
 
 describe("release verification", () => {
   it("creates a unique, recognizable synthetic survey id", () => {
@@ -12,7 +33,11 @@ describe("release verification", () => {
         new Date("2026-08-22T12:00:00Z"),
         "8a0dc3b1-7538-44a2-8b44-bdbfe58193bd",
       ),
-    ).toBe("lumi-release-verification-20260822-8a0dc3b1");
+    ).toBe(surveyId);
+  });
+
+  it("derives a stable, non-personal control code from the survey id", () => {
+    expect(createReleaseVerificationControlCode(surveyId)).toBe("RV-8A0DC3B1");
   });
 
   it("is enabled only for real dev or an explicit local backend", () => {
@@ -50,5 +75,262 @@ describe("release verification", () => {
     expect(canStartReleaseVerificationRun("success")).toBe(true);
     expect(canStartReleaseVerificationRun("error")).toBe(true);
     expect(canStartReleaseVerificationRun("sending")).toBe(false);
+  });
+
+  it("verifies the exact stored receipt and expected synthetic fields", () => {
+    const evidence = verifyReleaseVerificationReadback(
+      {
+        id: "receipt-id",
+        submittedAt: initialStoredAt,
+        surveyId,
+        app: "lumi-dashboard",
+        surveyType: "rating",
+        context: {
+          tags: {
+            purpose: "release-verification",
+            phase: "initial",
+            channel: "azure-obo",
+          },
+        },
+        answers: [
+          {
+            fieldId: "rating",
+            fieldType: "RATING",
+            value: { type: "rating", rating: 4 },
+          },
+          {
+            fieldId: "control-code",
+            fieldType: "SINGLE_CHOICE",
+            value: {
+              type: "singleChoice",
+              selectedOptionId: "rv-8a0dc3b1",
+            },
+          },
+        ],
+      },
+      {
+        receiptId: "receipt-id",
+        surveyId,
+        app: "lumi-dashboard",
+        phase: "initial",
+        channel: "azure-obo",
+        duplicate: false,
+      },
+    );
+
+    expect(evidence).toEqual({
+      phase: "initial",
+      status: "verified",
+      receiptId: "receipt-id",
+      duplicate: false,
+      storedAt: initialStoredAt,
+      mismatches: [],
+    });
+  });
+
+  it("reports all exact-readback mismatches without inventing a pass", () => {
+    const evidence = verifyReleaseVerificationReadback(
+      {
+        id: "wrong-receipt",
+        submittedAt: "not-a-date",
+        surveyId: "wrong-survey",
+        app: "wrong-app",
+        surveyType: "custom",
+        context: { tags: {} },
+        answers: [],
+      },
+      {
+        receiptId: "receipt-id",
+        surveyId,
+        app: "lumi-dashboard",
+        phase: "closing",
+        channel: "azure-obo",
+        duplicate: true,
+      },
+    );
+
+    expect(evidence.status).toBe("mismatch");
+    expect(evidence.duplicate).toBe(true);
+    expect(evidence.mismatches).toEqual([
+      "receipt-id",
+      "survey-id",
+      "app",
+      "survey-type",
+      "stored-at",
+      "context-purpose",
+      "context-phase",
+      "context-channel",
+      "rating-answer",
+      "control-code-answer",
+    ]);
+  });
+
+  it("keeps the report pending until the database-backed hold window closes", () => {
+    const report = createReleaseVerificationReport({
+      profile: "dev-authenticated-roundtrip",
+      environment: "dev-gcp",
+      surveyId,
+      now: "2026-08-22T09:00:00.000Z",
+      holdDurationMs: 15 * 60 * 1000,
+      preflight: {
+        status: "passed",
+        checkedAt: "2026-08-22T08:48:00.000Z",
+        team: "team-esyfo",
+        app: "lumi-dashboard",
+      },
+      initialProbe: verifiedProbe("initial"),
+    });
+
+    expect(report.schemaVersion).toBe(1);
+    expect(report.outcome).toBe("pending");
+    expect(report.observeAfter).toBe("2026-08-22T09:04:47.000Z");
+    expect(report.checks.map(({ status }) => status)).toEqual([
+      "passed",
+      "passed",
+      "pending",
+      "pending",
+    ]);
+  });
+
+  it("passes the controlled chain only after a closing exact readback", () => {
+    const report = createReleaseVerificationReport({
+      profile: "dev-authenticated-roundtrip",
+      environment: "dev-gcp",
+      surveyId,
+      now: "2026-08-22T09:05:00.000Z",
+      holdDurationMs: 15 * 60 * 1000,
+      preflight: {
+        status: "passed",
+        checkedAt: "2026-08-22T08:48:00.000Z",
+        team: "team-esyfo",
+        app: "lumi-dashboard",
+      },
+      initialProbe: verifiedProbe("initial"),
+      closingProbe: verifiedProbe("closing", "2026-08-22T09:05:00.000Z"),
+    });
+
+    expect(report.outcome).toBe("passed");
+    expect(report.finishedAt).toBe("2026-08-22T09:05:00.000Z");
+    expect(report.coverage).toEqual({
+      controlledRoundTrip: "passed",
+      localSubmissionProxy: "not-tested",
+      globalAzureHealth: "not-assessed",
+      trygdeetatenProxy: "not-tested",
+      navWideRelease: "pending",
+    });
+  });
+
+  it("keeps an early closing probe retryable instead of permanently failing", () => {
+    const report = createReleaseVerificationReport({
+      profile: "dev-authenticated-roundtrip",
+      environment: "dev-gcp",
+      surveyId,
+      now: "2026-08-22T09:05:00.000Z",
+      holdDurationMs: 15 * 60 * 1000,
+      preflight: {
+        status: "passed",
+        checkedAt: "2026-08-22T08:48:00.000Z",
+        team: "team-esyfo",
+        app: "lumi-dashboard",
+      },
+      initialProbe: verifiedProbe("initial"),
+      closingProbe: verifiedProbe("closing", "2026-08-22T09:04:46.999Z"),
+    });
+
+    expect(report.outcome).toBe("pending");
+    expect(
+      report.checks.find(({ id }) => id === "closing-round-trip")?.status,
+    ).toBe("pending");
+  });
+
+  it("keeps a transient readback failure pending for retry", () => {
+    const report = createReleaseVerificationReport({
+      profile: "dev-authenticated-roundtrip",
+      environment: "dev-gcp",
+      surveyId,
+      now: "2026-08-22T08:50:00.000Z",
+      holdDurationMs: 15 * 60 * 1000,
+      preflight: {
+        status: "passed",
+        checkedAt: "2026-08-22T08:48:00.000Z",
+        team: "team-esyfo",
+        app: "lumi-dashboard",
+      },
+      initialProbe: {
+        phase: "initial",
+        status: "unavailable",
+        receiptId: "initial-receipt-id",
+        duplicate: false,
+        storedAt: null,
+        mismatches: ["readback-http-503"],
+      },
+    });
+
+    expect(report.outcome).toBe("pending");
+    expect(report.checks[1].status).toBe("pending");
+  });
+
+  it("keeps a transient preflight failure pending instead of inventing a pass", () => {
+    const report = createReleaseVerificationReport({
+      profile: "dev-authenticated-roundtrip",
+      environment: "dev-gcp",
+      surveyId,
+      now: "2026-08-22T09:05:00.000Z",
+      holdDurationMs: 15 * 60 * 1000,
+      preflight: {
+        status: "unavailable",
+        checkedAt: "2026-08-22T09:05:00.000Z",
+        team: "team-esyfo",
+        app: "lumi-dashboard",
+        message: "API-et svarte ikke",
+      },
+      initialProbe: verifiedProbe("initial"),
+      closingProbe: verifiedProbe("closing", "2026-08-22T09:05:00.000Z"),
+    });
+
+    expect(report.outcome).toBe("pending");
+    expect(report.checks[0]).toMatchObject({
+      id: "team-preflight",
+      status: "pending",
+      detail: "API-et svarte ikke",
+    });
+  });
+
+  it("fails closed when team preflight or an exact readback fails", () => {
+    const failedPreflight = createReleaseVerificationReport({
+      profile: "dev-authenticated-roundtrip",
+      environment: "dev-gcp",
+      surveyId,
+      now: "2026-08-22T08:49:00.000Z",
+      holdDurationMs: 15 * 60 * 1000,
+      preflight: {
+        status: "failed",
+        checkedAt: "2026-08-22T08:48:00.000Z",
+        team: "team-esyfo",
+        app: "lumi-dashboard",
+        message: "Teamtilgang mangler",
+      },
+    });
+    expect(failedPreflight.outcome).toBe("failed");
+
+    const mismatchedInitial = createReleaseVerificationReport({
+      profile: "local-full-chain",
+      environment: "local",
+      surveyId,
+      now: "2026-08-22T08:49:00.000Z",
+      holdDurationMs: 0,
+      preflight: {
+        status: "passed",
+        checkedAt: "2026-08-22T08:48:00.000Z",
+        team: "local-dev",
+        app: "local-app",
+      },
+      initialProbe: {
+        ...verifiedProbe("initial"),
+        status: "mismatch",
+        mismatches: ["app"],
+      },
+    });
+    expect(mismatchedInitial.outcome).toBe("failed");
   });
 });

--- a/apps/lumi-dashboard/app/utils/releaseVerification.ts
+++ b/apps/lumi-dashboard/app/utils/releaseVerification.ts
@@ -1,4 +1,9 @@
 export const RELEASE_VERIFICATION_SURVEY_PREFIX = "lumi-release-verification-";
+export const RELEASE_VERIFICATION_SURVEY_ID_PATTERN =
+  /^lumi-release-verification-\d{8}-[a-f0-9]{8}$/;
+export const RELEASE_VERIFICATION_SCHEMA_VERSION = 1 as const;
+export const RELEASE_VERIFICATION_RATING = 4;
+export const RELEASE_VERIFICATION_CONTROL_FIELD_ID = "control-code";
 
 interface ReleaseVerificationEnvironment {
   cluster?: string;
@@ -11,6 +16,110 @@ export type ReleaseVerificationAttemptStatus =
   | "sending"
   | "success"
   | "error";
+
+export type ReleaseVerificationPhase = "initial" | "closing";
+export type ReleaseVerificationProfile =
+  | "local-full-chain"
+  | "dev-authenticated-roundtrip";
+export type ReleaseVerificationCheckStatus = "pending" | "passed" | "failed";
+
+export interface ReleaseVerificationPreflightEvidence {
+  status: "passed" | "failed" | "unavailable";
+  checkedAt: string;
+  team: string;
+  app: string;
+  message?: string;
+}
+
+export interface ReleaseVerificationProbeEvidence {
+  phase: ReleaseVerificationPhase;
+  status: "verified" | "not-found" | "mismatch" | "unavailable";
+  receiptId: string;
+  duplicate: boolean | null;
+  storedAt: string | null;
+  mismatches: string[];
+}
+
+export interface ReleaseVerificationCheck {
+  id:
+    | "team-preflight"
+    | "initial-round-trip"
+    | "hold-window"
+    | "closing-round-trip"
+    | "local-submission-proxy"
+    | "controlled-dashboard-round-trip";
+  status: ReleaseVerificationCheckStatus;
+  completedAt: string | null;
+  detail: string;
+}
+
+export interface ReleaseVerificationReportV1 {
+  schemaVersion: typeof RELEASE_VERIFICATION_SCHEMA_VERSION;
+  profileVersion: 1;
+  profile: ReleaseVerificationProfile;
+  runId: string;
+  environment: string;
+  generatedAt: string;
+  startedAt: string;
+  finishedAt: string | null;
+  outcome: ReleaseVerificationCheckStatus;
+  subject: {
+    surveyId: string;
+    team: string;
+    app: string;
+  };
+  observeAfter: string | null;
+  checks: ReleaseVerificationCheck[];
+  probes: {
+    initial: ReleaseVerificationProbeEvidence | null;
+    closing: ReleaseVerificationProbeEvidence | null;
+  };
+  coverage: {
+    controlledRoundTrip: ReleaseVerificationCheckStatus;
+    localSubmissionProxy: ReleaseVerificationCheckStatus | "not-tested";
+    globalAzureHealth: "not-assessed";
+    trygdeetatenProxy: "not-tested";
+    navWideRelease: "pending";
+  };
+}
+
+interface ReleaseVerificationReadback {
+  id: string;
+  submittedAt: string;
+  surveyId: string;
+  app: string | null;
+  surveyType?: string;
+  context?: { tags?: Record<string, string> };
+  answers: Array<{
+    fieldId: string;
+    fieldType: string;
+    value: {
+      type: string;
+      rating?: number;
+      selectedOptionId?: string;
+    };
+  }>;
+}
+
+interface ExpectedReleaseVerificationReadback {
+  receiptId: string;
+  surveyId: string;
+  app: string;
+  phase: ReleaseVerificationPhase;
+  channel: "azure-obo" | "local-bypass";
+  duplicate: boolean | null;
+}
+
+interface CreateReleaseVerificationReportInput {
+  profile: ReleaseVerificationProfile;
+  environment: string;
+  surveyId: string;
+  now: string;
+  holdDurationMs: number;
+  preflight: ReleaseVerificationPreflightEvidence;
+  initialProbe?: ReleaseVerificationProbeEvidence;
+  closingProbe?: ReleaseVerificationProbeEvidence;
+}
 
 export function canStartReleaseVerificationRun(
   status: ReleaseVerificationAttemptStatus,
@@ -27,6 +136,20 @@ export function createReleaseVerificationSurveyId(
   return `${RELEASE_VERIFICATION_SURVEY_PREFIX}${date}-${suffix}`;
 }
 
+export function createReleaseVerificationControlCode(surveyId: string): string {
+  const suffix = surveyId.split("-").at(-1)?.toUpperCase();
+  if (!suffix || !/^[A-F0-9]{8}$/.test(suffix)) {
+    throw new Error("surveyId must end with an eight-character hexadecimal id");
+  }
+  return `RV-${suffix}`;
+}
+
+export function createReleaseVerificationControlOptionId(
+  surveyId: string,
+): string {
+  return createReleaseVerificationControlCode(surveyId).toLowerCase();
+}
+
 export function isReleaseVerificationEnabled({
   cluster,
   mockMode,
@@ -34,4 +157,232 @@ export function isReleaseVerificationEnabled({
 }: ReleaseVerificationEnvironment): boolean {
   if (mockMode) return false;
   return cluster === "dev-gcp" || (!cluster && localAuthBypass);
+}
+
+export function verifyReleaseVerificationReadback(
+  feedback: ReleaseVerificationReadback | null,
+  expected: ExpectedReleaseVerificationReadback,
+): ReleaseVerificationProbeEvidence {
+  if (!feedback) {
+    return {
+      phase: expected.phase,
+      status: "not-found",
+      receiptId: expected.receiptId,
+      duplicate: expected.duplicate,
+      storedAt: null,
+      mismatches: ["receipt-not-found"],
+    };
+  }
+
+  const mismatches: string[] = [];
+  if (feedback.id !== expected.receiptId) mismatches.push("receipt-id");
+  if (feedback.surveyId !== expected.surveyId) mismatches.push("survey-id");
+  if (feedback.app !== expected.app) mismatches.push("app");
+  if (feedback.surveyType !== "rating") mismatches.push("survey-type");
+  if (!isValidTimestamp(feedback.submittedAt)) mismatches.push("stored-at");
+  if (feedback.context?.tags?.purpose !== "release-verification") {
+    mismatches.push("context-purpose");
+  }
+  if (feedback.context?.tags?.phase !== expected.phase) {
+    mismatches.push("context-phase");
+  }
+  if (feedback.context?.tags?.channel !== expected.channel) {
+    mismatches.push("context-channel");
+  }
+
+  const ratingAnswer = feedback.answers.find(
+    ({ fieldId }) => fieldId === "rating",
+  );
+  if (
+    ratingAnswer?.fieldType !== "RATING" ||
+    ratingAnswer.value.type !== "rating" ||
+    ratingAnswer.value.rating !== RELEASE_VERIFICATION_RATING
+  ) {
+    mismatches.push("rating-answer");
+  }
+
+  const controlAnswer = feedback.answers.find(
+    ({ fieldId }) => fieldId === RELEASE_VERIFICATION_CONTROL_FIELD_ID,
+  );
+  if (
+    controlAnswer?.fieldType !== "SINGLE_CHOICE" ||
+    controlAnswer.value.type !== "singleChoice" ||
+    controlAnswer.value.selectedOptionId !==
+      createReleaseVerificationControlOptionId(expected.surveyId)
+  ) {
+    mismatches.push("control-code-answer");
+  }
+
+  return {
+    phase: expected.phase,
+    status: mismatches.length === 0 ? "verified" : "mismatch",
+    receiptId: expected.receiptId,
+    duplicate: expected.duplicate,
+    storedAt: isValidTimestamp(feedback.submittedAt)
+      ? new Date(feedback.submittedAt).toISOString()
+      : null,
+    mismatches,
+  };
+}
+
+export function createReleaseVerificationReport({
+  profile,
+  environment,
+  surveyId,
+  now,
+  holdDurationMs,
+  preflight,
+  initialProbe,
+  closingProbe,
+}: CreateReleaseVerificationReportInput): ReleaseVerificationReportV1 {
+  const generatedAt = toIsoTimestamp(now, "now");
+  const initialPassed = initialProbe?.status === "verified";
+  const initialFailed =
+    initialProbe !== undefined &&
+    (initialProbe.status === "mismatch" || initialProbe.status === "not-found");
+  const observeAfter =
+    initialPassed && initialProbe.storedAt
+      ? new Date(
+          new Date(initialProbe.storedAt).getTime() + holdDurationMs,
+        ).toISOString()
+      : null;
+  const holdPassed = observeAfter
+    ? new Date(generatedAt).getTime() >= new Date(observeAfter).getTime()
+    : false;
+  const closingStoredAfterHold = Boolean(
+    closingProbe?.storedAt &&
+      observeAfter &&
+      new Date(closingProbe.storedAt).getTime() >=
+        new Date(observeAfter).getTime(),
+  );
+  const closingPassed =
+    closingProbe?.status === "verified" && closingStoredAfterHold;
+  const closingFailed =
+    closingProbe !== undefined &&
+    (closingProbe.status === "mismatch" || closingProbe.status === "not-found");
+
+  let outcome: ReleaseVerificationCheckStatus = "pending";
+  if (preflight.status === "failed" || initialFailed || closingFailed) {
+    outcome = "failed";
+  } else if (
+    preflight.status === "passed" &&
+    initialPassed &&
+    holdPassed &&
+    closingPassed
+  ) {
+    outcome = "passed";
+  }
+
+  const checks: ReleaseVerificationCheck[] = [
+    {
+      id: "team-preflight",
+      status: preflight.status === "unavailable" ? "pending" : preflight.status,
+      completedAt: preflight.checkedAt,
+      detail:
+        preflight.status === "passed"
+          ? `Lesetilgang bekreftet for ${preflight.team}/${preflight.app}`
+          : preflight.status === "unavailable"
+            ? (preflight.message ?? "Teamtilgang prøves på nytt senere")
+            : (preflight.message ?? "Teamtilgang kunne ikke bekreftes"),
+    },
+    {
+      id: "initial-round-trip",
+      status: probeCheckStatus(initialProbe),
+      completedAt: initialProbe?.storedAt ?? null,
+      detail: probeDetail(initialProbe, "Startproben er ikke sendt ennå"),
+    },
+    {
+      id: "hold-window",
+      status: initialFailed ? "failed" : holdPassed ? "passed" : "pending",
+      completedAt: holdPassed ? observeAfter : null,
+      detail: observeAfter
+        ? holdPassed
+          ? "Holdetiden er fullført"
+          : `Vent til ${observeAfter}`
+        : "Venter på lagret startprobe",
+    },
+    {
+      id: "closing-round-trip",
+      status: closingFailed ? "failed" : closingPassed ? "passed" : "pending",
+      completedAt: closingProbe?.storedAt ?? null,
+      detail: closingProbe
+        ? closingPassed
+          ? "Avsluttende receipt er lest tilbake etter holdetiden"
+          : closingProbe.status === "verified"
+            ? "Avsluttende probe ble lagret før holdetiden var ferdig"
+            : probeDetail(closingProbe, "")
+        : holdPassed
+          ? "Klar for avsluttende probe"
+          : "Venter på holdetiden",
+    },
+  ];
+
+  return {
+    schemaVersion: RELEASE_VERIFICATION_SCHEMA_VERSION,
+    profileVersion: 1,
+    profile,
+    runId: surveyId,
+    environment,
+    generatedAt,
+    startedAt: initialProbe?.storedAt
+      ? toIsoTimestamp(initialProbe.storedAt, "initialProbe.storedAt")
+      : toIsoTimestamp(preflight.checkedAt, "preflight.checkedAt"),
+    finishedAt:
+      outcome === "passed"
+        ? (closingProbe?.storedAt ?? generatedAt)
+        : outcome === "failed"
+          ? generatedAt
+          : null,
+    outcome,
+    subject: {
+      surveyId,
+      team: preflight.team,
+      app: preflight.app,
+    },
+    observeAfter,
+    checks,
+    probes: {
+      initial: initialProbe ?? null,
+      closing: closingProbe ?? null,
+    },
+    coverage: {
+      controlledRoundTrip: outcome,
+      localSubmissionProxy: "not-tested",
+      globalAzureHealth: "not-assessed",
+      trygdeetatenProxy: "not-tested",
+      navWideRelease: "pending",
+    },
+  };
+}
+
+function probeCheckStatus(
+  probe: ReleaseVerificationProbeEvidence | undefined,
+): ReleaseVerificationCheckStatus {
+  if (!probe) return "pending";
+  if (probe.status === "unavailable") return "pending";
+  return probe.status === "verified" ? "passed" : "failed";
+}
+
+function probeDetail(
+  probe: ReleaseVerificationProbeEvidence | undefined,
+  pendingDetail: string,
+): string {
+  if (!probe) return pendingDetail;
+  if (probe.status === "verified") {
+    return `Receipt ${probe.receiptId} er lest tilbake eksakt`;
+  }
+  if (probe.status === "unavailable") {
+    return "Readback er midlertidig utilgjengelig og prøves på nytt";
+  }
+  return `Readback feilet: ${probe.mismatches.join(", ")}`;
+}
+
+function isValidTimestamp(value: string): boolean {
+  return Number.isFinite(new Date(value).getTime());
+}
+
+function toIsoTimestamp(value: string, field: string): string {
+  if (!isValidTimestamp(value))
+    throw new Error(`${field} must be a valid timestamp`);
+  return new Date(value).toISOString();
 }

--- a/apps/lumi-dashboard/full-chain-e2e/submission.spec.ts
+++ b/apps/lumi-dashboard/full-chain-e2e/submission.spec.ts
@@ -1,13 +1,89 @@
-import { expect, test } from "@playwright/test";
+import { writeFile } from "node:fs/promises";
+import { resolve } from "node:path";
+import { expect, type Page, type TestInfo, test } from "@playwright/test";
 
 const DEMO_URL = process.env.LUMI_DEMO_URL ?? "http://127.0.0.1:3001";
 const DASHBOARD_URL = process.env.LUMI_DASHBOARD_URL ?? "http://127.0.0.1:3000";
 
-test("a SurveyDocumentV1 response travels from the widget to the dashboard", async ({
-  page,
-}) => {
-  const feedback = `full-chain-${Date.now()}`;
+interface FullChainReport {
+  schemaVersion: number;
+  profileVersion: number;
+  profile: string;
+  runId: string;
+  environment: string;
+  generatedAt: string;
+  startedAt: string;
+  finishedAt: string | null;
+  outcome: "pending" | "passed" | "failed";
+  subject: { surveyId: string; team: string; app: string };
+  observeAfter: string | null;
+  checks: Array<{
+    id: string;
+    status: "pending" | "passed" | "failed";
+    completedAt: string | null;
+    detail: string;
+  }>;
+  probes: Record<string, unknown>;
+  coverage: {
+    controlledRoundTrip: "pending" | "passed" | "failed";
+    localSubmissionProxy: "not-tested" | "passed" | "failed";
+    globalAzureHealth: "not-assessed";
+    trygdeetatenProxy: "not-tested";
+    navWideRelease: "pending";
+  };
+  automation?: {
+    runner: "playwright";
+    failures: string[];
+  };
+}
 
+test("the full chain produces one terminal release-verification report", async ({
+  page,
+}, testInfo) => {
+  const startedAt = new Date().toISOString();
+  const failures: string[] = [];
+  let localProxyStatus: "passed" | "failed" = "passed";
+  let controlledReport: FullChainReport | null = null;
+
+  try {
+    await verifyLocalProxyRoundTrip(page);
+  } catch (error) {
+    localProxyStatus = "failed";
+    failures.push(`local-submission-proxy: ${errorMessage(error)}`);
+  }
+
+  try {
+    controlledReport = await verifyControlledDashboardRoundTrip(page);
+  } catch (error) {
+    failures.push(`controlled-dashboard-round-trip: ${errorMessage(error)}`);
+  }
+
+  const finishedAt = new Date().toISOString();
+  const report = controlledReport ?? createFailedReport(startedAt, finishedAt);
+  report.coverage.localSubmissionProxy = localProxyStatus;
+  report.checks.push({
+    id: "local-submission-proxy",
+    status: localProxyStatus,
+    completedAt: finishedAt,
+    detail:
+      localProxyStatus === "passed"
+        ? "Widget → lokal proxy → API → Postgres → dashboard er verifisert"
+        : "Den lokale proxy-rundturen feilet",
+  });
+  report.automation = { runner: "playwright", failures };
+  report.generatedAt = finishedAt;
+  report.finishedAt = finishedAt;
+  if (failures.length > 0 || report.outcome !== "passed") {
+    report.outcome = "failed";
+  }
+
+  await writeEvidence(report, testInfo);
+  expect(failures, failures.join("\n")).toEqual([]);
+  expect(report.outcome).toBe("passed");
+});
+
+async function verifyLocalProxyRoundTrip(page: Page): Promise<void> {
+  const feedback = `full-chain-${Date.now()}`;
   await page.goto(DEMO_URL);
   await expect(
     page.getByRole("heading", { name: "Full-chain testbenk" }),
@@ -18,7 +94,6 @@ test("a SurveyDocumentV1 response travels from the widget to the dashboard", asy
     .getByRole("textbox", { name: "Har du andre tilbakemeldinger?" })
     .fill(feedback);
   await page.getByRole("button", { name: "Send" }).click();
-
   await expect(
     page.getByRole("heading", { name: "Signal lagret" }),
   ).toBeVisible();
@@ -29,27 +104,101 @@ test("a SurveyDocumentV1 response travels from the widget to the dashboard", asy
   await expect(
     page.getByRole("table").getByText(feedback, { exact: true }).first(),
   ).toBeVisible();
-});
+}
 
-test("the dev release rig stores and finds a synthetic response", async ({
-  page,
-}) => {
-  const trace = `release-rig-${Date.now()}`;
-
+async function verifyControlledDashboardRoundTrip(
+  page: Page,
+): Promise<FullChainReport> {
   await page.goto(`${DASHBOARD_URL}/release-verification`);
   await expect(
     page.getByRole("heading", { name: "Bevis kjeden før utrulling" }),
   ).toBeVisible();
-
-  await page.getByRole("radio", { name: "4. Bra" }).click();
-  await page
-    .getByRole("textbox", { name: "Legg inn en kort sporingsmerknad" })
-    .fill(trace);
-  await page.getByRole("button", { name: "Send" }).click();
-
-  await expect(page.getByText(/API-et bekreftet ny lagring/)).toBeVisible();
-  await page.getByRole("button", { name: "Kontroller i dashboardet" }).click();
   await expect(
-    page.getByRole("table").getByText(trace, { exact: true }).first(),
+    page.getByText("Teamtilgang er bekreftet før skrivetesten starter."),
   ).toBeVisible();
-});
+
+  await submitReleaseProbe(page);
+  await expect(page.getByText(/Holdetiden er ferdig/)).toBeVisible();
+  await submitReleaseProbe(page);
+  await expect(
+    page.getByRole("heading", {
+      name: "Kontrollert dev-kjede bestått",
+    }),
+  ).toBeVisible();
+
+  const reportText = await page.locator("pre").textContent();
+  expect(reportText).not.toBeNull();
+  const report = JSON.parse(reportText ?? "{}") as FullChainReport;
+  expect(report.schemaVersion).toBe(1);
+  expect(report.outcome).toBe("passed");
+  expect(report.coverage).toMatchObject({
+    controlledRoundTrip: "passed",
+    navWideRelease: "pending",
+  });
+  return report;
+}
+
+async function submitReleaseProbe(page: Page): Promise<void> {
+  await page.getByRole("radio", { name: "4. Bra" }).click();
+  await page.getByRole("radio", { name: /Kontrollkode RV-/ }).click();
+  await page.getByRole("button", { name: "Send" }).click();
+}
+
+function createFailedReport(
+  startedAt: string,
+  finishedAt: string,
+): FullChainReport {
+  return {
+    schemaVersion: 1,
+    profileVersion: 1,
+    profile: "local-full-chain",
+    runId: `full-chain-${Date.now()}`,
+    environment: "local",
+    generatedAt: finishedAt,
+    startedAt,
+    finishedAt,
+    outcome: "failed",
+    subject: {
+      surveyId: "not-created",
+      team: "local-dev",
+      app: "local-app",
+    },
+    observeAfter: null,
+    checks: [
+      {
+        id: "controlled-dashboard-round-trip",
+        status: "failed",
+        completedAt: finishedAt,
+        detail: "Dashboard-rundturen produserte ingen lesbar rapport",
+      },
+    ],
+    probes: { initial: null, closing: null },
+    coverage: {
+      controlledRoundTrip: "failed",
+      localSubmissionProxy: "not-tested",
+      globalAzureHealth: "not-assessed",
+      trygdeetatenProxy: "not-tested",
+      navWideRelease: "pending",
+    },
+  };
+}
+
+async function writeEvidence(
+  report: FullChainReport,
+  testInfo: TestInfo,
+): Promise<void> {
+  const evidencePath = resolve(
+    testInfo.project.outputDir,
+    "..",
+    "release-verification-report.json",
+  );
+  await writeFile(evidencePath, JSON.stringify(report, null, 2));
+  await testInfo.attach("release-verification-report.json", {
+    path: evidencePath,
+    contentType: "application/json",
+  });
+}
+
+function errorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}

--- a/apps/lumi-dashboard/playwright.full-chain.config.ts
+++ b/apps/lumi-dashboard/playwright.full-chain.config.ts
@@ -6,7 +6,11 @@ export default defineConfig({
   forbidOnly: !!process.env.CI,
   retries: process.env.CI ? 1 : 0,
   workers: 1,
-  reporter: "list",
+  reporter: [
+    ["list"],
+    ["json", { outputFile: "test-results/full-chain/playwright-report.json" }],
+  ],
+  outputDir: "test-results/full-chain/artifacts",
   timeout: 60_000,
   use: {
     trace: "on-first-retry",

--- a/docs/runbooks/nav-wide-rollout.md
+++ b/docs/runbooks/nav-wide-rollout.md
@@ -10,8 +10,8 @@ brukes som en måte å ta produktbeslutningen på.
 | --- | --- | --- |
 | Historiske surveys i dashboardet | Klar | Automatisk periode velges fra surveyens faktiske datointervall; eksplisitt valgt periode beholdes |
 | Pakket `@navikt/lumi-survey` | Automatisert | `pnpm run verify:lumi-survey-consumer` installerer tarballen i en ren konsument og kjører typecheck + Vite-build |
-| Widget → proxy → API → Postgres → dashboard | Automatisert | `pnpm run test:full-chain` kjører to Playwright-scenarier mot en isolert Compose-stack |
-| Ekte Azure OBO i dev | Klar til kjøring | `/release-verification` i dev-dashboardet bruker en ny syntetisk survey-ID per kjøring |
+| Widget → proxy → API → Postgres → dashboard | Automatisert | `pnpm run test:full-chain` kjører proxy- og dashboard-rundturen mot en isolert Compose-stack og CI laster opp én aggregert terminalrapport |
+| Ekte Azure OBO i dev | Selvbetjent | `/release-verification` kjører team-preflight, startprobe, 15 minutters hold og sluttprobe med eksakt receipt-readback |
 | Innsendingshelse | Instrumentert | `lumi_submissions_total` skiller kanal og utfall; prod varsler på serverfeil og rejection-spike |
 | Hvilke eksisterende surveys som skal fortsette | Avventer | Må avklares før migrering; surveys som skal stoppes migreres ikke |
 | Ekte trygdeetaten-proxy fra konsument i dev | Avventer canary | Verifiseres i første avklarte interne konsument før bredere migrering |
@@ -23,13 +23,32 @@ beholdes og skal fortsatt være lesbare selv om en survey skrus av.
 
 1. Hold fullkjedetesten, pakkekonsumenttesten, lint, typecheck og tester grønne.
 2. Deploy Lumi-endringene til dev etter ordinær review.
-3. Kjør `/release-verification` i dev og finn sporingsmerknaden i dashboardet.
-4. Bekreft `created` på `azure`-kanalen og fravær av `failed`/`rejected` i minst
-   15 minutter.
-5. Review canary-PR-en uten å merge den.
+3. Åpne `/release-verification` i dev. Ikke send noe dersom team-preflighten
+   feiler.
+4. Send startproben med de syntetiske valgene. Vent til siden låser opp
+   sluttproben etter 15 minutter, og send den.
+5. Del rapportlenken eller last ned JSON-beviset. For den kontrollerte kjeden
+   skal `outcome` og `coverage.controlledRoundTrip` være `passed`.
+6. Review canary-PR-en uten å merge den.
 
 Dette gir release-evidens uten å aktivere, migrere eller sende data fra en ekte
-survey.
+survey. Rapporten er bevisst avgrenset: `globalAzureHealth` er
+`not-assessed`, `trygdeetatenProxy` er `not-tested`, og `navWideRelease`
+forblir `pending`. Den kan derfor ikke alene brukes som godkjenning av en
+NAV-wide utrulling.
+
+### Hva rapporten faktisk beviser
+
+Dev-profilen går gjennom den publiserte widgeten, dashboardets innloggede
+Azure OBO-flyt, Lumi API, Postgres og det eksakte analytics-readbacket. Siden
+kan lukkes og åpnes igjen; receipt-ID-ene i URL-en rekonstruerer rapporten fra
+lagrede data i stedet for nettleserstate.
+
+Den lokale profilen bruker den samme rapportmodellen med null minutters hold.
+CI laster opp `apps/lumi-dashboard/test-results/full-chain` som
+`full-chain-release-verification-<run-id>`, også når testen feiler. Dette gjør
+resultatet lesbart for CI, en agent eller et menneske uten Grafana, NAIS-konsoll
+eller direkte loggtilgang.
 
 ## Beslutningstabell for neste uke
 
@@ -54,9 +73,17 @@ Regler:
 3. Deploy til dev uten auto-merge.
 4. Send ett gjenkjennelig testsvar gjennom den faktiske konsumenten. For en
    trygdeetaten-app skal dette gå gjennom `lumi-submission-proxy`.
-5. Finn svaret i dashboardet med automatisk periode og kontroller kanalmetrikken.
-6. Vent minst 15 minutter uten `failed` eller rejection-spike.
+5. Finn receipt/svaret i dashboardet med automatisk periode og kontroller team,
+   app, survey-ID og forventede syntetiske svar. Dette tester den faktiske
+   konsumentens proxy-integrasjon uten eksterne driftsverktøy.
+6. Vent minst 15 minutter og send en ny syntetisk probe gjennom den samme
+   canary-flaten. Kontroller også denne eksakte raden i dashboardet.
 7. Merge én liten produksjonsbatch, observer, og utvid først etter grønn holdetid.
+
+Lumi sin `/release-verification` kan ikke bevise en annen apps deployede
+trygdeetaten-proxy. Det beviset må komme fra første canary-app. Global
+kanalhelse og alarmer er supplerende operasjonell overvåking, ikke en skjult
+forutsetning for å produsere den selvbetjente rapporten.
 
 ## Stoppkriterier
 


### PR DESCRIPTION
## Hva
- gjør dev-verifikasjonen til en eksakt, kvitteringsbasert roundtrip med team-preflight, startprobe, 15 minutters holdetid og sluttprobe
- lagrer kjøringen i delbar URL og tilbyr versjonert JSON-rapport for menneske eller agent
- lar lokal full-chain CI produsere samme terminale rapport som artefakt, også når testen feiler
- dokumenterer tydelig at global Azure-helse, deployet trygdeetaten-proxy og NAV-wide release ikke er attestert av rapporten

## Hvorfor
Dette gir en selvstendig verifikasjonsrigg uten at agenten trenger Grafana, NAIS eller andre interne NAV-verktøy. Reell Azure OBO verifiseres av en innlogget bruker i dev; den lokale kjeden kan kjøres automatisk i CI.

## Verifisert
- pnpm run lint
- pnpm run typecheck
- pnpm test (614 tester)
- pnpm run api:test
- pnpm run test:full-chain (1 samlet terminal rapport)

## Bevisst avgrensning
Før faktisk canary må proxyen i den valgte trygdeetaten-appen fortsatt prøves gjennom appen. Surveyvalg og migrering tas separat når aktive surveys er avklart.