### PR TITLE
Dokumenter riktig mottaker for access policy

### DIFF
--- a/.github/ISSUE_TEMPLATE/access-request.yml
+++ b/.github/ISSUE_TEMPLATE/access-request.yml
@@ -1,5 +1,5 @@
 name: Tilgangsforespørsel
-description: Be om tilgang til å sende feedback til Lumi API
+description: Be om tilgang til å sende feedback til Lumi
 title: "[Tilgang] <app-navn> (<team>)"
 labels: ["access-request"]
 projects: ["navikt/157"]
@@ -7,8 +7,8 @@ body:
   - type: markdown
     attributes:
       value: |
-        Fyll ut skjemaet under for å be om tilgang til Lumi API.
-        Vi gir appen din inbound-tilgang så den kan sende inn feedback.
+        Fyll ut skjemaet under for å be om tilgang til Lumi-innsending.
+        Vi gir appen din inbound-tilgang i riktig mottaker, slik at den kan sende inn feedback.
         Se [integrasjonsguiden](https://navikt.github.io/lumi/kom-i-gang/koble-til-backend) for komplett oppsett.
   - type: input
     id: app-name
@@ -45,11 +45,33 @@ body:
         - label: dev-gcp
           required: true
         - label: prod-gcp
+  - type: dropdown
+    id: dev-azure-tenant
+    attributes:
+      label: Azure-tenant i dev
+      description: Brukes til å velge riktig mottaker for AzureAD i dev. Finn verdien i spec.azure.application.tenant i NAIS-manifestet.
+      options:
+        - Ikke relevant (TokenX eller ingen AzureAD-integrasjon i dev)
+        - nav.no
+        - trygdeetaten.no
+    validations:
+      required: true
   - type: markdown
     attributes:
       value: |
         ### Husk før deploy
-        Du må legge til `lumi-api` (namespace: `team-esyfo`) som **outbound** i appens `nais.yaml` før du deployer:
+
+        Velg samme mottaker for host, audience og access policy:
+
+        | Auth | Miljø / tenant | Mottaker |
+        | --- | --- | --- |
+        | TokenX | dev og prod | `lumi-api` |
+        | AzureAD | prod, eller dev med `nav.no` | `lumi-api` |
+        | AzureAD | dev med `trygdeetaten.no` | `lumi-submission-proxy` |
+
+        Legg mottakeren til som **outbound** i appens `nais.yaml` før du deployer.
+        For direkte kall til `lumi-api`:
+
         ```yaml
         spec:
           accessPolicy:
@@ -58,6 +80,19 @@ body:
                 - application: lumi-api
                   namespace: team-esyfo
         ```
+
+        For AzureAD i dev med `trygdeetaten.no`-tenant:
+
+        ```yaml
+        spec:
+          accessPolicy:
+            outbound:
+              rules:
+                - application: lumi-submission-proxy
+                  namespace: team-esyfo
+        ```
+
+        Team eSyfo bruker svarene over til å legge appen din til som inbound i riktig mottaker. Proxyen finnes bare i dev-gcp.
   - type: textarea
     id: context
     attributes:

--- a/apps/lumi-api/README.md
+++ b/apps/lumi-api/README.md
@@ -94,7 +94,20 @@ API-et maskerer automatisk PII i fritekst:
 
 Begge parter må konfigurere NAIS-tilgangspolicyer (Zero Trust).
 
-**Din app** (outbound):
+Mottakeren avhenger av auth, miljø og Azure-tenant:
+
+| Auth | Miljø | Azure-tenant i din app | Mottaker |
+| :--- | :--- | :--- | :--- |
+| TokenX | dev-gcp / prod-gcp | – | `lumi-api` |
+| AzureAD | dev-gcp | `nav.no` | `lumi-api` |
+| AzureAD | dev-gcp | `trygdeetaten.no` | `lumi-submission-proxy` |
+| AzureAD | prod-gcp | `nav.no` | `lumi-api` |
+
+Proxyen finnes bare i dev-gcp. Se
+[integrasjonsguiden](https://navikt.github.io/lumi/kom-i-gang/koble-til-backend)
+for riktige host- og audience-verdier.
+
+**Din app** (outbound ved direkte kall til `lumi-api`):
 
 ```yaml
 spec:
@@ -105,7 +118,18 @@ spec:
           namespace: team-esyfo
 ```
 
-**Lumi API** (inbound) — opprett en issue i dette repoet eller lag en PR:
+**Din app** (outbound via proxy for AzureAD fra `trygdeetaten.no` i dev):
+
+```yaml
+spec:
+  accessPolicy:
+    outbound:
+      rules:
+        - application: lumi-submission-proxy
+          namespace: team-esyfo
+```
+
+**Valgt mottaker** (inbound) — opprett en issue i dette repoet eller lag en PR:
 
 ```yaml
 spec:
@@ -115,6 +139,9 @@ spec:
         - application: din-app
           namespace: ditt-team
 ```
+
+Når appen går via proxyen, trenger den ikke en egen inbound-regel i
+`lumi-api`; proxyen har tilgang videre.
 
 Innsending er splittet på issuer:
 

--- a/docs/guider/feilsoking.md
+++ b/docs/guider/feilsoking.md
@@ -51,10 +51,18 @@ Uten CSS-import kan widgeten rendre med usynlige elementer. Se [Layout virker to
 
 **Symptom:** `transport.submit` feiler med HTTP 403.
 
-**Årsak:** NAIS access policies er ikke riktig konfigurert — enten utgående fra din app, eller innkommende til `lumi-api`.
+**Årsak:** NAIS access policies er ikke riktig konfigurert — enten utgående
+fra appen din, eller innkommende til Lumi-mottakeren.
 
 **Sjekk:**
-1. **Din app** har outbound-regel:
+
+1. **Finn riktig mottaker.** Bruk `lumi-api` for TokenX, produksjon og
+   AzureAD-apper med `nav.no`-tenant. Bruk `lumi-submission-proxy` bare for
+   AzureAD i dev når appen har `trygdeetaten.no`-tenant. Se den komplette
+   [rutetabellen](/kom-i-gang/koble-til-backend#_4-konfigurer-access-policies).
+
+2. **Din app** har outbound-regel mot denne mottakeren. For direkte kall til
+   `lumi-api`:
    ```yaml
    spec:
      accessPolicy:
@@ -64,7 +72,19 @@ Uten CSS-import kan widgeten rendre med usynlige elementer. Se [Layout virker to
              namespace: team-esyfo
    ```
 
-2. **Lumi API** har inbound-regel for din app:
+   For AzureAD i dev med `trygdeetaten.no`-tenant:
+   ```yaml
+   spec:
+     accessPolicy:
+       outbound:
+         rules:
+           - application: lumi-submission-proxy
+             namespace: team-esyfo
+   ```
+
+3. **Den samme mottakeren** har inbound-regel for appen din. Team eSyfo
+   vedlikeholder denne regelen etter en
+   [tilgangsforespørsel](https://github.com/navikt/lumi/issues/new?template=access-request.yml):
    ```yaml
    spec:
      accessPolicy:
@@ -74,17 +94,15 @@ Uten CSS-import kan widgeten rendre med usynlige elementer. Se [Layout virker to
              namespace: ditt-team
    ```
 
-3. **Token exchange** er korrekt konfigurert — sjekk at du bruker riktig endepunkt:
+4. **Token exchange** er korrekt konfigurert — sjekk at du bruker riktig endepunkt:
    - Sluttbruker (TokenX): `POST /api/tokenx/v1/feedback`
    - Intern (AzureAD): `POST /api/azure/v1/feedback`
 
-4. **Miljøvariabler** er satt i NAIS-manifest:
-   ```yaml
-   spec:
-     env:
-       - name: LUMI_API_HOST
-         value: http://lumi-api.team-esyfo
-   ```
+5. **Host og audience peker på samme mottaker som access policy.** Direkte
+   kall bruker `http://lumi-api.team-esyfo`; AzureAD fra
+   `trygdeetaten.no` i dev bruker
+   `http://lumi-submission-proxy.team-esyfo`. Se
+   [miljøvariablene for alle kombinasjoner](/kom-i-gang/koble-til-backend#_2-sett-miljøvariabler-i-nais).
 
 ## Ingen data i dashboard
 

--- a/docs/kom-i-gang/koble-til-backend.md
+++ b/docs/kom-i-gang/koble-til-backend.md
@@ -66,7 +66,7 @@ spec:
       value: "api://prod-gcp.team-esyfo.lumi-api/.default"
 ```
 
-**Dev:**
+**Dev med `trygdeetaten.no`-tenant:**
 
 ```yaml
 spec:
@@ -77,10 +77,26 @@ spec:
       value: "api://dev-gcp.team-esyfo.lumi-submission-proxy/.default"
 ```
 
-::: warning Tenant-mismatch i dev
-Lumi API bruker Azure-tenant `nav.no`. Hvis appen din bruker tenant `trygdeetaten.no` i dev (f.eks. Modia-apper), kan ikke AzureAD OBO-tokens krysse tenantgrensen. I dev må du derfor rute trafikken via `lumi-submission-proxy` — en proxyapp som brokerer mellom tenantene.
+**Dev med `nav.no`-tenant:**
 
-I **prod** bruker alle apper `nav.no`-tenant, og du kan kalle `lumi-api` direkte.
+```yaml
+spec:
+  env:
+    - name: LUMI_API_HOST
+      value: http://lumi-api.team-esyfo
+    - name: LUMI_AUDIENCE
+      value: "api://dev-gcp.team-esyfo.lumi-api/.default"
+```
+
+::: warning Tenant-mismatch i dev
+Lumi API bruker Azure-tenant `nav.no`. Hvis appen din bruker tenant
+`trygdeetaten.no` i dev (f.eks. Modia-apper), kan ikke AzureAD OBO-tokens
+krysse tenantgrensen. Da må du rute trafikken via
+`lumi-submission-proxy` — en proxyapp som brokerer mellom tenantene. Apper
+som bruker `nav.no` i dev, kaller `lumi-api` direkte.
+
+I **prod** bruker alle apper `nav.no`-tenant, proxyen finnes ikke, og du må
+kalle `lumi-api` direkte.
 :::
 
 ## 3. Send inn svar til Lumi API
@@ -118,11 +134,23 @@ export async function submitFeedback(
 
 ## 4. Konfigurer access policies
 
-Begge parter må konfigurere tilgangspolicyer (Zero Trust).
+Begge parter må konfigurere tilgangspolicyer (Zero Trust). Outbound-regelen,
+hosten og token-audience må peke på den samme mottakeren:
+
+| Auth | Miljø | Azure-tenant i din app | Mottaker |
+| :--- | :--- | :--- | :--- |
+| TokenX | dev-gcp | – | `lumi-api` |
+| TokenX | prod-gcp | – | `lumi-api` |
+| AzureAD | dev-gcp | `nav.no` | `lumi-api` |
+| AzureAD | dev-gcp | `trygdeetaten.no` | `lumi-submission-proxy` |
+| AzureAD | prod-gcp | `nav.no` | `lumi-api` |
+
+`lumi-submission-proxy` finnes bare i dev-gcp. Hvis du er usikker på hvilken
+tenant appen bruker, sjekk `spec.azure.application.tenant` i NAIS-manifestet.
 
 ### Din app (outbound)
 
-Legg til i ditt NAIS-manifest:
+For direkte kall til `lumi-api`, legg til:
 
 ```yaml
 spec:
@@ -133,9 +161,23 @@ spec:
           namespace: team-esyfo
 ```
 
-### Lumi API (inbound)
+For AzureAD i dev med `trygdeetaten.no`-tenant, legg i stedet til:
 
-Team eSyfo må legge til din app som inbound. [**Opprett en issue**](https://github.com/navikt/lumi/issues/new?template=access-request.yml) med app-navn, namespace og auth-type, så ordner vi resten:
+```yaml
+spec:
+  accessPolicy:
+    outbound:
+      rules:
+        - application: lumi-submission-proxy
+          namespace: team-esyfo
+```
+
+### Mottakeren (inbound)
+
+Team eSyfo må legge til appen din som inbound i mottakeren du fant i tabellen:
+`lumi-api` for direkte kall, eller `lumi-submission-proxy` for
+`trygdeetaten.no` i dev. [**Opprett en issue**](https://github.com/navikt/lumi/issues/new?template=access-request.yml)
+med app-navn, namespace, auth-type, miljø og dev-tenant, så ordner vi resten:
 
 ```yaml
 spec:
@@ -145,6 +187,9 @@ spec:
         - application: din-app
           namespace: ditt-team
 ```
+
+Når du går via proxyen, trenger appen din ikke i tillegg inbound i
+`lumi-api`; proxyen har allerede sin egen tilgang videre.
 
 ## 5. Storage-strategi
 
@@ -175,8 +220,8 @@ Før du deployer, verifiser at du har:
 - [ ] Token exchange i ditt endepunkt (TokenX eller AzureAD)
 - [ ] Riktig endepunkt (`/api/tokenx/v1/feedback` eller `/api/azure/v1/feedback`)
 - [ ] `LUMI_API_HOST` og `LUMI_AUDIENCE` satt i NAIS-manifest
-- [ ] Outbound access policy mot `lumi-api` i `team-esyfo`
-- [ ] Inbound access policy i Lumi API ([opprett issue](https://github.com/navikt/lumi/issues/new?template=access-request.yml))
+- [ ] Outbound access policy mot riktig mottaker (`lumi-api` eller `lumi-submission-proxy`) i `team-esyfo`
+- [ ] Inbound access policy i samme mottaker ([opprett issue](https://github.com/navikt/lumi/issues/new?template=access-request.yml))
 - [ ] Riktig `storageStrategy` (`consent` / `localStorage` / `none`)
 - [ ] Testet i dev — innsending → data synlig i dashboardet
 


### PR DESCRIPTION
## Hva

- dokumenterer riktig mottaker ut fra auth, miljø og Azure-tenant
- viser konkrete outbound-regler for direkte API-kall og dev-proxy
- retter 403-feilsøking og API-README etter samme matrise
- gjør tilgangsskjemaet entydig nok til å plassere inbound i riktig app

## Verifisering

- pnpm run lint
- pnpm run typecheck
- pnpm test
- pnpm run docs:build
- YAML- og issue-formvalidering
- genererte VitePress-ankere verifisert
- to subagent-reviews av eksakt SHA uten funn

Closes #491