### PR TITLE
Gi vurderingsspørsmål én navnekilde i tilgjengelighetstreet

### DIFF
--- a/apps/lumi-dashboard/e2e/survey-workshop.spec.ts
+++ b/apps/lumi-dashboard/e2e/survey-workshop.spec.ts
@@ -895,7 +895,7 @@ test("an any/all group over two conditions gates the question live in the stage"
 
   const stage = page.getByLabel("Forhåndsvisning");
   await expect(
-    stage.getByRole("group", { name: "Vil du utdype?" }),
+    stage.getByRole("radiogroup", { name: "Vil du utdype?" }),
   ).toBeVisible();
 
   // First condition: rating answered. Second: the text question answered.
@@ -921,13 +921,13 @@ test("an any/all group over two conditions gates the question live in the stage"
 
   // ALL: nothing answered yet → hidden; rating alone is not enough.
   await expect(
-    stage.getByRole("group", { name: "Vil du utdype?" }),
+    stage.getByRole("radiogroup", { name: "Vil du utdype?" }),
   ).not.toBeVisible({
     timeout: 10000,
   });
   await stage.getByRole("radio").nth(3).click();
   await expect(
-    stage.getByRole("group", { name: "Vil du utdype?" }),
+    stage.getByRole("radiogroup", { name: "Vil du utdype?" }),
   ).not.toBeVisible();
 
   // ANY: the document edit remounts the stage (answers reset), and one
@@ -935,11 +935,11 @@ test("an any/all group over two conditions gates the question live in the stage"
   await page.getByText("Minst én må stemme").click();
   await expect(page.locator('[data-state="saved"]')).toBeVisible();
   await expect(
-    stage.getByRole("group", { name: "Vil du utdype?" }),
+    stage.getByRole("radiogroup", { name: "Vil du utdype?" }),
   ).not.toBeVisible({ timeout: 10000 });
   await stage.getByRole("radio").nth(3).click();
   await expect(
-    stage.getByRole("group", { name: "Vil du utdype?" }),
+    stage.getByRole("radiogroup", { name: "Vil du utdype?" }),
   ).toBeVisible();
 
   await expect(page.locator('[data-state="saved"]')).toBeVisible();
@@ -953,11 +953,11 @@ test("an any/all group over two conditions gates the question live in the stage"
   await expect(page.getByText("Minst én må stemme")).toHaveCount(0);
   await expect(page.locator('[data-state="saved"]')).toBeVisible();
   await expect(
-    stage.getByRole("group", { name: "Vil du utdype?" }),
+    stage.getByRole("radiogroup", { name: "Vil du utdype?" }),
   ).not.toBeVisible({ timeout: 10000 });
   await stage.getByRole("radio").nth(3).click();
   await expect(
-    stage.getByRole("group", { name: "Vil du utdype?" }),
+    stage.getByRole("radiogroup", { name: "Vil du utdype?" }),
   ).toBeVisible();
   await expect(page.locator('[data-state="saved"]')).toBeVisible();
 });

--- a/packages/lumi-survey/CHANGELOG.md
+++ b/packages/lumi-survey/CHANGELOG.md
@@ -6,6 +6,15 @@ This project follows SemVer.
 
 ## [Unreleased]
 
+### Fixed
+
+- Rating questions now expose exactly one named group to assistive
+  technology. The prompt is the fieldset legend (a level 3 heading when
+  visible), the fieldset itself carries `role="radiogroup"`, and the
+  visually hidden legend copy no longer duplicates an external prompt
+  heading. Screen readers previously announced the question up to three
+  times per rating group.
+
 ## [2.1.1] - 2026-08-22
 
 ### Fixed

--- a/packages/lumi-survey/src/components/questions/DefaultQuestionRenderer/__tests__/DefaultQuestionRenderer.test.tsx
+++ b/packages/lumi-survey/src/components/questions/DefaultQuestionRenderer/__tests__/DefaultQuestionRenderer.test.tsx
@@ -328,7 +328,9 @@ describe("DefaultQuestionRenderer", () => {
     const errorRegion = container.querySelector(".aksel-fieldset__error");
 
     expect(fieldset).toHaveClass("aksel-fieldset");
-    expect(legend).toHaveClass("aksel-sr-only");
+    // The legend is the single, visible prompt for the group.
+    expect(legend).not.toHaveClass("aksel-sr-only");
+    expect(legend).toHaveTextContent(question.prompt);
     expect(errorRegion).toHaveClass("aksel-fieldset__error");
     expect(errorRegion).toHaveAttribute("aria-live", "polite");
     expect(errorRegion).toHaveTextContent("This field is required");

--- a/packages/lumi-survey/src/components/questions/rating/NpsRating.tsx
+++ b/packages/lumi-survey/src/components/questions/rating/NpsRating.tsx
@@ -99,71 +99,68 @@ export function NpsRating({
       fieldsetPaddingBlock={fieldsetPaddingBlock ?? "space-8"}
       fieldsetPaddingInline={fieldsetPaddingInline ?? "space-12"}
     >
-      {(groupProps) => (
-        <VStack gap="space-8">
-          <Box
-            {...groupProps}
-            as="div"
-            onKeyDown={radioGroup.onKeyDown}
-            style={{
-              width: "100%",
-              display: "grid",
-              gridTemplateColumns: "repeat(11, minmax(0, 1fr))",
-              gap: "var(--ax-space-2)",
-              overflow: "hidden",
-            }}
+      <VStack gap="space-8">
+        <Box
+          as="div"
+          onKeyDown={radioGroup.onKeyDown}
+          style={{
+            width: "100%",
+            display: "grid",
+            gridTemplateColumns: "repeat(11, minmax(0, 1fr))",
+            gap: "var(--ax-space-2)",
+            overflow: "hidden",
+          }}
+        >
+          {NPS_VALUES.map((value) => {
+            const isActive = activeState === value;
+            return (
+              <button
+                key={value}
+                type="button"
+                role="radio"
+                aria-checked={isActive}
+                aria-label={`${value} av 10`}
+                onClick={() => handleSelect(value)}
+                disabled={disabled}
+                tabIndex={radioGroup.getTabIndex(value)}
+                className="lumi-survey-rating__nps-button"
+                style={{
+                  ["--lumi-nps-bg" as string]: getNpsColor(value, isActive),
+                  ["--lumi-nps-border" as string]: getNpsBorderColor(
+                    value,
+                    isActive,
+                  ),
+                  ["--lumi-nps-hover-bg" as string]: isActive
+                    ? getNpsColor(value, true)
+                    : "var(--ax-bg-neutral-soft)",
+                  ["--lumi-nps-hover-border" as string]: isActive
+                    ? getNpsBorderColor(value, true)
+                    : "var(--ax-border-neutral-subtle)",
+                  ["--lumi-nps-font-weight" as string]: isActive ? 700 : 500,
+                }}
+              >
+                {value}
+              </button>
+            );
+          })}
+        </Box>
+        <HStack justify="space-between" style={{ width: "100%" }}>
+          <BodyShort
+            id={lowLabelId}
+            size="small"
+            style={{ color: "var(--ax-text-neutral-subtle)" }}
           >
-            {NPS_VALUES.map((value) => {
-              const isActive = activeState === value;
-              return (
-                <button
-                  key={value}
-                  type="button"
-                  role="radio"
-                  aria-checked={isActive}
-                  aria-label={`${value} av 10`}
-                  onClick={() => handleSelect(value)}
-                  disabled={disabled}
-                  tabIndex={radioGroup.getTabIndex(value)}
-                  className="lumi-survey-rating__nps-button"
-                  style={{
-                    ["--lumi-nps-bg" as string]: getNpsColor(value, isActive),
-                    ["--lumi-nps-border" as string]: getNpsBorderColor(
-                      value,
-                      isActive,
-                    ),
-                    ["--lumi-nps-hover-bg" as string]: isActive
-                      ? getNpsColor(value, true)
-                      : "var(--ax-bg-neutral-soft)",
-                    ["--lumi-nps-hover-border" as string]: isActive
-                      ? getNpsBorderColor(value, true)
-                      : "var(--ax-border-neutral-subtle)",
-                    ["--lumi-nps-font-weight" as string]: isActive ? 700 : 500,
-                  }}
-                >
-                  {value}
-                </button>
-              );
-            })}
-          </Box>
-          <HStack justify="space-between" style={{ width: "100%" }}>
-            <BodyShort
-              id={lowLabelId}
-              size="small"
-              style={{ color: "var(--ax-text-neutral-subtle)" }}
-            >
-              {lowLabel}
-            </BodyShort>
-            <BodyShort
-              id={highLabelId}
-              size="small"
-              style={{ color: "var(--ax-text-neutral-subtle)" }}
-            >
-              {highLabel}
-            </BodyShort>
-          </HStack>
-        </VStack>
-      )}
+            {lowLabel}
+          </BodyShort>
+          <BodyShort
+            id={highLabelId}
+            size="small"
+            style={{ color: "var(--ax-text-neutral-subtle)" }}
+          >
+            {highLabel}
+          </BodyShort>
+        </HStack>
+      </VStack>
     </RatingFieldset>
   );
 }

--- a/packages/lumi-survey/src/components/questions/rating/RatingFieldset.tsx
+++ b/packages/lumi-survey/src/components/questions/rating/RatingFieldset.tsx
@@ -1,15 +1,8 @@
 import { BodyShort, Box, Fieldset, Heading, VStack } from "@navikt/ds-react";
-import type { AriaAttributes, ComponentProps, ReactNode } from "react";
+import type { ComponentProps, ReactNode } from "react";
 import { useId } from "react";
 import type { RatingQuestion } from "../../../core/types.js";
 import { formatQuestionPrompt } from "../utils/formatQuestionPrompt.js";
-
-export interface RatingGroupAccessibilityProps {
-  role: "radiogroup";
-  "aria-labelledby": string;
-  "aria-describedby": AriaAttributes["aria-describedby"];
-  "aria-invalid": AriaAttributes["aria-invalid"];
-}
 
 interface RatingFieldsetProps {
   question: RatingQuestion;
@@ -24,7 +17,7 @@ interface RatingFieldsetProps {
   hideDescription?: boolean;
   fieldsetPaddingBlock?: ComponentProps<typeof Box>["paddingBlock"];
   fieldsetPaddingInline?: ComponentProps<typeof Box>["paddingInline"];
-  children: (groupProps: RatingGroupAccessibilityProps) => ReactNode;
+  children: ReactNode;
 }
 
 const joinIds = (...ids: Array<string | undefined>): string | undefined =>
@@ -33,6 +26,13 @@ const joinIds = (...ids: Array<string | undefined>): string | undefined =>
 /**
  * Uses Aksel for the standard form-field semantics while rating variants keep
  * their domain-specific visual controls and ARIA radio interaction.
+ *
+ * The fieldset itself carries `role="radiogroup"` (an allowed role for
+ * fieldset), so the accessibility tree exposes exactly one named group per
+ * question. The prompt exists in one place only: as the legend. When the
+ * prompt is visible it is a level 3 heading inside the legend; when an
+ * external heading labels the group, the legend copy is removed from the
+ * accessibility tree entirely.
  */
 export function RatingFieldset({
   question,
@@ -50,12 +50,10 @@ export function RatingFieldset({
   children,
 }: RatingFieldsetProps) {
   const instanceId = useId();
-  const fallbackHeadingId = `${instanceId}-heading`;
+  const headingId = `${instanceId}-heading`;
   const fallbackDescriptionId = `${instanceId}-description`;
   const legendContentId = `${instanceId}-legend`;
   const errorId = `${instanceId}-error`;
-  const headingId =
-    ariaLabelledBy ?? (!hidePrompt ? fallbackHeadingId : legendContentId);
   const descriptionId =
     !hideDescription && question.description
       ? fallbackDescriptionId
@@ -66,44 +64,49 @@ export function RatingFieldset({
     descriptionId,
     hasError ? errorId : undefined,
   );
+  const promptText = formatQuestionPrompt(question);
 
-  const groupProps: RatingGroupAccessibilityProps = {
-    role: "radiogroup",
-    "aria-labelledby": headingId,
-    "aria-describedby": describedBy,
-    "aria-invalid": hasError || undefined,
-  };
+  // Exactly one name source for the group:
+  // - visible prompt: the heading inside the legend (named via Aksel's legend
+  //   wiring, since no aria-labelledby is passed)
+  // - hidden prompt with an external heading: the external heading names the
+  //   group; the legend copy is aria-hidden so the text is not duplicated
+  // - hidden prompt without an external heading: the visually hidden legend
+  //   is the only name source
+  const legend = !hidePrompt ? (
+    <Heading id={headingId} level="3" size="xsmall">
+      {promptText}
+    </Heading>
+  ) : ariaLabelledBy ? (
+    <span aria-hidden="true">{promptText}</span>
+  ) : (
+    <span id={legendContentId}>{promptText}</span>
+  );
 
   return (
     <VStack gap="space-8" className={className}>
-      {!hidePrompt && (
-        <Heading
-          id={ariaLabelledBy ? undefined : fallbackHeadingId}
-          level="3"
-          size="xsmall"
-        >
-          {formatQuestionPrompt(question)}
-        </Heading>
-      )}
-      {question.description && !hideDescription && (
-        <BodyShort id={fallbackDescriptionId}>{question.description}</BodyShort>
-      )}
       <Fieldset
         className={fieldsetClassName}
-        legend={
-          <span id={legendContentId}>{formatQuestionPrompt(question)}</span>
-        }
-        hideLegend
+        legend={legend}
+        hideLegend={hidePrompt}
         error={hasError ? validationErrorMessage : undefined}
         errorId={errorId}
         disabled={disabled}
-        aria-labelledby={headingId}
+        role="radiogroup"
+        aria-labelledby={ariaLabelledBy}
+        aria-describedby={describedBy}
+        aria-invalid={hasError || undefined}
       >
+        {question.description && !hideDescription && (
+          <BodyShort id={fallbackDescriptionId}>
+            {question.description}
+          </BodyShort>
+        )}
         <Box
           paddingBlock={fieldsetPaddingBlock ?? "space-12"}
           paddingInline={fieldsetPaddingInline ?? "space-16"}
         >
-          {children(groupProps)}
+          {children}
         </Box>
       </Fieldset>
     </VStack>

--- a/packages/lumi-survey/src/components/questions/rating/RatingQuestionField.tsx
+++ b/packages/lumi-survey/src/components/questions/rating/RatingQuestionField.tsx
@@ -179,55 +179,52 @@ const EmojiRating = ({
       fieldsetPaddingBlock={fieldsetPaddingBlock}
       fieldsetPaddingInline={fieldsetPaddingInline}
     >
-      {(groupProps) => (
-        <HStack
-          {...groupProps}
-          gap="space-16"
-          justify="start"
-          align="center"
-          wrap={wrap}
-          className={joinClassNames(CLASS_NAMES.row, rowClassName)}
-          onKeyDown={radioGroup.onKeyDown}
-        >
-          {options.map((option, index) => {
-            const variant = resolveVariant(index);
-            const labelText = resolveLabel(
-              question as EmojiRatingQuestion,
-              option,
-            );
-            const isActive = activeState === option;
-            const buttonClass = joinClassNames(
-              CLASS_NAMES.button,
-              variant.className,
-              isActive ? CLASS_NAMES.active : undefined,
-              buttonClassName,
-            );
-            const buttonStyle = isActive
-              ? { color: variant.activeColor }
-              : undefined;
-            const Icon = variant.Icon;
-            const ariaLabel = `${option}. ${labelText}`;
+      <HStack
+        gap="space-16"
+        justify="start"
+        align="center"
+        wrap={wrap}
+        className={joinClassNames(CLASS_NAMES.row, rowClassName)}
+        onKeyDown={radioGroup.onKeyDown}
+      >
+        {options.map((option, index) => {
+          const variant = resolveVariant(index);
+          const labelText = resolveLabel(
+            question as EmojiRatingQuestion,
+            option,
+          );
+          const isActive = activeState === option;
+          const buttonClass = joinClassNames(
+            CLASS_NAMES.button,
+            variant.className,
+            isActive ? CLASS_NAMES.active : undefined,
+            buttonClassName,
+          );
+          const buttonStyle = isActive
+            ? { color: variant.activeColor }
+            : undefined;
+          const Icon = variant.Icon;
+          const ariaLabel = `${option}. ${labelText}`;
 
-            return (
-              <EmojiButton
-                key={option}
-                feedback={option}
-                activeState={activeState}
-                setActiveState={handleSelect}
-                className={buttonClass}
-                style={buttonStyle}
-                text={labelText}
-                renderText={!hideValueLabels}
-                ariaLabel={ariaLabel}
-                disabled={disabled}
-                tabIndex={radioGroup.getTabIndex(option)}
-              >
-                <Icon fill={isActive ? variant.activeFill : undefined} />
-              </EmojiButton>
-            );
-          })}
-        </HStack>
-      )}
+          return (
+            <EmojiButton
+              key={option}
+              feedback={option}
+              activeState={activeState}
+              setActiveState={handleSelect}
+              className={buttonClass}
+              style={buttonStyle}
+              text={labelText}
+              renderText={!hideValueLabels}
+              ariaLabel={ariaLabel}
+              disabled={disabled}
+              tabIndex={radioGroup.getTabIndex(option)}
+            >
+              <Icon fill={isActive ? variant.activeFill : undefined} />
+            </EmojiButton>
+          );
+        })}
+      </HStack>
     </RatingFieldset>
   );
 };

--- a/packages/lumi-survey/src/components/questions/rating/StarRating.tsx
+++ b/packages/lumi-survey/src/components/questions/rating/StarRating.tsx
@@ -99,122 +99,118 @@ export function StarRating({
       fieldsetPaddingBlock={fieldsetPaddingBlock}
       fieldsetPaddingInline={fieldsetPaddingInline}
     >
-      {(groupProps) => (
-        <VStack gap="space-4" align="center">
-          <HStack
-            {...groupProps}
-            gap="space-2"
-            justify="space-between"
-            align="center"
-            wrap={false}
-            onKeyDown={radioGroup.onKeyDown}
-            style={{ width: "100%", flexWrap: "nowrap" }}
-          >
-            {Array.from({ length: scale }, (_, index) => {
-              const starValue = index + 1;
-              const isFilled =
-                displayValue !== null && starValue <= displayValue;
-              const isActive = activeState === starValue;
-              const label = labels[starValue] ?? String(starValue);
+      <VStack gap="space-4" align="center">
+        <HStack
+          gap="space-2"
+          justify="space-between"
+          align="center"
+          wrap={false}
+          onKeyDown={radioGroup.onKeyDown}
+          style={{ width: "100%", flexWrap: "nowrap" }}
+        >
+          {Array.from({ length: scale }, (_, index) => {
+            const starValue = index + 1;
+            const isFilled = displayValue !== null && starValue <= displayValue;
+            const isActive = activeState === starValue;
+            const label = labels[starValue] ?? String(starValue);
 
-              return (
-                <button
-                  key={starValue}
-                  type="button"
-                  role="radio"
-                  aria-checked={isActive}
-                  aria-label={`${starValue} av ${scale} stjerner. ${label}`}
-                  onClick={() => handleSelect(starValue)}
-                  onMouseEnter={() => !disabled && setHoverValue(starValue)}
-                  onMouseLeave={() => setHoverValue(null)}
-                  onFocus={() => !disabled && setHoverValue(starValue)}
-                  onBlur={() => setHoverValue(null)}
-                  disabled={disabled}
-                  tabIndex={radioGroup.getTabIndex(starValue)}
+            return (
+              <button
+                key={starValue}
+                type="button"
+                role="radio"
+                aria-checked={isActive}
+                aria-label={`${starValue} av ${scale} stjerner. ${label}`}
+                onClick={() => handleSelect(starValue)}
+                onMouseEnter={() => !disabled && setHoverValue(starValue)}
+                onMouseLeave={() => setHoverValue(null)}
+                onFocus={() => !disabled && setHoverValue(starValue)}
+                onBlur={() => setHoverValue(null)}
+                disabled={disabled}
+                tabIndex={radioGroup.getTabIndex(starValue)}
+                style={{
+                  display: "flex",
+                  alignItems: "center",
+                  justifyContent: "center",
+                  padding:
+                    scale <= 5 ? "var(--ax-space-8)" : "var(--ax-space-6)",
+                  border: "none",
+                  borderRadius: "var(--ax-radius-4)",
+                  background: "transparent",
+                  cursor: disabled ? "not-allowed" : "pointer",
+                  opacity: disabled ? 0.5 : 1,
+                  transition: "transform 0.1s ease",
+                  transform:
+                    hoverValue === starValue ? "scale(1.2)" : "scale(1)",
+                  flex: "1 1 0",
+                  minWidth: 0,
+                }}
+              >
+                <span
+                  aria-hidden
                   style={{
-                    display: "flex",
-                    alignItems: "center",
-                    justifyContent: "center",
-                    padding:
-                      scale <= 5 ? "var(--ax-space-8)" : "var(--ax-space-6)",
-                    border: "none",
-                    borderRadius: "var(--ax-radius-4)",
-                    background: "transparent",
-                    cursor: disabled ? "not-allowed" : "pointer",
-                    opacity: disabled ? 0.5 : 1,
-                    transition: "transform 0.1s ease",
-                    transform:
-                      hoverValue === starValue ? "scale(1.2)" : "scale(1)",
-                    flex: "1 1 0",
-                    minWidth: 0,
+                    display: "inline-block",
+                    width: "2.5rem",
+                    height: "2.5rem",
+                    position: "relative",
+                    pointerEvents: "none",
                   }}
                 >
-                  <span
+                  <StarFillIcon
                     aria-hidden
                     style={{
-                      display: "inline-block",
+                      position: "absolute",
+                      inset: 0,
                       width: "2.5rem",
                       height: "2.5rem",
-                      position: "relative",
-                      pointerEvents: "none",
+                      color: "var(--ax-text-warning)",
+                      opacity: isFilled ? 1 : 0,
                     }}
-                  >
-                    <StarFillIcon
-                      aria-hidden
-                      style={{
-                        position: "absolute",
-                        inset: 0,
-                        width: "2.5rem",
-                        height: "2.5rem",
-                        color: "var(--ax-text-warning)",
-                        opacity: isFilled ? 1 : 0,
-                      }}
-                    />
-                    <StarIcon
-                      aria-hidden
-                      style={{
-                        position: "absolute",
-                        inset: 0,
-                        width: "2.5rem",
-                        height: "2.5rem",
-                        color: "var(--ax-text-neutral-subtle)",
-                        opacity: isFilled ? 0 : 1,
-                      }}
-                    />
-                  </span>
-                </button>
-              );
-            })}
-          </HStack>
-          {/* Label display based on showLabels prop */}
-          {showLabels === "always" && (
-            <BodyShort
-              size="small"
-              style={{
-                color: "var(--ax-text-neutral-subtle)",
-                minHeight: "1.5rem",
-                textAlign: "center",
-              }}
-            >
-              {activeState
-                ? (labels[activeState] ?? `${activeState} av ${scale}`)
-                : `Velg 1-${scale}`}
-            </BodyShort>
-          )}
-          {showLabels === "hover" && displayValue && (
-            <BodyShort
-              size="small"
-              style={{
-                color: "var(--ax-text-neutral-subtle)",
-                minHeight: "1.5rem",
-                textAlign: "center",
-              }}
-            >
-              {labels[displayValue] ?? `${displayValue} av ${scale}`}
-            </BodyShort>
-          )}
-        </VStack>
-      )}
+                  />
+                  <StarIcon
+                    aria-hidden
+                    style={{
+                      position: "absolute",
+                      inset: 0,
+                      width: "2.5rem",
+                      height: "2.5rem",
+                      color: "var(--ax-text-neutral-subtle)",
+                      opacity: isFilled ? 0 : 1,
+                    }}
+                  />
+                </span>
+              </button>
+            );
+          })}
+        </HStack>
+        {/* Label display based on showLabels prop */}
+        {showLabels === "always" && (
+          <BodyShort
+            size="small"
+            style={{
+              color: "var(--ax-text-neutral-subtle)",
+              minHeight: "1.5rem",
+              textAlign: "center",
+            }}
+          >
+            {activeState
+              ? (labels[activeState] ?? `${activeState} av ${scale}`)
+              : `Velg 1-${scale}`}
+          </BodyShort>
+        )}
+        {showLabels === "hover" && displayValue && (
+          <BodyShort
+            size="small"
+            style={{
+              color: "var(--ax-text-neutral-subtle)",
+              minHeight: "1.5rem",
+              textAlign: "center",
+            }}
+          >
+            {labels[displayValue] ?? `${displayValue} av ${scale}`}
+          </BodyShort>
+        )}
+      </VStack>
     </RatingFieldset>
   );
 }

--- a/packages/lumi-survey/src/components/questions/rating/ThumbsRating.tsx
+++ b/packages/lumi-survey/src/components/questions/rating/ThumbsRating.tsx
@@ -75,51 +75,48 @@ export function ThumbsRating({
       fieldsetPaddingBlock={fieldsetPaddingBlock}
       fieldsetPaddingInline={fieldsetPaddingInline}
     >
-      {(groupProps) => (
-        <HStack
-          {...groupProps}
-          gap="space-8"
-          justify="center"
-          align="center"
-          onKeyDown={radioGroup.onKeyDown}
-          wrap
-        >
-          <Box style={{ flex: "1 1 0" }}>
-            <Button
-              type="button"
-              role="radio"
-              aria-checked={activeState === 1}
-              aria-label="Nei, tommel ned"
-              onClick={() => handleSelect(1)}
-              disabled={disabled}
-              tabIndex={radioGroup.getTabIndex(1)}
-              data-color={activeState === 1 ? "danger" : undefined}
-              variant={activeState === 1 ? "primary" : "secondary"}
-              icon={<ThumbDownIcon fontSize="1.75rem" aria-hidden />}
-              style={{ width: "100%", justifyContent: "center" }}
-            >
-              Nei
-            </Button>
-          </Box>
+      <HStack
+        gap="space-8"
+        justify="center"
+        align="center"
+        onKeyDown={radioGroup.onKeyDown}
+        wrap
+      >
+        <Box style={{ flex: "1 1 0" }}>
+          <Button
+            type="button"
+            role="radio"
+            aria-checked={activeState === 1}
+            aria-label="Nei, tommel ned"
+            onClick={() => handleSelect(1)}
+            disabled={disabled}
+            tabIndex={radioGroup.getTabIndex(1)}
+            data-color={activeState === 1 ? "danger" : undefined}
+            variant={activeState === 1 ? "primary" : "secondary"}
+            icon={<ThumbDownIcon fontSize="1.75rem" aria-hidden />}
+            style={{ width: "100%", justifyContent: "center" }}
+          >
+            Nei
+          </Button>
+        </Box>
 
-          <Box style={{ flex: "1 1 0" }}>
-            <Button
-              type="button"
-              role="radio"
-              aria-checked={activeState === 2}
-              aria-label="Ja, tommel opp"
-              onClick={() => handleSelect(2)}
-              disabled={disabled}
-              tabIndex={radioGroup.getTabIndex(2)}
-              variant={activeState === 2 ? "primary" : "secondary"}
-              icon={<ThumbUpIcon fontSize="1.75rem" aria-hidden />}
-              style={{ width: "100%", justifyContent: "center" }}
-            >
-              Ja
-            </Button>
-          </Box>
-        </HStack>
-      )}
+        <Box style={{ flex: "1 1 0" }}>
+          <Button
+            type="button"
+            role="radio"
+            aria-checked={activeState === 2}
+            aria-label="Ja, tommel opp"
+            onClick={() => handleSelect(2)}
+            disabled={disabled}
+            tabIndex={radioGroup.getTabIndex(2)}
+            variant={activeState === 2 ? "primary" : "secondary"}
+            icon={<ThumbUpIcon fontSize="1.75rem" aria-hidden />}
+            style={{ width: "100%", justifyContent: "center" }}
+          >
+            Ja
+          </Button>
+        </Box>
+      </HStack>
     </RatingFieldset>
   );
 }

--- a/packages/lumi-survey/src/components/questions/rating/__tests__/RatingFieldset.test.tsx
+++ b/packages/lumi-survey/src/components/questions/rating/__tests__/RatingFieldset.test.tsx
@@ -1,0 +1,119 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import type { RatingQuestion } from "../../../../core/types.js";
+import { RatingQuestionField } from "../RatingQuestionField.js";
+
+const question: RatingQuestion = {
+  id: "rating",
+  type: "rating",
+  prompt: "Hvor fornøyd er du?",
+  required: true,
+};
+
+describe("RatingFieldset accessible naming", () => {
+  it("renders the prompt exactly once in the DOM", () => {
+    render(
+      <RatingQuestionField
+        question={question}
+        value={undefined}
+        onChange={() => {}}
+        validationErrorMessage="Velg en vurdering"
+        isMissing={false}
+        disabled={false}
+      />,
+    );
+
+    expect(screen.getAllByText("Hvor fornøyd er du?")).toHaveLength(1);
+  });
+
+  it("exposes exactly one named group: the radiogroup", () => {
+    render(
+      <RatingQuestionField
+        question={question}
+        value={undefined}
+        onChange={() => {}}
+        validationErrorMessage="Velg en vurdering"
+        isMissing={false}
+        disabled={false}
+      />,
+    );
+
+    const radiogroup = screen.getByRole("radiogroup", {
+      name: "Hvor fornøyd er du?",
+    });
+    expect(radiogroup).toBeInTheDocument();
+
+    // The fieldset must not appear as a second, separately named group
+    // wrapped around the radiogroup.
+    expect(
+      screen.queryByRole("group", { name: "Hvor fornøyd er du?" }),
+    ).not.toBeInTheDocument();
+  });
+
+  it("keeps the prompt reachable as a level 3 heading", () => {
+    render(
+      <RatingQuestionField
+        question={question}
+        value={undefined}
+        onChange={() => {}}
+        validationErrorMessage="Velg en vurdering"
+        isMissing={false}
+        disabled={false}
+      />,
+    );
+
+    expect(
+      screen.getByRole("heading", { level: 3, name: "Hvor fornøyd er du?" }),
+    ).toBeInTheDocument();
+  });
+
+  it("does not duplicate an external prompt heading in the hidden legend", () => {
+    render(
+      <>
+        <h2 id="external-heading">Hvor fornøyd er du?</h2>
+        <RatingQuestionField
+          question={question}
+          value={undefined}
+          onChange={() => {}}
+          validationErrorMessage="Velg en vurdering"
+          isMissing={false}
+          disabled={false}
+          hidePrompt
+          ariaLabelledBy="external-heading"
+        />
+      </>,
+    );
+
+    const radiogroup = screen.getByRole("radiogroup", {
+      name: "Hvor fornøyd er du?",
+    });
+    expect(radiogroup).toHaveAttribute("aria-labelledby", "external-heading");
+
+    // The prompt text must only exist once outside the widget; the sr-only
+    // legend copy must be hidden from the accessibility tree.
+    const copies = screen.getAllByText("Hvor fornøyd er du?");
+    const visibleToAssistiveTech = copies.filter(
+      (el) => !el.closest("[aria-hidden='true']"),
+    );
+    expect(visibleToAssistiveTech).toHaveLength(1);
+  });
+
+  it("keeps the sr-only legend as name source when the prompt is hidden without an external label", () => {
+    render(
+      <RatingQuestionField
+        question={question}
+        value={undefined}
+        onChange={() => {}}
+        validationErrorMessage="Velg en vurdering"
+        isMissing={false}
+        disabled={false}
+        hidePrompt
+      />,
+    );
+
+    expect(
+      screen.getByRole("radiogroup", { name: "Hvor fornøyd er du?" }),
+    ).toBeInTheDocument();
+    expect(screen.queryByRole("heading")).not.toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Hva

- gjør Aksel-legenden til rating-spørsmålets eneste navnekilde
- lar fieldset være den eneste radiogroup og fjerner det nøstede gruppelaget
- bevarer synlig h3, skjult prompt, ekstern aria-labelledby, feilbeskrivelse og tastaturnavigasjon
- oppdaterer Surveyverksted-E2E til den nye semantiske rollen
- legger til regresjonstester og changelog

Closes #501

## Reproduksjon

Tester mot gammel oppførsel viste spørsmålsteksten to ganger i DOM og både group og radiogroup med samme navn.

## Validering

- pnpm run lint
- pnpm run typecheck
- pnpm run test: widget 455, dashboard 617
- verify:lumi-survey og ren konsument-build
- release guards og release drift
- full Playwright 60/60 før siste rebase; eksakt rebase verifisert med berørt flyt og a11y 2/2

Avventer uavhengig review av eksakt SHA 0cef3a04cd6c8e315d8920d8d9e62d9bcebccd11. Skal ikke merges automatisk.