### PR TITLE
Skill tomtilstandene i tilbakemeldingslisten fra hverandre

### DIFF
--- a/apps/lumi-dashboard/app/components/feedback/FeedbackTable/EmptyState.tsx
+++ b/apps/lumi-dashboard/app/components/feedback/FeedbackTable/EmptyState.tsx
@@ -1,0 +1,123 @@
+import {
+  Link as AkselLink,
+  Alert,
+  BodyShort,
+  Button,
+  Heading,
+  VStack,
+} from "@navikt/ds-react";
+import { Link } from "@tanstack/react-router";
+import dayjs from "dayjs";
+
+interface FeedbackEmptyStateProps {
+  /** Whether the team has any submissions at all; undefined while unknown. */
+  hasAnyData: boolean | undefined;
+  hasActiveNonPeriodFilters: boolean;
+  onResetFilters: () => void;
+  periodFromDate?: string;
+  periodToDate?: string;
+  /** First-to-last submission span across the team's surveys. */
+  fullPeriod?: { fromDate: string; toDate: string };
+  onShowFullPeriod: (period: { fromDate: string; toDate: string }) => void;
+}
+
+const formatDate = (date: string) => dayjs(date).format("DD.MM.YYYY");
+
+const describeEmptyPeriod = (fromDate?: string, toDate?: string) => {
+  if (fromDate && toDate) {
+    return `Ingen tilbakemeldinger i perioden ${formatDate(fromDate)}–${formatDate(toDate)}.`;
+  }
+  if (fromDate) {
+    return `Ingen tilbakemeldinger fra og med ${formatDate(fromDate)}.`;
+  }
+  if (toDate) {
+    return `Ingen tilbakemeldinger til og med ${formatDate(toDate)}.`;
+  }
+  return undefined;
+};
+
+/**
+ * Empty state for the feedback list. Distinguishes three situations the
+ * generic "no results" message used to cover: the team has no data yet
+ * (onboarding), active filters exclude everything (reset), or the selected
+ * period is empty (show the full survey period).
+ */
+export function FeedbackEmptyState({
+  hasAnyData,
+  hasActiveNonPeriodFilters,
+  onResetFilters,
+  periodFromDate,
+  periodToDate,
+  fullPeriod,
+  onShowFullPeriod,
+}: FeedbackEmptyStateProps) {
+  const emptyPeriodDescription = describeEmptyPeriod(
+    periodFromDate,
+    periodToDate,
+  );
+
+  if (hasAnyData === false) {
+    return (
+      <Alert variant="info">
+        <VStack gap="space-8" align="start">
+          <Heading size="xsmall" level="2">
+            Ingen tilbakemeldinger ennå
+          </Heading>
+          <BodyShort>
+            Når en app sender inn svar via survey-widgeten, dukker de opp her.
+          </BodyShort>
+          <BodyShort>
+            <AkselLink href="https://navikt.github.io/lumi/kom-i-gang/hva-er-lumi">
+              Kom i gang med Lumi
+            </AkselLink>
+          </BodyShort>
+          <BodyShort>
+            <AkselLink as={Link} to="/surveyverksted">
+              Lag en survey i Surveyverksted
+            </AkselLink>
+          </BodyShort>
+        </VStack>
+      </Alert>
+    );
+  }
+
+  if (hasAnyData && hasActiveNonPeriodFilters) {
+    return (
+      <Alert variant="info">
+        <VStack gap="space-8" align="start">
+          <BodyShort>Ingen treff med gjeldende filtre</BodyShort>
+          <Button
+            type="button"
+            variant="secondary"
+            size="small"
+            onClick={onResetFilters}
+          >
+            Nullstill filtre
+          </Button>
+        </VStack>
+      </Alert>
+    );
+  }
+
+  if (hasAnyData && emptyPeriodDescription) {
+    return (
+      <Alert variant="info">
+        <VStack gap="space-8" align="start">
+          <BodyShort>{emptyPeriodDescription}</BodyShort>
+          {fullPeriod && (
+            <Button
+              type="button"
+              variant="secondary"
+              size="small"
+              onClick={() => onShowFullPeriod(fullPeriod)}
+            >
+              Vis hele svarperioden
+            </Button>
+          )}
+        </VStack>
+      </Alert>
+    );
+  }
+
+  return <Alert variant="info">Ingen tilbakemeldinger funnet</Alert>;
+}

--- a/apps/lumi-dashboard/app/components/feedback/FeedbackTable/__tests__/FeedbackTable.emptyState.test.tsx
+++ b/apps/lumi-dashboard/app/components/feedback/FeedbackTable/__tests__/FeedbackTable.emptyState.test.tsx
@@ -1,0 +1,308 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { FeedbackTable } from "../index";
+
+const {
+  mockParams,
+  mockBootstrap,
+  mockFeedback,
+  mockSetParam,
+  mockSetParams,
+  mockResetParams,
+} = vi.hoisted(() => ({
+  mockParams: {
+    team: "team-test",
+    surveyId: undefined as string | undefined,
+    app: undefined as string | undefined,
+    query: undefined as string | undefined,
+    dateMode: "auto" as "auto" | "fixed" | undefined,
+    fromDate: "2026-07-24" as string | undefined,
+    toDate: "2026-08-22" as string | undefined,
+    page: "1" as string | undefined,
+    showArchived: undefined as string | undefined,
+  },
+  mockBootstrap: {
+    data: undefined as unknown,
+    isPending: false,
+  },
+  mockFeedback: {
+    data: {
+      content: [] as Array<Record<string, unknown>>,
+      totalPages: 1,
+      totalElements: 0,
+      size: 10,
+    },
+    error: null as Error | null,
+    isPending: false,
+  },
+  mockSetParam: vi.fn(),
+  mockSetParams: vi.fn(),
+  mockResetParams: vi.fn(),
+}));
+
+vi.mock("~/hooks/useSearchParams", () => ({
+  useSearchParams: () => ({
+    params: mockParams,
+    setParam: mockSetParam,
+    setParams: mockSetParams,
+    resetParams: mockResetParams,
+  }),
+}));
+
+vi.mock("~/hooks/useFeedback", () => ({
+  useFeedback: () => mockFeedback,
+}));
+
+vi.mock("~/hooks/useFilterBootstrap", () => ({
+  useFilterBootstrap: () => mockBootstrap,
+}));
+
+vi.mock("~/hooks/useDeleteFeedback", () => ({
+  useDeleteFeedback: () => ({ mutate: vi.fn(), isPending: false }),
+}));
+
+vi.mock("~/hooks/useDeleteSurvey", () => ({
+  useDeleteSurvey: () => ({
+    mutateAsync: vi.fn(),
+    isError: false,
+    isPending: false,
+  }),
+}));
+
+vi.mock("~/hooks/useSurveyTotalCount", () => ({
+  useSurveyTotalCount: () => ({
+    data: 0,
+    isLoading: false,
+    isError: false,
+  }),
+}));
+
+vi.mock("~/hooks/useArchiveSurvey", () => ({
+  useArchiveSurvey: () => ({
+    archiveMutation: {
+      mutateAsync: vi.fn(),
+      reset: vi.fn(),
+      isError: false,
+      isPending: false,
+    },
+    restoreMutation: {
+      mutate: vi.fn(),
+      isError: false,
+      isPending: false,
+    },
+  }),
+}));
+
+vi.mock("@tanstack/react-router", () => ({
+  Link: ({
+    children,
+    to,
+    ...rest
+  }: {
+    children: React.ReactNode;
+    to: string;
+  }) => (
+    <a href={to} {...rest}>
+      {children}
+    </a>
+  ),
+}));
+
+function bootstrapWithData() {
+  return {
+    selectedTeam: "team-test",
+    availableTeams: ["team-test"],
+    apps: ["app-test"],
+    surveysByApp: { "app-test": ["survey-1"] },
+    tags: [],
+    surveyMeta: {
+      "survey-1": {
+        archivedAt: null,
+        firstSubmissionAt: "2026-01-10T09:00:00Z",
+        lastSubmissionAt: "2026-06-05T12:00:00Z",
+      },
+    },
+  };
+}
+
+function bootstrapWithoutData() {
+  return {
+    selectedTeam: "team-test",
+    availableTeams: ["team-test"],
+    apps: [],
+    surveysByApp: {},
+    tags: [],
+    surveyMeta: {},
+  };
+}
+
+describe("FeedbackTable empty states", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockParams.surveyId = undefined;
+    mockParams.app = undefined;
+    mockParams.query = undefined;
+    mockParams.dateMode = "auto";
+    mockParams.fromDate = "2026-07-24";
+    mockParams.toDate = "2026-08-22";
+    mockParams.page = "1";
+    mockParams.showArchived = undefined;
+    mockBootstrap.isPending = false;
+    mockFeedback.data = {
+      content: [],
+      totalPages: 1,
+      totalElements: 0,
+      size: 10,
+    };
+    mockFeedback.error = null;
+    mockFeedback.isPending = false;
+  });
+
+  it("shows onboarding guidance when the team has no data at all", () => {
+    mockBootstrap.data = bootstrapWithoutData();
+
+    render(<FeedbackTable />);
+
+    expect(screen.getByText("Ingen tilbakemeldinger ennå")).toBeInTheDocument();
+    expect(
+      screen.getByRole("link", { name: /kom i gang/i }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("link", { name: /surveyverksted/i }),
+    ).toBeInTheDocument();
+  });
+
+  it("offers a reset action when active filters exclude everything", () => {
+    mockBootstrap.data = bootstrapWithData();
+    mockParams.query = "finnesikke";
+
+    render(<FeedbackTable />);
+
+    expect(
+      screen.getByText("Ingen treff med gjeldende filtre"),
+    ).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: /nullstill filtre/i }));
+    expect(mockResetParams).toHaveBeenCalled();
+  });
+
+  it("shows the period and offers the full survey period when no filters are active", () => {
+    mockBootstrap.data = bootstrapWithData();
+
+    render(<FeedbackTable />);
+
+    expect(
+      screen.getByText(/Ingen tilbakemeldinger i perioden/),
+    ).toBeInTheDocument();
+    expect(screen.getByText(/24\.07\.2026.*22\.08\.2026/)).toBeInTheDocument();
+
+    fireEvent.click(
+      screen.getByRole("button", { name: /vis hele svarperioden/i }),
+    );
+    expect(mockSetParams).toHaveBeenCalledWith(
+      expect.objectContaining({
+        dateMode: "fixed",
+        fromDate: "2026-01-10",
+        toDate: "2026-06-05",
+        page: "1",
+      }),
+    );
+  });
+
+  it("explains a fixed period miss instead of calling the period a filter", () => {
+    mockBootstrap.data = bootstrapWithData();
+    mockParams.dateMode = "fixed";
+    mockParams.fromDate = "2026-07-01";
+    mockParams.toDate = "2026-07-31";
+
+    render(<FeedbackTable />);
+
+    expect(
+      screen.getByText(/Ingen tilbakemeldinger i perioden/),
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByText("Ingen treff med gjeldende filtre"),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: /vis hele svarperioden/i }),
+    ).toBeInTheDocument();
+  });
+
+  it.each([
+    {
+      fromDate: "2026-07-01",
+      toDate: undefined,
+      expected: "Ingen tilbakemeldinger fra og med 01.07.2026.",
+    },
+    {
+      fromDate: undefined,
+      toDate: "2026-07-31",
+      expected: "Ingen tilbakemeldinger til og med 31.07.2026.",
+    },
+  ])("explains a one-sided bookmarked period", ({
+    fromDate,
+    toDate,
+    expected,
+  }) => {
+    mockBootstrap.data = bootstrapWithData();
+    mockParams.dateMode = "fixed";
+    mockParams.fromDate = fromDate;
+    mockParams.toDate = toDate;
+
+    render(<FeedbackTable />);
+
+    expect(screen.getByText(expected)).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: /vis hele svarperioden/i }),
+    ).toBeInTheDocument();
+  });
+
+  it("does not offer an archived-only period while archived surveys are hidden", () => {
+    const bootstrap = bootstrapWithData();
+    mockBootstrap.data = {
+      ...bootstrap,
+      surveyMeta: {
+        "survey-1": {
+          ...bootstrap.surveyMeta["survey-1"],
+          archivedAt: "2026-06-06T12:00:00Z",
+        },
+      },
+    };
+
+    render(<FeedbackTable />);
+
+    expect(
+      screen.queryByRole("button", { name: /vis hele svarperioden/i }),
+    ).not.toBeInTheDocument();
+  });
+
+  it("returns to the last page when the current page no longer exists", async () => {
+    mockBootstrap.data = bootstrapWithData();
+    mockParams.page = "3";
+    mockFeedback.data = {
+      content: [],
+      totalPages: 2,
+      totalElements: 21,
+      size: 10,
+    };
+
+    render(<FeedbackTable />);
+
+    await waitFor(() => {
+      expect(mockSetParam).toHaveBeenCalledWith("page", "2");
+    });
+    expect(
+      screen.queryByText(/Ingen tilbakemeldinger|Ingen treff/),
+    ).not.toBeInTheDocument();
+  });
+
+  it("keeps the generic message while bootstrap is unavailable", () => {
+    mockBootstrap.data = undefined;
+
+    render(<FeedbackTable />);
+
+    expect(
+      screen.getByText("Ingen tilbakemeldinger funnet"),
+    ).toBeInTheDocument();
+  });
+});

--- a/apps/lumi-dashboard/app/components/feedback/FeedbackTable/index.tsx
+++ b/apps/lumi-dashboard/app/components/feedback/FeedbackTable/index.tsx
@@ -18,13 +18,15 @@ import {
   Tooltip,
   VStack,
 } from "@navikt/ds-react";
-import React, { useState } from "react";
+import React, { useEffect, useState } from "react";
 
+import { useActiveFilters } from "~/hooks/useActiveFilters";
 import { useArchiveSurvey } from "~/hooks/useArchiveSurvey";
 import { useDeleteFeedback } from "~/hooks/useDeleteFeedback";
 import { useFeedback } from "~/hooks/useFeedback";
 import { useFilterBootstrap } from "~/hooks/useFilterBootstrap";
 import { useSearchParams } from "~/hooks/useSearchParams";
+import { getTeamSubmissionPeriod } from "~/utils/dashboardPeriod";
 import {
   formatRelativeSubmissionTime,
   isReceivingAfterArchive,
@@ -33,6 +35,7 @@ import {
 import { ArchiveSurveyDialog } from "../../dashboard/ArchiveSurveyDialog";
 import { DeleteSurveyDialog } from "../../dashboard/DeleteSurveyDialog";
 import { DeleteFeedbackDialog } from "../DeleteFeedbackDialog";
+import { FeedbackEmptyState } from "./EmptyState";
 import { FeedbackCard } from "./FeedbackCard";
 import { FeedbackExpandedView } from "./FeedbackExpandedView";
 import { FeedbackRow } from "./FeedbackRow";
@@ -45,7 +48,7 @@ import styles from "./styles.module.css";
  * Supports expand/collapse for detailed view, deletion, and filtering.
  */
 export function FeedbackTable() {
-  const { params, setParam } = useSearchParams();
+  const { params, setParam, setParams } = useSearchParams();
   const page = Number.parseInt(params.page || "1", 10);
   const { data, error, isPending } = useFeedback();
   const [expandedRows, setExpandedRows] = useState<Set<string>>(new Set());
@@ -55,6 +58,22 @@ export function FeedbackTable() {
   const deleteFeedbackMutation = useDeleteFeedback();
   const { data: bootstrap } = useFilterBootstrap();
   const { restoreMutation } = useArchiveSurvey(params.surveyId);
+  const { hasActiveNonPeriodFilters, resetFilters } = useActiveFilters();
+  const feedbackList = data?.content || [];
+  const totalPages = data?.totalPages || 1;
+  const totalElements = data?.totalElements || 0;
+  const hasOutOfRangePage =
+    !isPending &&
+    !error &&
+    feedbackList.length === 0 &&
+    totalElements > 0 &&
+    page > totalPages;
+
+  useEffect(() => {
+    if (hasOutOfRangePage) {
+      setParam("page", String(totalPages));
+    }
+  }, [hasOutOfRangePage, setParam, totalPages]);
 
   const toggleExpanded = (id: string) => {
     setExpandedRows((prev) => {
@@ -75,14 +94,11 @@ export function FeedbackTable() {
 
   // isPending: no cached data AND fetching (TanStack Query v5 best practice)
   // With placeholderData: keepPreviousData, isPending stays false during refetches
-  if (isPending) {
+  if (isPending || hasOutOfRangePage) {
     return <FeedbackTableSkeleton showToolbar />;
   }
 
   // Data extraction
-  const feedbackList = data?.content || [];
-  const totalPages = data?.totalPages || 1;
-  const totalElements = data?.totalElements || 0;
   const selectedSurvey = params.surveyId;
   const selectedSurveyMeta = selectedSurvey
     ? bootstrap?.surveyMeta?.[selectedSurvey]
@@ -110,7 +126,24 @@ export function FeedbackTable() {
       )}
 
       {feedbackList.length === 0 ? (
-        <Alert variant="info">Ingen tilbakemeldinger funnet</Alert>
+        <FeedbackEmptyState
+          hasAnyData={bootstrap ? bootstrap.apps.length > 0 : undefined}
+          hasActiveNonPeriodFilters={hasActiveNonPeriodFilters}
+          onResetFilters={resetFilters}
+          periodFromDate={params.fromDate}
+          periodToDate={params.toDate}
+          fullPeriod={getTeamSubmissionPeriod(bootstrap?.surveyMeta, {
+            includeArchived: params.showArchived === "true",
+          })}
+          onShowFullPeriod={(period) =>
+            setParams({
+              dateMode: "fixed",
+              fromDate: period.fromDate,
+              toDate: period.toDate,
+              page: "1",
+            })
+          }
+        />
       ) : (
         <>
           {/* Desktop: Table view */}

--- a/apps/lumi-dashboard/app/components/shared/FilterBar/index.tsx
+++ b/apps/lumi-dashboard/app/components/shared/FilterBar/index.tsx
@@ -17,6 +17,7 @@ import dayjs from "dayjs";
 import { useEffect } from "react";
 import { PeriodSelector } from "~/components/dashboard/PeriodSelector";
 import { getSurveyFeatures } from "~/config/surveyConfig";
+import { useActiveFilters } from "~/hooks/useActiveFilters";
 import { useFilterBootstrap } from "~/hooks/useFilterBootstrap";
 import { useSearchParams } from "~/hooks/useSearchParams";
 import { useStats } from "~/hooks/useStats";
@@ -39,7 +40,7 @@ interface FilterBarProps {
 }
 
 export function FilterBar({ showDetails = false }: FilterBarProps) {
-  const { params, setParams, resetParams } = useSearchParams();
+  const { params, setParams } = useSearchParams();
   const { data: bootstrap, isPending: isPendingBootstrap } =
     useFilterBootstrap();
   const { data: stats, isPending: isPendingStats } = useStats();
@@ -57,6 +58,7 @@ export function FilterBar({ showDetails = false }: FilterBarProps) {
     toDate: params.toDate,
   });
   const rollingAutomaticPeriod = resolveDashboardPeriod({ dateMode: "auto" });
+  const { hasActiveFilters, resetFilters: handleReset } = useActiveFilters();
 
   const selectedTags = params.tag
     ? params.tag
@@ -311,16 +313,6 @@ export function FilterBar({ showDetails = false }: FilterBarProps) {
     showArchived,
   ]);
 
-  const handleReset = () => {
-    resetParams({
-      team: params.team,
-      dateMode: "auto",
-      fromDate: rollingAutomaticPeriod.fromDate,
-      toDate: rollingAutomaticPeriod.toDate,
-      page: "1",
-    });
-  };
-
   const handleTeamChange = (newTeam: string) => {
     setParams({
       team: newTeam,
@@ -349,29 +341,13 @@ export function FilterBar({ showDetails = false }: FilterBarProps) {
     });
   };
 
-  const hasActiveFilters =
-    params.dateMode === "fixed" ||
-    params.query ||
-    params.surveyId ||
-    params.app ||
-    params.lowRating ||
-    params.hasText ||
-    params.deviceType ||
-    params.tag ||
-    params.segment ||
-    params.task ||
-    params.theme ||
-    params.choice ||
-    params.rating ||
-    params.phrase;
-
   const isPending = isPendingBootstrap || isPendingStats;
 
   if (isPending) {
     return (
       <FilterBarSkeleton
         showDetails={showDetails}
-        hasActiveFilters={!!hasActiveFilters}
+        hasActiveFilters={hasActiveFilters}
       />
     );
   }

--- a/apps/lumi-dashboard/app/hooks/useActiveFilters.ts
+++ b/apps/lumi-dashboard/app/hooks/useActiveFilters.ts
@@ -1,0 +1,61 @@
+import { useCallback } from "react";
+import { type SearchParams, useSearchParams } from "~/hooks/useSearchParams";
+import { resolveDashboardPeriod } from "~/utils/dashboardPeriod";
+
+/**
+ * True when any user-adjustable filter deviates from the default view:
+ * a fixed period, free-text search, or any survey/app/field filter.
+ */
+export function hasActiveDashboardFilters(params: SearchParams): boolean {
+  return Boolean(
+    params.dateMode === "fixed" || hasActiveNonPeriodFilters(params),
+  );
+}
+
+/**
+ * Filters that can exclude feedback independently of the selected period.
+ * Kept separate so an empty state can explain a period-only miss precisely.
+ */
+export function hasActiveNonPeriodFilters(params: SearchParams): boolean {
+  return Boolean(
+    params.query ||
+      params.surveyId ||
+      params.app ||
+      params.lowRating ||
+      params.hasText ||
+      params.deviceType ||
+      params.tag ||
+      params.segment ||
+      params.task ||
+      params.theme ||
+      params.choice ||
+      params.rating ||
+      params.phrase,
+  );
+}
+
+/**
+ * Shared source for "are any filters active?" and the reset action, so the
+ * filter bar and empty states stay in sync on what counts as a filter and
+ * what the default view is.
+ */
+export function useActiveFilters() {
+  const { params, resetParams } = useSearchParams();
+
+  const resetFilters = useCallback(() => {
+    const rollingAutomaticPeriod = resolveDashboardPeriod({ dateMode: "auto" });
+    resetParams({
+      team: params.team,
+      dateMode: "auto",
+      fromDate: rollingAutomaticPeriod.fromDate,
+      toDate: rollingAutomaticPeriod.toDate,
+      page: "1",
+    });
+  }, [params.team, resetParams]);
+
+  return {
+    hasActiveFilters: hasActiveDashboardFilters(params),
+    hasActiveNonPeriodFilters: hasActiveNonPeriodFilters(params),
+    resetFilters,
+  };
+}

--- a/apps/lumi-dashboard/app/utils/__tests__/dashboardPeriod.test.ts
+++ b/apps/lumi-dashboard/app/utils/__tests__/dashboardPeriod.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, it } from "vitest";
-import { resolveDashboardPeriod } from "../dashboardPeriod";
+import {
+  getTeamSubmissionPeriod,
+  resolveDashboardPeriod,
+} from "../dashboardPeriod";
 
 describe("resolveDashboardPeriod", () => {
   it("uses a rolling 30-day period in auto mode when no survey is selected", () => {
@@ -95,6 +98,37 @@ describe("resolveDashboardPeriod", () => {
         toDate: "2024-02-18",
       },
       isOutsideSurveyPeriod: true,
+    });
+  });
+});
+
+describe("getTeamSubmissionPeriod", () => {
+  const surveyMeta = {
+    active: {
+      archivedAt: null,
+      firstSubmissionAt: "2026-02-01T12:00:00Z",
+      lastSubmissionAt: "2026-02-10T12:00:00Z",
+    },
+    archived: {
+      archivedAt: "2026-03-02T12:00:00Z",
+      firstSubmissionAt: "2026-01-01T12:00:00Z",
+      lastSubmissionAt: "2026-03-01T12:00:00Z",
+    },
+  };
+
+  it("uses only surveys visible under the default archive filter", () => {
+    expect(getTeamSubmissionPeriod(surveyMeta)).toEqual({
+      fromDate: "2026-02-01",
+      toDate: "2026-02-10",
+    });
+  });
+
+  it("includes archived surveys when they are visible", () => {
+    expect(
+      getTeamSubmissionPeriod(surveyMeta, { includeArchived: true }),
+    ).toEqual({
+      fromDate: "2026-01-01",
+      toDate: "2026-03-01",
     });
   });
 });

--- a/apps/lumi-dashboard/app/utils/dashboardPeriod.ts
+++ b/apps/lumi-dashboard/app/utils/dashboardPeriod.ts
@@ -21,8 +21,13 @@ export interface DashboardPeriod {
 }
 
 export interface SurveyPeriodMetadata {
+  archivedAt?: string | null;
   firstSubmissionAt?: string | null;
   lastSubmissionAt?: string | null;
+}
+
+interface TeamSubmissionPeriodOptions {
+  includeArchived?: boolean;
 }
 
 interface ResolveDashboardPeriodInput {
@@ -96,5 +101,36 @@ export function resolveDashboardPeriod({
     dateMode: "auto",
     fromDate: start.format("YYYY-MM-DD"),
     toDate: end.format("YYYY-MM-DD"),
+  };
+}
+
+/**
+ * The span from the team's first to its last registered submission across
+ * surveys visible under the current archive filter. Used by empty states to
+ * offer "show the full survey period" when the current period has no hits.
+ */
+export function getTeamSubmissionPeriod(
+  surveyMeta: Record<string, SurveyPeriodMetadata> | undefined,
+  { includeArchived = false }: TeamSubmissionPeriodOptions = {},
+): { fromDate: string; toDate: string } | undefined {
+  if (!surveyMeta) return undefined;
+
+  let first: dayjs.Dayjs | undefined;
+  let last: dayjs.Dayjs | undefined;
+
+  for (const meta of Object.values(surveyMeta)) {
+    if (!includeArchived && meta.archivedAt) continue;
+
+    const metaFirst = toOsloDate(meta.firstSubmissionAt);
+    const metaLast = toOsloDate(meta.lastSubmissionAt);
+    if (metaFirst && (!first || metaFirst.isBefore(first))) first = metaFirst;
+    if (metaLast && (!last || metaLast.isAfter(last))) last = metaLast;
+  }
+
+  if (!first || !last || first.isAfter(last, "day")) return undefined;
+
+  return {
+    fromDate: first.format("YYYY-MM-DD"),
+    toDate: last.format("YYYY-MM-DD"),
   };
 }

--- a/apps/lumi-dashboard/e2e/dashboard-period.spec.ts
+++ b/apps/lumi-dashboard/e2e/dashboard-period.spec.ts
@@ -57,9 +57,9 @@ test.describe("Dashboard response period", () => {
         .getByText(HISTORICAL_SURVEY_ID, { exact: true })
         .first(),
     ).toBeVisible();
-    await expect(page.getByText("Ingen tilbakemeldinger funnet")).toHaveCount(
-      0,
-    );
+    await expect(
+      page.getByText(/Ingen tilbakemeldinger|Ingen treff/),
+    ).toHaveCount(0);
 
     await page.getByRole("link", { name: "Eksporter" }).click();
     await expect(page).toHaveURL(/\/export/);

--- a/apps/lumi-dashboard/e2e/survey-views.spec.ts
+++ b/apps/lumi-dashboard/e2e/survey-views.spec.ts
@@ -101,9 +101,9 @@ test.describe("Survey Views", () => {
       await expect(
         page.getByText(new RegExp(`Viser ${expectedCount} svar`)),
       ).toBeVisible();
-      await expect(page.getByText("Ingen tilbakemeldinger funnet")).toHaveCount(
-        0,
-      );
+      await expect(
+        page.getByText(/Ingen tilbakemeldinger|Ingen treff/),
+      ).toHaveCount(0);
     });
 
     test("theme editor fits a narrow viewport without structural accessibility violations", async ({


### PR DESCRIPTION
## Hva

- deler tomlisten i onboarding, filtrert-bort og tom periode
- gir handlingene Nullstill filtre og Vis hele svarperioden
- støtter auto-, fast- og ensidige legacy-perioder
- følger arkivfilteret når full svarperiode beregnes
- normaliserer en side som ikke lenger finnes etter sletting
- deler filterdeteksjon og reset mellom FilterBar og tomtilstanden

Closes #503

## Reproduksjon

Tester skrevet mot den gamle oppførselen bekreftet at samme generiske melding ble brukt for alle tre situasjoner.

## Validering

- pnpm run lint
- pnpm run typecheck
- pnpm run test: widget 450, dashboard 628
- berørte Playwright-flyter: 15/15
- uavhengig review godkjente eksakt SHA c4dccd70e6d45a07f03ecccd1d9326567d3cbe9e uten funn

Skal ikke merges automatisk.