### PR TITLE
Dekk Surveyverksted i tilgjengelighetstestene

### DIFF
--- a/apps/lumi-dashboard/app/routes/surveyverksted.index.tsx
+++ b/apps/lumi-dashboard/app/routes/surveyverksted.index.tsx
@@ -296,7 +296,11 @@ function SurveyWorkshopIndex() {
               en app.
             </BodyLong>
           </VStack>
-          <div aria-hidden className={styles.mastheadMark}>
+          <div
+            aria-hidden
+            data-a11y-decorative="survey-workshop-masthead-mark"
+            className={styles.mastheadMark}
+          >
             01
           </div>
         </div>

--- a/apps/lumi-dashboard/e2e/accessibility.spec.ts
+++ b/apps/lumi-dashboard/e2e/accessibility.spec.ts
@@ -3,64 +3,40 @@ import { expect, test } from "@playwright/test";
 
 /**
  * Accessibility tests using axe-core.
- * Scans all main routes for WCAG violations.
+ * Scans stable landing routes for WCAG violations. Stateful Surveyverksted
+ * editor and revision screens are scanned after setup in survey-workshop.spec.ts.
  */
 
 test.describe("Accessibility - WCAG Compliance", () => {
-  test("Dashboard page has no critical a11y violations", async ({ page }) => {
-    await page.goto("/");
-    await page.waitForLoadState("networkidle");
+  const routes = [
+    ["Dashboard", "/"],
+    ["Feedback", "/feedback"],
+    ["Export", "/export"],
+    ["Surveyverksted", "/surveyverksted"],
+  ] as const;
 
-    const results = await new AxeBuilder({ page })
-      .withTags(["wcag2a", "wcag2aa", "wcag21a", "wcag21aa"])
-      .analyze();
+  for (const [name, route] of routes) {
+    test(`${name} page has no WCAG A/AA violations`, async ({ page }) => {
+      await page.goto(route);
+      await page.waitForLoadState("networkidle");
 
-    // Log violations for debugging
-    if (results.violations.length > 0) {
-      console.log(
-        "Dashboard a11y violations:",
-        JSON.stringify(results.violations, null, 2),
-      );
-    }
+      const results = await new AxeBuilder({ page })
+        .withTags(["wcag2a", "wcag2aa", "wcag21a", "wcag21aa"])
+        // WCAG 1.4.3 exempts pure decoration. Axe cannot infer that the
+        // aria-hidden workshop masthead number is visual decoration only.
+        .exclude('[data-a11y-decorative="survey-workshop-masthead-mark"]')
+        .analyze();
 
-    expect(results.violations).toEqual([]);
-  });
+      if (results.violations.length > 0) {
+        console.log(
+          `${name} a11y violations:`,
+          JSON.stringify(results.violations, null, 2),
+        );
+      }
 
-  test("Feedback page has no critical a11y violations", async ({ page }) => {
-    await page.goto("/feedback");
-    await page.waitForLoadState("networkidle");
-
-    const results = await new AxeBuilder({ page })
-      .withTags(["wcag2a", "wcag2aa", "wcag21a", "wcag21aa"])
-      .analyze();
-
-    if (results.violations.length > 0) {
-      console.log(
-        "Feedback a11y violations:",
-        JSON.stringify(results.violations, null, 2),
-      );
-    }
-
-    expect(results.violations).toEqual([]);
-  });
-
-  test("Export page has no critical a11y violations", async ({ page }) => {
-    await page.goto("/export");
-    await page.waitForLoadState("networkidle");
-
-    const results = await new AxeBuilder({ page })
-      .withTags(["wcag2a", "wcag2aa", "wcag21a", "wcag21aa"])
-      .analyze();
-
-    if (results.violations.length > 0) {
-      console.log(
-        "Export a11y violations:",
-        JSON.stringify(results.violations, null, 2),
-      );
-    }
-
-    expect(results.violations).toEqual([]);
-  });
+      expect(results.violations).toEqual([]);
+    });
+  }
 });
 
 test.describe("Keyboard Navigation", () => {


### PR DESCRIPTION
## Oppsummering

- parameteriser axe-skanningen av stabile dashboardruter og legg til `/surveyverksted`
- dokumenter at stateful editor- og revisjonsflater allerede skannes i Surveyverksted-E2E
- marker og unnta bare den eksplisitt dekorative, `aria-hidden` masthead-markøren i tråd med WCAG 1.4.3
- behold det opprinnelige visuelle uttrykket uendret

## Verifisering

- red/green-repro av Surveyverksted-ruten
- `pnpm run lint`
- `pnpm run typecheck`
- `pnpm test` (437 widgettester, 617 dashboardtester, 2 type-tester)
- `accessibility.spec.ts` (16/16 på siste kandidat)
- full `pnpm run e2e` (60/60)
- to uavhengige sluttreviewer uten funn

Closes #508