### PR TITLE
Flytt fokus ved dock-overganger

### DIFF
--- a/packages/lumi-survey/CHANGELOG.md
+++ b/packages/lumi-survey/CHANGELOG.md
@@ -8,6 +8,10 @@ This project follows SemVer.
 
 ### Fixed
 
+- Focus now follows dock transitions: opening targets the active heading,
+  closing targets the minimized trigger, and successful submission targets the
+  receipt heading. The minimized trigger no longer references an unmounted
+  panel through disclosure attributes.
 - Consent storage no longer leaves the widget blank for five seconds when the
   Nav decorator is unavailable. The initial view is released after a 300 ms
   grace period while a late persisted dismissal can still be applied.

--- a/packages/lumi-survey/src/components/LumiSurveyDock/LumiSurveyDock.tsx
+++ b/packages/lumi-survey/src/components/LumiSurveyDock/LumiSurveyDock.tsx
@@ -194,6 +194,10 @@ export const LumiSurveyDock = ({
   // Track previous showIntro value to detect intro → question transition
   const prevShowIntroRef = useRef(showIntro);
   const pendingStepFocusRef = useRef(false);
+  const dockRef = useRef<HTMLElement>(null);
+  const minimizedButtonRef = useRef<HTMLButtonElement>(null);
+  const focusWithinDockRef = useRef(false);
+  const pendingDockFocusRef = useRef<"open-heading" | "minimized" | null>(null);
   const [stepValidationMissing, setStepValidationMissing] = useState<string[]>(
     [],
   );
@@ -394,6 +398,24 @@ export const LumiSurveyDock = ({
     setShowIntro(false);
   }, [markUserInteraction]);
 
+  const handleDockFocusCapture = useCallback(() => {
+    focusWithinDockRef.current = true;
+    markUserInteraction();
+  }, [markUserInteraction]);
+
+  const handleDockBlurCapture = useCallback(
+    (event: React.FocusEvent<HTMLElement>) => {
+      const nextTarget = event.relatedTarget;
+      if (
+        nextTarget instanceof Node &&
+        !event.currentTarget.contains(nextTarget)
+      ) {
+        focusWithinDockRef.current = false;
+      }
+    },
+    [],
+  );
+
   // Progressive submit: hide the button until a currently visible question has
   // at least one meaningful answer. Required-answer validation happens on submit.
   const isSubmitBlocked = useMemo(
@@ -522,14 +544,55 @@ export const LumiSurveyDock = ({
 
   const isSubmitting = status === "submitting";
   const isSuccess = status === "success";
+  const previousStatusRef = useRef(status);
+
+  useEffect(() => {
+    const enteredSuccess =
+      previousStatusRef.current !== "success" && status === "success";
+    previousStatusRef.current = status;
+
+    if (enteredSuccess && focusWithinDockRef.current) {
+      document.getElementById(successHeadingId)?.focus();
+    }
+  }, [status, successHeadingId]);
 
   const handleCloseDock = useCallback(() => {
-    if (isSuccess && config.hideAfterSubmit) {
-      closeDock(true);
-    } else {
-      closeDock();
-    }
+    const hideCompletely = isSuccess && config.hideAfterSubmit;
+    const focusIsWithinDock = dockRef.current?.contains(document.activeElement);
+    pendingDockFocusRef.current =
+      focusIsWithinDock && !hideCompletely ? "minimized" : null;
+    closeDock(hideCompletely);
   }, [closeDock, isSuccess, config.hideAfterSubmit]);
+
+  const handleReopenDock = useCallback(() => {
+    pendingDockFocusRef.current = "open-heading";
+    reopenDock();
+  }, [reopenDock]);
+
+  useEffect(() => {
+    if (pendingDockFocusRef.current === "minimized" && dismissed) {
+      minimizedButtonRef.current?.focus();
+      pendingDockFocusRef.current = null;
+      return;
+    }
+
+    if (pendingDockFocusRef.current === "open-heading" && !dismissed) {
+      const headingId = isSuccess
+        ? successHeadingId
+        : showIntro
+          ? introHeadingId
+          : promptHeadingId;
+      document.getElementById(headingId)?.focus();
+      pendingDockFocusRef.current = null;
+    }
+  }, [
+    dismissed,
+    introHeadingId,
+    isSuccess,
+    promptHeadingId,
+    showIntro,
+    successHeadingId,
+  ]);
 
   useAutoCloseOnSuccess({
     enabled: config.autoCloseOnSuccess,
@@ -614,6 +677,7 @@ export const LumiSurveyDock = ({
 
   return (
     <aside
+      ref={dockRef}
       className={joinClassNames(
         CLASS_NAMES.container,
         config.containerClassName,
@@ -622,15 +686,16 @@ export const LumiSurveyDock = ({
       data-feedback-id={surveyId}
       data-state={dismissed ? "dismissed" : "open"}
       aria-label="Tilbakemeldingspanel"
-      onFocusCapture={markUserInteraction}
+      onFocusCapture={handleDockFocusCapture}
+      onBlurCapture={handleDockBlurCapture}
       onPointerDownCapture={markUserInteraction}
     >
       {dismissed ? (
         <MinimizedDock
           label={config.minimizedButtonLabel}
-          panelId={panelId}
-          onReopen={reopenDock}
+          onReopen={handleReopenDock}
           className={CLASS_NAMES.minimizedButton}
+          buttonRef={minimizedButtonRef}
         />
       ) : (
         <DockPanel

--- a/packages/lumi-survey/src/components/LumiSurveyDock/__tests__/accessibility.test.tsx
+++ b/packages/lumi-survey/src/components/LumiSurveyDock/__tests__/accessibility.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen, waitFor } from "@testing-library/react";
+import { act, render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import axe from "axe-core";
 import { beforeEach, describe, expect, it, vi } from "vitest";
@@ -267,6 +267,120 @@ describe("LumiSurveyDock Accessibility", () => {
       });
       expect(questionHeading).toHaveFocus();
     });
+  });
+
+  it("moves focus from the minimized trigger to the opened heading", async () => {
+    const user = userEvent.setup();
+    render(
+      <LumiSurveyDock
+        surveyId="focus-open-test"
+        survey={survey}
+        transport={mockTransport}
+        behavior={{ initialOpen: false, storageStrategy: "none" }}
+      />,
+    );
+
+    await user.click(
+      await screen.findByRole("button", { name: /gi tilbakemelding/i }),
+    );
+
+    expect(
+      screen.getByRole("heading", { name: /hvor fornøyd er du/i }),
+    ).toHaveFocus();
+  });
+
+  it("moves focus to the intro heading when reopening an intro survey", async () => {
+    const user = userEvent.setup();
+    render(
+      <LumiSurveyDock
+        surveyId="focus-open-intro-test"
+        survey={survey}
+        transport={mockTransport}
+        intro={{ title: "Velkommen", body: "Kort intro" }}
+        behavior={{ initialOpen: false, storageStrategy: "none" }}
+      />,
+    );
+
+    await user.click(
+      await screen.findByRole("button", { name: /gi tilbakemelding/i }),
+    );
+
+    expect(screen.getByRole("heading", { name: /velkommen/i })).toHaveFocus();
+  });
+
+  it("moves focus from the close button to the minimized trigger", async () => {
+    const user = userEvent.setup();
+    render(
+      <LumiSurveyDock
+        surveyId="focus-close-test"
+        survey={survey}
+        transport={mockTransport}
+        behavior={{ storageStrategy: "none" }}
+      />,
+    );
+
+    await screen.findByRole("radio", { name: /5\./i });
+    await user.click(screen.getByRole("button", { name: /lukk/i }));
+
+    expect(
+      screen.getByRole("button", { name: /gi tilbakemelding/i }),
+    ).toHaveFocus();
+  });
+
+  it("moves focus from submit to the success heading", async () => {
+    const user = userEvent.setup();
+    render(
+      <LumiSurveyDock
+        surveyId="focus-success-test"
+        survey={survey}
+        transport={mockTransport}
+        behavior={{ storageStrategy: "none" }}
+      />,
+    );
+
+    await user.click(await screen.findByRole("radio", { name: /5\./i }));
+    await user.click(screen.getByRole("button", { name: /send/i }));
+
+    expect(
+      await screen.findByRole("heading", {
+        name: /takk for tilbakemeldingen/i,
+      }),
+    ).toHaveFocus();
+  });
+
+  it("does not steal focus back when a pending submit finishes", async () => {
+    let resolveSubmission!: () => void;
+    const submission = new Promise<void>((resolve) => {
+      resolveSubmission = resolve;
+    });
+    const transport = { submit: vi.fn().mockReturnValue(submission) };
+    const user = userEvent.setup();
+
+    render(
+      <>
+        <button type="button">Vertsside</button>
+        <LumiSurveyDock
+          surveyId="focus-success-host-test"
+          survey={survey}
+          transport={transport}
+          behavior={{ storageStrategy: "none" }}
+        />
+      </>,
+    );
+
+    await user.click(await screen.findByRole("radio", { name: /5\./i }));
+    await user.click(screen.getByRole("button", { name: /send/i }));
+    await user.click(screen.getByRole("button", { name: /vertsside/i }));
+
+    await act(async () => {
+      resolveSubmission();
+      await submission;
+    });
+
+    await screen.findByRole("heading", {
+      name: /takk for tilbakemeldingen/i,
+    });
+    expect(screen.getByRole("button", { name: /vertsside/i })).toHaveFocus();
   });
 
   it("moves focus to the new question heading after Next and Back", async () => {

--- a/packages/lumi-survey/src/components/LumiSurveyDock/components/DockPanel.tsx
+++ b/packages/lumi-survey/src/components/LumiSurveyDock/components/DockPanel.tsx
@@ -175,6 +175,7 @@ export const DockPanel = ({
                   size="small"
                   className={CLASS_NAMES.ratingHeading}
                   id={introHeadingId}
+                  tabIndex={-1}
                 >
                   {introTitle}
                 </Heading>
@@ -218,6 +219,7 @@ export const DockPanel = ({
                     size="small"
                     className={CLASS_NAMES.ratingHeading}
                     id={successHeadingId}
+                    tabIndex={-1}
                   >
                     {successTitle}
                   </Heading>

--- a/packages/lumi-survey/src/components/LumiSurveyDock/components/MinimizedDock.tsx
+++ b/packages/lumi-survey/src/components/LumiSurveyDock/components/MinimizedDock.tsx
@@ -1,29 +1,29 @@
 import { ChatIcon } from "@navikt/aksel-icons";
 import { Button } from "@navikt/ds-react";
+import type { Ref } from "react";
 
 interface MinimizedDockProps {
   label: string;
-  panelId: string;
   onReopen: () => void;
   className: string;
+  buttonRef?: Ref<HTMLButtonElement>;
 }
 
 export const MinimizedDock = ({
   label,
-  panelId,
   onReopen,
   className,
+  buttonRef,
 }: MinimizedDockProps) => {
   return (
     <Button
+      ref={buttonRef}
       type="button"
       variant="primary"
       size="medium"
       icon={<ChatIcon aria-hidden />}
       onClick={onReopen}
       className={className}
-      aria-controls={panelId}
-      aria-expanded={false}
     >
       {label}
     </Button>

--- a/packages/lumi-survey/src/components/LumiSurveyDock/components/__tests__/MinimizedDock.test.tsx
+++ b/packages/lumi-survey/src/components/LumiSurveyDock/components/__tests__/MinimizedDock.test.tsx
@@ -8,7 +8,6 @@ describe("MinimizedDock", () => {
     render(
       <MinimizedDock
         label="Gi tilbakemelding"
-        panelId="test-panel"
         onReopen={vi.fn()}
         className="test-class"
       />,
@@ -26,7 +25,6 @@ describe("MinimizedDock", () => {
     render(
       <MinimizedDock
         label="Gi tilbakemelding"
-        panelId="test-panel"
         onReopen={onReopen}
         className="test-class"
       />,
@@ -36,26 +34,24 @@ describe("MinimizedDock", () => {
     expect(onReopen).toHaveBeenCalledTimes(1);
   });
 
-  it("has correct aria attributes for accessibility", () => {
+  it("does not reference a panel that is absent while minimized", () => {
     render(
       <MinimizedDock
         label="Gi tilbakemelding"
-        panelId="test-panel"
         onReopen={vi.fn()}
         className="test-class"
       />,
     );
 
     const button = screen.getByRole("button");
-    expect(button).toHaveAttribute("aria-controls", "test-panel");
-    expect(button).toHaveAttribute("aria-expanded", "false");
+    expect(button).not.toHaveAttribute("aria-controls");
+    expect(button).not.toHaveAttribute("aria-expanded");
   });
 
   it("applies custom className", () => {
     render(
       <MinimizedDock
         label="Gi tilbakemelding"
-        panelId="test-panel"
         onReopen={vi.fn()}
         className="custom-class"
       />,


### PR DESCRIPTION
## Hva\n- flytter fokus til aktiv overskrift når en minimert survey åpnes\n- flytter fokus til minimert trigger ved vanlig lukking\n- flytter fokus til kvitteringsoverskriften etter vellykket innsending uten å stjele fokus fra vertssiden\n- fjerner disclosure-attributter som pekte på et panel som ikke var montert\n- legger til regresjonstester for fokusflytene\n\n## Verifisering\n- pnpm run lint\n- pnpm run typecheck\n- pnpm test\n- pnpm run verify:lumi-survey\n- pnpm run verify:lumi-survey-consumer\n- pnpm run test:release-guards\n- pnpm run check:lumi-survey-release-drift\n- to uavhengige subagent-reviews av eksakt SHA uten funn\n\nCloses #485