### PR TITLE
fix(api): isolate global rate limit buckets

### DIFF
--- a/apps/lumi-api/nais/app/dev.yaml
+++ b/apps/lumi-api/nais/app/dev.yaml
@@ -81,3 +81,5 @@ spec:
       value: https://console.nav.cloud.nais.io/graphql
     - name: LUMI_CORS_ALLOWED_ORIGINS
       value: https://lumi-dashboard.ansatt.dev.nav.no
+    - name: LUMI_GLOBAL_REQUESTS_PER_SOURCE_PER_MINUTE
+      value: "10000"

--- a/apps/lumi-api/nais/app/prod.yaml
+++ b/apps/lumi-api/nais/app/prod.yaml
@@ -84,3 +84,5 @@ spec:
       value: https://console.nav.cloud.nais.io/graphql
     - name: LUMI_CORS_ALLOWED_ORIGINS
       value: https://lumi-dashboard.ansatt.nav.no
+    - name: LUMI_GLOBAL_REQUESTS_PER_SOURCE_PER_MINUTE
+      value: "10000"

--- a/apps/lumi-api/src/main/kotlin/no/nav/lumi/config/RateLimitEnv.kt
+++ b/apps/lumi-api/src/main/kotlin/no/nav/lumi/config/RateLimitEnv.kt
@@ -1,0 +1,27 @@
+package no.nav.lumi.config
+
+data class RateLimitEnv(
+    val globalRequestsPerSourcePerMinute: Int,
+) {
+    companion object {
+        private const val DEFAULT_GLOBAL_REQUESTS_PER_SOURCE_PER_MINUTE = 10_000
+        private const val GLOBAL_REQUESTS_PER_SOURCE_PER_MINUTE_ENV =
+            "LUMI_GLOBAL_REQUESTS_PER_SOURCE_PER_MINUTE"
+
+        fun fromEnvironment(
+            configuredValue: String? = System.getenv(GLOBAL_REQUESTS_PER_SOURCE_PER_MINUTE_ENV),
+        ): RateLimitEnv {
+            if (configuredValue == null) return default()
+
+            val requestsPerMinute = configuredValue.toIntOrNull()?.takeIf { it > 0 }
+                ?: throw IllegalStateException(
+                    "$GLOBAL_REQUESTS_PER_SOURCE_PER_MINUTE_ENV must be a positive integer"
+                )
+
+            return RateLimitEnv(requestsPerMinute)
+        }
+
+        fun default(): RateLimitEnv =
+            RateLimitEnv(DEFAULT_GLOBAL_REQUESTS_PER_SOURCE_PER_MINUTE)
+    }
+}

--- a/apps/lumi-api/src/main/kotlin/no/nav/lumi/config/RateLimiting.kt
+++ b/apps/lumi-api/src/main/kotlin/no/nav/lumi/config/RateLimiting.kt
@@ -37,6 +37,10 @@ import kotlin.time.Duration.Companion.minutes
  *   only after client and team authorization have completed. Rejected requests
  *   keep the permit and receive 429 after 30 attempts per minute, even when
  *   every token value is different.
+ * - Global guard: runs before route authentication, so it is keyed by the
+ *   non-spoofable socket peer instead of caller-controlled forwarding headers.
+ *   Internal health/metrics routes have zero request weight and can therefore
+ *   never be blocked by exhausted traffic buckets.
  */
 
 val SubmissionRateLimit = RateLimitName("submission")
@@ -55,7 +59,7 @@ private val RejectedExportAuthenticationRateLimit = createRouteScopedPlugin(
     val pluginApplication = application
 
     onCall { call ->
-        val key = call.sourceAddress()
+        val key = call.socketPeerAddress()
         val bucket = buckets.computeIfAbsent(key) {
             RejectedAuthenticationBucket(limit = EXPORT_REQUESTS_PER_MINUTE).also { created ->
                 pluginApplication.launch {
@@ -120,7 +124,9 @@ internal fun Route.refundRejectedExportAuthenticationAfterAuthorization() {
 }
 
 fun Application.configureRateLimiting(
-    submissionObservability: SubmissionObservability = defaultRateLimitSubmissionObservability
+    submissionObservability: SubmissionObservability = defaultRateLimitSubmissionObservability,
+    globalRequestsPerMinute: Int = ServerEnv.current.rateLimit.globalRequestsPerSourcePerMinute,
+    globalRequestKey: suspend (ApplicationCall) -> Any = { call -> call.socketPeerAddress() },
 ) {
     install(RateLimit) {
         register(SubmissionRateLimit) {
@@ -154,9 +160,13 @@ fun Application.configureRateLimiting(
             rateLimiter(limit = EXPORT_REQUESTS_PER_MINUTE, refillPeriod = RATE_LIMIT_REFILL_PERIOD)
             requestKey { call -> call.rateLimitKey() }
         }
-        
+
         global {
-            rateLimiter(limit = 1000, refillPeriod = RATE_LIMIT_REFILL_PERIOD)
+            rateLimiter(limit = globalRequestsPerMinute, refillPeriod = RATE_LIMIT_REFILL_PERIOD)
+            requestKey(globalRequestKey)
+            requestWeight { call, _ ->
+                if (call.request.path().startsWith("/internal/")) 0 else 1
+            }
             modifyResponse { call, state ->
                 recordRejectedSubmissionWhenExhausted(call, state, submissionObservability)
             }
@@ -207,15 +217,8 @@ private fun io.ktor.server.application.ApplicationCall.rateLimitKey(): String {
         }
     }
 
-    return sourceAddress()
+    return socketPeerAddress()
 }
 
-private fun io.ktor.server.application.ApplicationCall.sourceAddress(): String {
-    val forwardedFor = if (ServerEnv.current.nais.isNais) {
-        request.headers["X-Forwarded-For"]?.split(",")?.firstOrNull()?.trim()
-    } else {
-        null
-    }
-
-    return forwardedFor ?: request.local.remoteAddress
-}
+private fun io.ktor.server.application.ApplicationCall.socketPeerAddress(): String =
+    request.local.remoteAddress

--- a/apps/lumi-api/src/main/kotlin/no/nav/lumi/config/ServerEnv.kt
+++ b/apps/lumi-api/src/main/kotlin/no/nav/lumi/config/ServerEnv.kt
@@ -15,7 +15,8 @@ data class ServerEnv(
     val nais: NaisEnv,
     val auth: AuthEnv,
     val valkey: ValkeyEnv,
-    val naisApi: NaisApiEnv
+    val naisApi: NaisApiEnv,
+    val rateLimit: RateLimitEnv,
 ) {
     /**
      * Database connection configuration.
@@ -219,7 +220,8 @@ data class ServerEnv(
                 nais = nais,
                 auth = AuthEnv.fromEnvironment(nais.clusterName),
                 valkey = ValkeyEnv.fromEnvironment(),
-                naisApi = NaisApiEnv.fromEnvironment()
+                naisApi = NaisApiEnv.fromEnvironment(),
+                rateLimit = RateLimitEnv.fromEnvironment(),
             )
         }
         
@@ -234,7 +236,8 @@ data class ServerEnv(
                 nais = NaisEnv.forLocal(),
                 auth = AuthEnv.forLocal(),
                 valkey = ValkeyEnv.forLocal(),
-                naisApi = NaisApiEnv.forLocal()
+                naisApi = NaisApiEnv.forLocal(),
+                rateLimit = RateLimitEnv.fromEnvironment(),
             )
         }
         
@@ -258,7 +261,8 @@ data class ServerEnv(
                 nais = NaisEnv.forLocal(),
                 auth = AuthEnv.forLocal(),
                 valkey = ValkeyEnv.forLocal(),
-                naisApi = NaisApiEnv(graphqlUrl = null, tokenPath = null, staticKey = null)
+                naisApi = NaisApiEnv(graphqlUrl = null, tokenPath = null, staticKey = null),
+                rateLimit = RateLimitEnv.default(),
             )
         }
     }

--- a/apps/lumi-api/src/test/kotlin/no/nav/lumi/config/GlobalRateLimitingTest.kt
+++ b/apps/lumi-api/src/test/kotlin/no/nav/lumi/config/GlobalRateLimitingTest.kt
@@ -1,0 +1,102 @@
+package no.nav.lumi.config
+
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import io.ktor.client.request.get
+import io.ktor.http.HttpStatusCode
+import io.ktor.server.application.call
+import io.ktor.server.response.respond
+import io.ktor.server.routing.get
+import io.ktor.server.routing.routing
+import io.ktor.server.testing.testApplication
+
+class GlobalRateLimitingTest : FunSpec({
+    test("an exhausted global bucket never blocks internal health routes") {
+        testApplication {
+            application {
+                configureRateLimiting(globalRequestsPerMinute = 2)
+                routing {
+                    get("/load") {
+                        call.respond(HttpStatusCode.OK)
+                    }
+                    get("/internal/isAlive") {
+                        call.respond(HttpStatusCode.OK)
+                    }
+                    get("/internal/isReady") {
+                        call.respond(HttpStatusCode.OK)
+                    }
+                    get("/internal/prometheus") {
+                        call.respond(HttpStatusCode.OK)
+                    }
+                }
+            }
+
+            repeat(2) {
+                client.get("/load").status shouldBe HttpStatusCode.OK
+            }
+            client.get("/load").status shouldBe HttpStatusCode.TooManyRequests
+
+            listOf(
+                "/internal/isAlive",
+                "/internal/isReady",
+                "/internal/prometheus",
+            ).forEach { path ->
+                client.get(path).status shouldBe HttpStatusCode.OK
+            }
+        }
+    }
+
+    test("forwarded addresses cannot rotate the global bucket") {
+        testApplication {
+            application {
+                configureRateLimiting(globalRequestsPerMinute = 2)
+                routing {
+                    get("/load") {
+                        call.respond(HttpStatusCode.OK)
+                    }
+                }
+            }
+
+            listOf("192.0.2.10", "192.0.2.11").forEach { forwardedAddress ->
+                client.get("/load") {
+                    headers.append("X-Forwarded-For", forwardedAddress)
+                }.status shouldBe HttpStatusCode.OK
+            }
+            client.get("/load") {
+                headers.append("X-Forwarded-For", "192.0.2.12")
+            }.status shouldBe HttpStatusCode.TooManyRequests
+        }
+    }
+
+    test("global traffic buckets are isolated per trusted source key") {
+        testApplication {
+            application {
+                configureRateLimiting(
+                    globalRequestsPerMinute = 2,
+                    globalRequestKey = { call ->
+                        call.request.headers["X-Test-Source"] ?: "unknown"
+                    },
+                )
+                routing {
+                    get("/load") {
+                        call.respond(HttpStatusCode.OK)
+                    }
+                }
+            }
+
+            repeat(2) {
+                client.get("/load") {
+                    headers.append("X-Test-Source", "source-a")
+                }.status shouldBe HttpStatusCode.OK
+            }
+            client.get("/load") {
+                headers.append("X-Test-Source", "source-a")
+            }.status shouldBe HttpStatusCode.TooManyRequests
+
+            client.get("/load") {
+                headers.append("X-Test-Source", "source-b")
+            }.status shouldBe HttpStatusCode.OK
+        }
+    }
+
+})

--- a/apps/lumi-api/src/test/kotlin/no/nav/lumi/config/RateLimitEnvTest.kt
+++ b/apps/lumi-api/src/test/kotlin/no/nav/lumi/config/RateLimitEnvTest.kt
@@ -1,0 +1,21 @@
+package no.nav.lumi.config
+
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+class RateLimitEnvTest : FunSpec({
+    test("global limit defaults to ten thousand requests per source per minute") {
+        RateLimitEnv.fromEnvironment(null).globalRequestsPerSourcePerMinute shouldBe 10_000
+    }
+
+    test("global limit accepts a positive runtime override") {
+        RateLimitEnv.fromEnvironment("20000").globalRequestsPerSourcePerMinute shouldBe 20_000
+    }
+
+    test("global limit rejects an invalid runtime override") {
+        shouldThrow<IllegalStateException> {
+            RateLimitEnv.fromEnvironment("0")
+        }
+    }
+})


### PR DESCRIPTION
## Summary
- key the pre-auth global guard by the non-spoofable socket peer
- ignore caller-controlled forwarding headers and retain the guard for unauthenticated traffic
- give internal health and metrics routes zero global request weight
- raise the per-source default to 10,000/min and expose the same explicit runtime setting in dev/prod

## Verification
- pnpm run lint
- pnpm run typecheck
- pnpm run api:test
- targeted GlobalRateLimitingTest and RateLimitingKeyingTest
- regressions cover X-Forwarded-For rotation, keyed isolation, runtime configuration, and all internal endpoints

Closes #472