### PR TITLE
test: inkluder widgettestene i vanlig CI

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "verify:lumi-survey-consumer": "./scripts/verify-lumi-survey-consumer.sh",
     "check:lumi-survey-release-drift": "node scripts/check-lumi-survey-release-drift.mjs",
     "test:release-guards": "node --test scripts/check-lumi-survey-release-drift.test.mjs",
-    "test": "pnpm --filter @navikt/lumi-types run test && pnpm --filter lumi-dashboard run test",
+    "test": "pnpm --filter @navikt/lumi-types run test && pnpm --filter @navikt/lumi-survey run test && pnpm --filter lumi-dashboard run test",
     "e2e": "pnpm --filter lumi-dashboard run e2e",
     "e2e:full-chain": "pnpm --filter lumi-dashboard run e2e:full-chain",
     "test:full-chain": "./scripts/lumi-full-chain-e2e.sh",

--- a/packages/lumi-survey/package.json
+++ b/packages/lumi-survey/package.json
@@ -25,7 +25,7 @@
   "scripts": {
     "prepack": "pnpm run build",
     "build": "tsup --config tsup.config.ts",
-    "test": "vitest run --passWithNoTests",
+    "test": "vitest run",
     "storybook": "storybook dev -p 6006",
     "build-storybook": "storybook build",
     "clean": "rm -rf dist",


### PR DESCRIPTION
## Hva\n- inkluderer @navikt/lumi-survey i rotkommandoen pnpm test\n- lar widgetens Vitest-kommando feile hvis ingen tester blir oppdaget\n- gater dermed widgeten i PR-CI, merge queue, mise check og manuelle dashboard-sjekker\n\n## Verifisering\n- pnpm run lint\n- pnpm run typecheck\n- pnpm test\n  - 2 types-tester\n  - 432 widgettester i 28 filer\n  - 616 dashboardtester i 78 filer\n- to uavhengige pre-merge subagent-reviews uten funn\n\nCloses #475