### PR TITLE
Dokumenter riktig feedback-endepunkt i backend-eksemplet

### DIFF
--- a/docs/guider/feilsoking.md
+++ b/docs/guider/feilsoking.md
@@ -104,6 +104,30 @@ fra appen din, eller innkommende til Lumi-mottakeren.
    `http://lumi-submission-proxy.team-esyfo`. Se
    [miljøvariablene for alle kombinasjoner](/kom-i-gang/koble-til-backend#_2-sett-miljøvariabler-i-nais).
 
+## 401 eller 404 fra API
+
+**Symptom:** `transport.submit` feiler med HTTP 401 eller 404.
+
+- **401 Unauthorized** betyr vanligvis at tokenet ikke har issueren som
+  endepunktet forventer. TokenX-token skal sendes til
+  `/api/tokenx/v1/feedback`, mens AzureAD-token skal sendes til
+  `/api/azure/v1/feedback`.
+- **404 Not Found** betyr vanligvis at host og sti ikke passer sammen. Dette
+  skjer for eksempel hvis `/api/tokenx/v1/feedback` sendes til
+  `lumi-submission-proxy`, som bare eksponerer AzureAD-endepunktet.
+
+**Sjekk:**
+
+1. Velg miljøblokken som passer auth-type, miljø og Azure-tenant i
+   [backend-guiden](/kom-i-gang/koble-til-backend#_2-sett-miljøvariabler-i-nais).
+2. Kopier `LUMI_API_HOST`, `LUMI_AUDIENCE` og `LUMI_FEEDBACK_PATH` fra den
+   samme blokken. Ikke bland verdier fra ulike blokker.
+3. Verifiser at token exchange bruker `LUMI_AUDIENCE`, og at requesten sendes
+   til `${LUMI_API_HOST}${LUMI_FEEDBACK_PATH}`.
+
+Hvis responsen er **403**, er token og rute normalt funnet, men access policy
+mangler. Følg [403-sjekklisten](#_403-fra-api).
+
 ## Ingen data i dashboard
 
 **Symptom:** Innsending ser ut til å fungere (ingen feil), men data dukker ikke opp i dashboardet.

--- a/docs/kom-i-gang/koble-til-backend.md
+++ b/docs/kom-i-gang/koble-til-backend.md
@@ -40,6 +40,8 @@ spec:
       value: http://lumi-api.team-esyfo
     - name: LUMI_AUDIENCE
       value: "prod-gcp:team-esyfo:lumi-api"
+    - name: LUMI_FEEDBACK_PATH
+      value: /api/tokenx/v1/feedback
 ```
 
 **Dev:**
@@ -51,6 +53,8 @@ spec:
       value: http://lumi-api.team-esyfo
     - name: LUMI_AUDIENCE
       value: "dev-gcp:team-esyfo:lumi-api"
+    - name: LUMI_FEEDBACK_PATH
+      value: /api/tokenx/v1/feedback
 ```
 
 ### AzureAD (interne flater)
@@ -64,6 +68,8 @@ spec:
       value: http://lumi-api.team-esyfo
     - name: LUMI_AUDIENCE
       value: "api://prod-gcp.team-esyfo.lumi-api/.default"
+    - name: LUMI_FEEDBACK_PATH
+      value: /api/azure/v1/feedback
 ```
 
 **Dev med `trygdeetaten.no`-tenant:**
@@ -75,6 +81,8 @@ spec:
       value: http://lumi-submission-proxy.team-esyfo
     - name: LUMI_AUDIENCE
       value: "api://dev-gcp.team-esyfo.lumi-submission-proxy/.default"
+    - name: LUMI_FEEDBACK_PATH
+      value: /api/azure/v1/feedback
 ```
 
 **Dev med `nav.no`-tenant:**
@@ -86,6 +94,8 @@ spec:
       value: http://lumi-api.team-esyfo
     - name: LUMI_AUDIENCE
       value: "api://dev-gcp.team-esyfo.lumi-api/.default"
+    - name: LUMI_FEEDBACK_PATH
+      value: /api/azure/v1/feedback
 ```
 
 ::: warning Tenant-mismatch i dev
@@ -101,7 +111,10 @@ kalle `lumi-api` direkte.
 
 ## 3. Send inn svar til Lumi API
 
-Widgeten gir deg en `transportPayload` som du sender videre til Lumi API fra server-side. Her er et eksempel med [`@navikt/oasis`](https://github.com/navikt/oasis) for token exchange:
+Widgeten gir deg en `transportPayload` som du sender videre til Lumi API fra
+server-side. Miljøblokken du valgte i steg 2 setter host, audience og sti som
+én sammenhengende konfigurasjon. Her er et eksempel med
+[`@navikt/oasis`](https://github.com/navikt/oasis) for token exchange:
 
 ```ts
 import type { LumiSurveyTransportPayload } from "@navikt/lumi-survey";
@@ -111,20 +124,25 @@ export async function submitFeedback(
   token: string,
   payload: LumiSurveyTransportPayload,
 ) {
-  const obo = await requestOboToken(token, process.env.LUMI_AUDIENCE);
+  const host = process.env.LUMI_API_HOST;
+  const audience = process.env.LUMI_AUDIENCE;
+  const feedbackPath = process.env.LUMI_FEEDBACK_PATH;
+
+  if (!host || !audience || !feedbackPath) {
+    throw new Error("Lumi-konfigurasjon mangler");
+  }
+
+  const obo = await requestOboToken(token, audience);
   if (!obo.ok) throw new Error("Token exchange feilet");
 
-  const response = await fetch(
-    `${process.env.LUMI_API_HOST}/api/tokenx/v1/feedback`,
-    {
-      method: "POST",
-      headers: {
-        Authorization: `Bearer ${obo.token}`,
-        "Content-Type": "application/json",
-      },
-      body: JSON.stringify(payload),
+  const response = await fetch(`${host}${feedbackPath}`, {
+    method: "POST",
+    headers: {
+      Authorization: `Bearer ${obo.token}`,
+      "Content-Type": "application/json",
     },
-  );
+    body: JSON.stringify(payload),
+  });
 
   if (!response.ok) {
     throw new Error(`Lumi API svarte med ${response.status}`);
@@ -219,7 +237,7 @@ Før du deployer, verifiser at du har:
 - [ ] Implementert `transport.submit` som sender `submission.transportPayload` til din backend
 - [ ] Token exchange i ditt endepunkt (TokenX eller AzureAD)
 - [ ] Riktig endepunkt (`/api/tokenx/v1/feedback` eller `/api/azure/v1/feedback`)
-- [ ] `LUMI_API_HOST` og `LUMI_AUDIENCE` satt i NAIS-manifest
+- [ ] `LUMI_API_HOST`, `LUMI_AUDIENCE` og `LUMI_FEEDBACK_PATH` satt fra samme miljøblokk i NAIS-manifestet
 - [ ] Outbound access policy mot riktig mottaker (`lumi-api` eller `lumi-submission-proxy`) i `team-esyfo`
 - [ ] Inbound access policy i samme mottaker ([opprett issue](https://github.com/navikt/lumi/issues/new?template=access-request.yml))
 - [ ] Riktig `storageStrategy` (`consent` / `localStorage` / `none`)


### PR DESCRIPTION
## Hva

- legger riktig feedback-sti inn i hver konkrete host/audience-konfigurasjon
- gjør backend-eksemplet felles for TokenX og AzureAD uten hardkodet TokenX-sti
- feiler tidlig hvis Lumi-konfigurasjon mangler
- legger til målrettet feilsøking for 401 og 404, med skille mot 403

## Hvorfor

Det eneste kjørbare eksemplet brukte alltid `/api/tokenx/v1/feedback`. Interne AzureAD-team kunne derfor kopiere en ellers riktig host/audience-konfigurasjon og likevel få 404 via dev-proxyen eller 401 direkte mot API-et.

## Verifisering

- `pnpm run lint`
- `pnpm run typecheck`
- `pnpm test`: 2 types + 469 widget + 628 dashboard
- `pnpm run docs:build`
- alle fem YAML-kombinasjoner maskinparset og kontrollert mot forventet auth-sti
- genererte VitePress-ankere og interne lenker kontrollert

Closes #492

