### PR TITLE
Unngå fem sekunders venting uten consent-API

### DIFF
--- a/docs/guider/lagring.md
+++ b/docs/guider/lagring.md
@@ -31,6 +31,11 @@ Default-strategien for nav.no-flater. Widgeten leser fra `window.__DECORATOR_DAT
 `consent`-strategien fungerer kun på sider med Nav-dekoratøren (nav.no). Uten den kan ikke widgeten lagre dismissed-tilstand, og surveyen vil dukke opp igjen ved hver sidelast.
 :::
 
+Widgeten venter høyst 300 ms på den første consent-lesingen før den rendrer ut
+fra `initialOpen`. Consent-oppslaget fortsetter i bakgrunnen: Hvis dekoratøren
+blir klar senere, anvendes en lagret dismissal så lenge brukeren ikke allerede
+har interagert med surveyen.
+
 ## `localStorage`
 
 For interne flater (Modia, fagsystemer) som ikke har Nav-dekoratøren:
@@ -96,6 +101,9 @@ flowchart TD
 
 ::: danger Vanlig feil på interne flater
 Default er `consent`, som krever Nav consent API (`window.webStorageController`). Uten consent-API-et vil widgeten ikke kunne huske at brukeren lukket surveyen — den dukker opp igjen og igjen.
+
+Fravær av consent-API blokkerer ikke widgeten i mer enn 300 ms, men det gir
+fortsatt ingen persistering.
 
 **Løsning:** Sett `storageStrategy: "localStorage"` for alle interne flater.
 

--- a/packages/lumi-survey/CHANGELOG.md
+++ b/packages/lumi-survey/CHANGELOG.md
@@ -8,6 +8,9 @@ This project follows SemVer.
 
 ### Fixed
 
+- Consent storage no longer leaves the widget blank for five seconds when the
+  Nav decorator is unavailable. The initial view is released after a 300 ms
+  grace period while a late persisted dismissal can still be applied.
 - Rating questions now expose exactly one named group to assistive
   technology. The prompt is the fieldset legend (a level 3 heading when
   visible), the fieldset itself carries `role="radiogroup"`, and the

--- a/packages/lumi-survey/README.md
+++ b/packages/lumi-survey/README.md
@@ -116,6 +116,11 @@ Se [Koble til backend](https://navikt.github.io/lumi/kom-i-gang/koble-til-backen
 - `localStorage` passer for interne flater uten samtykke-API.
 - `none` lagrer ikke at brukeren har lukket widgeten.
 
+Ved `consent` venter widgeten høyst 300 ms på den første lagringslesingen før
+den rendrer ut fra `initialOpen`. Et consent-API som blir klart senere kan
+fortsatt anvende en lagret dismissal, så lenge brukeren ikke allerede har
+interagert med widgeten.
+
 ```tsx
 <LumiSurveyDock
   {...otherProps}

--- a/packages/lumi-survey/src/components/LumiSurveyDock/LumiSurveyDock.tsx
+++ b/packages/lumi-survey/src/components/LumiSurveyDock/LumiSurveyDock.tsx
@@ -191,10 +191,6 @@ export const LumiSurveyDock = ({
   const skipIntro = requestedPageExists;
   const [showIntro, setShowIntro] = useState(config.hasIntro && !skipIntro);
 
-  const handleIntroStart = useCallback(() => {
-    setShowIntro(false);
-  }, []);
-
   // Track previous showIntro value to detect intro → question transition
   const prevShowIntroRef = useRef(showIntro);
   const pendingStepFocusRef = useRef(false);
@@ -374,18 +370,29 @@ export const LumiSurveyDock = ({
     setShowIntro(config.hasIntro && !skipIntro);
   }, [reset, resetNavigation, config.hasIntro, skipIntro]);
 
-  const { dismissed, shouldHideCompletely, isLoading, closeDock, reopenDock } =
-    usePersistedDismissal({
-      surveyId,
-      initialOpen: config.initialOpen,
-      dismissCooldownDays: config.dismissCooldownDays,
-      events,
-      resetOnClose: config.resetOnClose,
-      onReset: handleFullReset,
-      storageStrategy: config.storageStrategy,
-      viewEnabled:
-        source === "legacy" || visibleQuestions.length > 0 || showIntro,
-    });
+  const {
+    dismissed,
+    shouldHideCompletely,
+    isLoading,
+    markUserInteraction,
+    closeDock,
+    reopenDock,
+  } = usePersistedDismissal({
+    surveyId,
+    initialOpen: config.initialOpen,
+    dismissCooldownDays: config.dismissCooldownDays,
+    events,
+    resetOnClose: config.resetOnClose,
+    onReset: handleFullReset,
+    storageStrategy: config.storageStrategy,
+    viewEnabled:
+      source === "legacy" || visibleQuestions.length > 0 || showIntro,
+  });
+
+  const handleIntroStart = useCallback(() => {
+    markUserInteraction();
+    setShowIntro(false);
+  }, [markUserInteraction]);
 
   // Progressive submit: hide the button until a currently visible question has
   // at least one meaningful answer. Required-answer validation happens on submit.
@@ -436,6 +443,8 @@ export const LumiSurveyDock = ({
   ]);
 
   const handleNext = useCallback(async () => {
+    markUserInteraction();
+
     if (source === "document-v1") {
       const missing = validateAnswers(currentPageQuestions, answers);
       if (missing.length > 0) {
@@ -467,20 +476,23 @@ export const LumiSurveyDock = ({
     currentPageQuestions,
     events,
     goToNext,
+    markUserInteraction,
     source,
     submit,
     visitedQuestions,
   ]);
 
   const handleBack = useCallback(() => {
+    markUserInteraction();
     const previousIndex = goToPrevious();
     if (previousIndex === null) return;
     setStepValidationMissing([]);
     pendingStepFocusRef.current = true;
-  }, [goToPrevious]);
+  }, [goToPrevious, markUserInteraction]);
 
   const handleQuestionChange = useCallback(
     (questionId: string, value: Parameters<typeof setAnswer>[1]) => {
+      markUserInteraction();
       setAnswer(questionId, value);
       setStepValidationMissing((missing) =>
         missing.includes(questionId)
@@ -488,12 +500,13 @@ export const LumiSurveyDock = ({
           : missing,
       );
     },
-    [setAnswer],
+    [markUserInteraction, setAnswer],
   );
 
   const handleSubmit = useCallback(
     async (event: React.FormEvent<HTMLFormElement>) => {
       event.preventDefault();
+      markUserInteraction();
       const missing = validateAnswers(visitedQuestions, answers);
       if (missing.length > 0) {
         setStepValidationMissing(missing);
@@ -504,7 +517,7 @@ export const LumiSurveyDock = ({
       setStepValidationMissing([]);
       await submit(visitedQuestions);
     },
-    [answers, events, submit, visitedQuestions],
+    [answers, events, markUserInteraction, submit, visitedQuestions],
   );
 
   const isSubmitting = status === "submitting";
@@ -609,6 +622,8 @@ export const LumiSurveyDock = ({
       data-feedback-id={surveyId}
       data-state={dismissed ? "dismissed" : "open"}
       aria-label="Tilbakemeldingspanel"
+      onFocusCapture={markUserInteraction}
+      onPointerDownCapture={markUserInteraction}
     >
       {dismissed ? (
         <MinimizedDock

--- a/packages/lumi-survey/src/components/LumiSurveyDock/__tests__/consentFocusInteraction.test.tsx
+++ b/packages/lumi-survey/src/components/LumiSurveyDock/__tests__/consentFocusInteraction.test.tsx
@@ -1,0 +1,69 @@
+import { act, render, screen } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { createRatingSurvey } from "../../../presets/index.js";
+import { LumiSurveyDock } from "../LumiSurveyDock.js";
+
+const survey = createRatingSurvey({
+  ratingPrompt: "Hvor fornøyd er du?",
+});
+
+describe("LumiSurveyDock late consent focus", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    localStorage.clear();
+    vi.stubGlobal("__DECORATOR_DATA__", undefined);
+    vi.stubGlobal("webStorageController", undefined);
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.unstubAllGlobals();
+  });
+
+  it("keeps the focused survey when a late dismissal arrives", async () => {
+    localStorage.setItem(
+      "lumi-dismissed-consent-focus",
+      JSON.stringify({
+        version: 1,
+        state: "dismissed",
+        dismissedAt: new Date().toISOString(),
+        resumeAt: null,
+        hideCompletely: true,
+      }),
+    );
+
+    render(
+      <LumiSurveyDock
+        surveyId="consent-focus"
+        survey={survey}
+        transport={{ submit: vi.fn().mockResolvedValue(undefined) }}
+      />,
+    );
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(300);
+    });
+
+    const answer = screen.getAllByRole("radio")[0];
+    answer.focus();
+    expect(answer).toHaveFocus();
+
+    vi.stubGlobal("__DECORATOR_DATA__", { mock: true });
+    vi.stubGlobal("webStorageController", {
+      isStorageKeyAllowed: (key: string) => key.startsWith("lumi-"),
+      getCurrentConsent: () => ({
+        consent: { analytics: true, surveys: true },
+        userActionTaken: true,
+      }),
+    });
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(50);
+    });
+
+    expect(
+      document.querySelector('[data-feedback-id="consent-focus"]'),
+    ).toHaveAttribute("data-state", "open");
+    expect(answer).toHaveFocus();
+  });
+});

--- a/packages/lumi-survey/src/components/LumiSurveyDock/__tests__/consentInteraction.test.tsx
+++ b/packages/lumi-survey/src/components/LumiSurveyDock/__tests__/consentInteraction.test.tsx
@@ -1,0 +1,69 @@
+import { act, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { createRatingSurvey } from "../../../presets/index.js";
+import { LumiSurveyDock } from "../LumiSurveyDock.js";
+
+const survey = createRatingSurvey({
+  ratingPrompt: "Hvor fornøyd er du?",
+});
+
+describe("LumiSurveyDock late consent interaction", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    localStorage.clear();
+    vi.stubGlobal("__DECORATOR_DATA__", undefined);
+    vi.stubGlobal("webStorageController", undefined);
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.unstubAllGlobals();
+  });
+
+  it("keeps an in-progress answer when a late dismissal arrives", async () => {
+    localStorage.setItem(
+      "lumi-dismissed-consent-interaction",
+      JSON.stringify({
+        version: 1,
+        state: "dismissed",
+        dismissedAt: new Date().toISOString(),
+        resumeAt: null,
+        hideCompletely: true,
+      }),
+    );
+
+    render(
+      <LumiSurveyDock
+        surveyId="consent-interaction"
+        survey={survey}
+        transport={{ submit: vi.fn().mockResolvedValue(undefined) }}
+      />,
+    );
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(300);
+    });
+
+    const answer = screen.getAllByRole("radio")[0];
+    fireEvent.click(answer);
+    expect(answer).toBeChecked();
+
+    vi.stubGlobal("__DECORATOR_DATA__", { mock: true });
+    vi.stubGlobal("webStorageController", {
+      isStorageKeyAllowed: (key: string) => key.startsWith("lumi-"),
+      getCurrentConsent: () => ({
+        consent: { analytics: true, surveys: true },
+        userActionTaken: true,
+      }),
+    });
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(50);
+    });
+
+    expect(
+      document.querySelector('[data-feedback-id="consent-interaction"]'),
+    ).toHaveAttribute("data-state", "open");
+    expect(answer).toBeChecked();
+  });
+});

--- a/packages/lumi-survey/src/components/LumiSurveyDock/__tests__/consentLoading.test.tsx
+++ b/packages/lumi-survey/src/components/LumiSurveyDock/__tests__/consentLoading.test.tsx
@@ -1,0 +1,72 @@
+import { act, render } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { createRatingSurvey } from "../../../presets/index.js";
+import { LumiSurveyDock } from "../LumiSurveyDock.js";
+
+const survey = createRatingSurvey({
+  ratingPrompt: "Hvor fornøyd er du?",
+});
+
+describe("LumiSurveyDock consent loading", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    localStorage.clear();
+    vi.stubGlobal("__DECORATOR_DATA__", undefined);
+    vi.stubGlobal("webStorageController", undefined);
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.unstubAllGlobals();
+  });
+
+  it("renders after a short grace period and still applies a late dismissal", async () => {
+    localStorage.setItem(
+      "lumi-dismissed-consent-delay",
+      JSON.stringify({
+        version: 1,
+        state: "dismissed",
+        dismissedAt: new Date().toISOString(),
+        resumeAt: null,
+        hideCompletely: true,
+      }),
+    );
+
+    render(
+      <LumiSurveyDock
+        surveyId="consent-delay"
+        survey={survey}
+        transport={{ submit: vi.fn().mockResolvedValue(undefined) }}
+      />,
+    );
+
+    expect(
+      document.querySelector('[data-feedback-id="consent-delay"]'),
+    ).not.toBeInTheDocument();
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(300);
+    });
+
+    expect(
+      document.querySelector('[data-feedback-id="consent-delay"]'),
+    ).toHaveAttribute("data-state", "open");
+
+    vi.stubGlobal("__DECORATOR_DATA__", { mock: true });
+    vi.stubGlobal("webStorageController", {
+      isStorageKeyAllowed: (key: string) => key.startsWith("lumi-"),
+      getCurrentConsent: () => ({
+        consent: { analytics: true, surveys: true },
+        userActionTaken: true,
+      }),
+    });
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(50);
+    });
+
+    expect(
+      document.querySelector('[data-feedback-id="consent-delay"]'),
+    ).not.toBeInTheDocument();
+  });
+});

--- a/packages/lumi-survey/src/components/LumiSurveyDock/hooks/__tests__/usePersistedDismissal.test.ts
+++ b/packages/lumi-survey/src/components/LumiSurveyDock/hooks/__tests__/usePersistedDismissal.test.ts
@@ -1,0 +1,190 @@
+import { act, renderHook } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const storageMocks = vi.hoisted(() => ({
+  read: vi.fn(),
+  write: vi.fn(),
+  remove: vi.fn(),
+}));
+
+vi.mock("../storageAdapters.js", () => ({
+  getStorageAdapter: () => storageMocks,
+}));
+
+import { usePersistedDismissal } from "../usePersistedDismissal.js";
+
+const createDeferred = <T>() => {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((resolvePromise) => {
+    resolve = resolvePromise;
+  });
+  return { promise, resolve };
+};
+
+const renderDismissalHook = () =>
+  renderHook(() =>
+    usePersistedDismissal({
+      surveyId: "test-survey",
+      initialOpen: true,
+      dismissCooldownDays: 0,
+      resetOnClose: false,
+      onReset: vi.fn(),
+      storageStrategy: "consent",
+    }),
+  );
+
+describe("usePersistedDismissal consent loading", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    storageMocks.read.mockReset();
+    storageMocks.write.mockReset().mockResolvedValue({ outcome: "applied" });
+    storageMocks.remove.mockReset().mockResolvedValue({ outcome: "applied" });
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("stops blocking rendering while a consent read is still pending", async () => {
+    const pendingRead = createDeferred<string | null>();
+    storageMocks.read.mockReturnValue(pendingRead.promise);
+    const { result } = renderDismissalHook();
+
+    expect(result.current.isLoading).toBe(true);
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(300);
+    });
+
+    expect(result.current.isLoading).toBe(false);
+    expect(result.current.dismissed).toBe(false);
+
+    await act(async () => {
+      pendingRead.resolve(
+        JSON.stringify({
+          version: 1,
+          state: "dismissed",
+          resumeAt: null,
+          hideCompletely: true,
+        }),
+      );
+      await pendingRead.promise;
+    });
+
+    expect(result.current.dismissed).toBe(true);
+    expect(result.current.shouldHideCompletely).toBe(true);
+  });
+
+  it("does not let a late consent read override user interaction", async () => {
+    const pendingRead = createDeferred<string | null>();
+    storageMocks.read.mockReturnValue(pendingRead.promise);
+    const { result } = renderDismissalHook();
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(300);
+    });
+
+    act(() => {
+      result.current.closeDock(true);
+    });
+    act(() => {
+      result.current.reopenDock();
+    });
+
+    await act(async () => {
+      pendingRead.resolve(
+        JSON.stringify({
+          version: 1,
+          state: "dismissed",
+          resumeAt: null,
+          hideCompletely: true,
+        }),
+      );
+      await pendingRead.promise;
+    });
+
+    expect(result.current.dismissed).toBe(false);
+    expect(result.current.shouldHideCompletely).toBe(false);
+  });
+
+  it("does not let a late consent read override survey interaction", async () => {
+    const pendingRead = createDeferred<string | null>();
+    storageMocks.read.mockReturnValue(pendingRead.promise);
+    const { result } = renderDismissalHook();
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(300);
+    });
+
+    act(() => {
+      result.current.markUserInteraction();
+    });
+
+    await act(async () => {
+      pendingRead.resolve(
+        JSON.stringify({
+          version: 1,
+          state: "dismissed",
+          resumeAt: null,
+          hideCompletely: true,
+        }),
+      );
+      await pendingRead.promise;
+    });
+
+    expect(result.current.dismissed).toBe(false);
+    expect(result.current.shouldHideCompletely).toBe(false);
+  });
+
+  it("does not remove a new dismissal after reading an expired old value", async () => {
+    const pendingRead = createDeferred<string | null>();
+    storageMocks.read.mockReturnValue(pendingRead.promise);
+    const { result } = renderDismissalHook();
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(300);
+    });
+
+    act(() => {
+      result.current.closeDock(true);
+    });
+
+    await act(async () => {
+      pendingRead.resolve(
+        JSON.stringify({
+          version: 1,
+          state: "dismissed",
+          resumeAt: "2000-01-01T00:00:00.000Z",
+          hideCompletely: false,
+        }),
+      );
+      await pendingRead.promise;
+    });
+
+    expect(storageMocks.write).toHaveBeenCalledOnce();
+    expect(storageMocks.remove).not.toHaveBeenCalled();
+    expect(result.current.dismissed).toBe(true);
+    expect(result.current.shouldHideCompletely).toBe(true);
+  });
+
+  it("clears the render grace when storage responds first", async () => {
+    storageMocks.read.mockResolvedValue(null);
+    const { result } = renderDismissalHook();
+
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    expect(result.current.isLoading).toBe(false);
+    expect(vi.getTimerCount()).toBe(0);
+  });
+
+  it("clears the render grace when the hook unmounts", () => {
+    storageMocks.read.mockReturnValue(createDeferred<string | null>().promise);
+    const { unmount } = renderDismissalHook();
+
+    expect(vi.getTimerCount()).toBe(1);
+    unmount();
+    expect(vi.getTimerCount()).toBe(0);
+  });
+});

--- a/packages/lumi-survey/src/components/LumiSurveyDock/hooks/usePersistedDismissal.ts
+++ b/packages/lumi-survey/src/components/LumiSurveyDock/hooks/usePersistedDismissal.ts
@@ -4,6 +4,7 @@ import type { StorageStrategy } from "../propTypes.js";
 import { getStorageAdapter } from "./storageAdapters.js";
 
 const MS_IN_DAY = 86_400_000;
+const CONSENT_INITIAL_RENDER_GRACE_MS = 300;
 
 interface PersistedDismissalState {
   version?: number;
@@ -52,6 +53,7 @@ export interface UsePersistedDismissalReturn {
   dismissed: boolean;
   shouldHideCompletely: boolean;
   isLoading: boolean;
+  markUserInteraction: () => void;
   closeDock: (hideCompletely?: boolean) => void;
   reopenDock: () => void;
 }
@@ -96,12 +98,34 @@ export const usePersistedDismissal = (
     }
   }, []);
 
+  const markUserInteraction = useCallback(() => {
+    userInteractedRef.current = true;
+  }, []);
+
   useEffect(() => {
     let cancelled = false;
+    let renderGraceTimer: ReturnType<typeof setTimeout> | undefined;
+
+    const finishLoading = () => {
+      if (renderGraceTimer !== undefined) {
+        clearTimeout(renderGraceTimer);
+        renderGraceTimer = undefined;
+      }
+      setIsLoading(false);
+    };
+
+    if (storageStrategy === "consent") {
+      renderGraceTimer = setTimeout(() => {
+        renderGraceTimer = undefined;
+        if (!cancelled) {
+          setIsLoading(false);
+        }
+      }, CONSENT_INITIAL_RENDER_GRACE_MS);
+    }
 
     const loadDismissedState = async () => {
       if (typeof window === "undefined") {
-        setIsLoading(false);
+        finishLoading();
         return;
       }
 
@@ -111,20 +135,24 @@ export const usePersistedDismissal = (
         return;
       }
 
+      // Once the rendered survey has been touched, this load is stale. It must
+      // neither replace UI state nor remove a newer dismissal written by that
+      // interaction.
+      if (userInteractedRef.current) {
+        finishLoading();
+        return;
+      }
+
       if (!persistedValue) {
-        if (!userInteractedRef.current) {
-          setDismissed(!initialOpen);
-        }
-        setIsLoading(false);
+        setDismissed(!initialOpen);
+        finishLoading();
         return;
       }
 
       const parsed = parsePersistedDismissal(persistedValue);
       if (!parsed) {
-        if (!userInteractedRef.current) {
-          setDismissed(true);
-        }
-        setIsLoading(false);
+        setDismissed(true);
+        finishLoading();
         return;
       }
 
@@ -136,27 +164,32 @@ export const usePersistedDismissal = (
         if (result.outcome === "failed") {
           notifyPersistenceFailure(result.error);
         }
-        if (!userInteractedRef.current) {
-          setDismissed(!initialOpen);
-          setShouldHideCompletely(false);
-        }
-        setIsLoading(false);
+        setDismissed(!initialOpen);
+        setShouldHideCompletely(false);
+        finishLoading();
         return;
       }
 
-      if (!userInteractedRef.current) {
-        setDismissed(true);
-        setShouldHideCompletely(parsed.hideCompletely ?? false);
-      }
-      setIsLoading(false);
+      setDismissed(true);
+      setShouldHideCompletely(parsed.hideCompletely ?? false);
+      finishLoading();
     };
 
     void loadDismissedState();
 
     return () => {
       cancelled = true;
+      if (renderGraceTimer !== undefined) {
+        clearTimeout(renderGraceTimer);
+      }
     };
-  }, [initialOpen, notifyPersistenceFailure, storageKey, storageAdapter]);
+  }, [
+    initialOpen,
+    notifyPersistenceFailure,
+    storageKey,
+    storageAdapter,
+    storageStrategy,
+  ]);
 
   useEffect(() => {
     if (dismissed || !viewEnabled) {
@@ -231,12 +264,18 @@ export const usePersistedDismissal = (
         onReset();
       }
 
-      userInteractedRef.current = true;
+      markUserInteraction();
       setDismissed(true);
       setShouldHideCompletely(hideCompletely ?? false);
       void persistDismissedState(true, hideCompletely);
     },
-    [dismissed, persistDismissedState, resetOnClose, onReset],
+    [
+      dismissed,
+      markUserInteraction,
+      persistDismissedState,
+      resetOnClose,
+      onReset,
+    ],
   );
 
   const reopenDock = useCallback(() => {
@@ -244,16 +283,17 @@ export const usePersistedDismissal = (
       return;
     }
 
-    userInteractedRef.current = true;
+    markUserInteraction();
     setDismissed(false);
     setShouldHideCompletely(false);
     void persistDismissedState(false);
-  }, [dismissed, persistDismissedState]);
+  }, [dismissed, markUserInteraction, persistDismissedState]);
 
   return {
     dismissed,
     shouldHideCompletely,
     isLoading,
+    markUserInteraction,
     closeDock,
     reopenDock,
   };


### PR DESCRIPTION
## Oppsummering

- rendrer widgeten etter en kort grace-periode på 300 ms når consent-API-et ikke er klart
- lar consent-lesingen fortsette i bakgrunnen uten å bytte til usikret localStorage
- beskytter en aktiv survey mot sene dismissals etter fokus, pointer, svar, navigasjon eller innsending
- hindrer at en gammel utløpt lesing sletter en ny dismissal
- dokumenterer oppførselen og dekker kalde sidelaster, races og timer-cleanup

## Verifisering

- `pnpm run lint`
- `pnpm run typecheck`
- `pnpm test`
- `pnpm run verify:lumi-survey`
- `pnpm run verify:lumi-survey-consumer`
- `pnpm run test:release-guards`
- `pnpm run check:lumi-survey-release-drift`
- to uavhengige subagent-reviews av eksakt SHA `fe900a0710f7f45229de08b62a52c8fda064a004`

Closes #486