### PR TITLE
fix: korriger overskriftshierarkiet i dashboardet

### DIFF
--- a/apps/lumi-dashboard/app/components/dashboard/ChartCard.tsx
+++ b/apps/lumi-dashboard/app/components/dashboard/ChartCard.tsx
@@ -27,7 +27,9 @@ export function ChartCard({
     <DashboardCard padding={{ xs: "space-16", md: "space-24" }}>
       <VStack gap="space-16">
         <VStack gap="space-4">
-          <Heading size="small">{title}</Heading>
+          <Heading size="small" level="2">
+            {title}
+          </Heading>
           {subtitle && <span className={styles.subtitle}>{subtitle}</span>}
         </VStack>
         <div className={chartHeightClass}>{children}</div>

--- a/apps/lumi-dashboard/app/components/dashboard/SegmentBreakdown.tsx
+++ b/apps/lumi-dashboard/app/components/dashboard/SegmentBreakdown.tsx
@@ -51,7 +51,7 @@ export function SegmentBreakdown({
 
   return (
     <VStack gap="space-16" marginBlock="space-24 space-16">
-      <Heading level="3" size="small">
+      <Heading level="2" size="small">
         Segmentering
       </Heading>
 
@@ -93,7 +93,7 @@ function SegmentCard({ segmentKey, values, onValueClick }: SegmentCardProps) {
   return (
     <DashboardCard padding={{ xs: "space-16", md: "space-24" }}>
       <VStack gap="space-12">
-        <Heading level="4" size="xsmall">
+        <Heading level="3" size="xsmall">
           {label}
         </Heading>
         <VStack gap="space-4">

--- a/apps/lumi-dashboard/app/components/dashboard/TPI/index.tsx
+++ b/apps/lumi-dashboard/app/components/dashboard/TPI/index.tsx
@@ -89,7 +89,9 @@ export function TPIDashboard({ data }: TPIDashboardProps) {
             <span className={styles.headerIcon}>
               <ThumbUpIcon fontSize="1.25rem" aria-hidden />
             </span>
-            <Heading size="small">TPI per oppgave</Heading>
+            <Heading size="small" level="2">
+              TPI per oppgave
+            </Heading>
           </HStack>
           <BodyShort
             size="small"

--- a/apps/lumi-dashboard/app/components/dashboard/sections/FieldStats/DeviceBreakdownSection.tsx
+++ b/apps/lumi-dashboard/app/components/dashboard/sections/FieldStats/DeviceBreakdownSection.tsx
@@ -17,7 +17,9 @@ export function DeviceBreakdownSection({
   return (
     <DashboardCard padding={{ xs: "space-16", md: "space-24" }}>
       <VStack gap="space-16">
-        <Heading size="small">Enheter</Heading>
+        <Heading size="small" level="2">
+          Enheter
+        </Heading>
         <DeviceBreakdownChart showRating={showRating} />
       </VStack>
     </DashboardCard>

--- a/apps/lumi-dashboard/app/components/dashboard/sections/FieldStats/index.tsx
+++ b/apps/lumi-dashboard/app/components/dashboard/sections/FieldStats/index.tsx
@@ -30,7 +30,7 @@ export function FieldStatsSection() {
       gap="space-16"
       marginBlock="space-24 space-16"
     >
-      <Heading level="3" size="small">
+      <Heading level="2" size="small">
         Statistikk per felt
       </Heading>
 

--- a/apps/lumi-dashboard/app/components/dashboard/sections/Timeline/index.tsx
+++ b/apps/lumi-dashboard/app/components/dashboard/sections/Timeline/index.tsx
@@ -29,7 +29,9 @@ export function TimelineSection({
   return (
     <DashboardCard padding={{ xs: "space-12", md: "space-16" }}>
       <VStack gap="space-12">
-        <Heading size="small">{title}</Heading>
+        <Heading size="small" level="2">
+          {title}
+        </Heading>
         <div className={styles.chartContainer}>
           {variant === "topTasks" ? (
             <TopTasksTimelineChart />

--- a/apps/lumi-dashboard/app/components/dashboard/sections/UrgentUrls/index.tsx
+++ b/apps/lumi-dashboard/app/components/dashboard/sections/UrgentUrls/index.tsx
@@ -37,7 +37,7 @@ export function UrgentUrls() {
         borderWidth="0 0 1 0"
         borderColor="neutral-subtle"
       >
-        <Heading size="small" className={styles.titleRow}>
+        <Heading size="small" level="2" className={styles.titleRow}>
           <LinkIcon aria-hidden /> Sider med lavest score
         </Heading>
       </Box>

--- a/apps/lumi-dashboard/app/components/dashboard/views/Overview/Dashboard.tsx
+++ b/apps/lumi-dashboard/app/components/dashboard/views/Overview/Dashboard.tsx
@@ -23,7 +23,9 @@ export function OverviewDashboard() {
       <DashboardGrid columns={{ xs: 1, md: 3 }}>
         <DashboardCard padding={{ xs: "space-16", md: "space-24" }}>
           <VStack gap="space-16">
-            <Heading size="small">Tilbakemeldinger per app</Heading>
+            <Heading size="small" level="2">
+              Tilbakemeldinger per app
+            </Heading>
             <div className={styles.chartContainer}>
               <TopAppsChart />
             </div>
@@ -32,7 +34,9 @@ export function OverviewDashboard() {
 
         <DashboardCard padding={{ xs: "space-16", md: "space-24" }}>
           <VStack gap="space-16">
-            <Heading size="small">Enheter</Heading>
+            <Heading size="small" level="2">
+              Enheter
+            </Heading>
             <div className={styles.chartContainer}>
               <DeviceBreakdownChart showScreenResolution={false} />
             </div>
@@ -41,7 +45,9 @@ export function OverviewDashboard() {
 
         <DashboardCard padding={{ xs: "space-16", md: "space-24" }}>
           <VStack gap="space-16">
-            <Heading size="small">Survey-typer</Heading>
+            <Heading size="small" level="2">
+              Survey-typer
+            </Heading>
             <div className={styles.chartContainer}>
               <SurveyTypeDistribution height="100%" />
             </div>

--- a/apps/lumi-dashboard/app/components/dashboard/views/Rating/Dashboard.tsx
+++ b/apps/lumi-dashboard/app/components/dashboard/views/Rating/Dashboard.tsx
@@ -143,7 +143,9 @@ export function RatingDashboard({
           <DashboardCard padding={{ xs: "space-12", md: "space-16" }}>
             <VStack gap="space-12">
               <HStack justify="space-between" align="center" wrap gap="space-8">
-                <Heading size="small">Gjennomsnittlig vurdering</Heading>
+                <Heading size="small" level="2">
+                  Gjennomsnittlig vurdering
+                </Heading>
                 <Button
                   variant="secondary"
                   size="small"

--- a/apps/lumi-dashboard/app/components/dashboard/views/TaskPriority/index.tsx
+++ b/apps/lumi-dashboard/app/components/dashboard/views/TaskPriority/index.tsx
@@ -64,7 +64,9 @@ export function TaskPriorityAnalysis({ data }: TaskPriorityAnalysisProps) {
             <span className={styles.headerIcon}>
               <TasklistIcon fontSize="1.25rem" aria-hidden />
             </span>
-            <Heading size="small">Task Priority - "Long Neck"</Heading>
+            <Heading size="small" level="2">
+              Task Priority - "Long Neck"
+            </Heading>
           </HStack>
           <BodyShort
             size="small"

--- a/apps/lumi-dashboard/app/components/dashboard/views/TopTasks/Guide.tsx
+++ b/apps/lumi-dashboard/app/components/dashboard/views/TopTasks/Guide.tsx
@@ -28,7 +28,9 @@ export function TopTasksGuide() {
           <span className={styles.headerIcon}>
             <InformationIcon fontSize="1.25rem" aria-hidden />
           </span>
-          <Heading size="small">Top Tasks Guide</Heading>
+          <Heading size="small" level="2">
+            Top Tasks Guide
+          </Heading>
         </HStack>
         <BodyShort size="small" textColor="subtle" className={styles.introText}>
           Forstå metodikken og metrikker

--- a/apps/lumi-dashboard/app/components/dashboard/views/TopTasks/Overview.tsx
+++ b/apps/lumi-dashboard/app/components/dashboard/views/TopTasks/Overview.tsx
@@ -82,7 +82,9 @@ export function TopTasksOverview() {
       <TimelineSection title="Suksessrate over tid" variant="topTasks" />
       <DashboardCard padding={{ xs: "space-16", md: "space-24" }}>
         <Box paddingBlock="space-0 space-16">
-          <Heading size="small">Oppgavekvadrant</Heading>
+          <Heading size="small" level="2">
+            Oppgavekvadrant
+          </Heading>
           <BodyShort size="small" className={styles.quadrantDescription}>
             Volum vs suksessrate. Klikk på et punkt for å filtrere hele
             dashboardet.
@@ -101,7 +103,7 @@ export function TopTasksOverview() {
           borderWidth="0 0 1 0"
           borderColor="neutral-subtle"
         >
-          <Heading size="small">
+          <Heading size="small" level="2">
             {data.questionText ? `Spørsmål: ${data.questionText}` : "Spørsmål"}
           </Heading>
         </Box>
@@ -158,7 +160,7 @@ export function TopTasksOverview() {
                     content={
                       hasBlockers ? (
                         <div className={styles.expandableContent}>
-                          <Heading size="xsmall" level="4" spacing>
+                          <Heading size="xsmall" level="3" spacing>
                             Årsaker til at oppgaven stoppet
                           </Heading>
                           <VStack gap="space-12">

--- a/apps/lumi-dashboard/app/components/export/Panel.tsx
+++ b/apps/lumi-dashboard/app/components/export/Panel.tsx
@@ -115,7 +115,9 @@ export function ExportPanel() {
       )}
       <DashboardCard padding="space-24">
         <VStack gap="space-16">
-          <Heading size="small">Velg format</Heading>
+          <Heading size="small" level="2">
+            Velg format
+          </Heading>
 
           <RadioGroup
             legend="Eksportformat"
@@ -169,7 +171,9 @@ export function ExportPanel() {
       </DashboardCard>
       <DashboardCard padding="space-24">
         <VStack gap="space-16">
-          <Heading size="small">Aktive filtre</Heading>
+          <Heading size="small" level="2">
+            Aktive filtre
+          </Heading>
           <ActiveFilters params={params} />
           <BodyShort size="small" textColor="subtle">
             Eksporten inkluderer alle svar med metadata (enhet, side, tidspunkt)

--- a/apps/lumi-dashboard/app/components/export/TopTasksExport.tsx
+++ b/apps/lumi-dashboard/app/components/export/TopTasksExport.tsx
@@ -123,7 +123,9 @@ export function TopTasksExport({ data, surveyId }: TopTasksExportProps) {
           <span className={styles.headerIcon}>
             <DownloadIcon fontSize="1.25rem" aria-hidden />
           </span>
-          <Heading size="small">Eksporter data</Heading>
+          <Heading size="small" level="2">
+            Eksporter data
+          </Heading>
         </HStack>
         <BodyShort size="small" textColor="subtle" className={styles.introText}>
           Last ned Top Tasks data for videre analyse

--- a/apps/lumi-dashboard/app/components/shared/PrivacyMaskedNotice/index.tsx
+++ b/apps/lumi-dashboard/app/components/shared/PrivacyMaskedNotice/index.tsx
@@ -14,7 +14,9 @@ export function PrivacyMaskedNotice({ privacy }: PrivacyMaskedNoticeProps) {
     <Box marginBlock="space-16">
       <Alert variant="info">
         <VStack gap="space-4">
-          <Heading size="xsmall">For få svar til å vise statistikk</Heading>
+          <Heading size="xsmall" level="2">
+            For få svar til å vise statistikk
+          </Heading>
           <BodyShort size="small">
             For å beskytte personvernet til de som har svart, kreves det minst{" "}
             {privacy.threshold} svar før statistikk vises. Akkurat nå har denne

--- a/apps/lumi-dashboard/app/routes/export.tsx
+++ b/apps/lumi-dashboard/app/routes/export.tsx
@@ -37,7 +37,9 @@ function ExportPage() {
         as="main"
       >
         <VStack gap="space-24">
-          <Heading size="large">Eksporter data</Heading>
+          <Heading size="large" level="1">
+            Eksporter data
+          </Heading>
 
           <FilterBar showDetails />
 

--- a/apps/lumi-dashboard/app/routes/feedback.tsx
+++ b/apps/lumi-dashboard/app/routes/feedback.tsx
@@ -38,7 +38,9 @@ function FeedbackPage() {
         as="main"
       >
         <VStack gap="space-24">
-          <Heading size="large">Tilbakemeldinger</Heading>
+          <Heading size="large" level="1">
+            Tilbakemeldinger
+          </Heading>
           <FilterBar showDetails />
           <ActiveFiltersChips />
           <FeedbackTable />

--- a/apps/lumi-dashboard/app/routes/index.tsx
+++ b/apps/lumi-dashboard/app/routes/index.tsx
@@ -163,7 +163,9 @@ function DashboardPage() {
           {/* Page header */}
           <HStack justify="space-between" align="center" wrap gap="space-8">
             <HStack align="center" gap={{ xs: "space-8", md: "space-16" }}>
-              <Heading size="large">Dashboard</Heading>
+              <Heading size="large" level="1">
+                Dashboard
+              </Heading>
               {hasSurveyFilter && config && surveyType && (
                 <Tooltip content={SURVEY_DESCRIPTIONS[surveyType]}>
                   <Tag

--- a/apps/lumi-dashboard/app/routes/release-verification.tsx
+++ b/apps/lumi-dashboard/app/routes/release-verification.tsx
@@ -235,7 +235,9 @@ function ReleaseVerificationPage() {
           </HStack>
 
           <VStack gap="space-8">
-            <Heading size="xlarge">Bevis kjeden før utrulling</Heading>
+            <Heading size="xlarge" level="1">
+              Bevis kjeden før utrulling
+            </Heading>
             <BodyLong size="large">
               En kontrollert, syntetisk kjøring gjennom widget, innlogget
               dashboard, Lumi API og Postgres. Resultatet bygges fra eksakt

--- a/apps/lumi-dashboard/e2e/accessibility.spec.ts
+++ b/apps/lumi-dashboard/e2e/accessibility.spec.ts
@@ -145,3 +145,46 @@ test.describe("Screen Reader Announcements", () => {
     expect(header).toBeGreaterThan(0);
   });
 });
+
+test.describe("Heading hierarchy", () => {
+  const dashboardViews = [
+    ["aggregert dashboard", "/?fromDate=2000-01-01"],
+    ["vurderingsdashboard", "/?surveyId=survey-vurdering&fromDate=2000-01-01"],
+    ["Top Tasks-dashboard", "/?surveyId=survey-top-tasks&fromDate=2000-01-01"],
+    ["Discovery-dashboard", "/?surveyId=survey-discovery&fromDate=2000-01-01"],
+    [
+      "Task Priority-dashboard",
+      "/?surveyId=survey-task-priority&fromDate=2000-01-01",
+    ],
+  ] as const;
+
+  for (const [name, url] of dashboardViews) {
+    test(`${name} has one page heading without level skips`, async ({
+      page,
+    }) => {
+      await page.goto(url);
+      await page.waitForLoadState("networkidle");
+
+      const headings = page.locator(
+        "main h1, main h2, main h3, main h4, main h5, main h6",
+      );
+      const levels = await headings.evaluateAll((elements) =>
+        elements
+          // Closed Aksel modals stay mounted, but are not exposed visually or
+          // in the accessibility tree and are not part of the page hierarchy.
+          .filter((element) => element.getClientRects().length > 0)
+          .map((element) => Number(element.tagName.slice(1))),
+      );
+
+      expect(levels.filter((level) => level === 1)).toHaveLength(1);
+      expect(levels[0]).toBe(1);
+
+      for (let index = 1; index < levels.length; index++) {
+        expect(
+          levels[index],
+          `${name} har nivårekkefølgen ${levels.join(" → ")}`,
+        ).toBeLessThanOrEqual(levels[index - 1] + 1);
+      }
+    });
+  }
+});

--- a/apps/lumi-dashboard/e2e/accessibility.spec.ts
+++ b/apps/lumi-dashboard/e2e/accessibility.spec.ts
@@ -148,22 +148,47 @@ test.describe("Screen Reader Announcements", () => {
 
 test.describe("Heading hierarchy", () => {
   const dashboardViews = [
-    ["aggregert dashboard", "/?fromDate=2000-01-01"],
-    ["vurderingsdashboard", "/?surveyId=survey-vurdering&fromDate=2000-01-01"],
-    ["Top Tasks-dashboard", "/?surveyId=survey-top-tasks&fromDate=2000-01-01"],
-    ["Discovery-dashboard", "/?surveyId=survey-discovery&fromDate=2000-01-01"],
+    ["aggregert dashboard", "/?fromDate=2000-01-01", "Vurderingsfordeling"],
+    [
+      "vurderingsdashboard",
+      "/?surveyId=survey-vurdering&fromDate=2000-01-01",
+      "Antall tilbakemeldinger",
+    ],
+    [
+      "custom-dashboard",
+      "/?surveyId=survey-custom&fromDate=2000-01-01",
+      "Antall tilbakemeldinger",
+    ],
+    [
+      "Top Tasks-dashboard",
+      "/?surveyId=survey-top-tasks&fromDate=2000-01-01",
+      "Oppgavekvadrant",
+    ],
+    [
+      "Discovery-dashboard",
+      "/?surveyId=survey-discovery&fromDate=2000-01-01",
+      "Det brukerne prøver å gjøre",
+    ],
     [
       "Task Priority-dashboard",
       "/?surveyId=survey-task-priority&fromDate=2000-01-01",
+      'Task Priority - "Long Neck"',
     ],
   ] as const;
 
-  for (const [name, url] of dashboardViews) {
+  for (const [name, url, expectedSection] of dashboardViews) {
     test(`${name} has one page heading without level skips`, async ({
       page,
     }) => {
       await page.goto(url);
       await page.waitForLoadState("networkidle");
+      await expect(
+        page.getByRole("heading", {
+          level: 2,
+          name: expectedSection,
+          exact: true,
+        }),
+      ).toBeVisible({ timeout: 15000 });
 
       const headings = page.locator(
         "main h1, main h2, main h3, main h4, main h5, main h6",


### PR DESCRIPTION
## Sammendrag
- setter eksplisitt `level` på alle Aksel-overskrifter i dashboardet
- bruker én h1 per side, h2 for seksjoner/kort og h3 for underseksjoner
- retter eksisterende nivåhopp i segment- og feltseksjonene
- legger til E2E-regresjon for én eksponert h1 og sammenhengende nivåer i alle surveyvisninger

## Verifisering
- `pnpm run lint`
- `pnpm run typecheck`
- `pnpm test` (616 tester)
- `pnpm --filter lumi-dashboard exec playwright test e2e/accessibility.spec.ts` (13 tester)

Closes #499