### PR TITLE
Vis eksplisitt feiltilstand når dashboardkall feiler

### DIFF
--- a/apps/lumi-dashboard/app/components/dashboard/ContextTagsFilter/index.tsx
+++ b/apps/lumi-dashboard/app/components/dashboard/ContextTagsFilter/index.tsx
@@ -1,4 +1,5 @@
 import { Box, Label, Select, VStack } from "@navikt/ds-react";
+import { DataFetchBoundary } from "~/components/shared/DataFetchBoundary";
 import { useContextTags } from "~/hooks/useContextTags";
 import { useSegmentFilter } from "~/hooks/useSegmentFilter";
 import { formatMetadataLabel, formatMetadataValue } from "~/utils/segmentUtils";
@@ -12,8 +13,29 @@ interface ContextTagsFilterProps {
  * Renders one single-select per key.
  */
 export function ContextTagsFilter({ surveyId }: ContextTagsFilterProps) {
+  const contextTagsQuery = useContextTags(surveyId);
+
+  return (
+    <DataFetchBoundary
+      title="Kunne ikke hente segmentfiltre"
+      queries={[contextTagsQuery]}
+    >
+      <ContextTagsFilterContent
+        surveyId={surveyId}
+        contextTagsQuery={contextTagsQuery}
+      />
+    </DataFetchBoundary>
+  );
+}
+
+function ContextTagsFilterContent({
+  surveyId,
+  contextTagsQuery,
+}: ContextTagsFilterProps & {
+  contextTagsQuery: ReturnType<typeof useContextTags>;
+}) {
   const { activeFilters, addSegment, removeSegment } = useSegmentFilter();
-  const { data } = useContextTags(surveyId);
+  const { data } = contextTagsQuery;
 
   const contextTags = data?.contextTags || {};
   const hasTags = Object.keys(contextTags).length > 0;

--- a/apps/lumi-dashboard/app/components/dashboard/SegmentBreakdown.tsx
+++ b/apps/lumi-dashboard/app/components/dashboard/SegmentBreakdown.tsx
@@ -1,5 +1,6 @@
 import { Heading, Skeleton, VStack } from "@navikt/ds-react";
 import { DashboardCard, DashboardGrid } from "~/components/dashboard";
+import { DataFetchBoundary } from "~/components/shared/DataFetchBoundary";
 import { useContextTags } from "~/hooks/useContextTags";
 import type { MetadataValueWithCount } from "~/types/api";
 import { formatMetadataLabel } from "~/utils/segmentUtils";
@@ -31,15 +32,31 @@ export function SegmentBreakdown({
   surveyId,
   onSegmentClick,
 }: SegmentBreakdownProps) {
-  const { data, isLoading, error } = useContextTags(surveyId);
+  const contextTagsQuery = useContextTags(surveyId);
+
+  return (
+    <DataFetchBoundary
+      title="Kunne ikke hente segmentering"
+      queries={[contextTagsQuery]}
+    >
+      <SegmentBreakdownContent
+        contextTagsQuery={contextTagsQuery}
+        onSegmentClick={onSegmentClick}
+      />
+    </DataFetchBoundary>
+  );
+}
+
+function SegmentBreakdownContent({
+  contextTagsQuery,
+  onSegmentClick,
+}: Pick<SegmentBreakdownProps, "onSegmentClick"> & {
+  contextTagsQuery: ReturnType<typeof useContextTags>;
+}) {
+  const { data, isLoading } = contextTagsQuery;
 
   if (isLoading) {
     return <SegmentBreakdownSkeleton />;
-  }
-
-  if (error) {
-    console.error("SegmentBreakdown error:", error);
-    return null;
   }
 
   const contextTags = data?.contextTags ?? {};

--- a/apps/lumi-dashboard/app/components/dashboard/views/Discovery/BlockerAnalysis.tsx
+++ b/apps/lumi-dashboard/app/components/dashboard/views/Discovery/BlockerAnalysis.tsx
@@ -1,4 +1,5 @@
 import { SPECIALIZED_SURVEY_FIELD_IDS } from "@navikt/lumi-survey";
+import { DataFetchBoundary } from "~/components/shared/DataFetchBoundary";
 import { TextAnalysis } from "~/components/shared/TextAnalysis";
 import { useBlockerStats } from "~/hooks/useBlockerStats";
 import type { BlockerResponse } from "~/types/api";
@@ -14,6 +15,26 @@ interface BlockerAnalysisProps {
 export function BlockerAnalysis({ data: providedData }: BlockerAnalysisProps) {
   const blockerQuery = useBlockerStats();
 
+  return (
+    <DataFetchBoundary
+      title="Kunne ikke hente hindringer"
+      queries={providedData ? [] : [blockerQuery]}
+    >
+      <BlockerAnalysisContent
+        providedData={providedData}
+        blockerQuery={blockerQuery}
+      />
+    </DataFetchBoundary>
+  );
+}
+
+function BlockerAnalysisContent({
+  providedData,
+  blockerQuery,
+}: {
+  providedData?: BlockerResponse;
+  blockerQuery: ReturnType<typeof useBlockerStats>;
+}) {
   // Use provided data or fetch from hook
   const data = providedData ?? blockerQuery.data;
   const isLoading =

--- a/apps/lumi-dashboard/app/components/dashboard/views/Discovery/Dashboard.tsx
+++ b/apps/lumi-dashboard/app/components/dashboard/views/Discovery/Dashboard.tsx
@@ -2,6 +2,7 @@ import { SegmentBreakdown } from "~/components/dashboard/SegmentBreakdown";
 import { DeviceBreakdownSection } from "~/components/dashboard/sections/FieldStats/DeviceBreakdownSection";
 import { StatsCards } from "~/components/dashboard/sections/StatsCards";
 import { TimelineSection } from "~/components/dashboard/sections/Timeline";
+import { DataFetchBoundary } from "~/components/shared/DataFetchBoundary";
 import { useDiscoveryStats } from "~/hooks/useDiscoveryStats";
 import { useSearchParams } from "~/hooks/useSearchParams";
 import { useSegmentFilter } from "~/hooks/useSegmentFilter";
@@ -12,13 +13,17 @@ import { Skeleton as DiscoveryAnalysisSkeleton } from "./Skeleton";
  * Discovery dashboard — recurring tasks, examples and owner-defined themes.
  */
 export function DiscoveryDashboard() {
-  const { data, isPending } = useDiscoveryStats();
+  const discoveryQuery = useDiscoveryStats();
+  const { data, isPending } = discoveryQuery;
   const { params } = useSearchParams();
   const { addSegment } = useSegmentFilter();
   const surveyId = params.surveyId;
 
   return (
-    <>
+    <DataFetchBoundary
+      title="Kunne ikke hente Discovery-data"
+      queries={[discoveryQuery]}
+    >
       <StatsCards />
 
       {/* Timeline */}
@@ -38,6 +43,6 @@ export function DiscoveryDashboard() {
 
       {/* Device breakdown */}
       <DeviceBreakdownSection />
-    </>
+    </DataFetchBoundary>
   );
 }

--- a/apps/lumi-dashboard/app/components/dashboard/views/TaskPriority/Dashboard.tsx
+++ b/apps/lumi-dashboard/app/components/dashboard/views/TaskPriority/Dashboard.tsx
@@ -1,6 +1,7 @@
 import { SegmentBreakdown } from "~/components/dashboard/SegmentBreakdown";
 import { DeviceBreakdownSection } from "~/components/dashboard/sections/FieldStats/DeviceBreakdownSection";
 import { TimelineSection } from "~/components/dashboard/sections/Timeline";
+import { DataFetchBoundary } from "~/components/shared/DataFetchBoundary";
 import { useSearchParams } from "~/hooks/useSearchParams";
 import { useSegmentFilter } from "~/hooks/useSegmentFilter";
 import { useTaskPriorityStats } from "~/hooks/useTaskPriorityStats";
@@ -11,13 +12,17 @@ import { Skeleton as TaskPriorityAnalysisSkeleton } from "./Skeleton";
  * Task Priority Dashboard - Long Neck chart, vote distribution
  */
 export function TaskPriorityDashboard() {
-  const { data, isPending } = useTaskPriorityStats();
+  const taskPriorityQuery = useTaskPriorityStats();
+  const { data, isPending } = taskPriorityQuery;
   const { params } = useSearchParams();
   const { addSegment } = useSegmentFilter();
   const surveyId = params.surveyId;
 
   return (
-    <>
+    <DataFetchBoundary
+      title="Kunne ikke hente Task Priority-data"
+      queries={[taskPriorityQuery]}
+    >
       {/* Task Priority Analysis - show skeleton while loading */}
       {isPending ? (
         <TaskPriorityAnalysisSkeleton />
@@ -35,6 +40,6 @@ export function TaskPriorityDashboard() {
 
       {/* Device breakdown */}
       <DeviceBreakdownSection />
-    </>
+    </DataFetchBoundary>
   );
 }

--- a/apps/lumi-dashboard/app/components/dashboard/views/TopTasks/Overview.tsx
+++ b/apps/lumi-dashboard/app/components/dashboard/views/TopTasks/Overview.tsx
@@ -14,6 +14,7 @@ import { DeviceBreakdownSection } from "~/components/dashboard/sections/FieldSta
 import { TimelineSection } from "~/components/dashboard/sections/Timeline";
 import { BlockerAnalysis } from "~/components/dashboard/views/Discovery/BlockerAnalysis";
 import { TaskQuadrantChart } from "~/components/shared/Charts/TaskQuadrantChart";
+import { DataFetchBoundary } from "~/components/shared/DataFetchBoundary";
 import { useSearchParams } from "~/hooks/useSearchParams";
 import { useSegmentFilter } from "~/hooks/useSegmentFilter";
 import { useTopTasksStats } from "~/hooks/useTopTasksStats";
@@ -46,7 +47,24 @@ const THEME_DOT_CLASS_BY_HEX: Record<string, string> = {
 };
 
 export function TopTasksOverview() {
-  const { data, isLoading } = useTopTasksStats();
+  const topTasksQuery = useTopTasksStats();
+
+  return (
+    <DataFetchBoundary
+      title="Kunne ikke hente Top Tasks-data"
+      queries={[topTasksQuery]}
+    >
+      <TopTasksOverviewContent topTasksQuery={topTasksQuery} />
+    </DataFetchBoundary>
+  );
+}
+
+function TopTasksOverviewContent({
+  topTasksQuery,
+}: {
+  topTasksQuery: ReturnType<typeof useTopTasksStats>;
+}) {
+  const { data, isLoading } = topTasksQuery;
   const { params, setParams } = useSearchParams();
   const { addSegment } = useSegmentFilter();
   const surveyId = params.surveyId;

--- a/apps/lumi-dashboard/app/components/feedback/FeedbackTable/__tests__/FeedbackTable.emptyState.test.tsx
+++ b/apps/lumi-dashboard/app/components/feedback/FeedbackTable/__tests__/FeedbackTable.emptyState.test.tsx
@@ -34,6 +34,9 @@ const {
     },
     error: null as Error | null,
     isPending: false,
+    isError: false,
+    isFetching: false,
+    refetch: vi.fn().mockResolvedValue(undefined),
   },
   mockSetParam: vi.fn(),
   mockSetParams: vi.fn(),
@@ -156,6 +159,29 @@ describe("FeedbackTable empty states", () => {
     };
     mockFeedback.error = null;
     mockFeedback.isPending = false;
+    mockFeedback.isError = false;
+    mockFeedback.isFetching = false;
+  });
+
+  it("shows an explicit error instead of an empty state and can retry", () => {
+    mockBootstrap.data = bootstrapWithData();
+    mockFeedback.error = new Error("API unavailable");
+    mockFeedback.isError = true;
+    mockFeedback.refetch.mockImplementationOnce(
+      () => new Promise<never>(() => undefined),
+    );
+
+    render(<FeedbackTable />);
+
+    expect(
+      screen.getByText("Kunne ikke hente tilbakemeldinger"),
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByText(/Ingen tilbakemeldinger/),
+    ).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: "Prøv igjen" }));
+    expect(mockFeedback.refetch).toHaveBeenCalledOnce();
   });
 
   it("shows onboarding guidance when the team has no data at all", () => {

--- a/apps/lumi-dashboard/app/components/feedback/FeedbackTable/index.tsx
+++ b/apps/lumi-dashboard/app/components/feedback/FeedbackTable/index.tsx
@@ -4,7 +4,6 @@ import {
   TrashIcon,
 } from "@navikt/aksel-icons";
 import {
-  Alert,
   BodyShort,
   Box,
   Button,
@@ -34,6 +33,7 @@ import {
 } from "~/utils/surveyArchiveUtils";
 import { ArchiveSurveyDialog } from "../../dashboard/ArchiveSurveyDialog";
 import { DeleteSurveyDialog } from "../../dashboard/DeleteSurveyDialog";
+import { DataFetchBoundary } from "../../shared/DataFetchBoundary";
 import { DeleteFeedbackDialog } from "../DeleteFeedbackDialog";
 import { FeedbackEmptyState } from "./EmptyState";
 import { FeedbackCard } from "./FeedbackCard";
@@ -48,9 +48,26 @@ import styles from "./styles.module.css";
  * Supports expand/collapse for detailed view, deletion, and filtering.
  */
 export function FeedbackTable() {
+  const feedbackQuery = useFeedback();
+
+  return (
+    <DataFetchBoundary
+      title="Kunne ikke hente tilbakemeldinger"
+      queries={[feedbackQuery]}
+    >
+      <FeedbackTableContent feedbackQuery={feedbackQuery} />
+    </DataFetchBoundary>
+  );
+}
+
+function FeedbackTableContent({
+  feedbackQuery,
+}: {
+  feedbackQuery: ReturnType<typeof useFeedback>;
+}) {
   const { params, setParam, setParams } = useSearchParams();
   const page = Number.parseInt(params.page || "1", 10);
-  const { data, error, isPending } = useFeedback();
+  const { data, error, isPending } = feedbackQuery;
   const [expandedRows, setExpandedRows] = useState<Set<string>>(new Set());
   const [deleteDialogOpen, setDeleteDialogOpen] = useState(false);
   const [archiveDialogOpen, setArchiveDialogOpen] = useState(false);
@@ -86,11 +103,6 @@ export function FeedbackTable() {
       return next;
     });
   };
-
-  // Loading and error states
-  if (error) {
-    return <Alert variant="error">Kunne ikke laste tilbakemeldinger</Alert>;
-  }
 
   // isPending: no cached data AND fetching (TanStack Query v5 best practice)
   // With placeholderData: keepPreviousData, isPending stays false during refetches

--- a/apps/lumi-dashboard/app/components/shared/Charts/SurveyTypeDistribution.tsx
+++ b/apps/lumi-dashboard/app/components/shared/Charts/SurveyTypeDistribution.tsx
@@ -11,6 +11,7 @@ import {
 import { ChartEmptyState } from "~/components/shared/Charts/ChartEmptyState";
 import { ChartLoadingState } from "~/components/shared/Charts/ChartLoadingState";
 import { ResponsiveContainerWithInitialSize } from "~/components/shared/Charts/ResponsiveContainerWithInitialSize";
+import { DataFetchBoundary } from "~/components/shared/DataFetchBoundary";
 import { useTheme } from "~/context/ThemeContext";
 import { useSurveyTypeDistribution } from "~/hooks/useSurveyTypeDistribution";
 import type { SurveyType } from "~/types/api";
@@ -62,7 +63,28 @@ function SurveyTypeBarShape(props: SurveyTypeBarShapeProps) {
 export function SurveyTypeDistribution({
   height = "100%",
 }: SurveyTypeDistributionProps) {
-  const { data: distribution, isPending } = useSurveyTypeDistribution();
+  const distributionQuery = useSurveyTypeDistribution();
+
+  return (
+    <DataFetchBoundary
+      title="Kunne ikke hente surveytyper"
+      queries={[distributionQuery]}
+    >
+      <SurveyTypeDistributionContent
+        height={height}
+        distributionQuery={distributionQuery}
+      />
+    </DataFetchBoundary>
+  );
+}
+
+function SurveyTypeDistributionContent({
+  height,
+  distributionQuery,
+}: Required<SurveyTypeDistributionProps> & {
+  distributionQuery: ReturnType<typeof useSurveyTypeDistribution>;
+}) {
+  const { data: distribution, isPending } = distributionQuery;
   const { theme } = useTheme();
 
   const colors = theme === "light" ? CHART_COLORS_LIGHT : CHART_COLORS;

--- a/apps/lumi-dashboard/app/components/shared/DataFetchBoundary/DataFetchBoundary.module.css
+++ b/apps/lumi-dashboard/app/components/shared/DataFetchBoundary/DataFetchBoundary.module.css
@@ -1,0 +1,11 @@
+.srOnly {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  margin: -1px;
+  padding: 0;
+  overflow: hidden;
+  clip-path: inset(50%);
+  white-space: nowrap;
+  border: 0;
+}

--- a/apps/lumi-dashboard/app/components/shared/DataFetchBoundary/__tests__/DataFetchBoundary.test.tsx
+++ b/apps/lumi-dashboard/app/components/shared/DataFetchBoundary/__tests__/DataFetchBoundary.test.tsx
@@ -1,0 +1,134 @@
+import {
+  act,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { DataFetchBoundary } from "../index";
+
+describe("DataFetchBoundary", () => {
+  it("renders its content when all queries have succeeded", () => {
+    render(
+      <DataFetchBoundary
+        title="Kunne ikke hente dashboarddata"
+        queries={[
+          {
+            isError: false,
+            isFetching: false,
+            refetch: vi.fn(),
+          },
+        ]}
+      >
+        <div>42 tilbakemeldinger</div>
+      </DataFetchBoundary>,
+    );
+
+    expect(screen.getByText("42 tilbakemeldinger")).toBeInTheDocument();
+    expect(
+      screen.queryByText("Kunne ikke hente dashboarddata"),
+    ).not.toBeInTheDocument();
+  });
+
+  it("hides potentially misleading content and retries only failed queries", () => {
+    const failedRefetch = vi.fn(() => new Promise<never>(() => undefined));
+    const successfulRefetch = vi.fn().mockResolvedValue(undefined);
+
+    render(
+      <DataFetchBoundary
+        title="Kunne ikke hente dashboarddata"
+        queries={[
+          {
+            isError: true,
+            isFetching: false,
+            refetch: failedRefetch,
+          },
+          {
+            isError: false,
+            isFetching: false,
+            refetch: successfulRefetch,
+          },
+        ]}
+      >
+        <div>0 tilbakemeldinger</div>
+      </DataFetchBoundary>,
+    );
+
+    expect(
+      screen.getByText("Kunne ikke hente dashboarddata"),
+    ).toBeInTheDocument();
+    expect(screen.queryByText("0 tilbakemeldinger")).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: "Prøv igjen" }));
+
+    expect(failedRefetch).toHaveBeenCalledOnce();
+    expect(successfulRefetch).not.toHaveBeenCalled();
+  });
+
+  it("keeps the alert and focus stable during retry, then announces recovery", async () => {
+    let resolveRefetch: (value: { isError: false }) => void = () => undefined;
+    const refetch = vi.fn(
+      () =>
+        new Promise<{ isError: false }>((resolve) => {
+          resolveRefetch = resolve;
+        }),
+    );
+    const query = {
+      isError: true,
+      isFetching: false,
+      refetch,
+    };
+    const { rerender } = render(
+      <DataFetchBoundary
+        title="Kunne ikke hente dashboarddata"
+        queries={[query]}
+      >
+        <div>42 tilbakemeldinger</div>
+      </DataFetchBoundary>,
+    );
+
+    const retryButton = screen.getByRole("button", { name: "Prøv igjen" });
+    retryButton.focus();
+    fireEvent.click(retryButton);
+
+    query.isError = false;
+    query.isFetching = true;
+    rerender(
+      <DataFetchBoundary
+        title="Kunne ikke hente dashboarddata"
+        queries={[query]}
+      >
+        <div>42 tilbakemeldinger</div>
+      </DataFetchBoundary>,
+    );
+
+    expect(screen.getByRole("alert")).toBeInTheDocument();
+    expect(retryButton).toHaveFocus();
+    expect(screen.queryByText("42 tilbakemeldinger")).not.toBeInTheDocument();
+
+    await act(async () => resolveRefetch({ isError: false }));
+
+    await waitFor(() =>
+      expect(screen.getByText("42 tilbakemeldinger")).toBeInTheDocument(),
+    );
+    expect(screen.getByRole("status")).toHaveTextContent(
+      "Dataene er lastet inn.",
+    );
+
+    query.isError = true;
+    query.isFetching = false;
+    rerender(
+      <DataFetchBoundary
+        title="Kunne ikke hente dashboarddata"
+        queries={[query]}
+      >
+        <div>0 tilbakemeldinger</div>
+      </DataFetchBoundary>,
+    );
+
+    expect(screen.getByRole("alert")).toBeInTheDocument();
+    expect(screen.queryByRole("status")).not.toBeInTheDocument();
+    expect(screen.queryByText("0 tilbakemeldinger")).not.toBeInTheDocument();
+  });
+});

--- a/apps/lumi-dashboard/app/components/shared/DataFetchBoundary/index.tsx
+++ b/apps/lumi-dashboard/app/components/shared/DataFetchBoundary/index.tsx
@@ -1,0 +1,100 @@
+import { ArrowCirclepathIcon } from "@navikt/aksel-icons";
+import { Alert, BodyShort, Button, VStack } from "@navikt/ds-react";
+import { type ReactNode, useState } from "react";
+import styles from "./DataFetchBoundary.module.css";
+
+interface RefetchableQuery {
+  isError: boolean;
+  isFetching: boolean;
+  refetch: () => Promise<unknown>;
+}
+
+interface DataFetchBoundaryProps {
+  children?: ReactNode;
+  queries: RefetchableQuery[];
+  title: string;
+}
+
+/**
+ * Prevents failed queries from being mistaken for valid empty data.
+ * Only failed queries are retried, so unrelated successful requests stay cached.
+ */
+export function DataFetchBoundary({
+  children,
+  queries,
+  title,
+}: DataFetchBoundaryProps) {
+  const [isRetrying, setIsRetrying] = useState(false);
+  const [recoveryAnnouncement, setRecoveryAnnouncement] = useState("");
+  const failedQueries = queries.filter((query) => query.isError);
+
+  const retryFailedQueries = async () => {
+    setRecoveryAnnouncement("");
+    setIsRetrying(true);
+
+    try {
+      const results = await Promise.all(
+        failedQueries.map((query) => query.refetch()),
+      );
+      const recovered = results.every((result) => {
+        if (!result || typeof result !== "object" || !("isError" in result)) {
+          return true;
+        }
+        return result.isError === false;
+      });
+
+      if (recovered) {
+        setRecoveryAnnouncement("Dataene er lastet inn.");
+      }
+    } catch {
+      // The query owns the error state; keep the same retryable alert visible.
+      setRecoveryAnnouncement("");
+    } finally {
+      setIsRetrying(false);
+    }
+  };
+
+  const recoveryStatus =
+    recoveryAnnouncement && failedQueries.length === 0 && !isRetrying ? (
+      <span role="status" aria-live="polite" className={styles.srOnly}>
+        {recoveryAnnouncement}
+      </span>
+    ) : null;
+
+  if (failedQueries.length === 0 && !isRetrying) {
+    return (
+      <>
+        {recoveryStatus}
+        {children}
+      </>
+    );
+  }
+
+  const isFetching =
+    isRetrying || failedQueries.some((query) => query.isFetching);
+
+  return (
+    <>
+      {recoveryStatus}
+      <Alert variant="error" role="alert">
+        <VStack gap="space-8" align="start">
+          <BodyShort weight="semibold">{title}</BodyShort>
+          <BodyShort size="small">
+            Vi viser ikke data før forespørselen lykkes, fordi et tomt resultat
+            kan være misvisende.
+          </BodyShort>
+          <Button
+            type="button"
+            variant="tertiary"
+            size="small"
+            icon={<ArrowCirclepathIcon aria-hidden />}
+            loading={isFetching}
+            onClick={() => void retryFailedQueries()}
+          >
+            Prøv igjen
+          </Button>
+        </VStack>
+      </Alert>
+    </>
+  );
+}

--- a/apps/lumi-dashboard/app/components/shared/FilterBar/__tests__/FilterBar.archive.test.tsx
+++ b/apps/lumi-dashboard/app/components/shared/FilterBar/__tests__/FilterBar.archive.test.tsx
@@ -3,7 +3,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import { resolveDashboardPeriod } from "~/utils/dashboardPeriod";
 import { FilterBar } from "../index";
 
-const { mockParams, mockSetParams, mockResetParams, mockBootstrap } =
+const { mockParams, mockSetParams, mockResetParams, mockBootstrap, mockStats } =
   vi.hoisted(() => ({
     mockParams: {
       team: "team-test",
@@ -20,6 +20,16 @@ const { mockParams, mockSetParams, mockResetParams, mockBootstrap } =
     mockBootstrap: {
       data: undefined as unknown,
       isPending: false,
+      isError: false,
+      isFetching: false,
+      refetch: vi.fn().mockResolvedValue(undefined),
+    },
+    mockStats: {
+      data: undefined as unknown,
+      isPending: false,
+      isError: false,
+      isFetching: false,
+      refetch: vi.fn().mockResolvedValue(undefined),
     },
   }));
 
@@ -93,7 +103,7 @@ function sharedSurveyBootstrapData() {
 }
 
 vi.mock("~/hooks/useStats", () => ({
-  useStats: () => ({ data: undefined, isPending: false }),
+  useStats: () => mockStats,
 }));
 
 vi.mock("~/hooks/useThemes", () => ({
@@ -111,8 +121,34 @@ describe("FilterBar archive state", () => {
     mockParams.query = undefined;
     mockBootstrap.data = loadedBootstrapData();
     mockBootstrap.isPending = false;
+    mockBootstrap.isError = false;
+    mockBootstrap.isFetching = false;
+    mockStats.isError = false;
+    mockStats.isFetching = false;
     mockSetParams.mockClear();
     mockResetParams.mockClear();
+    mockBootstrap.refetch.mockClear();
+    mockStats.refetch.mockClear();
+  });
+
+  it("shows an explicit error instead of empty filters and retries the failed query", () => {
+    mockBootstrap.isError = true;
+    mockBootstrap.refetch.mockImplementationOnce(
+      () => new Promise<never>(() => undefined),
+    );
+
+    render(<FilterBar />);
+
+    expect(screen.getByText("Kunne ikke hente filtre")).toBeInTheDocument();
+    expect(
+      screen.queryByRole("combobox", { name: "App" }),
+    ).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: "Prøv igjen" }));
+
+    expect(mockBootstrap.refetch).toHaveBeenCalledOnce();
+    expect(mockStats.refetch).not.toHaveBeenCalled();
+    expect(mockSetParams).not.toHaveBeenCalled();
   });
 
   it("does not clear an app filter while bootstrap is still loading", () => {

--- a/apps/lumi-dashboard/app/components/shared/FilterBar/index.tsx
+++ b/apps/lumi-dashboard/app/components/shared/FilterBar/index.tsx
@@ -16,6 +16,7 @@ import {
 import dayjs from "dayjs";
 import { useEffect } from "react";
 import { PeriodSelector } from "~/components/dashboard/PeriodSelector";
+import { DataFetchBoundary } from "~/components/shared/DataFetchBoundary";
 import { getSurveyFeatures } from "~/config/surveyConfig";
 import { useActiveFilters } from "~/hooks/useActiveFilters";
 import { useFilterBootstrap } from "~/hooks/useFilterBootstrap";
@@ -40,10 +41,34 @@ interface FilterBarProps {
 }
 
 export function FilterBar({ showDetails = false }: FilterBarProps) {
+  const bootstrapQuery = useFilterBootstrap();
+  const statsQuery = useStats();
+
+  return (
+    <DataFetchBoundary
+      title="Kunne ikke hente filtre"
+      queries={[bootstrapQuery, statsQuery]}
+    >
+      <FilterBarContent
+        showDetails={showDetails}
+        bootstrapQuery={bootstrapQuery}
+        statsQuery={statsQuery}
+      />
+    </DataFetchBoundary>
+  );
+}
+
+function FilterBarContent({
+  showDetails,
+  bootstrapQuery,
+  statsQuery,
+}: Required<FilterBarProps> & {
+  bootstrapQuery: ReturnType<typeof useFilterBootstrap>;
+  statsQuery: ReturnType<typeof useStats>;
+}) {
   const { params, setParams } = useSearchParams();
-  const { data: bootstrap, isPending: isPendingBootstrap } =
-    useFilterBootstrap();
-  const { data: stats, isPending: isPendingStats } = useStats();
+  const { data: bootstrap, isPending: isPendingBootstrap } = bootstrapQuery;
+  const { data: stats, isPending: isPendingStats } = statsQuery;
   const { themes } = useThemes();
 
   const features = getSurveyFeatures(stats?.surveyType);

--- a/apps/lumi-dashboard/app/mock/mockData.timezone.test.ts
+++ b/apps/lumi-dashboard/app/mock/mockData.timezone.test.ts
@@ -1,0 +1,31 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+describe("timezone-safe mock data", () => {
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.resetModules();
+  });
+
+  it("keeps the ordering survey inside the current Oslo date across UTC midnight", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-08-22T22:30:00Z"));
+    vi.resetModules();
+
+    const { getMockStats } = await import("~/mock/mockData");
+    const stats = getMockStats(
+      new URLSearchParams({
+        surveyId: "survey-ordering",
+        fromDate: "2026-08-23",
+        toDate: "2026-08-23",
+      }),
+    );
+
+    expect(stats.totalCount).toBe(12);
+    expect(stats.fieldStats?.map((field) => field.label)).toEqual([
+      "Ordering Q1",
+      "Ordering Q2",
+      "Ordering Q3",
+      "Ordering Q4",
+    ]);
+  });
+});

--- a/apps/lumi-dashboard/app/mock/mockData.ts
+++ b/apps/lumi-dashboard/app/mock/mockData.ts
@@ -63,7 +63,23 @@ export {
 
 function generateFieldStatsOrderingSurveyData(count: number): FeedbackDto[] {
   const items: FeedbackDto[] = [];
-  const now = new Date();
+  const osloDateParts = new Intl.DateTimeFormat("en-GB", {
+    timeZone: "Europe/Oslo",
+    year: "numeric",
+    month: "2-digit",
+    day: "2-digit",
+  })
+    .formatToParts(new Date())
+    .reduce<Record<string, string>>((parts, part) => {
+      if (part.type !== "literal") parts[part.type] = part.value;
+      return parts;
+    }, {});
+  // Mock date filters compare ISO strings to calendar-date query params. Keep
+  // this E2E-only survey safely inside today's Oslo date, including the hours
+  // after Oslo midnight but before UTC midnight.
+  const now = new Date(
+    `${osloDateParts.year}-${osloDateParts.month}-${osloDateParts.day}T12:00:00Z`,
+  );
 
   for (let i = 0; i < count; i++) {
     const minutesAgo = i * 7;

--- a/apps/lumi-dashboard/app/routes/index.tsx
+++ b/apps/lumi-dashboard/app/routes/index.tsx
@@ -9,6 +9,7 @@ import { RatingDashboard } from "~/components/dashboard/views/Rating/Dashboard";
 import { TaskPriorityDashboard } from "~/components/dashboard/views/TaskPriority/Dashboard";
 import { TopTasksOverview } from "~/components/dashboard/views/TopTasks/Overview";
 import { ActiveFiltersChips } from "~/components/shared/ActiveFiltersChips";
+import { DataFetchBoundary } from "~/components/shared/DataFetchBoundary";
 import { FilterBar } from "~/components/shared/FilterBar";
 import { Header } from "~/components/shared/Header";
 import { PrivacyMaskedNotice } from "~/components/shared/PrivacyMaskedNotice";
@@ -106,7 +107,8 @@ export const Route = createFileRoute("/")({
 
 function DashboardPage() {
   const { params, setParams } = useSearchParams();
-  const { data: stats, isPending } = useStats();
+  const statsQuery = useStats();
+  const { data: stats, isPending } = statsQuery;
   const hasSurveyFilter = !!params.surveyId;
   const surveyType = stats?.surveyType;
   const isPrivacyMasked = stats?.privacy?.masked;
@@ -180,13 +182,18 @@ function DashboardPage() {
             </HStack>
           </HStack>
 
-          <FilterBar />
+          <DataFetchBoundary
+            title="Kunne ikke hente dashboarddata"
+            queries={[statsQuery]}
+          >
+            <FilterBar />
 
-          {/* Active drill-down filters (global) */}
-          <ActiveFiltersChips />
+            {/* Active drill-down filters (global) */}
+            <ActiveFiltersChips />
 
-          {/* Type-specific dashboard view */}
-          {renderDashboardContent()}
+            {/* Type-specific dashboard view */}
+            {renderDashboardContent()}
+          </DataFetchBoundary>
         </VStack>
       </Box>
     </>

--- a/apps/lumi-dashboard/e2e/dashboard.spec.ts
+++ b/apps/lumi-dashboard/e2e/dashboard.spec.ts
@@ -1,4 +1,4 @@
-import { expect, test } from "@playwright/test";
+import { expect, type Route, test } from "@playwright/test";
 
 test.describe("Dashboard", () => {
   test("loads dashboard page", async ({ page }) => {
@@ -13,6 +13,42 @@ test.describe("Dashboard", () => {
 
     // Check for main element
     await expect(page.locator("main")).toBeVisible({ timeout: 15000 });
+  });
+
+  test("shows a retryable error instead of empty data when stats fail", async ({
+    page,
+  }) => {
+    await page.goto("/");
+
+    const surveySelect = page.getByRole("combobox", { name: "Survey" });
+    await expect(surveySelect).toBeVisible();
+
+    const failDashboardRequests = async (route: Route) => {
+      const request = route.request();
+      if (["fetch", "xhr"].includes(request.resourceType())) {
+        await route.fulfill({ status: 500, body: "simulated stats failure" });
+        return;
+      }
+      await route.continue();
+    };
+    await page.route("**/*", failDashboardRequests);
+
+    await surveySelect.selectOption("survey-vurdering");
+
+    const errorAlert = page.getByRole("alert");
+    await expect(errorAlert).toContainText("Kunne ikke hente dashboarddata", {
+      timeout: 15000,
+    });
+    await expect(page.getByText(/Ingen data for valgt periode/)).toHaveCount(0);
+
+    await page.unroute("**/*", failDashboardRequests);
+    await errorAlert.getByRole("button", { name: "Prøv igjen" }).click();
+
+    await expect(errorAlert).toHaveCount(0);
+    await expect(
+      page.getByRole("status").filter({ hasText: "Dataene er lastet inn." }),
+    ).toHaveCount(1);
+    await expect(page.getByText("Vurdering", { exact: true })).toBeVisible();
   });
 
   test("archive visibility survives navigation and reload", async ({


### PR DESCRIPTION
## Hva
- skjuler potensielt misvisende tom-/nullvisning når dashboardqueries feiler
- gir en felles Aksel-feiltilstand med målrettet retry
- dekker hovedstats, filter/feedback og surveyspesifikke datakilder
- beholder alert og fokus under retry, og annonserer vellykket recovery
- legger til en Chromium-test som tvinger nettverkskall til HTTP 500 og verifiserer recovery
- gjør feltrekkefølge-fixturen stabil mellom Oslo- og UTC-midnatt, med en låst regresjonstest

## Verifisering
- pnpm run lint
- pnpm run typecheck
- pnpm test (2 typer, 469 widget, 634 dashboard)
- pnpm --filter lumi-dashboard run e2e (61/61)

Closes #476