### PR TITLE
Kjør widgettestene i vanlig CI

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "verify:lumi-survey-consumer": "./scripts/verify-lumi-survey-consumer.sh",
     "check:lumi-survey-release-drift": "node scripts/check-lumi-survey-release-drift.mjs",
     "test:release-guards": "node --test scripts/check-lumi-survey-release-drift.test.mjs",
-    "test": "pnpm --filter @navikt/lumi-types run test && pnpm --filter lumi-dashboard run test",
+    "test": "pnpm --filter @navikt/lumi-types run test && pnpm --filter @navikt/lumi-survey exec vitest run && pnpm --filter lumi-dashboard run test",
     "e2e": "pnpm --filter lumi-dashboard run e2e",
     "e2e:full-chain": "pnpm --filter lumi-dashboard run e2e:full-chain",
     "test:full-chain": "./scripts/lumi-full-chain-e2e.sh",


### PR DESCRIPTION
## Hva
- lar rotkommandoen pnpm test kjøre lumi-survey sine 432 tester før dashboardtestene
- kaller Vitest direkte, slik at null oppdagede widgettester feiler vanlig PR-CI
- holder endringen utenfor den publiserte widgetpakken; ingen versjonsbump eller changelog

## Hvorfor
Vanlig CI kjørte 614 dashboardtester, mens widgetens 432 tester bare ble kjørt i egne/full-chain-løp. Årsaken var det eksplisitte filteret i rotkommandoen.

## Verifisert
- pnpm run typecheck
- pnpm test: 2 type-tester + 432 widgettester + 614 dashboardtester
- pnpm run lint
- pnpm run check:lumi-survey-release-drift
- pnpm run test:release-guards
- git diff --check

Closes #475