### PR TITLE
Rett kontrasten i Top Tasks-tooltipen

### DIFF
--- a/apps/lumi-dashboard/app/components/shared/Charts/Charts.module.css
+++ b/apps/lumi-dashboard/app/components/shared/Charts/Charts.module.css
@@ -234,15 +234,15 @@
 }
 
 .tooltipRatingGood {
-  color: #34d399;
+  color: var(--ax-text-success);
 }
 
 .tooltipRatingMedium {
-  color: #fbbf24;
+  color: var(--ax-text-warning);
 }
 
 .tooltipRatingLow {
-  color: #f87171;
+  color: var(--ax-text-danger);
 }
 
 /* Rating bar rows */


### PR DESCRIPTION
## Hva
- bruker Aksels semantiske teksttokens for bra-, overvåk- og krisesonen i Top Tasks-tooltipen
- lar fargene følge både lyst og mørkt tema

## Hvorfor
De tidligere pastellfargene ga bare 1,7–2,8:1 kontrast mot lys tooltipbakgrunn. Endringen påvirker kun presentasjon, ikke data eller soneklassifisering.

## Verifisert
- faktisk UI med mockdata: 15,0–15,1:1 i lyst tema
- faktisk UI med mockdata: 10,9–11,0:1 i mørkt tema
- pnpm run lint
- pnpm run typecheck
- pnpm test: 2 delte tester og 614 dashboardtester
- git diff --check

Closes #496