### PR TITLE
Stabiliser widgetens lifecycle-callbacks

### DIFF
--- a/packages/lumi-survey/CHANGELOG.md
+++ b/packages/lumi-survey/CHANGELOG.md
@@ -20,6 +20,8 @@ This project follows SemVer.
 - Text answers that exceed the configured limit, or the API maximum of 2000
   characters, are now blocked in the widget with a field-level validation
   message instead of failing permanently as a generic transport error.
+- Inline `events` objects no longer count parent re-renders as new dock views
+  or restart the success auto-close timer.
 
 ### Internal
 

--- a/packages/lumi-survey/src/components/LumiSurveyDock/__tests__/LumiSurveyDock.test.tsx
+++ b/packages/lumi-survey/src/components/LumiSurveyDock/__tests__/LumiSurveyDock.test.tsx
@@ -6,6 +6,7 @@ import {
   waitFor,
 } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
+import { StrictMode } from "react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type {
   LumiSurveyEvents,
@@ -1370,6 +1371,74 @@ describe("LumiSurveyDock", () => {
     renderDock({ events });
 
     expect(events.onViewDock).toHaveBeenCalledWith("dock-feedback");
+  });
+
+  it("counts a StrictMode mount as one dock view", () => {
+    const onViewDock = vi.fn();
+
+    render(
+      <StrictMode>
+        <LumiSurveyDock
+          surveyId="dock-feedback"
+          survey={createSurvey()}
+          transport={{ submit: vi.fn().mockResolvedValue(undefined) }}
+          events={{ onViewDock }}
+        />
+      </StrictMode>,
+    );
+
+    expect(onViewDock).toHaveBeenCalledOnce();
+  });
+
+  it("counts reopening the dock as a new view", async () => {
+    const onViewDock = vi.fn();
+    const user = userEvent.setup();
+
+    renderDock({
+      events: { onViewDock },
+      behavior: { storageStrategy: "none" },
+    });
+
+    expect(onViewDock).toHaveBeenCalledOnce();
+
+    await user.click(await screen.findByRole("button", { name: "Lukk" }));
+    await user.click(
+      await screen.findByRole("button", { name: "Gi tilbakemelding" }),
+    );
+
+    expect(onViewDock).toHaveBeenCalledTimes(2);
+  });
+
+  it("does not count parent rerenders as new dock views", () => {
+    const initialOnViewDock = vi.fn();
+    const latestOnViewDock = vi.fn();
+    const survey = createSurvey();
+    const transport: LumiSurveyTransport = {
+      submit: vi.fn().mockResolvedValue(undefined),
+    };
+    const dock = (surveyId: string, onViewDock: (surveyId: string) => void) => (
+      <LumiSurveyDock
+        surveyId={surveyId}
+        survey={survey}
+        transport={transport}
+        events={{ onViewDock }}
+      />
+    );
+    const { rerender } = render(dock("dock-feedback", initialOnViewDock));
+
+    expect(initialOnViewDock).toHaveBeenCalledTimes(1);
+
+    for (let index = 0; index < 5; index++) {
+      rerender(dock("dock-feedback", latestOnViewDock));
+    }
+
+    expect(initialOnViewDock).toHaveBeenCalledTimes(1);
+    expect(latestOnViewDock).not.toHaveBeenCalled();
+
+    rerender(dock("another-survey", latestOnViewDock));
+
+    expect(latestOnViewDock).toHaveBeenCalledOnce();
+    expect(latestOnViewDock).toHaveBeenCalledWith("another-survey");
   });
 
   it("renders the minimized button when initialOpen is false", async () => {

--- a/packages/lumi-survey/src/components/LumiSurveyDock/hooks/__tests__/useAutoCloseOnSuccess.test.ts
+++ b/packages/lumi-survey/src/components/LumiSurveyDock/hooks/__tests__/useAutoCloseOnSuccess.test.ts
@@ -127,4 +127,31 @@ describe("useAutoCloseOnSuccess", () => {
     });
     expect(onClose).toHaveBeenCalledTimes(1);
   });
+
+  it("keeps the deadline when the onClose reference changes", () => {
+    const firstOnClose = vi.fn();
+    const latestOnClose = vi.fn();
+
+    const { rerender } = renderHook(
+      ({ onClose }: { onClose: () => void }) =>
+        useAutoCloseOnSuccess({
+          enabled: true,
+          status: "success",
+          delayMs: 1000,
+          onClose,
+        }),
+      { initialProps: { onClose: firstOnClose } },
+    );
+
+    act(() => {
+      vi.advanceTimersByTime(500);
+    });
+    rerender({ onClose: latestOnClose });
+    act(() => {
+      vi.advanceTimersByTime(500);
+    });
+
+    expect(firstOnClose).not.toHaveBeenCalled();
+    expect(latestOnClose).toHaveBeenCalledTimes(1);
+  });
 });

--- a/packages/lumi-survey/src/components/LumiSurveyDock/hooks/useAutoCloseOnSuccess.ts
+++ b/packages/lumi-survey/src/components/LumiSurveyDock/hooks/useAutoCloseOnSuccess.ts
@@ -1,4 +1,4 @@
-import { useEffect } from "react";
+import { useEffect, useRef } from "react";
 import type { LumiSurveyStatus } from "../../../core/types.js";
 
 interface AutoCloseOptions {
@@ -14,15 +14,19 @@ export const useAutoCloseOnSuccess = ({
   delayMs,
   onClose,
 }: AutoCloseOptions): void => {
+  // Keep the deadline tied to survey state, while invoking the latest callback.
+  const onCloseRef = useRef(onClose);
+  onCloseRef.current = onClose;
+
   useEffect(() => {
     if (!enabled || status !== "success") {
       return undefined;
     }
 
     const timeout = window.setTimeout(() => {
-      onClose();
+      onCloseRef.current();
     }, delayMs);
 
     return () => window.clearTimeout(timeout);
-  }, [delayMs, enabled, onClose, status]);
+  }, [delayMs, enabled, status]);
 };

--- a/packages/lumi-survey/src/components/LumiSurveyDock/hooks/usePersistedDismissal.ts
+++ b/packages/lumi-survey/src/components/LumiSurveyDock/hooks/usePersistedDismissal.ts
@@ -82,6 +82,11 @@ export const usePersistedDismissal = (
     useState<boolean>(false);
   const [isLoading, setIsLoading] = useState<boolean>(true);
   const userInteractedRef = useRef(false);
+  // Consumer examples use inline event objects. Their identity must not define
+  // a new view, while future lifecycle transitions should use fresh callbacks.
+  const eventsRef = useRef(events);
+  eventsRef.current = events;
+  const viewedSurveyIdRef = useRef<string | null>(null);
 
   useEffect(() => {
     let cancelled = false;
@@ -140,10 +145,18 @@ export const usePersistedDismissal = (
   }, [initialOpen, storageKey, storageAdapter]);
 
   useEffect(() => {
-    if (!dismissed && viewEnabled) {
-      events?.onViewDock?.(surveyId);
+    if (dismissed || !viewEnabled) {
+      viewedSurveyIdRef.current = null;
+      return;
     }
-  }, [dismissed, events, surveyId, viewEnabled]);
+
+    if (viewedSurveyIdRef.current === surveyId) {
+      return;
+    }
+
+    viewedSurveyIdRef.current = surveyId;
+    eventsRef.current?.onViewDock?.(surveyId);
+  }, [dismissed, surveyId, viewEnabled]);
 
   const persistDismissedState = useCallback(
     async (nextDismissed: boolean, hideCompletely?: boolean) => {
@@ -170,10 +183,10 @@ export const usePersistedDismissal = (
             JSON.stringify(payload),
           );
           if (result.allowed && !result.persisted) {
-            events?.onDismissalPersistFailed?.(result.error);
+            eventsRef.current?.onDismissalPersistFailed?.(result.error);
           }
         } catch (persistError) {
-          events?.onDismissalPersistFailed?.(persistError);
+          eventsRef.current?.onDismissalPersistFailed?.(persistError);
         }
         return;
       }
@@ -181,10 +194,10 @@ export const usePersistedDismissal = (
       try {
         await storageAdapter.remove(storageKey);
       } catch (persistError) {
-        events?.onDismissalPersistFailed?.(persistError);
+        eventsRef.current?.onDismissalPersistFailed?.(persistError);
       }
     },
-    [dismissCooldownDays, events, storageKey, storageAdapter],
+    [dismissCooldownDays, storageKey, storageAdapter],
   );
 
   const closeDock = useCallback(


### PR DESCRIPTION
## Hva
- hindrer inline `events`-objekter fra å registrere foreldre-renders som nye dock-visninger
- beholder success auto-close-fristen når callback-referanser endres, men bruker alltid siste callback
- dedupliserer React StrictMode-effect-replay uten å miste ekte gjenåpninger eller surveybytter
- legger til målrettede regresjonstester og changelog

## Verifisering
- `pnpm run lint`
- `pnpm run typecheck`
- `pnpm test`
- `pnpm run verify:lumi-survey`
- `pnpm run verify:lumi-survey-consumer`
- `pnpm run test:release-guards`
- `pnpm run check:lumi-survey-release-drift`
- widget-suiten etter StrictMode-forbedringen: 441 tester
- to uavhengige subagent-reviews av eksakt SHA `39935275aac35ceb8d90146699f90562091a1b26`: godkjent uten funn

Closes #488