### PR TITLE
Dokumenter faktisk PII-maskering per felt

### DIFF
--- a/docs/guider/context-og-tags.md
+++ b/docs/guider/context-og-tags.md
@@ -4,7 +4,7 @@ title: Context & tags
 
 # Context & tags
 
-Kontekst gir deg metadata om *hvem* og *hvor* tilbakemeldingen kom fra — uten å samle personopplysninger. Bruk det til å segmentere data i dashboardet.
+Kontekst gir metadata om *hvor* og i hvilken situasjon tilbakemeldingen kom fra. Bruk lavkardinalitetsverdier til segmentering i dashboardet, og ikke legg person- eller saksidentifikatorer i konteksten.
 
 ## Automatisk innsamling
 
@@ -76,9 +76,9 @@ Tags brukes til segmentering og grafer i dashboardet. Hold kardinaliteten lav �
 
 ❌ **Dårlige tags**: `behandlingId: "abc-123"`, `timestamp: 1699000000`
 
-### `context.debug` — høy kardinalitet OK
+### `context.debug` — høy kardinalitet, ikke synlig i dag
 
-Debug-verdier vises kun i detaljvisningen for enkeltinnsendinger. De brukes *ikke* til grafer eller segmentering.
+Debug-verdier lagres med innsendingen, men inngår ikke i dagens lesemodell og vises derfor verken i dashboardet eller eksport. De brukes *ikke* til grafer eller segmentering. Ikke send person-, saks- eller andre identifikatorer i feltet.
 
 ```tsx
 <LumiSurveyDock
@@ -88,8 +88,8 @@ Debug-verdier vises kun i detaljvisningen for enkeltinnsendinger. De brukes *ikk
   context={{
     tags: { rolle: "arbeidsgiver" },
     debug: {
-      sessionId: "abc-123",
       buildVersion: "2.4.1",
+      featureVariant: "ny-kvittering",
     },
   }}
 />
@@ -100,7 +100,7 @@ Debug-verdier vises kun i detaljvisningen for enkeltinnsendinger. De brukes *ikk
 | Felt | Kardinalitet | Brukes til | Eksempel |
 | :--- | :--- | :--- | :--- |
 | `context.tags` | Lav | Segmentering, grafer i dashboard | `rolle`, `tjeneste`, `abTest` |
-| `context.debug` | Høy OK | Feilsøking av enkeltinnsendinger | `sessionId`, `buildVersion` |
+| `context.debug` | Høy OK | Lagres, men er ikke tilgjengelig i dagens lesemodell | `buildVersion`, `featureVariant` |
 
 ## Komplett eksempel
 
@@ -116,9 +116,6 @@ Debug-verdier vises kun i detaljvisningen for enkeltinnsendinger. De brukes *ikk
       abTest: "A",
       rolle: "arbeidsgiver",
     },
-    debug: {
-      sessionId: crypto.randomUUID(),
-    },
   }}
 />
 ```
@@ -129,7 +126,7 @@ Debug-verdier vises kun i detaljvisningen for enkeltinnsendinger. De brukes *ikk
 - Bruk aldri person-ID, fødselsnummer, eller behandlings-ID i `context`
 - Unngå `collectLocation: true` på dynamiske ruter med ID-er i URL-en
 - `tags` skal ha lav kardinalitet — ikke bruk unike verdier
-- Backend (lumi-api) maskerer PII automatisk, men unngå å sende det i utgangspunktet
+- Backend maskerer kjente PII-mønstre i URL, pathname, tags og debug-data ved lagring. Se [hvor og når maskering skjer](/referanse/sikkerhet#pii-feltdekning), og unngå å sende personopplysninger i utgangspunktet
 :::
 
-Lumi er designet for **privacy by design** — all data forblir i Nav-clusteret, og PII reduseres i hele kjeden. Kontekst-feltet skal brukes til å forstå *mønstre*, ikke identifisere enkeltpersoner.
+Lumi har innebygde personvernmekanismer, men mønsterbasert maskering erstatter ikke dataminimering. Kontekstfeltet skal brukes til å forstå *mønstre*, ikke identifisere enkeltpersoner.

--- a/docs/index.md
+++ b/docs/index.md
@@ -20,7 +20,7 @@ features:
     details: Bygg surveyen i Surveyverksted eller TypeScript. Appen eier versjonen som møter brukerne.
   - icon: 🔒
     title: Data forblir i Nav
-    details: Zero trust hele veien. All data lagres internt, og personopplysninger maskeres automatisk.
+    details: Zero trust hele veien. All data lagres internt, og kjente personopplysningsmønstre maskeres i utvalgte felt.
   - icon: 🎨
     title: Designet for Nav
     details: Bruker Aksel-komponenter. Ser ut og føles som resten av tjenesten din.

--- a/docs/kom-i-gang/hva-er-lumi.md
+++ b/docs/kom-i-gang/hva-er-lumi.md
@@ -9,7 +9,7 @@ Lumi er et verktøy for å kjøre personvernvennlige surveys i Nav-apper. Du def
 ## Hvorfor Lumi?
 
 - **Survey som dokument** — bygg sider og spørsmål i Surveyverksted eller TypeScript. Appen eier produksjonsversjonen.
-- **Privacy by design** — all data blir i Nav-clusteret, og personopplysninger maskeres automatisk.
+- **Privacy by design** — all data blir i Nav-clusteret, og kjente personopplysningsmønstre maskeres i utvalgte felt som et sikkerhetsnett. Se [Sikkerhet & personvern](/referanse/sikkerhet#pii-maskering) for begrensningene.
 - **Aksel-basert** — widgeten bruker Navs designsystem og følger WCAG.
 - **Rask integrasjon** — installer en React-widget, koble til backend, ferdig.
 - **Dashboard** — filtrer, segmenter og eksporter survey-data med teambasert tilgangsstyring.

--- a/docs/referanse/bruksvilkar.md
+++ b/docs/referanse/bruksvilkar.md
@@ -27,7 +27,7 @@ Før du tar i bruk Lumi, må du:
 
 ## Personvern og ansvar
 
-Lumi maskerer personopplysninger automatisk, men du har fortsatt ansvar for å bruke verktøyet riktig.
+Lumi maskerer automatisk kjente personopplysningsmønstre i utvalgte felt. Dette er et sikkerhetsnett, og du har fortsatt ansvar for å bruke verktøyet riktig.
 
 ::: danger Ikke bruk Lumi til
 - **Rekruttering** til brukerundersøkelser eller brukertesting
@@ -39,7 +39,7 @@ Lumi er laget for anonyme tilbakemeldinger. Ikke oppfordre brukere til å oppgi 
 
 ## Hva sporer Lumi?
 
-Widgeten samler kontekstdata for segmentering i dashboardet. Ingen av feltene identifiserer enkeltpersoner.
+Widgeten samler kontekstdata for segmentering i dashboardet. De innebygde feltene er tekniske egenskaper, men kombinasjonen kan bidra til å skille enheter eller brukere, og valgfrie felt kan inneholde identifikatorer. Konteksten må derfor ikke behandles som garantert anonym.
 
 | Felt | Beskrivelse | Alltid sendt? |
 | :--- | :--- | :--- |
@@ -58,23 +58,24 @@ Lumi bruker ikke cookies. Dismiss-tilstand lagres via consent-API-et på nav.no,
 
 ## Hvordan personopplysninger kan komme inn
 
-Selv om Lumi ikke ber om personopplysninger, kan de dukke opp på tre måter:
+Selv om Lumi ikke ber om personopplysninger, kan de blant annet dukke opp slik:
 
 1. **Fritekstfelt** — brukere kan skrive hva som helst, inkludert navn, fødselsnummer eller kontaktinfo. Lumi maskerer automatisk de vanligste mønstrene i fritekst-svar.
-2. **URL-er og pathname** — noen Nav-URL-er inneholder fødselsnummer eller andre identifikatorer som query-parametere. Disse maskeres **ikke** automatisk — det er ditt ansvar å unngå å samle inn URL-er med sensitive parametere.
+2. **URL-er og pathname** — noen Nav-URL-er inneholder fødselsnummer eller andre identifikatorer som query-parametere. Lumi maskerer kjente PII-mønstre ved lagring, men du må fortsatt unngå dynamiske URL-er, tokens og identifikatorer.
 3. **Svaralternativer** — hvis du utformer alternativer som avslører sensitiv informasjon. Disse maskeres **ikke** — du må selv sørge for at alternativene ikke er identifiserende.
+4. **Tags og debug-data** — valgfrie kontekstverdier kan inneholde identifikatorer. Kjente PII-mønstre maskeres ved lagring, men feltene skal ikke brukes til person- eller saksidentifikatorer.
 
 ## Automatisk PII-maskering
 
-Lumi maskerer personopplysninger automatisk i **fritekst-svar** ved lagring *og* ved lesing. Følgende mønstre fanges opp: fødselsnummer, Nav-ident, e-post, telefonnummer, kortnummer, kontonummer og hemmelig adresse.
+Lumi maskerer kjente PII-mønstre i **fritekstsvar** og utvalgte kontekstfelt ved lagring. Bare fritekstsvar kontrolleres på nytt ved lesing.
 
-Maskeringen erstatter sensitive data med plassholdere som `[FØDSELSNUMMER FJERNET]`. De vanligste mønstrene fjernes ved lagring, og en ekstra sjekk kjøres ved lesing som sikkerhetsnett.
+Maskeringen erstatter treff med plassholdere som `[FØDSELSNUMMER FJERNET]`. Se den normative tabellen under [Hvor og når maskering skjer](/referanse/sikkerhet#pii-feltdekning) for hvilke felt som dekkes.
 
-::: warning Maskering gjelder kun fritekst-svar
-URL-er, pathname, context-tags og svaralternativer maskeres **ikke** automatisk. Du er selv ansvarlig for at disse feltene ikke inneholder personopplysninger.
+::: warning Maskering er et sikkerhetsnett
+Ikke samle personopplysninger med vilje. `userAgent`, surveydefinert metadata og strukturerte svar PII-maskeres ikke. For URL, pathname, tags og debug-data fanges bare kjente mønstre, så også disse feltene må holdes fri for identifikatorer.
 :::
 
-Se [Sikkerhet & personvern](/referanse/sikkerhet#pii-maskering) for fullstendig liste over mønstre og eksempler.
+Se [Sikkerhet & personvern](/referanse/sikkerhet#pii-maskering) for mønstre, feltdekning og begrensninger.
 
 ## Informasjonsplikt
 
@@ -85,11 +86,11 @@ Du må opplyse brukerne om at Lumi brukes til innsiktsarbeid. Avhengig av flaten
 
 ## Bruk av fritekstfelt
 
-Lumi maskerer automatisk de vanligste personopplysningene i fritekst. Du trenger ikke sette opp egne filtre eller gjøre manuelle sjekker.
+Lumi maskerer automatisk de vanligste personopplysningene i fritekst. Du trenger ikke sette opp egne PII-filtre, men bør kontrollere svarene fordi maskeringen ikke kan fange alt.
 
 Likevel bør du:
 
-- **Vurdere om du trenger fritekst.** Lukkede spørsmål gir strukturerte data og eliminerer risikoen helt.
+- **Vurdere om du trenger fritekst.** Lukkede spørsmål reduserer risikoen for at brukeren skriver personopplysninger, men surveydefinisjon, svaralternativer og kontekst må fortsatt være fri for identifikatorer.
 - **Informere brukerne.** Hvis du bruker fritekstfelt, legg til en kort tekst som ber brukerne unngå å skrive personopplysninger.
 - **Sjekke svarene jevnlig** i dashboardet, spesielt etter lansering. PII-maskeringen dekker de vanligste mønstrene, men kan ikke fange alt.
 

--- a/docs/referanse/datakontrakt.md
+++ b/docs/referanse/datakontrakt.md
@@ -90,21 +90,25 @@ interface LumiContext {
   // Segmentering (LAV KARDINALITET → dashboard-grafer)
   tags?: Record<string, string | number | boolean>;
 
-  // Debugging (HØY KARDINALITET → kun i detaljvisning)
+  // Valgfri debug-data (lagres, men finnes ikke i dagens lesemodell)
   debug?: Record<string, unknown>;
 }
 ```
+
+`userAgent` og `debug` tas imot og lagres, men returneres ikke av dagens lesemodell og er derfor ikke tilgjengelige i dashboard eller eksport.
 
 ### Tags vs. debug
 
 | Felt | Kardinalitet | Bruksområde | Eksempel |
 | :--- | :--- | :--- | :--- |
 | `tags` | Lav (< 10 verdier) | Grafer, segmentering | `{ abTest: "A", rolle: "arbeidsgiver" }` |
-| `debug` | Høy (OK) | Inspeksjon av enkeltinnslag | `{ sessionId: "abc-123", behandlingId: "..." }` |
+| `debug` | Høy (OK) | Lagres, men er ikke tilgjengelig i dagens lesemodell | `{ buildVersion: "2.4.1", featureVariant: "ny-kvittering" }` |
 
-::: warning Ikke legg høy-kardinalitet i tags
-Tags med mange unike verdier (f.eks. bruker-IDer) gir ubrukelige grafer i dashboardet. Bruk `debug`-feltet for slike verdier.
+::: warning Hold identifikatorer ute av context
+Tags med mange unike verdier gir ubrukelige grafer i dashboardet. Ikke flytt bruker-, person- eller saksidentifikatorer til `debug`; feltet lagres selv om det ikke kan leses i dagens dashboard eller eksport.
 :::
+
+Se [hvor og når PII-maskering skjer](/referanse/sikkerhet#pii-feltdekning) for nøyaktig feltdekning og begrensninger.
 
 ## Survey-typer
 

--- a/docs/referanse/sikkerhet.md
+++ b/docs/referanse/sikkerhet.md
@@ -4,15 +4,15 @@ title: Sikkerhet & personvern
 
 # Sikkerhet & personvern
 
-Lumi håndterer sikkerhet og personvern automatisk — du trenger ikke gjøre noe spesielt i din integrasjon.
+Lumi har innebygde sikkerhets- og personvernmekanismer. De reduserer risiko, men erstatter ikke ansvaret for å unngå personopplysninger i surveyen og konteksten.
 
 ## PII-maskering {#pii-maskering}
 
-API-et maskerer automatisk personlig identifiserbar informasjon (PII) i fritekst-svar. Maskering skjer **ved lagring**, slik at sensitive data aldri finnes i klartekst i databasen.
+API-et maskerer kjente mønstre for personlig identifiserbar informasjon (PII) i fritekstsvar og utvalgte kontekstfelt. Maskeringen er mønsterbasert og er et sikkerhetsnett, ikke en garanti for at alle personopplysninger fanges opp.
 
 | Mønster | Eksempel | Erstatning |
 | :--- | :--- | :--- |
-| Fødselsnummer | `12345678901` | `[FØDSELSNUMMER FJERNET]` |
+| Fødselsnummer | `01020349294` | `[FØDSELSNUMMER FJERNET]` |
 | Nav-ident | `A123456` | `[NAVIDENT FJERNET]` |
 | E-post | `test@nav.no` | `[E-POST FJERNET]` |
 | Telefonnummer | `12345678` | `[TELEFON FJERNET]` |
@@ -20,8 +20,21 @@ API-et maskerer automatisk personlig identifiserbar informasjon (PII) i fritekst
 | Kontonummer | `1234.56.12345` | `[KONTONUMMER FJERNET]` |
 | Hemmelig adresse | «hemmelig adresse» | `[HEMMELIG ADRESSE]` |
 
+### Hvor og når maskering skjer {#pii-feltdekning}
+
+| Felt | Ved lagring | Ved lesing | Merknad |
+| :--- | :--- | :--- | :--- |
+| Fritekstsvar (`answers[].value.text`) | PII-mønstre maskeres | PII-mønstre maskeres på nytt | Det eneste feltet med dobbel maskering |
+| `context.url` | PII-mønstre maskeres i path, query-parametere og fragment | Ingen ekstra maskering | Maskeringen dekoder URL-verdier for å fange kodede mønstre |
+| `context.pathname` | PII-mønstre maskeres etter URL-dekoding | Ingen ekstra maskering | Samle helst en statisk eller allerede renset path |
+| `context.tags` | PII-mønstre maskeres i både nøkler og verdier | Ingen ekstra maskering | Bruk kun lavkardinalitetsverdier, aldri identifikatorer |
+| `context.debug` | PII-mønstre maskeres rekursivt i nøkler og verdier | Ingen ekstra maskering | Feltet finnes ikke i dagens lesemodell |
+| `context.userAgent` | HTML fjernes, men PII-mønstre maskeres ikke | Ingen ekstra maskering | Sendes automatisk av widgeten og finnes ikke i dagens lesemodell |
+| Surveydefinert metadata (`surveyId`, `fieldId`, spørsmålstekst/-beskrivelse og svaralternativenes ID/tekst) | PII-mønstre maskeres ikke | PII-mønstre maskeres ikke | Verdiene valideres, men må ikke inneholde personopplysninger |
+| Strukturerte svar (rating, valgte alternativ-ID-er og dato) | PII-mønstre maskeres ikke | PII-mønstre maskeres ikke | Bruk bare svarverdier som ikke identifiserer personen |
+
 ::: info Dobbel maskering
-PII-redaksjon kjøres både ved lagring og ved lesing. Selv om et mønster slipper gjennom ved lagring, fanges det ved visning.
+Dobbel maskering gjelder bare fritekstsvar. Kontekstfeltene som er markert i tabellen maskeres ved lagring, men får ingen ny PII-kontroll ved lesing.
 :::
 
 ## Rate limiting

--- a/packages/lumi-survey/src/components/LumiSurveyDock/LumiSurveyDock.tsx
+++ b/packages/lumi-survey/src/components/LumiSurveyDock/LumiSurveyDock.tsx
@@ -103,7 +103,9 @@ export interface LumiSurveyDockProps {
   intro?: LumiSurveyIntroConfig;
 
   /**
-   * Structured context for segmentation (tags) and debugging (debug).
+   * Structured context for segmentation (`tags`) and optional diagnostic data (`debug`).
+   * Debug data is stored with submissions, but is not exposed by the current
+   * dashboard/export read model.
    * System fields (viewport, screenResolution, deviceType, userAgent) are
    * auto-collected. `deviceType` uses browser client hints and user-agent
    * parsing first, with viewport width as a final fallback.

--- a/packages/lumi-survey/src/core/types.ts
+++ b/packages/lumi-survey/src/core/types.ts
@@ -360,34 +360,38 @@ export interface LumiSurveyTransportPayload {
 export type DeviceType = "mobile" | "tablet" | "desktop";
 
 /**
- * Structured context for feedback segmentation and debugging.
+ * Structured context stored with a survey submission.
  *
  * @example
  * ```tsx
  * <LumiSurveyDock
  *   context={{
- *     tags: { abTest: "A", rolle: "arbeidsgiver" },
- *     debug: { sessionId: "abc-123" }
+ *     tags: { abTest: "A", rolle: "arbeidsgiver" }
  *   }}
  * />
  * ```
  */
 export interface LumiSurveyContext {
   // ============================================
+  // Location (not included by default)
+  // ============================================
+
+  /** Current page URL. Never auto-collected. */
+  url?: string;
+  /** Current pathname (without domain). Explicit context or opt-in via collectLocation. */
+  pathname?: string;
+
+  // ============================================
   // System-collected (auto-populated by widget)
   // ============================================
 
-  /** Current page URL */
-  url?: string;
-  /** Current pathname (without domain) */
-  pathname?: string;
   /** Browser viewport dimensions */
   viewport?: { width: number; height: number };
   /** Physical screen resolution (unaffected by window size) */
   screenResolution?: { width: number; height: number };
   /** Device type derived from UA Client Hints, user-agent parsing, or viewport fallback */
   deviceType?: DeviceType;
-  /** Browser user agent */
+  /** Browser user agent. Stored, but not returned by the current dashboard/export read model. */
   userAgent?: string;
 
   // ============================================
@@ -405,13 +409,12 @@ export interface LumiSurveyContext {
   tags?: Record<string, string | number | boolean>;
 
   // ============================================
-  // Debug (for detailed debugging) - HIGH CARDINALITY OK
-  // Shown only in individual feedback detail view
+  // Optional debug data (stored, but not exposed by the current read model)
   // ============================================
 
   /**
-   * High-cardinality debug info for individual feedback inspection.
-   * Not used for graphs/segmentation.
+   * Optional diagnostic data. Not used for graphs/segmentation.
+   * Never include personal, user, or case identifiers.
    */
   debug?: Record<string, unknown>;
 }

--- a/packages/lumi-survey/src/core/useLumiSurvey.ts
+++ b/packages/lumi-survey/src/core/useLumiSurvey.ts
@@ -24,7 +24,10 @@ export interface UseLumiSurveyOptions {
   questions: LumiSurveyQuestion[];
   transport: LumiSurveyTransport;
   events?: LumiSurveyEvents;
-  /** Structured context for segmentation (tags) and debugging (debug) */
+  /**
+   * Structured context. `tags` support segmentation; `debug` is stored but is
+   * not exposed by the current dashboard/export read model.
+   */
   context?: LumiSurveyContext;
   initialAnswers?: Record<string, LumiSurveyAnswerValue>;
   surveyType?: SurveyType;

--- a/packages/lumi-types/src/api.ts
+++ b/packages/lumi-types/src/api.ts
@@ -24,7 +24,7 @@ export interface SubmissionContextV1 {
   userAgent?: string | null;
   /** Low-cardinality segmentation tags (values must be JSON primitives). */
   tags?: Record<string, JsonPrimitive> | null;
-  /** Debug payload (ignored by backend storage/analytics). */
+  /** Stored with the submission, but not exposed by the current read model or analytics. */
   debug?: Record<string, unknown> | null;
 }
 


### PR DESCRIPTION
## Sammendrag

- samler faktisk write/read-dekning for PII-maskering i én normativ tabell
- korrigerer bruksvilkår og context-guiden og lenker dem til tabellen
- presiserer at mønsterbasert maskering er et sikkerhetsnett, ikke en garanti
- endrer ingen runtime-oppførsel eller personvernpolicy

## Verifisering

- `pnpm run lint`
- `pnpm run typecheck`
- `pnpm run docs:build`
- `./gradlew test --tests no.nav.lumi.service.FeedbackServiceTest --tests no.nav.lumi.repository.FeedbackSecurityTest`
- `git diff --check`
- verifisert rendret `#pii-feltdekning`-anker og interne lenker

Closes #493