### PR TITLE
test: gjør E2E-testen for oppgavefilteret reell

### DIFF
--- a/apps/lumi-dashboard/e2e/task-filter.spec.ts
+++ b/apps/lumi-dashboard/e2e/task-filter.spec.ts
@@ -1,62 +1,43 @@
 import { expect, test } from "@playwright/test";
 
-test.describe("Top Tasks - Task Filter", () => {
-  // This test requires mock data mode to run reliably
-  test.beforeEach(async ({ page }) => {
-    await page.goto("/");
-    // Wait for dashboard to load
-    await expect(page.locator("main")).toBeVisible({ timeout: 15000 });
-  });
+const topTasksDashboard =
+  "/?surveyId=survey-top-tasks&dateMode=fixed&fromDate=2000-01-01&toDate=2099-12-31";
 
+test.describe("Top Tasks - Task Filter", () => {
   test("clicking on task quadrant point updates URL with task filter", async ({
     page,
   }) => {
-    // Navigate to a Top Tasks survey (assumes mock data has one)
-    // First check if we can see the task quadrant
-    const quadrant = page.locator('text="Oppgavekvadrant"');
-
-    // Skip test if not on Top Tasks view (different survey type selected)
-    if (!(await quadrant.isVisible({ timeout: 5000 }).catch(() => false))) {
-      test.skip(true, "Top Tasks view not available");
-      return;
-    }
+    await page.goto(topTasksDashboard);
+    await expect(
+      page.getByRole("heading", { name: "Oppgavekvadrant", exact: true }),
+    ).toBeVisible({ timeout: 15000 });
 
     // Find and click on a scatter point in the quadrant chart
     const scatterChart = page.locator(".recharts-scatter-symbol").first();
+    await expect(scatterChart).toBeVisible({ timeout: 5000 });
+    await scatterChart.click();
 
-    if (await scatterChart.isVisible({ timeout: 5000 }).catch(() => false)) {
-      await scatterChart.click();
-
-      // Check that URL now contains task parameter
-      await expect(page).toHaveURL(/[?&]task=/, { timeout: 5000 });
-
-      // Check that filter chip appears
-      const filterChip = page.locator('text="Oppgave:"');
-      await expect(filterChip).toBeVisible({ timeout: 5000 });
-    }
+    await expect
+      .poll(() => new URL(page.url()).searchParams.get("task"), {
+        timeout: 5000,
+      })
+      .not.toBeNull();
+    await expect(
+      page.getByRole("button", { name: /Fjern filter Oppgave:/ }),
+    ).toBeVisible({ timeout: 5000 });
   });
 
   test("removing task filter chip clears URL parameter", async ({ page }) => {
-    // Set task filter directly in URL (survey-top-tasks is the mock survey ID)
-    await page.goto("/?surveyId=survey-top-tasks&task=TestTask");
-    await expect(page.locator("main")).toBeVisible({ timeout: 15000 });
+    await page.goto(`${topTasksDashboard}&task=lage-oppfolgingsplan`);
+    await expect(
+      page.getByRole("heading", { name: "Oppgavekvadrant", exact: true }),
+    ).toBeVisible({ timeout: 15000 });
 
-    // Wait for URL to stabilize — the period selector adds fromDate/toDate
-    // defaults after initial render. Clicking before that finishes causes a
-    // race where the default-navigation overwrites our removal.
-    await expect
-      .poll(() => new URL(page.url()).searchParams.has("fromDate"), {
-        timeout: 5000,
-      })
-      .toBe(true);
-    await page.waitForLoadState("networkidle");
-
-    // Wait for the chip to render
-    const chipText = page.getByText("Oppgave: TestTask");
-    await expect(chipText).toBeVisible({ timeout: 5000 });
-
-    // Click the remove button using getByRole for reliable interaction
-    await page.getByRole("button", { name: /Fjern filter Oppgave/ }).click();
+    const removeButton = page.getByRole("button", {
+      name: /Fjern filter Oppgave:/,
+    });
+    await expect(removeButton).toBeVisible({ timeout: 5000 });
+    await removeButton.click();
 
     // URL should no longer contain task parameter
     await expect
@@ -67,14 +48,22 @@ test.describe("Top Tasks - Task Filter", () => {
   });
 
   test("task filter persists in URL after page reload", async ({ page }) => {
-    // Navigate with task filter
-    const taskName = "Finne svar på spørsmål";
-    await page.goto(`/?task=${encodeURIComponent(taskName)}`);
+    const taskId = "lage-oppfolgingsplan";
+    const topTasksHeading = page.getByRole("heading", {
+      name: "Oppgavekvadrant",
+      exact: true,
+    });
+    const removeButton = page.getByRole("button", {
+      name: /Fjern filter Oppgave:/,
+    });
+    await page.goto(`${topTasksDashboard}&task=${taskId}`);
+    await expect(topTasksHeading).toBeVisible({ timeout: 15000 });
+    await expect(removeButton).toBeVisible({ timeout: 5000 });
 
-    // Reload page
     await page.reload();
 
-    // Check URL still has task parameter
-    await expect(page).toHaveURL(/[?&]task=/, { timeout: 5000 });
+    await expect(topTasksHeading).toBeVisible({ timeout: 15000 });
+    await expect(removeButton).toBeVisible({ timeout: 5000 });
+    expect(new URL(page.url()).searchParams.get("task")).toBe(taskId);
   });
 });


### PR DESCRIPTION
## Hva\n- navigerer deterministisk til Top Tasks med komplett fast periode\n- fjerner betinget skip og assertions bak synlighetsvakter\n- verifiserer punktvalg, fjernbar filterchip og persistens etter reload\n- venter på ferdig hydrert Top Tasks-visning før interaksjon\n\n## Verifisering\n- før: 1 skipped, 2 passed\n- etter: 3 passed\n- stresstest: 30/30 passed\n- uavhengig re-review: 9/9 passed\n- pnpm run lint\n- pnpm run typecheck\n- pnpm test (78 filer / 616 tester, før siste test-only stabilisering)\n- to pre-merge subagent-reviews godkjent\n\nCloses #498