### PR TITLE
Rapporter reelle feil ved lagring av dismissal

### DIFF
--- a/packages/lumi-survey/CHANGELOG.md
+++ b/packages/lumi-survey/CHANGELOG.md
@@ -22,6 +22,8 @@ This project follows SemVer.
   message instead of failing permanently as a generic transport error.
 - Inline `events` objects no longer count parent re-renders as new dock views
   or restart the success auto-close timer.
+- Dismissal storage failures now invoke `onDismissalPersistFailed` with their
+  cause, while intentional `none` storage and server rendering remain silent.
 
 ### Internal
 

--- a/packages/lumi-survey/src/components/LumiSurveyDock/__tests__/LumiSurveyDock.test.tsx
+++ b/packages/lumi-survey/src/components/LumiSurveyDock/__tests__/LumiSurveyDock.test.tsx
@@ -7,7 +7,7 @@ import {
 } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { StrictMode } from "react";
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type {
   LumiSurveyEvents,
   LumiSurveyTransport,
@@ -1504,6 +1504,165 @@ describe("LumiSurveyDock", () => {
       expect(
         screen.getByRole("heading", { name: /hvor fornøyd er du/i }),
       ).toBeInTheDocument();
+    });
+  });
+
+  describe("dismissal persistence failures", () => {
+    afterEach(() => {
+      vi.restoreAllMocks();
+    });
+
+    it("reports localStorage write failures with their cause", async () => {
+      const persistError = new DOMException(
+        "The quota has been exceeded",
+        "QuotaExceededError",
+      );
+      vi.spyOn(window.localStorage, "setItem").mockImplementation(() => {
+        throw persistError;
+      });
+      const onDismissalPersistFailed = vi.fn();
+      const user = userEvent.setup();
+
+      renderDock({
+        behavior: { storageStrategy: "localStorage" },
+        events: { onDismissalPersistFailed },
+      });
+
+      await user.click(await screen.findByRole("button", { name: "Lukk" }));
+
+      await waitFor(() => {
+        expect(onDismissalPersistFailed).toHaveBeenCalledOnce();
+      });
+      expect(onDismissalPersistFailed).toHaveBeenCalledWith(persistError);
+    });
+
+    it("does not retry a consumer failure callback that throws", async () => {
+      const persistError = new DOMException(
+        "The quota has been exceeded",
+        "QuotaExceededError",
+      );
+      vi.spyOn(window.localStorage, "setItem").mockImplementation(() => {
+        throw persistError;
+      });
+      const onDismissalPersistFailed = vi.fn(() => {
+        throw new Error("consumer callback failed");
+      });
+      const user = userEvent.setup();
+
+      renderDock({
+        behavior: { storageStrategy: "localStorage" },
+        events: { onDismissalPersistFailed },
+      });
+
+      await user.click(await screen.findByRole("button", { name: "Lukk" }));
+
+      await waitFor(() => {
+        expect(onDismissalPersistFailed).toHaveBeenCalledOnce();
+      });
+      expect(onDismissalPersistFailed).toHaveBeenCalledWith(persistError);
+    });
+
+    it("reports localStorage removal failures when reopening", async () => {
+      const removalError = new DOMException(
+        "Storage is unavailable",
+        "SecurityError",
+      );
+      vi.spyOn(window.localStorage, "removeItem").mockImplementation(() => {
+        throw removalError;
+      });
+      const onDismissalPersistFailed = vi.fn();
+      const user = userEvent.setup();
+
+      renderDock({
+        behavior: { storageStrategy: "localStorage" },
+        events: { onDismissalPersistFailed },
+      });
+
+      await user.click(await screen.findByRole("button", { name: "Lukk" }));
+      await user.click(
+        await screen.findByRole("button", { name: "Gi tilbakemelding" }),
+      );
+
+      await waitFor(() => {
+        expect(onDismissalPersistFailed).toHaveBeenCalledOnce();
+      });
+      expect(onDismissalPersistFailed).toHaveBeenCalledWith(removalError);
+    });
+
+    it("reports denied survey consent with a meaningful cause", async () => {
+      const controller = (
+        globalThis as unknown as {
+          webStorageController: {
+            getCurrentConsent: () => {
+              consent: { analytics: boolean; surveys: boolean };
+              userActionTaken: boolean;
+            };
+          };
+        }
+      ).webStorageController;
+      vi.spyOn(controller, "getCurrentConsent").mockReturnValue({
+        consent: { analytics: true, surveys: false },
+        userActionTaken: true,
+      });
+      const onDismissalPersistFailed = vi.fn();
+      const user = userEvent.setup();
+
+      renderDock({ events: { onDismissalPersistFailed } });
+
+      await user.click(await screen.findByRole("button", { name: "Lukk" }));
+
+      await waitFor(() => {
+        expect(onDismissalPersistFailed).toHaveBeenCalledOnce();
+      });
+      expect(onDismissalPersistFailed).toHaveBeenCalledWith(expect.any(Error));
+      expect(onDismissalPersistFailed.mock.calls[0]?.[0]).toHaveProperty(
+        "message",
+        expect.stringMatching(/consent/i),
+      );
+    });
+
+    it("recovers when the consent controller throws", async () => {
+      const controllerError = new Error("consent controller failed");
+      const controller = (
+        globalThis as unknown as {
+          webStorageController: {
+            isStorageKeyAllowed: (key: string) => boolean;
+          };
+        }
+      ).webStorageController;
+      vi.spyOn(controller, "isStorageKeyAllowed").mockImplementation(() => {
+        throw controllerError;
+      });
+      const onDismissalPersistFailed = vi.fn();
+      const user = userEvent.setup();
+
+      renderDock({ events: { onDismissalPersistFailed } });
+
+      await user.click(await screen.findByRole("button", { name: "Lukk" }));
+
+      await waitFor(() => {
+        expect(onDismissalPersistFailed).toHaveBeenCalledOnce();
+      });
+      expect(onDismissalPersistFailed).toHaveBeenCalledWith(controllerError);
+    });
+
+    it("keeps the intentional none strategy silent", async () => {
+      const onDismissalPersistFailed = vi.fn();
+      const user = userEvent.setup();
+
+      renderDock({
+        behavior: { storageStrategy: "none" },
+        events: { onDismissalPersistFailed },
+      });
+
+      await user.click(await screen.findByRole("button", { name: "Lukk" }));
+
+      await waitFor(() => {
+        expect(
+          document.querySelector('[data-feedback-id="dock-feedback"]'),
+        ).toHaveAttribute("data-state", "dismissed");
+      });
+      expect(onDismissalPersistFailed).not.toHaveBeenCalled();
     });
   });
 

--- a/packages/lumi-survey/src/components/LumiSurveyDock/hooks/__tests__/storageAdapters.test.ts
+++ b/packages/lumi-survey/src/components/LumiSurveyDock/hooks/__tests__/storageAdapters.test.ts
@@ -12,12 +12,13 @@ describe("getStorageAdapter", () => {
     const adapter = getStorageAdapter("localStorage");
 
     await expect(adapter.write("lumi-test", "dismissed")).resolves.toEqual({
-      persisted: true,
-      allowed: true,
+      outcome: "applied",
     });
     await expect(adapter.read("lumi-test")).resolves.toBe("dismissed");
 
-    await adapter.remove("lumi-test");
+    await expect(adapter.remove("lumi-test")).resolves.toEqual({
+      outcome: "applied",
+    });
 
     await expect(adapter.read("lumi-test")).resolves.toBeNull();
   });
@@ -26,23 +27,25 @@ describe("getStorageAdapter", () => {
     const adapter = getStorageAdapter("none");
 
     await expect(adapter.write("lumi-test", "dismissed")).resolves.toEqual({
-      persisted: false,
-      allowed: true,
+      outcome: "skipped",
     });
     await expect(adapter.read("lumi-test")).resolves.toBeNull();
-    await expect(adapter.remove("lumi-test")).resolves.toBeUndefined();
+    await expect(adapter.remove("lumi-test")).resolves.toEqual({
+      outcome: "skipped",
+    });
   });
 
   it("persists allowed values with the consent strategy", async () => {
     const adapter = getStorageAdapter("consent");
 
     await expect(adapter.write("lumi-test", "dismissed")).resolves.toEqual({
-      persisted: true,
-      allowed: true,
+      outcome: "applied",
     });
     await expect(adapter.read("lumi-test")).resolves.toBe("dismissed");
 
-    await adapter.remove("lumi-test");
+    await expect(adapter.remove("lumi-test")).resolves.toEqual({
+      outcome: "applied",
+    });
 
     await expect(adapter.read("lumi-test")).resolves.toBeNull();
   });
@@ -53,10 +56,11 @@ describe("getStorageAdapter", () => {
 
     await expect(adapter.read("lumi-test")).resolves.toBeNull();
     await expect(adapter.write("lumi-test", "dismissed")).resolves.toEqual({
-      persisted: false,
-      allowed: false,
+      outcome: "skipped",
     });
-    await expect(adapter.remove("lumi-test")).resolves.toBeUndefined();
+    await expect(adapter.remove("lumi-test")).resolves.toEqual({
+      outcome: "skipped",
+    });
   });
 
   it("reports localStorage quota errors without throwing", async () => {
@@ -70,9 +74,24 @@ describe("getStorageAdapter", () => {
     });
 
     await expect(adapter.write("lumi-test", "dismissed")).resolves.toEqual({
-      persisted: false,
-      allowed: false,
+      outcome: "failed",
       error: quotaError,
+    });
+  });
+
+  it("reports localStorage removal errors without throwing", async () => {
+    const adapter = getStorageAdapter("localStorage");
+    const removalError = new DOMException(
+      "Storage is unavailable",
+      "SecurityError",
+    );
+    vi.spyOn(window.localStorage, "removeItem").mockImplementation(() => {
+      throw removalError;
+    });
+
+    await expect(adapter.remove("lumi-test")).resolves.toEqual({
+      outcome: "failed",
+      error: removalError,
     });
   });
 });

--- a/packages/lumi-survey/src/components/LumiSurveyDock/hooks/storageAdapters.ts
+++ b/packages/lumi-survey/src/components/LumiSurveyDock/hooks/storageAdapters.ts
@@ -1,17 +1,15 @@
 import {
   readConsentValue,
   removeConsentValue,
+  type StorageMutationResult,
   writeConsentValue,
 } from "../../shared/consentStorage.js";
 import type { StorageStrategy } from "../propTypes.js";
 
 export interface StorageAdapter {
   read(key: string): Promise<string | null>;
-  write(
-    key: string,
-    value: string,
-  ): Promise<{ persisted: boolean; allowed: boolean; error?: unknown }>;
-  remove(key: string): Promise<void>;
+  write(key: string, value: string): Promise<StorageMutationResult>;
+  remove(key: string): Promise<StorageMutationResult>;
 }
 
 // Simple localStorage wrapper
@@ -24,25 +22,22 @@ const localStorageAdapter: StorageAdapter = {
       return null;
     }
   },
-  async write(
-    key: string,
-    value: string,
-  ): Promise<{ persisted: boolean; allowed: boolean; error?: unknown }> {
-    if (typeof window === "undefined")
-      return { persisted: false, allowed: false };
+  async write(key: string, value: string): Promise<StorageMutationResult> {
+    if (typeof window === "undefined") return { outcome: "skipped" };
     try {
       window.localStorage.setItem(key, value);
-      return { persisted: true, allowed: true };
+      return { outcome: "applied" };
     } catch (error) {
-      return { persisted: false, allowed: false, error };
+      return { outcome: "failed", error };
     }
   },
-  async remove(key: string): Promise<void> {
-    if (typeof window === "undefined") return;
+  async remove(key: string): Promise<StorageMutationResult> {
+    if (typeof window === "undefined") return { outcome: "skipped" };
     try {
       window.localStorage.removeItem(key);
-    } catch {
-      // ignore
+      return { outcome: "applied" };
+    } catch (error) {
+      return { outcome: "failed", error };
     }
   },
 };
@@ -52,15 +47,11 @@ const noopStorageAdapter: StorageAdapter = {
   async read(): Promise<string | null> {
     return null;
   },
-  async write(): Promise<{
-    persisted: boolean;
-    allowed: boolean;
-    error?: unknown;
-  }> {
-    return { persisted: false, allowed: true };
+  async write(): Promise<StorageMutationResult> {
+    return { outcome: "skipped" };
   },
-  async remove(): Promise<void> {
-    // no-op
+  async remove(): Promise<StorageMutationResult> {
+    return { outcome: "skipped" };
   },
 };
 

--- a/packages/lumi-survey/src/components/LumiSurveyDock/hooks/usePersistedDismissal.ts
+++ b/packages/lumi-survey/src/components/LumiSurveyDock/hooks/usePersistedDismissal.ts
@@ -88,6 +88,14 @@ export const usePersistedDismissal = (
   eventsRef.current = events;
   const viewedSurveyIdRef = useRef<string | null>(null);
 
+  const notifyPersistenceFailure = useCallback((cause: unknown) => {
+    try {
+      eventsRef.current?.onDismissalPersistFailed?.(cause);
+    } catch {
+      // Consumer event handlers must not reject detached persistence work.
+    }
+  }, []);
+
   useEffect(() => {
     let cancelled = false;
 
@@ -121,8 +129,14 @@ export const usePersistedDismissal = (
       }
 
       if (isResumeExpired(parsed.resumeAt ?? null)) {
-        await storageAdapter.remove(storageKey);
-        if (!cancelled && !userInteractedRef.current) {
+        const result = await storageAdapter.remove(storageKey);
+        if (cancelled) {
+          return;
+        }
+        if (result.outcome === "failed") {
+          notifyPersistenceFailure(result.error);
+        }
+        if (!userInteractedRef.current) {
           setDismissed(!initialOpen);
           setShouldHideCompletely(false);
         }
@@ -142,7 +156,7 @@ export const usePersistedDismissal = (
     return () => {
       cancelled = true;
     };
-  }, [initialOpen, storageKey, storageAdapter]);
+  }, [initialOpen, notifyPersistenceFailure, storageKey, storageAdapter]);
 
   useEffect(() => {
     if (dismissed || !viewEnabled) {
@@ -177,27 +191,34 @@ export const usePersistedDismissal = (
           hideCompletely: hideCompletely ?? false,
         };
 
+        let result: Awaited<ReturnType<typeof storageAdapter.write>>;
         try {
-          const result = await storageAdapter.write(
+          result = await storageAdapter.write(
             storageKey,
             JSON.stringify(payload),
           );
-          if (result.allowed && !result.persisted) {
-            eventsRef.current?.onDismissalPersistFailed?.(result.error);
-          }
         } catch (persistError) {
-          eventsRef.current?.onDismissalPersistFailed?.(persistError);
+          notifyPersistenceFailure(persistError);
+          return;
+        }
+        if (result.outcome === "failed") {
+          notifyPersistenceFailure(result.error);
         }
         return;
       }
 
+      let result: Awaited<ReturnType<typeof storageAdapter.remove>>;
       try {
-        await storageAdapter.remove(storageKey);
+        result = await storageAdapter.remove(storageKey);
       } catch (persistError) {
-        eventsRef.current?.onDismissalPersistFailed?.(persistError);
+        notifyPersistenceFailure(persistError);
+        return;
+      }
+      if (result.outcome === "failed") {
+        notifyPersistenceFailure(result.error);
       }
     },
-    [dismissCooldownDays, storageKey, storageAdapter],
+    [dismissCooldownDays, notifyPersistenceFailure, storageKey, storageAdapter],
   );
 
   const closeDock = useCallback(

--- a/packages/lumi-survey/src/components/shared/__tests__/consentStorage.test.ts
+++ b/packages/lumi-survey/src/components/shared/__tests__/consentStorage.test.ts
@@ -1,0 +1,44 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+describe("consent storage mutations", () => {
+  beforeEach(() => {
+    vi.resetModules();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.unstubAllGlobals();
+  });
+
+  it("reports a missing consent API as a failure", async () => {
+    vi.useFakeTimers();
+    vi.stubGlobal("__DECORATOR_DATA__", undefined);
+    vi.stubGlobal("webStorageController", undefined);
+    const { writeConsentValue } = await import("../consentStorage.js");
+
+    const resultPromise = writeConsentValue("lumi-test", "dismissed");
+    await vi.advanceTimersByTimeAsync(5000);
+
+    const result = await resultPromise;
+    expect(result.outcome).toBe("failed");
+    expect(result).toHaveProperty("error", expect.any(Error));
+    expect(result).toHaveProperty(
+      "error.message",
+      expect.stringMatching(/consent API is unavailable/i),
+    );
+  });
+
+  it("keeps server-side mutations silent", async () => {
+    vi.stubGlobal("window", undefined);
+    const { removeConsentValue, writeConsentValue } = await import(
+      "../consentStorage.js"
+    );
+
+    await expect(writeConsentValue("lumi-test", "dismissed")).resolves.toEqual({
+      outcome: "skipped",
+    });
+    await expect(removeConsentValue("lumi-test")).resolves.toEqual({
+      outcome: "skipped",
+    });
+  });
+});

--- a/packages/lumi-survey/src/components/shared/consentStorage.ts
+++ b/packages/lumi-survey/src/components/shared/consentStorage.ts
@@ -32,16 +32,16 @@ interface ConsentWindow extends Window {
   webStorageController?: WebStorageController;
 }
 
-interface StorageResult {
-  storage: StorageLike | null;
-  allowed: boolean;
-}
+type StorageAccessResult =
+  | { outcome: "available"; storage: StorageLike }
+  | { outcome: "skipped" }
+  | { outcome: "failed"; error: unknown };
 
-interface WriteResult {
-  persisted: boolean;
-  allowed: boolean;
-  error?: unknown;
-}
+/** `skipped` is reserved for intentional no-persistence contexts such as SSR. */
+export type StorageMutationResult =
+  | { outcome: "applied" }
+  | { outcome: "skipped" }
+  | { outcome: "failed"; error: unknown };
 
 const CONSENT_READY_TIMEOUT_MS = 5000;
 const CONSENT_POLL_INTERVAL_MS = 50;
@@ -90,7 +90,11 @@ const getConsentController = (): WebStorageController | null => {
   return (window as ConsentWindow).webStorageController ?? null;
 };
 
-const getStorage = async (key: string): Promise<StorageResult> => {
+const getStorage = async (key: string): Promise<StorageAccessResult> => {
+  if (typeof window === "undefined") {
+    return { outcome: "skipped" };
+  }
+
   const ready = await awaitConsentApi();
 
   if (!ready) {
@@ -100,7 +104,10 @@ const getStorage = async (key: string): Promise<StorageResult> => {
         "[Lumi] Consent API not available - using initialOpen without persistence",
       );
     }
-    return { storage: null, allowed: false };
+    return {
+      outcome: "failed",
+      error: new Error("NAV consent API is unavailable"),
+    };
   }
 
   const controller = getConsentController();
@@ -110,17 +117,36 @@ const getStorage = async (key: string): Promise<StorageResult> => {
     typeof controller.isStorageKeyAllowed !== "function" ||
     typeof controller.getCurrentConsent !== "function"
   ) {
-    return { storage: null, allowed: false };
+    return {
+      outcome: "failed",
+      error: new Error("NAV consent API is not usable"),
+    };
   }
 
-  if (!controller.isStorageKeyAllowed(key)) {
+  let storageKeyAllowed: boolean;
+  try {
+    storageKeyAllowed = controller.isStorageKeyAllowed(key);
+  } catch (error) {
+    if (process.env.NODE_ENV === "development") {
+      // eslint-disable-next-line no-console -- development diagnostics only
+      console.log("[Lumi] Could not check the storage key:", error);
+    }
+    return { outcome: "failed", error };
+  }
+
+  if (!storageKeyAllowed) {
     if (process.env.NODE_ENV === "development") {
       // eslint-disable-next-line no-console -- development diagnostics only
       console.log(
         `[Lumi] Storage key "${key}" not in allowed storage list - using initialOpen without persistence.`,
       );
     }
-    return { storage: null, allowed: false };
+    return {
+      outcome: "failed",
+      error: new Error(
+        `Storage key "${key}" is not allowed by the NAV consent API`,
+      ),
+    };
   }
 
   try {
@@ -132,14 +158,17 @@ const getStorage = async (key: string): Promise<StorageResult> => {
           "[Lumi] User has not granted surveys consent - using initialOpen without persistence",
         );
       }
-      return { storage: null, allowed: false };
+      return {
+        outcome: "failed",
+        error: new Error("Survey storage consent has not been granted"),
+      };
     }
   } catch (error) {
     if (process.env.NODE_ENV === "development") {
       // eslint-disable-next-line no-console -- development diagnostics only
       console.log("[Lumi] Could not check consent:", error);
     }
-    return { storage: null, allowed: false };
+    return { outcome: "failed", error };
   }
 
   if (process.env.NODE_ENV === "development") {
@@ -148,17 +177,17 @@ const getStorage = async (key: string): Promise<StorageResult> => {
   }
 
   try {
-    return { storage: window.localStorage, allowed: true };
-  } catch {
-    return { storage: null, allowed: false };
+    return { outcome: "available", storage: window.localStorage };
+  } catch (error) {
+    return { outcome: "failed", error };
   }
 };
 
 export const readConsentValue = async (key: string): Promise<string | null> => {
-  const { storage } = await getStorage(key);
-  if (storage) {
+  const result = await getStorage(key);
+  if (result.outcome === "available") {
     try {
-      return storage.getItem(key);
+      return result.storage.getItem(key);
     } catch (error) {
       if (process.env.NODE_ENV === "development") {
         // eslint-disable-next-line no-console -- development diagnostics only
@@ -172,37 +201,41 @@ export const readConsentValue = async (key: string): Promise<string | null> => {
 export const writeConsentValue = async (
   key: string,
   value: string,
-): Promise<WriteResult> => {
-  const { storage, allowed } = await getStorage(key);
+): Promise<StorageMutationResult> => {
+  const result = await getStorage(key);
 
-  if (storage && allowed) {
+  if (result.outcome === "available") {
     try {
-      storage.setItem(key, value);
-      return { persisted: true, allowed: true };
+      result.storage.setItem(key, value);
+      return { outcome: "applied" };
     } catch (error) {
       if (process.env.NODE_ENV === "development") {
         // eslint-disable-next-line no-console -- development diagnostics only
         console.warn("[Lumi] Failed to write to consent storage", error);
       }
-      return { persisted: false, allowed: false, error };
+      return { outcome: "failed", error };
     }
   }
 
-  return { persisted: false, allowed: false };
+  return result;
 };
 
-export const removeConsentValue = async (key: string): Promise<void> => {
-  const { storage } = await getStorage(key);
-  if (storage) {
+export const removeConsentValue = async (
+  key: string,
+): Promise<StorageMutationResult> => {
+  const result = await getStorage(key);
+  if (result.outcome === "available") {
     try {
-      storage.removeItem(key);
+      result.storage.removeItem(key);
+      return { outcome: "applied" };
     } catch (error) {
       if (process.env.NODE_ENV === "development") {
         // eslint-disable-next-line no-console -- development diagnostics only
         console.warn("[Lumi] Failed to remove from consent storage", error);
       }
+      return { outcome: "failed", error };
     }
   }
-};
 
-export type { WriteResult };
+  return result;
+};


### PR DESCRIPTION
## Hva
- erstatter tvetydige `persisted`/`allowed`-bools med eksplisitte interne utfall: `applied`, `skipped` og `failed`
- fyrer `onDismissalPersistFailed` for reelle localStorage- og consent-feil med en meningsfull årsak
- holder bevisst `storageStrategy: "none"` og SSR stille
- rapporterer også remove-feil uten å la en kastende forbruker-callback destabilisere widgeten
- håndterer kast fra consent-controlleren og avbrutte async load-effekter

## Verifisering
- røde før-fiks-tester for quota, consent-nekt og falskt `none`-event
- `pnpm run lint`
- `pnpm run typecheck`
- `pnpm test` (450 widgettester, 617 dashboardtester)
- `pnpm run verify:lumi-survey`
- `pnpm run verify:lumi-survey-consumer`
- `pnpm run test:release-guards` (31 tester)
- `pnpm run check:lumi-survey-release-drift`
- to uavhengige subagent-reviews av eksakt SHA `1aafc52fb96ad0db3a6951dc88388e50a0d050d0`: godkjent uten funn

Closes #487