### PR TITLE
Fiks validering av lange fritekstsvar

### DIFF
--- a/apps/lumi-api/src/main/kotlin/no/nav/lumi/validation/SurveyAuthoringDocumentValidator.kt
+++ b/apps/lumi-api/src/main/kotlin/no/nav/lumi/validation/SurveyAuthoringDocumentValidator.kt
@@ -213,8 +213,14 @@ object SurveyAuthoringDocumentValidator {
     private fun validateText(question: JsonObject, questionId: String): FieldDefinition {
         for (key in listOf("maxLength", "minRows")) {
             question[key]?.let { value ->
-                val number = (value as? JsonPrimitive)?.doubleOrNull
-                if (number == null || !number.isFinite() || number <= 0) {
+                val primitive = value as? JsonPrimitive
+                val number = primitive?.takeUnless { it.isString }?.doubleOrNull
+                if (
+                    number == null ||
+                    !number.isFinite() ||
+                    number <= 0 ||
+                    (key == "maxLength" && number % 1.0 != 0.0)
+                ) {
                     invalid("Text question '$questionId' has invalid $key")
                 }
             }

--- a/apps/lumi-api/src/test/kotlin/no/nav/lumi/validation/SurveyAuthoringDocumentValidatorTest.kt
+++ b/apps/lumi-api/src/test/kotlin/no/nav/lumi/validation/SurveyAuthoringDocumentValidatorTest.kt
@@ -43,6 +43,28 @@ class SurveyAuthoringDocumentValidatorTest : FunSpec({
         changed.definition.computeHash() shouldBe original.definition.computeHash()
     }
 
+    test("rejects fractional text maxLength") {
+        val invalid = Json.parseToJsonElement(
+            validDocument().toString().replace("\"maxLength\":1000", "\"maxLength\":0.5"),
+        ).jsonObject
+
+        shouldThrow<ApiErrorException.BadRequestException> {
+            SurveyAuthoringDocumentValidator.validate(invalid, "survey-v1")
+        }.errorMessage shouldBe "Text question 'comment' has invalid maxLength"
+    }
+
+    test("rejects quoted text numeric fields") {
+        listOf("maxLength" to "1000", "minRows" to "4").forEach { (field, number) ->
+            val invalid = Json.parseToJsonElement(
+                validDocument().toString().replace("\"$field\":$number", "\"$field\":\"$number\""),
+            ).jsonObject
+
+            shouldThrow<ApiErrorException.BadRequestException> {
+                SurveyAuthoringDocumentValidator.validate(invalid, "survey-v1")
+            }.errorMessage shouldBe "Text question 'comment' has invalid $field"
+        }
+    }
+
     test("document hash is independent of object key order") {
         val original = SurveyAuthoringDocumentValidator.validate(validDocument(), "survey-v1")
         val reordered = Json.parseToJsonElement(

--- a/docs/guider/sporsmalstyper.md
+++ b/docs/guider/sporsmalstyper.md
@@ -90,7 +90,9 @@ NPS bruker en skala fra 0 til 10 med valgfrie tekster i hver ende.
 
 ## Text
 
-Fritekstfelt med valgfri maks-lengde. Bra for oppfølgingsspørsmål.
+Fritekstfelt med valgfri maks-lengde. Bra for oppfølgingsspørsmål. Standardgrensen
+er 1000 tegn, og API-kontrakten tillater maksimalt 2000 tegn. `maxLength` må
+være et positivt heltall. Høyere verdier begrenses til 2000 i widgeten.
 
 ```tsx
 {
@@ -111,7 +113,7 @@ Fritekstfelt med valgfri maks-lengde. Bra for oppfølgingsspørsmål.
 | `prompt` | `string` | ✅ | Spørsmålsteksten |
 | `description` | `string` | ❌ | Hjelpetekst under prompt |
 | `required` | `boolean` | ❌ | Om svaret er påkrevd |
-| `maxLength` | `number` | ❌ | Maks antall tegn |
+| `maxLength` | `number` | ❌ | Positivt heltall (standard 1000, øvre grense 2000) |
 | `minRows` | `number` | ❌ | Minimum antall rader i tekstfeltet |
 | `placeholder` | `string` | ❌ | Plassholdertekst |
 | `autoComplete` | `string` | ❌ | HTML autocomplete-attributt |

--- a/docs/referanse/props-referanse.md
+++ b/docs/referanse/props-referanse.md
@@ -160,6 +160,8 @@ Velkomstsiden og bekreftelsen etter innsending er ikke med i fremdriften.
 | `submitPending` | `string` | `"Sender inn..."` | Knapp mens innsending pågår |
 | `cancel` | `string` | `"Lukk"` | Knapp for å lukke |
 | `validationError` | `string` | `"Vennligst fyll ut alle påkrevde felt"` | Feil ved manglende svar |
+| `validationSummary` | `string` | `"Du må rette svarene før du kan fortsette:"` | Overskrift når flere svar må rettes |
+| `textTooLong` | `(maxLength: number) => string` | Norsk feilmelding med grensen | Feilformatter når et fritekstsvar er for langt |
 | `transportError` | `string` | `"Noe gikk galt ved innsending. Prøv igjen senere."` | Feil ved innsending |
 | `minimizedButton` | `string` | `"Gi tilbakemelding"` | Knapp når widgeten er minimert |
 
@@ -168,6 +170,9 @@ Velkomstsiden og bekreftelsen etter innsending er ikke med i fremdriften.
   labels={{
     submit: "Send tilbakemelding",
     cancel: "Avbryt",
+    validationSummary: "Correct these answers:",
+    textTooLong: (maxLength) =>
+      `Answer must be at most ${maxLength} characters.`,
     minimizedButton: "Hjelp oss å bli bedre",
   }}
 />

--- a/packages/lumi-survey/CHANGELOG.md
+++ b/packages/lumi-survey/CHANGELOG.md
@@ -17,6 +17,9 @@ This project follows SemVer.
   feedback changes. In Chromium, swapping the icon element during a real
   pointer interaction could leave the star focused but unchecked, so a
   required star question could not be submitted.
+- Text answers that exceed the configured limit, or the API maximum of 2000
+  characters, are now blocked in the widget with a field-level validation
+  message instead of failing permanently as a generic transport error.
 
 ### Internal
 

--- a/packages/lumi-survey/src/components/LumiSurveyDock/LumiSurveyDock.tsx
+++ b/packages/lumi-survey/src/components/LumiSurveyDock/LumiSurveyDock.tsx
@@ -671,6 +671,8 @@ export const LumiSurveyDock = ({
             promptDescriptionIsQuestionDescription,
             questionAnchorPrefix: `${surveyId}-question`,
             validationErrorMessage: config.validationErrorMessage,
+            validationSummaryHeading: config.validationSummaryHeading,
+            textTooLongErrorMessage: config.textTooLongErrorMessage,
           }}
           intro={{
             isIntro: showIntro,

--- a/packages/lumi-survey/src/components/LumiSurveyDock/__tests__/LumiSurveyDock.test.tsx
+++ b/packages/lumi-survey/src/components/LumiSurveyDock/__tests__/LumiSurveyDock.test.tsx
@@ -1,4 +1,10 @@
-import { act, render, screen, waitFor } from "@testing-library/react";
+import {
+  act,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type {
@@ -16,6 +22,7 @@ import type {
 } from "../../surveyTypes.js";
 import { CLASS_NAMES } from "../classNames.js";
 import { LumiSurveyDock } from "../LumiSurveyDock.js";
+import type { LumiSurveyLabels } from "../propTypes.js";
 
 function createSurvey(): LumiSurveyConfig {
   return createRatingSurvey({
@@ -47,6 +54,7 @@ function renderDock(options?: {
   context?: Record<string, unknown>;
   initialOpen?: boolean;
   behavior?: Record<string, unknown>;
+  labels?: LumiSurveyLabels;
 }) {
   const transport: LumiSurveyTransport = options?.transport ?? {
     submit: vi.fn().mockResolvedValue(undefined),
@@ -58,6 +66,7 @@ function renderDock(options?: {
       survey={options?.survey ?? createSurvey()}
       transport={transport}
       events={options?.events}
+      labels={options?.labels}
       context={options?.context}
       behavior={{
         initialOpen: options?.initialOpen ?? true,
@@ -136,7 +145,7 @@ describe("LumiSurveyDock", () => {
     await user.click(screen.getByRole("button", { name: "Neste" }));
 
     const errorSummary = await screen.findByText(
-      "Du må svare på disse spørsmålene før du kan fortsette:",
+      "Du må rette svarene før du kan fortsette:",
     );
     expect(errorSummary).toHaveFocus();
     expect(
@@ -340,18 +349,14 @@ describe("LumiSurveyDock", () => {
     renderDock({ survey, behavior: { storageStrategy: "none" } });
     await user.click(await screen.findByRole("button", { name: "Neste" }));
     expect(
-      screen.getByText(
-        "Du må svare på disse spørsmålene før du kan fortsette:",
-      ),
+      screen.getByText("Du må rette svarene før du kan fortsette:"),
     ).toBeInTheDocument();
 
     await user.click(screen.getByRole("button", { name: "Lukk" }));
     await user.click(screen.getByRole("button", { name: "Gi tilbakemelding" }));
 
     expect(
-      screen.queryByText(
-        "Du må svare på disse spørsmålene før du kan fortsette:",
-      ),
+      screen.queryByText("Du må rette svarene før du kan fortsette:"),
     ).not.toBeInTheDocument();
   });
 
@@ -506,18 +511,14 @@ describe("LumiSurveyDock", () => {
     await user.click(await screen.findByRole("radio", { name: "Ja" }));
     await user.click(screen.getByRole("button", { name: "Neste" }));
     expect(
-      screen.getByText(
-        "Du må svare på disse spørsmålene før du kan fortsette:",
-      ),
+      screen.getByText("Du må rette svarene før du kan fortsette:"),
     ).toBeInTheDocument();
 
     const noOption = screen.getByRole("radio", { name: "Nei" });
     await user.click(noOption);
 
     expect(
-      screen.queryByText(
-        "Du må svare på disse spørsmålene før du kan fortsette:",
-      ),
+      screen.queryByText("Du må rette svarene før du kan fortsette:"),
     ).not.toBeInTheDocument();
     expect(noOption).toHaveFocus();
   });
@@ -1314,6 +1315,51 @@ describe("LumiSurveyDock", () => {
       expect.arrayContaining(["feedback"]),
     );
     expect(screen.getByLabelText(/hva kan vi forbedre/i)).toHaveFocus();
+  });
+
+  it("blocks text answers that exceed the configured limit", async () => {
+    const user = userEvent.setup();
+    const events: LumiSurveyEvents = { onValidationFailed: vi.fn() };
+    const transport: LumiSurveyTransport = {
+      submit: vi.fn().mockResolvedValue(undefined),
+    };
+    const survey: SurveyDocumentV1 = {
+      authoringSchemaVersion: 1,
+      pages: [
+        {
+          id: "feedback-page",
+          questions: [
+            {
+              id: "feedback",
+              type: "text",
+              prompt: "Hva kan vi forbedre?",
+              maxLength: 5,
+            },
+          ],
+        },
+      ],
+    };
+
+    renderDock({
+      survey,
+      events,
+      transport,
+      labels: {
+        textTooLong: (maxLength) =>
+          `Answer must be at most ${maxLength} characters.`,
+      },
+    });
+    fireEvent.change(
+      await screen.findByRole("textbox", { name: /hva kan vi forbedre/i }),
+      { target: { value: "123456" } },
+    );
+    await user.click(screen.getByRole("button", { name: /send/i }));
+
+    expect(transport.submit).not.toHaveBeenCalled();
+    expect(events.onValidationFailed).toHaveBeenCalledWith(["feedback"]);
+    expect(
+      screen.getByText("Answer must be at most 5 characters."),
+    ).toBeInTheDocument();
   });
 
   it("calls onViewDock when the dock mounts", () => {

--- a/packages/lumi-survey/src/components/LumiSurveyDock/__tests__/accessibility.test.tsx
+++ b/packages/lumi-survey/src/components/LumiSurveyDock/__tests__/accessibility.test.tsx
@@ -361,9 +361,7 @@ describe("LumiSurveyDock Accessibility", () => {
 
     await user.click(await screen.findByRole("button", { name: "Neste" }));
     expect(
-      await screen.findByText(
-        "Du må svare på disse spørsmålene før du kan fortsette:",
-      ),
+      await screen.findByText("Du må rette svarene før du kan fortsette:"),
     ).toHaveFocus();
 
     const results = await axe.run(container);

--- a/packages/lumi-survey/src/components/LumiSurveyDock/components/DockQuestionRenderer.tsx
+++ b/packages/lumi-survey/src/components/LumiSurveyDock/components/DockQuestionRenderer.tsx
@@ -10,6 +10,7 @@ interface DockQuestionRendererProps extends LumiSurveyRenderQuestionProps {
   promptDescriptionId?: string;
   promptDescriptionIsQuestionDescription?: boolean;
   validationErrorMessage: string;
+  textTooLongErrorMessage: (maxLength: number) => string;
 }
 
 export const DockQuestionRenderer = React.memo(
@@ -25,6 +26,7 @@ export const DockQuestionRenderer = React.memo(
     promptDescriptionId,
     promptDescriptionIsQuestionDescription = true,
     validationErrorMessage,
+    textTooLongErrorMessage,
   }: DockQuestionRendererProps) => {
     if (question.type === "rating") {
       const rating = question as RatingQuestion;
@@ -73,6 +75,7 @@ export const DockQuestionRenderer = React.memo(
         isMissing={isMissing}
         disabled={disabled}
         validationErrorMessage={validationErrorMessage}
+        textTooLongErrorMessage={textTooLongErrorMessage}
         hideLabel={hideLabel}
       />
     );

--- a/packages/lumi-survey/src/components/LumiSurveyDock/components/SurveyFormContent.tsx
+++ b/packages/lumi-survey/src/components/LumiSurveyDock/components/SurveyFormContent.tsx
@@ -10,6 +10,7 @@ import {
 } from "@navikt/ds-react";
 import React, { useCallback, useEffect, useRef } from "react";
 import type { LumiSurveyAnswerValue, LumiSurveyQuestion } from "../../../core";
+import { getAnswerValidationIssue } from "../../../core/validation.js";
 import { formatQuestionPrompt } from "../../questions/utils/formatQuestionPrompt.js";
 import type { CanonicalSurveyPage } from "../../shared/canonicalSurvey.js";
 import { CLASS_NAMES } from "../classNames.js";
@@ -113,6 +114,8 @@ export const SurveyFormContent = React.memo(
       promptDescriptionIsQuestionDescription,
       questionAnchorPrefix,
       validationErrorMessage,
+      validationSummaryHeading,
+      textTooLongErrorMessage,
     } = questionContext;
     const currentStepNumber = currentStep + 1;
     const stepStatus = hasBranching
@@ -190,6 +193,7 @@ export const SurveyFormContent = React.memo(
               promptDescriptionIsQuestionDescription
             }
             validationErrorMessage={validationErrorMessage}
+            textTooLongErrorMessage={textTooLongErrorMessage}
           />
         </div>
       );
@@ -199,12 +203,18 @@ export const SurveyFormContent = React.memo(
       <ErrorSummary
         ref={errorSummaryRef}
         size="small"
-        heading="Du må svare på disse spørsmålene før du kan fortsette:"
+        heading={validationSummaryHeading}
       >
         {validationMissing.map((questionId) => {
           const question = orderedQuestions.find(
             (candidate) => candidate.id === questionId,
           );
+          const issue = question
+            ? getAnswerValidationIssue(question, answers[questionId])
+            : undefined;
+          const questionLabel = question
+            ? formatQuestionPrompt(question)
+            : validationErrorMessage;
           return (
             <ErrorSummary.Item
               key={questionId}
@@ -214,9 +224,9 @@ export const SurveyFormContent = React.memo(
                 focusQuestionField(questionAnchorPrefix, questionId);
               }}
             >
-              {question
-                ? formatQuestionPrompt(question)
-                : validationErrorMessage}
+              {issue?.type === "textTooLong"
+                ? `${questionLabel}: ${textTooLongErrorMessage(issue.maxLength)}`
+                : questionLabel}
             </ErrorSummary.Item>
           );
         })}

--- a/packages/lumi-survey/src/components/LumiSurveyDock/components/__tests__/DockQuestionRenderer.test.tsx
+++ b/packages/lumi-survey/src/components/LumiSurveyDock/components/__tests__/DockQuestionRenderer.test.tsx
@@ -60,6 +60,8 @@ const baseProps = {
   promptHeadingId: "heading-id",
   promptDescriptionId: "desc-id",
   validationErrorMessage: "Feltet er påkrevd",
+  textTooLongErrorMessage: (maxLength: number) =>
+    `Svaret kan være maks ${maxLength} tegn`,
 };
 
 // ---------------------------------------------------------------------------

--- a/packages/lumi-survey/src/components/LumiSurveyDock/components/__tests__/SurveyFormContent.test.tsx
+++ b/packages/lumi-survey/src/components/LumiSurveyDock/components/__tests__/SurveyFormContent.test.tsx
@@ -82,6 +82,9 @@ function defaultProps(
       promptHeadingId: "heading-id",
       questionAnchorPrefix: "survey-question",
       validationErrorMessage: "Feltet er påkrevd",
+      validationSummaryHeading: "Rett svarene før du fortsetter:",
+      textTooLongErrorMessage: (maxLength: number) =>
+        `Svaret kan være maks ${maxLength} tegn.`,
     },
 
     // Notices
@@ -234,6 +237,46 @@ describe("SurveyFormContent", () => {
       render(<SurveyFormContent {...defaultProps()} />);
 
       expect(screen.getByRole("button", { name: /send/i })).toBeInTheDocument();
+    });
+
+    it("uses localized, cause-specific copy for mixed validation errors", () => {
+      const requiredRating = { ...ratingQuestion, required: true };
+      const limitedText = {
+        ...textQuestion,
+        required: true,
+        maxLength: 5,
+      };
+
+      render(
+        <SurveyFormContent
+          {...defaultProps({
+            orderedQuestions: [requiredRating, limitedText],
+            answers: { feedback: "123456" },
+            validationMissing: ["rating", "feedback"],
+            questionContext: {
+              promptQuestionId: "rating",
+              promptHeadingId: "heading-id",
+              questionAnchorPrefix: "survey-question",
+              validationErrorMessage: "This field is required",
+              validationSummaryHeading: "Correct these answers:",
+              textTooLongErrorMessage: (maxLength: number) =>
+                `Answer must be at most ${maxLength} characters.`,
+            },
+          })}
+        />,
+      );
+
+      expect(
+        screen.getByRole("heading", { name: "Correct these answers:" }),
+      ).toBeInTheDocument();
+      expect(
+        screen.getByRole("link", { name: "Hvor fornøyd er du?" }),
+      ).toBeInTheDocument();
+      expect(
+        screen.getByRole("link", {
+          name: "Hva kan vi forbedre?: Answer must be at most 5 characters.",
+        }),
+      ).toBeInTheDocument();
     });
   });
 

--- a/packages/lumi-survey/src/components/LumiSurveyDock/dockTypes.ts
+++ b/packages/lumi-survey/src/components/LumiSurveyDock/dockTypes.ts
@@ -30,6 +30,8 @@ export interface QuestionContextProps {
   promptDescriptionIsQuestionDescription?: boolean;
   questionAnchorPrefix: string;
   validationErrorMessage: string;
+  validationSummaryHeading: string;
+  textTooLongErrorMessage: (maxLength: number) => string;
 }
 
 export interface IntroProps {

--- a/packages/lumi-survey/src/components/LumiSurveyDock/propTypes.ts
+++ b/packages/lumi-survey/src/components/LumiSurveyDock/propTypes.ts
@@ -14,6 +14,10 @@ export interface LumiSurveyLabels {
   cancel?: string;
   /** Error message for validation failures. @default "Vennligst fyll ut alle påkrevde felt" */
   validationError?: string;
+  /** Heading shown when multiple answers need correction. */
+  validationSummary?: string;
+  /** Error formatter for a text answer above its effective character limit. */
+  textTooLong?: (maxLength: number) => string;
   /** Error message for transport failures. @default "Noe gikk galt ved innsending. Prøv igjen senere." */
   transportError?: string;
   /** Label for the minimized button. @default "Gi tilbakemelding" */

--- a/packages/lumi-survey/src/components/LumiSurveyDock/resolveConfig.ts
+++ b/packages/lumi-survey/src/components/LumiSurveyDock/resolveConfig.ts
@@ -20,6 +20,8 @@ export interface ResolvedConfig {
   submitPendingLabel: string;
   cancelLabel: string;
   validationErrorMessage: string;
+  validationSummaryHeading: string;
+  textTooLongErrorMessage: (maxLength: number) => string;
   transportErrorMessage: string;
   minimizedButtonLabel: string;
 
@@ -78,6 +80,10 @@ export function resolveConfig(
     cancelLabel: labels?.cancel ?? DEFAULT_COPY.cancelLabel,
     validationErrorMessage:
       labels?.validationError ?? DEFAULT_COPY.validationErrorMessage,
+    validationSummaryHeading:
+      labels?.validationSummary ?? DEFAULT_COPY.validationSummaryHeading,
+    textTooLongErrorMessage:
+      labels?.textTooLong ?? DEFAULT_COPY.textTooLongErrorMessage,
     transportErrorMessage:
       labels?.transportError ?? DEFAULT_COPY.transportErrorMessage,
     minimizedButtonLabel: labels?.minimizedButton ?? "Gi tilbakemelding",

--- a/packages/lumi-survey/src/components/questions/DefaultQuestionRenderer/DefaultQuestionRenderer.tsx
+++ b/packages/lumi-survey/src/components/questions/DefaultQuestionRenderer/DefaultQuestionRenderer.tsx
@@ -17,6 +17,7 @@ export const DefaultQuestionRenderer = ({
   value,
   onChange,
   validationErrorMessage,
+  textTooLongErrorMessage,
   isMissing,
   disabled,
   hideLabel,
@@ -44,6 +45,7 @@ export const DefaultQuestionRenderer = ({
           value={value}
           onChange={(next: string) => onChange(next)}
           validationErrorMessage={validationErrorMessage}
+          textTooLongErrorMessage={textTooLongErrorMessage}
           isMissing={isMissing}
           disabled={disabled}
           hideLabel={hideLabel}

--- a/packages/lumi-survey/src/components/questions/DefaultQuestionRenderer/__tests__/DefaultQuestionRenderer.test.tsx
+++ b/packages/lumi-survey/src/components/questions/DefaultQuestionRenderer/__tests__/DefaultQuestionRenderer.test.tsx
@@ -483,6 +483,36 @@ describe("DefaultQuestionRenderer", () => {
     expect(handleChange).toHaveBeenCalledWith("Great");
   });
 
+  it("shows the effective text limit and a specific over-limit error", () => {
+    const textTooLongErrorMessage = vi.fn(
+      (maxLength: number) => `Answer must be at most ${maxLength} characters.`,
+    );
+
+    render(
+      <DefaultQuestionRenderer
+        question={{
+          id: "text-limit",
+          type: "text",
+          prompt: "Describe your experience",
+          maxLength: 5_000,
+        }}
+        value={"a".repeat(2_001)}
+        onChange={() => undefined}
+        validationErrorMessage="You must answer"
+        textTooLongErrorMessage={textTooLongErrorMessage}
+        isMissing={false}
+        disabled={false}
+      />,
+    );
+
+    expect(textTooLongErrorMessage).toHaveBeenCalledWith(2_000);
+    expect(
+      screen.getByText("Answer must be at most 2000 characters."),
+    ).toBeInTheDocument();
+    expect(screen.getByRole("textbox")).toHaveAttribute("aria-invalid", "true");
+    expect(screen.queryByText("You must answer")).not.toBeInTheDocument();
+  });
+
   it("renders a single choice question and shows validation message when missing", () => {
     const handleChange = vi.fn();
     const question = {

--- a/packages/lumi-survey/src/components/questions/text/TextQuestionField.tsx
+++ b/packages/lumi-survey/src/components/questions/text/TextQuestionField.tsx
@@ -1,6 +1,8 @@
 import { Textarea } from "@navikt/ds-react";
 import type React from "react";
 import type { LumiSurveyAnswerValue, TextQuestion } from "../../../core";
+import { getTextAnswerMaxLength } from "../../../core/textAnswerLimits.js";
+import { DEFAULT_COPY } from "../../shared/commonDefaults.js";
 import { formatQuestionPrompt } from "../utils/formatQuestionPrompt.js";
 
 interface TextQuestionFieldProps {
@@ -8,6 +10,7 @@ interface TextQuestionFieldProps {
   value: LumiSurveyAnswerValue | undefined;
   onChange: (value: string) => void;
   validationErrorMessage: string;
+  textTooLongErrorMessage?: (maxLength: number) => string;
   isMissing: boolean;
   disabled: boolean;
   hideLabel?: boolean;
@@ -18,23 +21,33 @@ export const TextQuestionField = ({
   value,
   onChange,
   validationErrorMessage,
+  textTooLongErrorMessage = DEFAULT_COPY.textTooLongErrorMessage,
   isMissing,
   disabled,
   hideLabel,
-}: TextQuestionFieldProps) => (
-  <Textarea
-    label={formatQuestionPrompt(question)}
-    hideLabel={hideLabel}
-    description={question.description}
-    value={typeof value === "string" ? value : ""}
-    onChange={(event: React.ChangeEvent<HTMLTextAreaElement>) =>
-      onChange(event.target.value)
-    }
-    maxLength={question.maxLength ?? 1000}
-    minRows={question.minRows}
-    placeholder={question.placeholder}
-    autoComplete={question.autoComplete}
-    disabled={disabled}
-    error={isMissing ? validationErrorMessage : undefined}
-  />
-);
+}: TextQuestionFieldProps) => {
+  const textValue = typeof value === "string" ? value : "";
+  const maxLength = getTextAnswerMaxLength(question);
+  const isOverLimit = textValue.length > maxLength;
+  const errorMessage = isOverLimit
+    ? textTooLongErrorMessage(maxLength)
+    : validationErrorMessage;
+
+  return (
+    <Textarea
+      label={formatQuestionPrompt(question)}
+      hideLabel={hideLabel}
+      description={question.description}
+      value={textValue}
+      onChange={(event: React.ChangeEvent<HTMLTextAreaElement>) =>
+        onChange(event.target.value)
+      }
+      maxLength={maxLength}
+      minRows={question.minRows}
+      placeholder={question.placeholder}
+      autoComplete={question.autoComplete}
+      disabled={disabled}
+      error={isMissing || isOverLimit ? errorMessage : undefined}
+    />
+  );
+};

--- a/packages/lumi-survey/src/components/shared/__tests__/canonicalSurvey.test.ts
+++ b/packages/lumi-survey/src/components/shared/__tests__/canonicalSurvey.test.ts
@@ -255,6 +255,14 @@ describe("buildCanonicalSurvey", () => {
       buildRaw({
         id: "page",
         questions: [
+          { id: "text", type: "text", prompt: "Text", maxLength: 0.5 },
+        ],
+      }),
+    ).toThrowError(/invalid maxLength/i);
+    expect(() =>
+      buildRaw({
+        id: "page",
+        questions: [
           {
             id: "choice",
             type: "multiChoice",

--- a/packages/lumi-survey/src/components/shared/canonicalSurvey.ts
+++ b/packages/lumi-survey/src/components/shared/canonicalSurvey.ts
@@ -472,7 +472,10 @@ function validateDocumentQuestion(
       const value = candidate[numberKey];
       if (
         value !== undefined &&
-        (typeof value !== "number" || !Number.isFinite(value) || value <= 0)
+        (typeof value !== "number" ||
+          !Number.isFinite(value) ||
+          value <= 0 ||
+          (numberKey === "maxLength" && !Number.isInteger(value)))
       ) {
         throw new Error(
           `Lumi: Text question "${candidate.id}" has an invalid ${numberKey}`,

--- a/packages/lumi-survey/src/components/shared/commonDefaults.ts
+++ b/packages/lumi-survey/src/components/shared/commonDefaults.ts
@@ -3,6 +3,9 @@ export const DEFAULT_COPY = {
   submitPendingLabel: "Sender…",
   cancelLabel: "Lukk",
   validationErrorMessage: "Du må svare på spørsmålet.",
+  validationSummaryHeading: "Du må rette svarene før du kan fortsette:",
+  textTooLongErrorMessage: (maxLength: number) =>
+    `Svaret kan ikke være lengre enn ${maxLength} tegn.`,
   transportErrorMessage:
     "Kunne ikke sende tilbakemeldingen. Prøv igjen senere.",
   successTitle: "Takk for tilbakemeldingen!",

--- a/packages/lumi-survey/src/core/__tests__/validation.test.ts
+++ b/packages/lumi-survey/src/core/__tests__/validation.test.ts
@@ -77,6 +77,76 @@ describe("validateAnswers", () => {
     ]);
   });
 
+  it("rejects text answers longer than the configured maxLength", () => {
+    const question: LumiSurveyQuestion = {
+      id: "feedback",
+      type: "text",
+      prompt: "Kommentar",
+      maxLength: 5,
+    };
+
+    expect(validateAnswers([question], { feedback: "12345" })).toEqual([]);
+    expect(validateAnswers([question], { feedback: "123456" })).toEqual([
+      "feedback",
+    ]);
+  });
+
+  it("uses the widget default and caps configured text limits at the API maximum", () => {
+    const defaultQuestion: LumiSurveyQuestion = {
+      id: "default-feedback",
+      type: "text",
+      prompt: "Kommentar",
+    };
+    const oversizedQuestion: LumiSurveyQuestion = {
+      id: "oversized-feedback",
+      type: "text",
+      prompt: "Kommentar",
+      maxLength: 5_000,
+    };
+    const fractionalLegacyQuestion: LumiSurveyQuestion = {
+      id: "fractional-legacy-feedback",
+      type: "text",
+      prompt: "Kommentar",
+      maxLength: 0.5,
+    };
+
+    expect(
+      validateAnswers([defaultQuestion], {
+        "default-feedback": "a".repeat(1_000),
+      }),
+    ).toEqual([]);
+    expect(
+      validateAnswers([defaultQuestion], {
+        "default-feedback": "a".repeat(1_001),
+      }),
+    ).toEqual(["default-feedback"]);
+    expect(
+      validateAnswers([oversizedQuestion], {
+        "oversized-feedback": "a".repeat(2_000),
+      }),
+    ).toEqual([]);
+    expect(
+      validateAnswers([oversizedQuestion], {
+        "oversized-feedback": "a".repeat(2_001),
+      }),
+    ).toEqual(["oversized-feedback"]);
+    expect(
+      validateAnswers([defaultQuestion], {
+        "default-feedback": " ".repeat(1_001),
+      }),
+    ).toEqual(["default-feedback"]);
+    expect(
+      validateAnswers([fractionalLegacyQuestion], {
+        "fractional-legacy-feedback": "a",
+      }),
+    ).toEqual([]);
+    expect(
+      validateAnswers([fractionalLegacyQuestion], {
+        "fractional-legacy-feedback": "ab",
+      }),
+    ).toEqual(["fractional-legacy-feedback"]);
+  });
+
   it("enforces unique multi-choice values and maxSelections", () => {
     const question: LumiSurveyQuestion = {
       id: "priority",

--- a/packages/lumi-survey/src/core/textAnswerLimits.ts
+++ b/packages/lumi-survey/src/core/textAnswerLimits.ts
@@ -1,0 +1,24 @@
+import type { TextQuestion } from "./types.js";
+
+export const DEFAULT_TEXT_ANSWER_MAX_LENGTH = 1_000;
+
+// Keep aligned with SubmissionValidator.MAX_TEXT_ANSWER_LENGTH in lumi-api.
+export const MAX_TEXT_ANSWER_LENGTH = 2_000;
+
+export function getTextAnswerMaxLength(question: TextQuestion): number {
+  const configuredMaxLength = question.maxLength;
+  if (
+    configuredMaxLength === undefined ||
+    !Number.isFinite(configuredMaxLength) ||
+    configuredMaxLength <= 0
+  ) {
+    return DEFAULT_TEXT_ANSWER_MAX_LENGTH;
+  }
+
+  // Authored documents reject fractions. Normalize legacy/untyped configs
+  // defensively so a positive fraction cannot make the field impossible.
+  return Math.min(
+    Math.max(1, Math.floor(configuredMaxLength)),
+    MAX_TEXT_ANSWER_LENGTH,
+  );
+}

--- a/packages/lumi-survey/src/core/validation.ts
+++ b/packages/lumi-survey/src/core/validation.ts
@@ -1,9 +1,11 @@
+import { getTextAnswerMaxLength } from "./textAnswerLimits.js";
 import type {
   ChoiceOption,
   ChoiceQuestion,
   LumiSurveyAnswerValue,
   LumiSurveyQuestion,
   RatingQuestion,
+  TextQuestion,
 } from "./types";
 
 export function validateAnswers(
@@ -13,19 +15,40 @@ export function validateAnswers(
   const missingIds: string[] = [];
 
   for (const question of questions) {
-    const answer = answers[question.id];
-
-    if (!isAnswerPresent(answer)) {
-      if (question.required) missingIds.push(question.id);
-      continue;
-    }
-
-    if (!isAnswerValidForQuestion(question, answer)) {
+    if (getAnswerValidationIssue(question, answers[question.id])) {
       missingIds.push(question.id);
     }
   }
 
   return missingIds;
+}
+
+export type AnswerValidationIssue =
+  | { type: "missing" }
+  | { type: "invalid" }
+  | { type: "textTooLong"; maxLength: number };
+
+export function getAnswerValidationIssue(
+  question: LumiSurveyQuestion,
+  answer: LumiSurveyAnswerValue | undefined,
+): AnswerValidationIssue | undefined {
+  // Optional blank answers are normally ignored. Check the raw text length
+  // first so an over-limit whitespace value from initial state cannot reach
+  // the API even though it trims to an empty answer.
+  if (question.type === "text" && typeof answer === "string") {
+    const maxLength = getTextAnswerMaxLength(question);
+    if (answer.length > maxLength) {
+      return { type: "textTooLong", maxLength };
+    }
+  }
+
+  if (!isAnswerPresent(answer)) {
+    return question.required ? { type: "missing" } : undefined;
+  }
+
+  return isAnswerValidForQuestion(question, answer)
+    ? undefined
+    : { type: "invalid" };
 }
 
 function isAnswerPresent(
@@ -54,7 +77,7 @@ function isAnswerValidForQuestion(
     case "rating":
       return isValidRatingAnswer(question, rawAnswer);
     case "text":
-      return typeof rawAnswer === "string";
+      return isValidTextAnswer(question, rawAnswer);
     case "singleChoice":
       return isValidSingleChoiceAnswer(question, rawAnswer);
     case "multiChoice":
@@ -62,6 +85,16 @@ function isAnswerValidForQuestion(
     default:
       return true;
   }
+}
+
+function isValidTextAnswer(
+  question: TextQuestion,
+  rawAnswer: LumiSurveyAnswerValue,
+): boolean {
+  return (
+    typeof rawAnswer === "string" &&
+    rawAnswer.length <= getTextAnswerMaxLength(question)
+  );
 }
 
 function isValidRatingAnswer(

--- a/packages/lumi-survey/src/types.ts
+++ b/packages/lumi-survey/src/types.ts
@@ -15,4 +15,5 @@ export interface LumiSurveyRenderQuestionProps {
 export interface LumiSurveyDefaultQuestionProps
   extends LumiSurveyRenderQuestionProps {
   validationErrorMessage: string;
+  textTooLongErrorMessage?: (maxLength: number) => string;
 }


### PR DESCRIPTION
## Oppsummering

- håndhev effektiv lengdegrense for fritekstsvar før transport (standard 1000, API-tak 2000)
- vis lokaliserbar feltfeil og presis oppsummering også ved blandede valideringsfeil
- samkjør validering av forfatterdokumenter i widget og API, inkludert heltall og avvisning av tall kodet som tekst
- dokumenter grensene og de nye valgfrie labelene

## Verifisering

- `pnpm run lint`
- `pnpm run typecheck`
- `pnpm test`
- `./gradlew test` i `apps/lumi-api`
- dokumentasjonsbygg
- release guards, package verify og ren consumer-build av tarball
- to uavhengige sluttreviewer uten funn

Closes #489