### PR TITLE
Stabiliser recency-test rundt Oslo-midnatt

### DIFF
--- a/apps/lumi-dashboard/app/components/feedback/FeedbackTable/__tests__/FeedbackTable.recency.test.tsx
+++ b/apps/lumi-dashboard/app/components/feedback/FeedbackTable/__tests__/FeedbackTable.recency.test.tsx
@@ -1,5 +1,5 @@
 import { render, screen } from "@testing-library/react";
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { FeedbackTable } from "../index";
 
 const DAY_MS = 24 * 60 * 60 * 1000;
@@ -87,8 +87,14 @@ function bootstrapWith(surveyMeta: Record<string, unknown>) {
 
 describe("FeedbackTable recency and badge", () => {
   beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-08-12T12:00:00Z"));
     mockParams.surveyId = "survey-1";
     mockBootstrap.isPending = false;
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
   });
 
   it("shows relative last-submission time for the selected survey", () => {


### PR DESCRIPTION
## Hva

- fryser systemklokken i recency-komponenttestene
- gjenoppretter ekte timere etter hver test

## Hvorfor

Testen bygget «26 timer siden» fra den virkelige klokken, men forventet alltid «i går». Rundt midnatt i Oslo er 26 timer siden to kalenderdager tilbake, så testen feilet selv om produktkoden var korrekt.

## Verifisering

- målrettet recency-suite: 3/3 grønn ved Oslo-midnatt
- `pnpm run lint`
- `pnpm run typecheck`
- `pnpm test`: 2 types + 469 widget + 628 dashboard
- Playwright: 59/60 i første kjøring; den ene eksisterende dev-server-flaken ble rerunnet på ren server og besto

