### PR TITLE
Verifiser hele survey-kontrakten i fullkjeden

### DIFF
--- a/apps/lumi-dashboard/full-chain-e2e/submission.spec.ts
+++ b/apps/lumi-dashboard/full-chain-e2e/submission.spec.ts
@@ -1,6 +1,12 @@
 import { writeFile } from "node:fs/promises";
 import { resolve } from "node:path";
-import { expect, type Page, type TestInfo, test } from "@playwright/test";
+import {
+  expect,
+  type Locator,
+  type Page,
+  type TestInfo,
+  test,
+} from "@playwright/test";
 
 const DEMO_URL = process.env.LUMI_DEMO_URL ?? "http://127.0.0.1:3001";
 const DASHBOARD_URL = process.env.LUMI_DASHBOARD_URL ?? "http://127.0.0.1:3000";
@@ -27,6 +33,7 @@ interface FullChainReport {
   coverage: {
     controlledRoundTrip: "pending" | "passed" | "failed";
     localSubmissionProxy: "not-tested" | "passed" | "failed";
+    surveyContractMatrix?: "not-tested" | "passed" | "failed";
     globalAzureHealth: "not-assessed";
     trygdeetatenProxy: "not-tested";
     navWideRelease: "pending";
@@ -34,22 +41,315 @@ interface FullChainReport {
   automation?: {
     runner: "playwright";
     failures: string[];
+    matrix: MatrixScenarioEvidence[];
   };
 }
+
+interface TransportFieldDefinition {
+  fieldId: string;
+  fieldType: "RATING" | "TEXT" | "SINGLE_CHOICE" | "MULTI_CHOICE";
+  ratingVariant?: "emoji" | "thumbs" | "stars" | "nps";
+  ratingScale?: number;
+  maxSelections?: number;
+}
+
+interface TransportAnswer {
+  fieldId: string;
+  fieldType: TransportFieldDefinition["fieldType"];
+  value: {
+    type: "rating" | "text" | "singleChoice" | "multiChoice";
+    rating?: number;
+    ratingVariant?: "emoji" | "thumbs" | "stars" | "nps";
+    ratingScale?: number;
+    text?: string;
+    selectedOptionId?: string;
+    selectedOptionIds?: string[];
+  };
+}
+
+interface TransportPayload {
+  schemaVersion: number;
+  surveyId: string;
+  surveyType: string;
+  definition: {
+    surveyType: string;
+    fields: TransportFieldDefinition[];
+  };
+  context?: { tags?: Record<string, string> };
+  answers: TransportAnswer[];
+}
+
+type MatrixAction =
+  | { kind: "radio"; name: string | RegExp }
+  | { kind: "textbox"; name: string; suffix: string }
+  | { kind: "checkbox"; name: string }
+  | { kind: "combobox"; name: string; options: string[] }
+  | { kind: "next" };
+
+interface MatrixScenario {
+  id: string;
+  surveyType: "rating" | "topTasks" | "discovery" | "taskPriority" | "custom";
+  dashboardType:
+    | "Vurdering"
+    | "Top Tasks"
+    | "Discovery"
+    | "Task Priority"
+    | "Custom";
+  facets: string[];
+  actions: MatrixAction[];
+  fields: TransportFieldDefinition[];
+  expectedAnswers: (marker: string) => TransportAnswer[];
+  dashboardValues: (marker: string) => string[];
+}
+
+interface MatrixScenarioEvidence {
+  scenarioId: string;
+  surveyId: string;
+  surveyType: MatrixScenario["surveyType"];
+  facets: string[];
+  status: "passed" | "failed";
+  receiptId: string | null;
+  detail: string;
+}
+
+class MatrixScenarioFailure extends Error {
+  constructor(
+    message: string,
+    readonly receiptId: string | null,
+  ) {
+    super(message);
+    this.name = "MatrixScenarioFailure";
+  }
+}
+
+const TASK_OPTIONS = [
+  "apply",
+  "status",
+  "message",
+  "document",
+  "payment",
+  "change",
+];
+
+const MATRIX_SCENARIOS: MatrixScenario[] = [
+  ratingScenario({
+    id: "rating-emoji",
+    facet: "emoji",
+    ratingFieldId: "rating",
+    ratingAction: { kind: "radio", name: "4. Bra" },
+    rating: 4,
+    textFieldId: "feedback",
+    textPrompt: "Har du andre tilbakemeldinger?",
+  }),
+  ratingScenario({
+    id: "rating-thumbs",
+    facet: "thumbs",
+    ratingFieldId: "helpful",
+    ratingAction: { kind: "radio", name: "Ja, tommel opp" },
+    rating: 2,
+    textFieldId: "feedback",
+    textPrompt: "Har du forslag til forbedringer?",
+  }),
+  ratingScenario({
+    id: "rating-stars",
+    facet: "stars",
+    ratingFieldId: "stars",
+    ratingAction: {
+      kind: "radio",
+      name: "4 av 5 stjerner. Bra",
+    },
+    rating: 4,
+    textFieldId: "feedback",
+    textPrompt: "Legg gjerne til en begrunnelse",
+  }),
+  ratingScenario({
+    id: "rating-nps",
+    facet: "nps",
+    ratingFieldId: "nps",
+    ratingAction: { kind: "radio", name: "8 av 10" },
+    rating: 8,
+    textFieldId: "reason",
+    textPrompt: "Legg gjerne til en begrunnelse",
+  }),
+  {
+    id: "discovery",
+    surveyType: "discovery",
+    dashboardType: "Discovery",
+    facets: ["text", "singleChoice", "pages", "visibleIf"],
+    actions: [
+      {
+        kind: "textbox",
+        name: "Hva kom du hit for å gjøre i dag?",
+        suffix: "-task",
+      },
+      { kind: "next" },
+      { kind: "radio", name: "Delvis" },
+      { kind: "next" },
+      { kind: "textbox", name: "Hva hindret deg?", suffix: "-blocker" },
+    ],
+    fields: [
+      { fieldId: "task", fieldType: "TEXT" },
+      { fieldId: "success", fieldType: "SINGLE_CHOICE" },
+      { fieldId: "blocker", fieldType: "TEXT" },
+    ],
+    expectedAnswers: (marker) => [
+      textAnswer("task", `${marker}-task`),
+      singleChoiceAnswer("success", "partial"),
+      textAnswer("blocker", `${marker}-blocker`),
+    ],
+    dashboardValues: (marker) => [
+      `${marker}-task`,
+      "Delvis",
+      `${marker}-blocker`,
+    ],
+  },
+  {
+    id: "top-tasks",
+    surveyType: "topTasks",
+    dashboardType: "Top Tasks",
+    facets: ["singleChoice", "text", "pages", "visibleIf"],
+    actions: [
+      { kind: "radio", name: "Noe annet" },
+      { kind: "next" },
+      {
+        kind: "textbox",
+        name: "Beskriv hva du prøvde å gjøre",
+        suffix: "-other-task",
+      },
+      { kind: "next" },
+      { kind: "radio", name: "Delvis" },
+      { kind: "next" },
+      { kind: "textbox", name: "Hva hindret deg?", suffix: "-blocker" },
+    ],
+    fields: [
+      { fieldId: "task", fieldType: "SINGLE_CHOICE" },
+      { fieldId: "otherTask", fieldType: "TEXT" },
+      { fieldId: "success", fieldType: "SINGLE_CHOICE" },
+      { fieldId: "blocker", fieldType: "TEXT" },
+    ],
+    expectedAnswers: (marker) => [
+      singleChoiceAnswer("task", "other"),
+      textAnswer("otherTask", `${marker}-other-task`),
+      singleChoiceAnswer("success", "partial"),
+      textAnswer("blocker", `${marker}-blocker`),
+    ],
+    dashboardValues: (marker) => [
+      "Noe annet",
+      `${marker}-other-task`,
+      "Delvis",
+      `${marker}-blocker`,
+    ],
+  },
+  taskPriorityScenario("task-priority-checkbox", "checkbox", [
+    { kind: "checkbox", name: "Søke om en ytelse" },
+    { kind: "checkbox", name: "Sjekke status" },
+  ]),
+  taskPriorityScenario("task-priority-combobox", "combobox", [
+    {
+      kind: "combobox",
+      name: "Hvilke oppgaver er viktigst for deg?",
+      options: ["Søke om en ytelse", "Sjekke status"],
+    },
+  ]),
+  {
+    id: "custom-field-matrix",
+    surveyType: "custom",
+    dashboardType: "Custom",
+    facets: ["text", "singleChoice", "multiChoice", "checkbox"],
+    actions: [
+      {
+        kind: "textbox",
+        name: "Hva vil du teste i dag?",
+        suffix: "-custom",
+      },
+      { kind: "radio", name: "Web" },
+      { kind: "checkbox", name: "Tydelig" },
+      { kind: "checkbox", name: "Trygg" },
+    ],
+    fields: [
+      { fieldId: "customText", fieldType: "TEXT" },
+      { fieldId: "customSingle", fieldType: "SINGLE_CHOICE" },
+      { fieldId: "customMulti", fieldType: "MULTI_CHOICE" },
+    ],
+    expectedAnswers: (marker) => [
+      textAnswer("customText", `${marker}-custom`),
+      singleChoiceAnswer("customSingle", "web"),
+      multiChoiceAnswer("customMulti", ["clear", "safe"]),
+    ],
+    dashboardValues: (marker) => [
+      `${marker}-custom`,
+      "Web",
+      "Tydelig",
+      "Trygg",
+    ],
+  },
+  {
+    id: "pages-multi-question",
+    surveyType: "custom",
+    dashboardType: "Custom",
+    facets: ["pages", "multi-question", "visibleIf", "stars"],
+    actions: [
+      { kind: "radio", name: "4 av 5 stjerner. Bra" },
+      {
+        kind: "textbox",
+        name: "Hva la du særlig merke til?",
+        suffix: "-noticed",
+      },
+      { kind: "next" },
+      { kind: "radio", name: "Ja" },
+      {
+        kind: "textbox",
+        name: "Hva bør vi forbedre?",
+        suffix: "-improvement",
+      },
+    ],
+    fields: [
+      ratingField("pageRating", "stars", 5),
+      { fieldId: "pageReason", fieldType: "TEXT" },
+      { fieldId: "pageFollowUp", fieldType: "SINGLE_CHOICE" },
+      { fieldId: "pageImprovement", fieldType: "TEXT" },
+    ],
+    expectedAnswers: (marker) => [
+      ratingAnswer("pageRating", "stars", 5, 4),
+      textAnswer("pageReason", `${marker}-noticed`),
+      singleChoiceAnswer("pageFollowUp", "yes"),
+      textAnswer("pageImprovement", `${marker}-improvement`),
+    ],
+    dashboardValues: (marker) => [
+      `${marker}-noticed`,
+      "Ja",
+      `${marker}-improvement`,
+    ],
+  },
+];
 
 test("the full chain produces one terminal release-verification report", async ({
   page,
 }, testInfo) => {
+  test.setTimeout(180_000);
   const startedAt = new Date().toISOString();
   const failures: string[] = [];
+  let matrixEvidence: MatrixScenarioEvidence[] = [];
   let localProxyStatus: "passed" | "failed" = "passed";
   let controlledReport: FullChainReport | null = null;
 
   try {
-    await verifyLocalProxyRoundTrip(page);
+    matrixEvidence = await verifyLocalSurveyMatrix(page);
+    const matrixFailures = matrixEvidence.filter(
+      ({ status }) => status === "failed",
+    );
+    if (matrixFailures.length > 0) {
+      localProxyStatus = "failed";
+      failures.push(
+        ...matrixFailures.map(
+          ({ scenarioId, detail }) =>
+            `survey-contract-matrix/${scenarioId}: ${detail}`,
+        ),
+      );
+    }
   } catch (error) {
     localProxyStatus = "failed";
-    failures.push(`local-submission-proxy: ${errorMessage(error)}`);
+    failures.push(`survey-contract-matrix: ${errorMessage(error)}`);
   }
 
   try {
@@ -61,16 +361,30 @@ test("the full chain produces one terminal release-verification report", async (
   const finishedAt = new Date().toISOString();
   const report = controlledReport ?? createFailedReport(startedAt, finishedAt);
   report.coverage.localSubmissionProxy = localProxyStatus;
+  report.coverage.surveyContractMatrix = localProxyStatus;
   report.checks.push({
     id: "local-submission-proxy",
     status: localProxyStatus,
     completedAt: finishedAt,
     detail:
       localProxyStatus === "passed"
-        ? "Widget → lokal proxy → API → Postgres → dashboard er verifisert"
+        ? "Widget → lokal proxy → API → Postgres → dashboard er verifisert for hele matrisen"
         : "Den lokale proxy-rundturen feilet",
   });
-  report.automation = { runner: "playwright", failures };
+  report.checks.push({
+    id: "survey-contract-matrix",
+    status: localProxyStatus,
+    completedAt: finishedAt,
+    detail:
+      localProxyStatus === "passed"
+        ? `${matrixEvidence.length}/${MATRIX_SCENARIOS.length} survey- og feltvarianter er verifisert`
+        : `${matrixEvidence.filter(({ status }) => status === "passed").length}/${MATRIX_SCENARIOS.length} survey- og feltvarianter er verifisert`,
+  });
+  report.automation = {
+    runner: "playwright",
+    failures,
+    matrix: matrixEvidence,
+  };
   report.generatedAt = finishedAt;
   report.finishedAt = finishedAt;
   if (failures.length > 0 || report.outcome !== "passed") {
@@ -82,28 +396,315 @@ test("the full chain produces one terminal release-verification report", async (
   expect(report.outcome).toBe("passed");
 });
 
-async function verifyLocalProxyRoundTrip(page: Page): Promise<void> {
-  const feedback = `full-chain-${Date.now()}`;
+async function verifyLocalSurveyMatrix(
+  page: Page,
+): Promise<MatrixScenarioEvidence[]> {
   await page.goto(DEMO_URL);
   await expect(
     page.getByRole("heading", { name: "Full-chain testbenk" }),
   ).toBeVisible();
+  const scenarioSelect = page.getByRole("combobox", {
+    name: "Survey- og feltvariant",
+  });
+  const renderedScenarioIds = await scenarioSelect
+    .locator("option")
+    .evaluateAll((options) =>
+      options.map((option) => (option as HTMLOptionElement).value),
+    );
+  expect(renderedScenarioIds).toEqual(MATRIX_SCENARIOS.map(({ id }) => id));
 
-  await page.getByRole("radio", { name: "4. Bra" }).click();
-  await page
-    .getByRole("textbox", { name: "Har du andre tilbakemeldinger?" })
-    .fill(feedback);
-  await page.getByRole("button", { name: "Send" }).click();
-  await expect(
-    page.getByRole("heading", { name: "Signal lagret" }),
-  ).toBeVisible();
+  const evidence: MatrixScenarioEvidence[] = [];
+  for (const scenario of MATRIX_SCENARIOS) {
+    try {
+      evidence.push(await verifyMatrixScenario(page, scenario));
+    } catch (error) {
+      evidence.push({
+        scenarioId: scenario.id,
+        surveyId: `local-demo-${scenario.id}`,
+        surveyType: scenario.surveyType,
+        facets: scenario.facets,
+        status: "failed",
+        receiptId:
+          error instanceof MatrixScenarioFailure ? error.receiptId : null,
+        detail: errorMessage(error),
+      });
+    }
+  }
+  return evidence;
+}
 
-  await page.goto(
-    `${DASHBOARD_URL}/feedback?team=local-dev&app=local-app&surveyId=local-demo-rating-emoji&dateMode=auto`,
-  );
-  await expect(
-    page.getByRole("table").getByText(feedback, { exact: true }).first(),
-  ).toBeVisible();
+async function verifyMatrixScenario(
+  page: Page,
+  scenario: MatrixScenario,
+): Promise<MatrixScenarioEvidence> {
+  const surveyId = `local-demo-${scenario.id}`;
+  const marker = `matrix-${scenario.id}-${Date.now()}`;
+  let receiptId: string | null = null;
+  try {
+    await page.goto(DEMO_URL);
+    await page
+      .getByRole("combobox", { name: "Survey- og feltvariant" })
+      .selectOption(scenario.id);
+    await expect(page.getByText(surveyId, { exact: true })).toBeVisible();
+
+    const widget = page.getByRole("complementary", {
+      name: "Tilbakemeldingspanel",
+    });
+    for (const action of scenario.actions) {
+      await performMatrixAction(page, widget, action, marker);
+    }
+
+    const responsePromise = page.waitForResponse(
+      (response) =>
+        response.request().method() === "POST" &&
+        response.url().includes("/api/azure/v1/feedback"),
+    );
+    await widget.getByRole("button", { name: "Send", exact: true }).click();
+    const response = await responsePromise;
+    expect(response.ok()).toBe(true);
+    const receipt = (await response.json()) as { id?: string };
+    expect(receipt.id).toEqual(expect.any(String));
+    receiptId = receipt.id ?? null;
+    const payload = response.request().postDataJSON() as TransportPayload;
+    assertTransportPayload(payload, scenario, surveyId, marker);
+
+    await expect(
+      page.getByRole("heading", { name: "Signal lagret" }),
+    ).toBeVisible();
+
+    await page.goto(
+      `${DASHBOARD_URL}/feedback?team=local-dev&app=local-app&surveyId=${encodeURIComponent(surveyId)}&dateMode=auto`,
+    );
+    await expect(page.getByText(/Viser \d+ svar for/)).toBeVisible();
+    const feedbackTable = page.getByRole("table");
+    const newestRow = feedbackTable.getByRole("row").nth(1);
+    await expect(newestRow).toBeVisible();
+    await newestRow
+      .getByRole("button", { name: "Utvid rad" })
+      .click({ timeout: 5_000 });
+    const expandedRow = feedbackTable.getByRole("row").nth(2);
+    await expect(expandedRow).toBeVisible();
+    for (const value of scenario.dashboardValues(marker)) {
+      await expect(expandedRow).toContainText(value);
+    }
+
+    await page.goto(
+      `${DASHBOARD_URL}/?team=local-dev&app=local-app&surveyId=${encodeURIComponent(surveyId)}&dateMode=auto`,
+    );
+    await expect(
+      page
+        .locator("main")
+        .getByText(scenario.dashboardType, { exact: true })
+        .first(),
+    ).toBeVisible();
+
+    return {
+      scenarioId: scenario.id,
+      surveyId,
+      surveyType: scenario.surveyType,
+      facets: scenario.facets,
+      status: "passed",
+      receiptId,
+      detail: "Payload, lagring, feedbackrad og dashboardtype er verifisert",
+    };
+  } catch (error) {
+    throw new MatrixScenarioFailure(errorMessage(error), receiptId);
+  }
+}
+
+async function performMatrixAction(
+  page: Page,
+  widget: Locator,
+  action: MatrixAction,
+  marker: string,
+): Promise<void> {
+  switch (action.kind) {
+    case "radio":
+      await widget
+        .getByRole("radio", { name: action.name })
+        .click({ timeout: 5_000 });
+      return;
+    case "textbox":
+      await widget
+        .getByRole("textbox", { name: action.name })
+        .fill(`${marker}${action.suffix}`, { timeout: 5_000 });
+      return;
+    case "checkbox":
+      await widget
+        .getByRole("checkbox", { name: action.name })
+        .check({ timeout: 5_000 });
+      return;
+    case "combobox": {
+      const combobox = widget.getByRole("combobox", { name: action.name });
+      for (const option of action.options) {
+        await combobox.fill(option, { timeout: 5_000 });
+        await page
+          .getByRole("option", { name: option, exact: true })
+          .click({ timeout: 5_000 });
+      }
+      return;
+    }
+    case "next":
+      await widget
+        .getByRole("button", { name: "Neste", exact: true })
+        .click({ timeout: 5_000 });
+      return;
+  }
+}
+
+function assertTransportPayload(
+  payload: TransportPayload,
+  scenario: MatrixScenario,
+  surveyId: string,
+  marker: string,
+): void {
+  expect(payload).toMatchObject({
+    schemaVersion: 2,
+    surveyId,
+    surveyType: scenario.surveyType,
+    definition: { surveyType: scenario.surveyType },
+    context: {
+      tags: {
+        environment: "local-full-chain",
+        scenario: scenario.id,
+      },
+    },
+  });
+  expect(payload.definition.fields).toHaveLength(scenario.fields.length);
+  for (const expectedField of scenario.fields) {
+    expect(
+      payload.definition.fields.find(
+        ({ fieldId }) => fieldId === expectedField.fieldId,
+      ),
+    ).toMatchObject(expectedField);
+  }
+
+  const expectedAnswers = scenario.expectedAnswers(marker);
+  expect(payload.answers).toHaveLength(expectedAnswers.length);
+  for (const expectedAnswer of expectedAnswers) {
+    expect(
+      payload.answers.find(({ fieldId }) => fieldId === expectedAnswer.fieldId),
+    ).toMatchObject(expectedAnswer);
+  }
+}
+
+function ratingScenario({
+  id,
+  facet,
+  ratingFieldId,
+  ratingAction,
+  rating,
+  textFieldId,
+  textPrompt,
+}: {
+  id: string;
+  facet: "emoji" | "thumbs" | "stars" | "nps";
+  ratingFieldId: string;
+  ratingAction: Extract<MatrixAction, { kind: "radio" }>;
+  rating: number;
+  textFieldId: string;
+  textPrompt: string;
+}): MatrixScenario {
+  const scale = facet === "thumbs" ? 2 : facet === "nps" ? 11 : 5;
+  return {
+    id,
+    surveyType: "rating",
+    dashboardType: "Vurdering",
+    facets: ["rating", facet, "text", "visibleIf"],
+    actions: [
+      ratingAction,
+      {
+        kind: "textbox",
+        name: textPrompt,
+        suffix: `-${facet}`,
+      },
+    ],
+    fields: [
+      ratingField(ratingFieldId, facet, scale),
+      { fieldId: textFieldId, fieldType: "TEXT" },
+    ],
+    expectedAnswers: (marker) => [
+      ratingAnswer(ratingFieldId, facet, scale, rating),
+      textAnswer(textFieldId, `${marker}-${facet}`),
+    ],
+    dashboardValues: (marker) => [`${marker}-${facet}`],
+  };
+}
+
+function taskPriorityScenario(
+  id: string,
+  facet: "checkbox" | "combobox",
+  actions: MatrixAction[],
+): MatrixScenario {
+  return {
+    id,
+    surveyType: "taskPriority",
+    dashboardType: "Task Priority",
+    facets: ["multiChoice", facet],
+    actions,
+    fields: [
+      {
+        fieldId: "priority",
+        fieldType: "MULTI_CHOICE",
+        maxSelections: 3,
+      },
+    ],
+    expectedAnswers: () => [
+      multiChoiceAnswer("priority", [TASK_OPTIONS[0], TASK_OPTIONS[1]]),
+    ],
+    dashboardValues: () => ["Søke om en ytelse", "Sjekke status"],
+  };
+}
+
+function ratingField(
+  fieldId: string,
+  ratingVariant: "emoji" | "thumbs" | "stars" | "nps",
+  ratingScale: number,
+): TransportFieldDefinition {
+  return { fieldId, fieldType: "RATING", ratingVariant, ratingScale };
+}
+
+function ratingAnswer(
+  fieldId: string,
+  ratingVariant: "emoji" | "thumbs" | "stars" | "nps",
+  ratingScale: number,
+  rating: number,
+): TransportAnswer {
+  return {
+    fieldId,
+    fieldType: "RATING",
+    value: { type: "rating", rating, ratingVariant, ratingScale },
+  };
+}
+
+function textAnswer(fieldId: string, text: string): TransportAnswer {
+  return {
+    fieldId,
+    fieldType: "TEXT",
+    value: { type: "text", text },
+  };
+}
+
+function singleChoiceAnswer(
+  fieldId: string,
+  selectedOptionId: string,
+): TransportAnswer {
+  return {
+    fieldId,
+    fieldType: "SINGLE_CHOICE",
+    value: { type: "singleChoice", selectedOptionId },
+  };
+}
+
+function multiChoiceAnswer(
+  fieldId: string,
+  selectedOptionIds: string[],
+): TransportAnswer {
+  return {
+    fieldId,
+    fieldType: "MULTI_CHOICE",
+    value: { type: "multiChoice", selectedOptionIds },
+  };
 }
 
 async function verifyControlledDashboardRoundTrip(

--- a/docs/runbooks/nav-wide-rollout.md
+++ b/docs/runbooks/nav-wide-rollout.md
@@ -10,7 +10,7 @@ brukes som en måte å ta produktbeslutningen på.
 | --- | --- | --- |
 | Historiske surveys i dashboardet | Klar | Automatisk periode velges fra surveyens faktiske datointervall; eksplisitt valgt periode beholdes |
 | Pakket `@navikt/lumi-survey` | Automatisert | `pnpm run verify:lumi-survey-consumer` installerer tarballen i en ren konsument og kjører typecheck + Vite-build |
-| Widget → proxy → API → Postgres → dashboard | Automatisert | `pnpm run test:full-chain` kjører proxy- og dashboard-rundturen mot en isolert Compose-stack og CI laster opp én aggregert terminalrapport |
+| Widget → proxy → API → Postgres → dashboard | Automatisert | `pnpm run test:full-chain` kjører alle ti stabile survey- og feltvarianter mot en isolert Compose-stack og CI laster opp én aggregert terminalrapport med receipt per scenario |
 | Ekte Azure OBO i dev | Selvbetjent | `/release-verification` kjører team-preflight, startprobe, 15 minutters hold og sluttprobe med eksakt receipt-readback |
 | Innsendingshelse | Instrumentert | `lumi_submissions_total` skiller kanal og utfall; prod varsler på serverfeil og rejection-spike |
 | Hvilke eksisterende surveys som skal fortsette | Avventer | Må avklares før migrering; surveys som skal stoppes migreres ikke |
@@ -49,6 +49,28 @@ CI laster opp `apps/lumi-dashboard/test-results/full-chain` som
 `full-chain-release-verification-<run-id>`, også når testen feiler. Dette gjør
 resultatet lesbart for CI, en agent eller et menneske uten Grafana, NAIS-konsoll
 eller direkte loggtilgang.
+
+### Automatisk kontraktsmatrise
+
+Fullkjedetesten oppdager scenarioene som den lokale testbenken faktisk viser og
+feiler dersom den kjente matrisen driver fra disse. Hvert scenario går gjennom
+den publiserte widgeten, lokal submission-proxy, Lumi API, Postgres og
+dashboardets feedback- og typevisning. V2-definisjonen og alle svar
+sammenlignes før transport; den utvidede feedbackraden sammenlignes etter
+lagring.
+
+Matrisen dekker:
+
+- surveytypene `rating`, `discovery`, `topTasks`, `taskPriority` og `custom`
+- ratingvariantene emoji, tommel, stjerner og NPS
+- tekst, enkeltvalg, flervalg med avkryssing og flervalg med komboboks
+- `SurveyDocumentV1` med flere sider, flere spørsmål per side og `visibleIf`
+
+`DATE` finnes i den bredere API-kontrakten for lagrede svar, men er ikke en
+spørsmålstype som `@navikt/lumi-survey` kan authorere eller rendre. Den er derfor
+ikke del av widgetens støttede kontraktsmatrise. Hvis dato skal bli en offentlig
+widgetfunksjon, må renderer, authoring, transport og fullkjedescenario legges til
+samlet.
 
 ## Beslutningstabell for neste uke
 

--- a/packages/lumi-survey/CHANGELOG.md
+++ b/packages/lumi-survey/CHANGELOG.md
@@ -6,6 +6,21 @@ This project follows SemVer.
 
 ## [Unreleased]
 
+## [2.1.1] - 2026-08-22
+
+### Fixed
+
+- Star-rating icons now keep a stable pointer target while hover and focus
+  feedback changes. In Chromium, swapping the icon element during a real
+  pointer interaction could leave the star focused but unchecked, so a
+  required star question could not be submitted.
+
+### Internal
+
+- The local full-chain verification now exercises every stable survey and
+  field scenario from the test bench and records per-scenario receipts in the
+  release evidence.
+
 ## [2.1.0] - 2026-08-20
 
 ### Added

--- a/packages/lumi-survey/package.json
+++ b/packages/lumi-survey/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@navikt/lumi-survey",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "private": false,
   "description": "Aksel-based React widget for configurable NAV Lumi surveys.",
   "type": "module",

--- a/packages/lumi-survey/src/components/questions/rating/StarRating.tsx
+++ b/packages/lumi-survey/src/components/questions/rating/StarRating.tsx
@@ -150,25 +150,39 @@ export function StarRating({
                     minWidth: 0,
                   }}
                 >
-                  {isFilled ? (
+                  <span
+                    aria-hidden
+                    style={{
+                      display: "inline-block",
+                      width: "2.5rem",
+                      height: "2.5rem",
+                      position: "relative",
+                      pointerEvents: "none",
+                    }}
+                  >
                     <StarFillIcon
                       aria-hidden
                       style={{
+                        position: "absolute",
+                        inset: 0,
                         width: "2.5rem",
                         height: "2.5rem",
                         color: "var(--ax-text-warning)",
+                        opacity: isFilled ? 1 : 0,
                       }}
                     />
-                  ) : (
                     <StarIcon
                       aria-hidden
                       style={{
+                        position: "absolute",
+                        inset: 0,
                         width: "2.5rem",
                         height: "2.5rem",
                         color: "var(--ax-text-neutral-subtle)",
+                        opacity: isFilled ? 0 : 1,
                       }}
                     />
-                  )}
+                  </span>
                 </button>
               );
             })}


### PR DESCRIPTION
## Hva

- kjører alle 10 stabile survey- og feltvarianter gjennom widget, lokal submission-proxy, API, Postgres og dashboard
- validerer V2-definisjon og typede svar før transport, og leser verdiene tilbake fra utvidet feedbackrad
- feiler ved drift mellom testbenken og kontraktsmatrisen og legger receipt per scenario i terminalrapporten
- gjør stjerneratingens pointer-target stabilt; den nye Chromium-testen avdekket at ikonbytte under hover/fokus kunne gi fokusert, men ikke valgt stjerne
- dokumenterer dekningsgrensen: DATE er lagringskontrakt, ikke støttet widgetfelt
- bumper lumi-survey til 2.1.1

## Verifisert

- pnpm run lint
- pnpm run typecheck
- pnpm test (77 filer / 614 tester)
- pnpm --filter @navikt/lumi-survey run test (28 filer / 432 tester)
- pnpm run test:full-chain (10/10 scenarier, alle med receipt)
- pnpm run verify:lumi-survey
- pnpm run verify:lumi-survey-consumer
- pnpm run check:lumi-survey-release-drift
- pnpm run test:release-guards (17/17)
- git diff --check

## Avgrensning

Dette verifiserer kjente widgetkontrakter og den lokale proxykjeden. Ekte Azure OBO i dev er allerede verifisert separat med to receipts og 15 minutters hold. Trygdeetaten-proxy og NAV-wide release står fortsatt som ikke testet/pending til vi har valgt faktisk canary-app.

PR #510 bruker også versjon 2.1.1. Hvis den merges først, må denne rebases og få neste patchversjon. Ingen automerge er aktivert.