### PR TITLE
Rett periodetekst og kontekstdokumentasjon

### DIFF
--- a/apps/lumi-dashboard/app/components/dashboard/sections/StatsCards/__tests__/StatsCards.test.tsx
+++ b/apps/lumi-dashboard/app/components/dashboard/sections/StatsCards/__tests__/StatsCards.test.tsx
@@ -38,6 +38,27 @@ beforeEach(() => {
 });
 
 describe("StatsCards", () => {
+  it("describes a historical period with its actual dates", () => {
+    givenSearchParams({ surveyId: "survey-1" });
+    givenStats({
+      totalCount: 12,
+      countWithText: 4,
+      period: {
+        fromDate: "2024-01-05",
+        toDate: "2024-03-20",
+        days: 76,
+      },
+      privacy: { masked: false, threshold: 5 },
+    });
+
+    render(<StatsCards />);
+
+    expect(
+      screen.getByText("I perioden 05.01.2024–20.03.2024"),
+    ).toBeInTheDocument();
+    expect(screen.queryByText("Siste 76 dager")).not.toBeInTheDocument();
+  });
+
   it("renders detailed survey stats using fieldStats when surveyId is set", () => {
     givenSearchParams({ surveyId: "survey-1" });
     givenStats({

--- a/apps/lumi-dashboard/app/components/dashboard/sections/StatsCards/index.tsx
+++ b/apps/lumi-dashboard/app/components/dashboard/sections/StatsCards/index.tsx
@@ -10,6 +10,7 @@ import { DashboardCard, DashboardGrid } from "~/components/dashboard";
 import { useSearchParams } from "~/hooks/useSearchParams";
 import { useStats } from "~/hooks/useStats";
 import type { RatingStats, TextStats } from "~/types/api";
+import { formatDateLong } from "~/utils/dateUtils";
 import {
   calculateThumbsPositiveRate,
   getRatingScaleLabel,
@@ -62,6 +63,10 @@ export function StatsCards({ showRating = false }: StatsCardsProps) {
 
   const totalCount = stats?.totalCount || 0;
   const periodDays = stats?.period?.days || 30;
+  const periodSubtitle =
+    stats?.period?.fromDate && stats.period.toDate
+      ? `I perioden ${formatDateLong(stats.period.fromDate)}–${formatDateLong(stats.period.toDate)}`
+      : "I valgt periode";
   const countWithText = stats?.countWithText || 0;
   const textPercentage =
     totalCount > 0 ? Math.round((countWithText / totalCount) * 100) : 0;
@@ -156,7 +161,7 @@ export function StatsCards({ showRating = false }: StatsCardsProps) {
           icon={<ChatIcon fontSize="1.25rem" aria-hidden />}
           label="Tilbakemeldinger"
           value={isPrivacyMasked ? "–" : totalCount.toLocaleString("no-NO")}
-          subtitle={`Siste ${periodDays} dager`}
+          subtitle={periodSubtitle}
         />
 
         {showRating && (
@@ -199,7 +204,7 @@ export function StatsCards({ showRating = false }: StatsCardsProps) {
         icon={<ChatIcon fontSize="1.25rem" aria-hidden />}
         label="Tilbakemeldinger"
         value={totalCount.toLocaleString("no-NO")}
-        subtitle={`Siste ${periodDays} dager`}
+        subtitle={periodSubtitle}
       />
 
       <StatCard

--- a/docs/guider/context-og-tags.md
+++ b/docs/guider/context-og-tags.md
@@ -14,16 +14,16 @@ Widgeten samler automatisk disse verdiene fra browseren:
 | :--- | :--- | :--- |
 | `viewport` | `{ width, height }` | Nettleservinduets dimensjoner |
 | `screenResolution` | `{ width, height }` | Skjermens dimensjoner rapportert av nettleseren |
-| `deviceType` | `"mobile" \| "tablet" \| "desktop"` | Basert på viewport-bredde (ikke fysisk enhet) |
+| `deviceType` | `"mobile" \| "tablet" \| "desktop"` | Bruker nettleserens device hints og user agent først, med viewport-bredde som fallback |
 | `userAgent` | `string` | Nettleserens user agent-streng |
 
-::: info deviceType er viewport-basert
-`deviceType` utledes fra viewport-bredde, ikke den fysiske enheten. Hvis DevTools er åpent, kan viewporten bli smalere enn forventet.
+::: info Hvordan deviceType bestemmes
+`deviceType` er en best-effort-klassifisering. Widgeten prioriterer kjente nettbrettsignaler, browserens Client Hints og mønstre i user agent før viewport-bredde brukes som fallback. I Surveyverkstedets innebygde preview klassifiseres `deviceType` bevisst fra `behavior.simulatedViewport`, slik at forhåndsvisningen følger den simulerte bredden i stedet for maskinen du bruker.
 :::
 
 ### Hva som *ikke* samles inn automatisk
 
-`url` og `pathname` samles **ikke** automatisk. Dette er bevisst — dynamiske ruter kan inneholde identifikatorer (f.eks. `/sak/12345`).
+`url` samles **aldri** automatisk. `pathname` samles ikke som standard, men kan velges inn med `collectLocation`. Dette er bevisst — dynamiske ruter kan inneholde identifikatorer (f.eks. `/sak/12345`).
 
 ## Valgfri innsamling: `collectLocation`
 

--- a/docs/referanse/datakontrakt.md
+++ b/docs/referanse/datakontrakt.md
@@ -81,8 +81,10 @@ interface LumiContext {
   screenResolution?: { width: number; height: number };
   userAgent?: string;
 
-  // Opt-in (krever collectLocation: true)
+  // Kun eksplisitt context (samles aldri inn automatisk)
   url?: string;              // Gjeldende side-URL
+
+  // Eksplisitt context, eller automatisk med collectLocation: true
   pathname?: string;         // URL pathname
 
   // Segmentering (LAV KARDINALITET → dashboard-grafer)
@@ -132,6 +134,8 @@ Bruk de ferdige oppsettene i Surveyverkstedet eller funksjonene som er beskrevet
 `success` skal ha nøyaktig de tre svarverdiene i tabellen; ekstra utfall kan ikke klassifiseres av analysen og blir avvist.
 
 ## Komplett eksempel
+
+I eksempelet er `context.url` satt eksplisitt av konsumentappen; widgeten samler aldri inn full URL automatisk. `pathname` kan settes eksplisitt eller samles inn med `collectLocation: true`.
 
 ```json
 {


### PR DESCRIPTION
## Oppsummering

- vis faktiske datoer i tilbakemeldingskortet i stedet for å kalle historiske perioder «Siste N dager»
- dokumenter den faktiske prioriteringen for `deviceType`, inkludert Surveyverksted-preview
- presiser at `url` bare settes eksplisitt, mens `pathname` også kan velges inn med `collectLocation`

## Verifisering

- `pnpm run lint`
- `pnpm run typecheck`
- `pnpm test` (437 widgettester, 617 dashboardtester, 2 type-tester)
- `pnpm run e2e` (59/59)
- `pnpm run docs:build`
- to uavhengige subagent-reviewer uten funn

Closes #504