### PR TITLE
fix: gi dashboarddiagrammer tekstalternativer

### DIFF
--- a/apps/lumi-dashboard/app/components/shared/Charts/SurveyTypeDistribution.tsx
+++ b/apps/lumi-dashboard/app/components/shared/Charts/SurveyTypeDistribution.tsx
@@ -97,6 +97,8 @@ export function SurveyTypeDistribution({
         data={data}
         layout="vertical"
         margin={{ top: 5, right: 30, left: 80, bottom: 5 }}
+        role="img"
+        aria-label={`Søylediagram som viser antall surveys per type: ${data.map((item) => `${item.label} ${item.count}`).join(", ")}`}
       >
         <CartesianGrid strokeDasharray="3 3" opacity={0.1} horizontal={false} />
         <XAxis type="number" hide />

--- a/apps/lumi-dashboard/app/components/shared/Charts/TaskQuadrantChart.tsx
+++ b/apps/lumi-dashboard/app/components/shared/Charts/TaskQuadrantChart.tsx
@@ -183,7 +183,11 @@ export function TaskQuadrantChart({
       minWidth={2}
       minHeight={2}
     >
-      <ScatterChart margin={{ top: 20, right: 30, left: 20, bottom: 20 }}>
+      <ScatterChart
+        margin={{ top: 20, right: 30, left: 20, bottom: 20 }}
+        role="img"
+        aria-label={`Punktdiagram som viser volum og suksessrate for ${data.length} oppgaver. Samme data vises i tabellen.`}
+      >
         {/* Quadrant background zones */}
         {/* Bottom-right: CRISIS (high volume, low success) */}
         <ReferenceArea

--- a/apps/lumi-dashboard/app/components/shared/Charts/__tests__/ChartAccessibility.test.tsx
+++ b/apps/lumi-dashboard/app/components/shared/Charts/__tests__/ChartAccessibility.test.tsx
@@ -1,0 +1,111 @@
+import { render, screen } from "@testing-library/react";
+import type { ReactNode, SVGProps } from "react";
+import { describe, expect, it, vi } from "vitest";
+import { SurveyTypeDistribution } from "../SurveyTypeDistribution";
+import { TaskQuadrantChart } from "../TaskQuadrantChart";
+
+const { surveyTypeDistribution, topTasksStats } = vi.hoisted(() => ({
+  surveyTypeDistribution: {
+    data: {
+      totalSurveys: 3,
+      distribution: [
+        { type: "rating", count: 2, percentage: 67 },
+        { type: "topTasks", count: 1, percentage: 33 },
+      ],
+    },
+    isPending: false,
+  },
+  topTasksStats: {
+    data: {
+      tasks: [
+        {
+          taskId: "task-1",
+          task: "Søke om sykepenger",
+          totalCount: 80,
+          successRate: 0.75,
+        },
+        {
+          taskId: "task-2",
+          task: "Finne vedtak",
+          totalCount: 40,
+          successRate: 0.6,
+        },
+      ],
+    },
+    isPending: false,
+  },
+}));
+
+vi.mock("~/hooks/useSurveyTypeDistribution", () => ({
+  useSurveyTypeDistribution: () => surveyTypeDistribution,
+}));
+
+vi.mock("~/hooks/useTopTasksStats", () => ({
+  useTopTasksStats: () => topTasksStats,
+}));
+
+vi.mock("~/context/ThemeContext", () => ({
+  useTheme: () => ({ theme: "light" }),
+}));
+
+vi.mock(
+  "~/components/shared/Charts/ResponsiveContainerWithInitialSize",
+  () => ({
+    ResponsiveContainerWithInitialSize: ({
+      children,
+    }: {
+      children: ReactNode;
+    }) => <>{children}</>,
+  }),
+);
+
+vi.mock("recharts", () => {
+  const Chart = ({
+    children,
+    role,
+    "aria-label": ariaLabel,
+    ...props
+  }: SVGProps<SVGSVGElement>) => (
+    <svg {...props} role={role} aria-label={ariaLabel}>
+      {children}
+    </svg>
+  );
+  const Empty = () => null;
+
+  return {
+    Bar: Empty,
+    BarChart: Chart,
+    CartesianGrid: Empty,
+    Rectangle: Empty,
+    ReferenceArea: Empty,
+    ReferenceLine: Empty,
+    Scatter: Empty,
+    ScatterChart: Chart,
+    Tooltip: Empty,
+    XAxis: Empty,
+    YAxis: Empty,
+    ZAxis: Empty,
+  };
+});
+
+describe("chart text alternatives", () => {
+  it("summarizes the survey type distribution", () => {
+    render(<SurveyTypeDistribution />);
+
+    expect(
+      screen.getByRole("img", {
+        name: "Søylediagram som viser antall surveys per type: Vurdering 2, Top Tasks 1",
+      }),
+    ).toBeInTheDocument();
+  });
+
+  it("names the task quadrant and points to the equivalent table", () => {
+    render(<TaskQuadrantChart />);
+
+    expect(
+      screen.getByRole("img", {
+        name: "Punktdiagram som viser volum og suksessrate for 2 oppgaver. Samme data vises i tabellen.",
+      }),
+    ).toBeInTheDocument();
+  });
+});

--- a/apps/lumi-dashboard/e2e/survey-views.spec.ts
+++ b/apps/lumi-dashboard/e2e/survey-views.spec.ts
@@ -18,6 +18,11 @@ test.describe("Survey Views", () => {
       await expect(
         page.getByRole("heading", { name: "Det som hindrer brukerne" }),
       ).toBeVisible();
+      await expect(
+        page.getByRole("img", {
+          name: /punktdiagram som viser volum og suksessrate for \d+ oppgaver/i,
+        }),
+      ).toBeVisible();
       const blockerPhrase = page
         .getByRole("link", { name: /tilbakemeldinger med uttrykket/i })
         .first();


### PR DESCRIPTION
## Sammendrag
- gir Survey-typer-diagrammet et dynamisk tekstalternativ med type og antall
- gir oppgavekvadranten et tilgjengelig navn og peker til den ekvivalente tabellen
- legger til komponentregresjoner og en faktisk Playwright-assert for Top Tasks

## Verifisering
- `pnpm run lint`
- `pnpm run typecheck`
- `pnpm test` (616 tester)
- `pnpm --filter lumi-dashboard exec playwright test e2e/survey-views.spec.ts` (12 tester)

Closes #500