### PR TITLE
Valider visibleIf-operatorer mot referert spørsmålstype

### DIFF
--- a/apps/lumi-dashboard/app/utils/surveyDocument.ts
+++ b/apps/lumi-dashboard/app/utils/surveyDocument.ts
@@ -1,4 +1,5 @@
 import {
+  allowedVisibleIfOperators,
   createDiscoverySurveyDocument,
   createTaskPrioritySurveyDocument,
   createTopTasksSurveyDocument,
@@ -871,22 +872,13 @@ export function insertPageAt(
 
 /**
  * Operators that behave correctly against the referenced question type at
- * runtime. multiChoice answers are arrays: strict EQ/NEQ never match, so
- * only EXISTS and CONTAINS are offered.
+ * runtime. Delegates to the widget package's canonical table, so the
+ * workshop's operator picker and the document validator can never disagree.
  */
 export function allowedConditionOperators(
   type: SurveyQuestionV1["type"],
 ): string[] {
-  switch (type) {
-    case "rating":
-      return ["EXISTS", "EQ", "NEQ", "GT", "LT"];
-    case "singleChoice":
-      return ["EXISTS", "EQ", "NEQ"];
-    case "multiChoice":
-      return ["EXISTS", "CONTAINS"];
-    default:
-      return ["EXISTS", "EQ", "NEQ", "CONTAINS"];
-  }
+  return [...allowedVisibleIfOperators(type)];
 }
 
 export interface HandoffIssue {

--- a/apps/lumi-dashboard/app/utils/surveyDocument.ts
+++ b/apps/lumi-dashboard/app/utils/surveyDocument.ts
@@ -871,14 +871,19 @@ export function insertPageAt(
 }
 
 /**
- * Operators that behave correctly against the referenced question type at
- * runtime. Delegates to the widget package's canonical table, so the
- * workshop's operator picker and the document validator can never disagree.
+ * Operators offered by the workshop for the referenced question type.
+ * The package's runtime-compatible table also permits CONTAINS for string
+ * singleChoice answers to preserve code-authored V1 documents. The workshop
+ * intentionally keeps exact equality for that type, matching the backend's
+ * release-gate policy and avoiding ambiguous substring conditions.
  */
 export function allowedConditionOperators(
   type: SurveyQuestionV1["type"],
 ): string[] {
-  return [...allowedVisibleIfOperators(type)];
+  const compatible = allowedVisibleIfOperators(type);
+  return type === "singleChoice"
+    ? compatible.filter((operator) => operator !== "CONTAINS")
+    : [...compatible];
 }
 
 export interface HandoffIssue {

--- a/packages/lumi-survey/CHANGELOG.md
+++ b/packages/lumi-survey/CHANGELOG.md
@@ -13,9 +13,11 @@ This project follows SemVer.
   example `EQ` against a multiChoice question, whose array answers never
   strictly equal a single value. The error names the owning question, the
   referenced question and its type, and the operators that are allowed. The
-  allowed set per type is exported as `allowedVisibleIfOperators` and is the
-  same table the workshop's condition editor uses. METADATA conditions and
-  legacy flat surveys are unaffected.
+  runtime-compatible set per type is exported as
+  `allowedVisibleIfOperators`. `CONTAINS` remains supported for string-valued
+  single-choice answers so existing code-authored V1 documents keep working;
+  the workshop continues to offer exact equality for that type. METADATA
+  conditions and legacy flat surveys are unaffected.
 
 - Focus now follows dock transitions: opening targets the active heading,
   closing targets the minimized trigger, and successful submission targets the

--- a/packages/lumi-survey/CHANGELOG.md
+++ b/packages/lumi-survey/CHANGELOG.md
@@ -8,6 +8,15 @@ This project follows SemVer.
 
 ### Fixed
 
+- `validateSurveyDocumentV1` and `buildCanonicalSurvey` now reject `visibleIf`
+  operators that cannot work against the referenced question's type — for
+  example `EQ` against a multiChoice question, whose array answers never
+  strictly equal a single value. The error names the owning question, the
+  referenced question and its type, and the operators that are allowed. The
+  allowed set per type is exported as `allowedVisibleIfOperators` and is the
+  same table the workshop's condition editor uses. METADATA conditions and
+  legacy flat surveys are unaffected.
+
 - Focus now follows dock transitions: opening targets the active heading,
   closing targets the minimized trigger, and successful submission targets the
   receipt heading. The minimized trigger no longer references an unmounted

--- a/packages/lumi-survey/src/components/shared/__tests__/canonicalSurvey.test.ts
+++ b/packages/lumi-survey/src/components/shared/__tests__/canonicalSurvey.test.ts
@@ -736,7 +736,7 @@ describe("visibleIf operator validation against referenced question type", () =>
     expect(() => validateSurveyDocumentV1(valid)).not.toThrow();
   });
 
-  it("rejects CONTAINS against a singleChoice question", () => {
+  it("keeps CONTAINS against a singleChoice question compatible", () => {
     expect(() =>
       validateSurveyDocumentV1(
         documentWithFollowUp(
@@ -749,7 +749,23 @@ describe("visibleIf operator validation against referenced question type", () =>
           },
         ),
       ),
-    ).toThrowError(/"follow".*CONTAINS.*singleChoice.*EXISTS, EQ, NEQ/s);
+    ).not.toThrow();
+  });
+
+  it("rejects numeric comparisons against a singleChoice question", () => {
+    expect(() =>
+      validateSurveyDocumentV1(
+        documentWithFollowUp(
+          { operator: "GT", questionId: "single", value: 1 },
+          {
+            id: "single",
+            type: "singleChoice",
+            prompt: "Velg én",
+            options: [{ value: "a", label: "A" }],
+          },
+        ),
+      ),
+    ).toThrowError(/"follow".*GT.*singleChoice.*EXISTS, EQ, NEQ, CONTAINS/s);
   });
 
   it("rejects GT against a text question but accepts it against rating", () => {

--- a/packages/lumi-survey/src/components/shared/__tests__/canonicalSurvey.test.ts
+++ b/packages/lumi-survey/src/components/shared/__tests__/canonicalSurvey.test.ts
@@ -635,3 +635,173 @@ describe("validateSurveyDocumentV1", () => {
     ).toThrow(/success/i);
   });
 });
+
+describe("visibleIf operator validation against referenced question type", () => {
+  const documentWithFollowUp = (
+    visibleIf: unknown,
+    referencedQuestion?: unknown,
+  ): SurveyDocumentV1 =>
+    ({
+      authoringSchemaVersion: 1,
+      type: "custom",
+      pages: [
+        {
+          id: "p1",
+          questions: [
+            referencedQuestion ?? {
+              id: "multi",
+              type: "multiChoice",
+              prompt: "Hva brukte du?",
+              options: [
+                { value: "sok", label: "Søk" },
+                { value: "meny", label: "Meny" },
+              ],
+            },
+          ],
+        },
+        {
+          id: "p2",
+          questions: [
+            {
+              id: "follow",
+              type: "text",
+              prompt: "Fortell mer",
+              visibleIf,
+            },
+          ],
+        },
+      ],
+    }) as unknown as SurveyDocumentV1;
+
+  it.each([
+    "EQ",
+    "NEQ",
+  ] as const)("rejects %s against a multiChoice question", (operator) => {
+    expect(() =>
+      validateSurveyDocumentV1(
+        documentWithFollowUp({ operator, questionId: "multi", value: "sok" }),
+      ),
+    ).toThrowError(/"follow".*EQ|NEQ.*"multi".*multiChoice.*EXISTS, CONTAINS/s);
+  });
+
+  it("names the owner, the referenced question, its type, the operator and the allowed set", () => {
+    expect(() =>
+      validateSurveyDocumentV1(
+        documentWithFollowUp({
+          operator: "EQ",
+          questionId: "multi",
+          value: "sok",
+        }),
+      ),
+    ).toThrowError(
+      /Question "follow".*EQ.*"multi".*\(multiChoice\).*EXISTS, CONTAINS/s,
+    );
+  });
+
+  it.each([
+    { operator: "CONTAINS", value: "sok" },
+    { operator: "EXISTS", value: undefined },
+  ])("accepts $operator against a multiChoice question", ({
+    operator,
+    value,
+  }) => {
+    const document = documentWithFollowUp({
+      operator,
+      questionId: "multi",
+      ...(value !== undefined && { value }),
+    });
+    expect(() => validateSurveyDocumentV1(document)).not.toThrow();
+  });
+
+  it.each([
+    "any",
+    "all",
+  ] as const)("applies the same rules to leaves in an %s group", (groupKey) => {
+    const invalid = documentWithFollowUp({
+      [groupKey]: [
+        { operator: "EXISTS", questionId: "multi" },
+        { operator: "EQ", questionId: "multi", value: "sok" },
+      ],
+    });
+    expect(() => validateSurveyDocumentV1(invalid)).toThrowError(
+      /"follow".*EQ.*multiChoice/s,
+    );
+
+    const valid = documentWithFollowUp({
+      [groupKey]: [
+        { operator: "EXISTS", questionId: "multi" },
+        { operator: "CONTAINS", questionId: "multi", value: "sok" },
+      ],
+    });
+    expect(() => validateSurveyDocumentV1(valid)).not.toThrow();
+  });
+
+  it("rejects CONTAINS against a singleChoice question", () => {
+    expect(() =>
+      validateSurveyDocumentV1(
+        documentWithFollowUp(
+          { operator: "CONTAINS", questionId: "single", value: "a" },
+          {
+            id: "single",
+            type: "singleChoice",
+            prompt: "Velg én",
+            options: [{ value: "a", label: "A" }],
+          },
+        ),
+      ),
+    ).toThrowError(/"follow".*CONTAINS.*singleChoice.*EXISTS, EQ, NEQ/s);
+  });
+
+  it("rejects GT against a text question but accepts it against rating", () => {
+    expect(() =>
+      validateSurveyDocumentV1(
+        documentWithFollowUp(
+          { operator: "GT", questionId: "fritekst", value: 2 },
+          { id: "fritekst", type: "text", prompt: "Skriv" },
+        ),
+      ),
+    ).toThrowError(/"follow".*GT.*text.*EXISTS, EQ, NEQ, CONTAINS/s);
+
+    expect(() =>
+      validateSurveyDocumentV1(
+        documentWithFollowUp(
+          { operator: "GT", questionId: "score", value: 3 },
+          { id: "score", type: "rating", prompt: "Vurder" },
+        ),
+      ),
+    ).not.toThrow();
+  });
+
+  it("keeps METADATA conditions structurally validated only", () => {
+    expect(() =>
+      validateSurveyDocumentV1(
+        documentWithFollowUp({
+          field: "METADATA",
+          key: "kanal",
+          operator: "EQ",
+          value: "web",
+        }),
+      ),
+    ).not.toThrow();
+  });
+
+  it("does not tighten legacy flat surveys", () => {
+    const legacy: LumiSurveyConfig = {
+      questions: [
+        {
+          id: "multi",
+          type: "multiChoice",
+          prompt: "Hva brukte du?",
+          options: [{ value: "sok", label: "Søk" }],
+        },
+        {
+          id: "follow",
+          type: "text",
+          prompt: "Fortell mer",
+          visibleIf: { operator: "EQ", questionId: "multi", value: "sok" },
+        },
+      ] as unknown as LumiSurveyConfig["questions"],
+    };
+    expect(() => buildCanonicalSurvey(legacy)).not.toThrow();
+  });
+});

--- a/packages/lumi-survey/src/components/shared/canonicalSurvey.ts
+++ b/packages/lumi-survey/src/components/shared/canonicalSurvey.ts
@@ -1,4 +1,5 @@
 import {
+  allowedVisibleIfOperators,
   getLeafConditions,
   isConditionGroup,
   isLeafCondition,
@@ -107,6 +108,8 @@ export function buildCanonicalSurvey(
     ids.add(question.id);
   }
 
+  const questionById = new Map(questions.map((q) => [q.id, q]));
+
   // Validate cross-references in visibility and branching logic
   for (const question of questions) {
     const visibleIf = question.visibleIf;
@@ -209,6 +212,17 @@ export function buildCanonicalSurvey(
           throw new Error(
             `Lumi: Question "${question.id}" has visibleIf.questionId "${leaf.questionId}", but version 1 survey documents may only reference earlier questions`,
           );
+        }
+        if (isDocument && leaf.field !== "METADATA" && leaf.questionId) {
+          const referenced = questionById.get(leaf.questionId);
+          const allowed = referenced
+            ? allowedVisibleIfOperators(referenced.type)
+            : undefined;
+          if (referenced && allowed && !allowed.includes(leaf.operator)) {
+            throw new Error(
+              `Lumi: Question "${question.id}" has a ${leaf.operator} visibleIf against question "${leaf.questionId}" (${referenced.type}) — allowed operators for ${referenced.type} are ${allowed.join(", ")}`,
+            );
+          }
         }
       }
     }

--- a/packages/lumi-survey/src/core/conditionUtils.ts
+++ b/packages/lumi-survey/src/core/conditionUtils.ts
@@ -1,6 +1,8 @@
 import type {
   LogicConditionGroup,
   LogicLeafCondition,
+  LogicOperator,
+  LumiSurveyQuestionType,
   VisibleIfCondition,
 } from "./types.js";
 
@@ -58,4 +60,25 @@ export function isLeafCondition(
     typeof (condition as { operator?: unknown }).operator === "string" &&
     LOGIC_OPERATORS.has((condition as { operator: string }).operator)
   );
+}
+
+/**
+ * The operators that are meaningful against each question type in
+ * `visibleIf`. multiChoice answers are arrays, so strict EQ/NEQ never
+ * match; GT/LT compare numbers and only fit rating scores. Authoring
+ * validation and the workshop's operator picker share this table.
+ */
+export function allowedVisibleIfOperators(
+  type: LumiSurveyQuestionType,
+): readonly LogicOperator[] {
+  switch (type) {
+    case "rating":
+      return ["EXISTS", "EQ", "NEQ", "GT", "LT"];
+    case "singleChoice":
+      return ["EXISTS", "EQ", "NEQ"];
+    case "multiChoice":
+      return ["EXISTS", "CONTAINS"];
+    case "text":
+      return ["EXISTS", "EQ", "NEQ", "CONTAINS"];
+  }
 }

--- a/packages/lumi-survey/src/core/conditionUtils.ts
+++ b/packages/lumi-survey/src/core/conditionUtils.ts
@@ -75,7 +75,7 @@ export function allowedVisibleIfOperators(
     case "rating":
       return ["EXISTS", "EQ", "NEQ", "GT", "LT"];
     case "singleChoice":
-      return ["EXISTS", "EQ", "NEQ"];
+      return ["EXISTS", "EQ", "NEQ", "CONTAINS"];
     case "multiChoice":
       return ["EXISTS", "CONTAINS"];
     case "text":

--- a/packages/lumi-survey/src/index.ts
+++ b/packages/lumi-survey/src/index.ts
@@ -22,6 +22,7 @@ export type {
   SurveySuccessV1,
   SurveyType,
 } from "./components/surveyTypes.js";
+export { allowedVisibleIfOperators } from "./core/conditionUtils.js";
 export * from "./core/index.js";
 export {
   createDiscoverySurvey,


### PR DESCRIPTION
## Hva

- `buildCanonicalSurvey`/`validateSurveyDocumentV1` avviser nå `visibleIf`-operatorer som ikke kan fungere mot det refererte spørsmålets type i V1-dokumenter
- den runtime-kompatible operator-matrisen `allowedVisibleIfOperators` ligger i pakken og eksporteres fra `@navikt/lumi-survey`
- Surveyverkstedet baserer operator-policyen på pakkens matrise, men beholder med hensikt en smalere policy for enkeltvalg: eksakt EQ/NEQ i stedet for tvetydige substring-betingelser
- regresjonstester dekker hele matrisen, inkludert leaves i `any`- og `all`-grupper og eksisterende `CONTAINS`-støtte for strengverdier

## Hvorfor

`visibleIf` evaluerer `EQ`/`NEQ` strengt. Flervalgssvar er arrays, så `EQ` mot et flervalg treffer aldri — oppfølgingsspørsmålet vises aldri, og datasettet mangler oppfølgingen uten feilmelding. `NEQ` gir motsatt effekt: spørsmålet vises til alle. Verkstedet har hatt vern mot dette; kodeforfattede surveyer hadde ingen tilsvarende V1-validering.

Closes #502

## Reproduksjon

Avvisningstestene ble skrevet først og kjørt mot `origin/main` (`a8a0134`):

```text
× rejects EQ against a multiChoice question
× rejects NEQ against a multiChoice question
× names the owner, the referenced question, its type, the operator and the allowed set
× applies the same rules to leaves in an any group
× applies the same rules to leaves in an all group
× rejects numeric comparisons against incompatible answer types
```

En egen kompatibilitetsrepro viste at `CONTAINS` mot et enkeltvalg allerede fungerer i runtime fordi enkeltvalgssvar er strenger. Testen feilet mot den første PR-versjonen, og matrisen ble korrigert før merge slik at eksisterende kodeforfattede V1-dokumenter fortsatt fungerer.

## Operator-policy

Runtime-kompatibel matrise i pakken:

| Type | Tillatt |
| :--- | :--- |
| rating | EXISTS, EQ, NEQ, GT, LT |
| singleChoice | EXISTS, EQ, NEQ, CONTAINS |
| multiChoice | EXISTS, CONTAINS |
| text | EXISTS, EQ, NEQ, CONTAINS |

Surveyverkstedet tilbyr fortsatt bare `EXISTS`, `EQ` og `NEQ` for enkeltvalg. Det samsvarer med backendens release-gate og unngår substring-betingelser mellom alternativ-ID-er. Den smalere authoring-policyen er en bevisst delmengde av det runtime fortsatt kan kjøre bakoverkompatibelt.

Feilmeldingen er handlingsrettet:

```text
Lumi: Question "follow" has a EQ visibleIf against question "multi" (multiChoice)
— allowed operators for multiChoice are EXISTS, CONTAINS
```

## Avgrensninger

- kun ANSWER-betingelser i V1-dokumenter der referert spørsmål kan slås opp; METADATA beholder dagens strukturelle validering
- legacy flate surveyer og `logic` er ikke strammet inn
- runtime-semantikken i `evaluateVisibility` og `branchingEngine` er urørt; evaluator-unifisering er fortsatt utsatt i ADR 0001
- Verkstedets validering av alternativverdier, ratingskala og tom tekst er uendret
- ingen versjonsbump eller publisering i denne PR-en

## Kompatibilitet og versjonering

Endringen avviser kombinasjoner som ikke kan fungere mot runtime-svartypen, men bevarer fungerende streng-`CONTAINS`. METADATA og legacy er uendret.

`allowedVisibleIfOperators` er en ny bakoverkompatibel offentlig eksport. Changeloggen er oppdatert under `[Unreleased]`; neste pakkeutgivelse skal bruke SemVer minor (minst `2.2.0`) og må ikke publiseres som dagens manifestversjon `2.1.1`.

## Validering

- `pnpm run lint`
- `pnpm run typecheck`
- `pnpm test` — 2 typekontrakttester, 481 widgettester og 638 dashboardtester
- målrettet runtime/canonicalSurvey — 71 tester
- målrettet Surveyverksted — 128 tester
- `pnpm run verify:lumi-survey` — OK
- CI merge gate, CodeQL og full-chain smoke på PR-head kreves før merge

