### PR TITLE
ci: scope API deploy workflow

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -48,6 +48,7 @@ jobs:
               - 'packages/**'
               - 'scripts/check-lumi-survey-release-drift.mjs'
               - 'scripts/check-lumi-survey-release-drift.test.mjs'
+              - 'scripts/verify-deploy-api-trigger.test.mjs'
               - 'scripts/verify-github-actions-pins.test.mjs'
               - 'scripts/verify-lumi-survey-package.mjs'
               - 'scripts/verify-lumi-survey-package.test.mjs'

--- a/.github/workflows/deploy-api.yaml
+++ b/.github/workflows/deploy-api.yaml
@@ -4,7 +4,12 @@ on:
   push:
     branches:
       - main
+    paths:
+      - 'apps/lumi-api/**'
   pull_request:
+    paths:
+      - 'apps/lumi-api/**'
+      - '.github/workflows/deploy-api.yaml'
   workflow_dispatch:
     inputs:
       target:
@@ -66,8 +71,9 @@ jobs:
 
   deploy-dev:
     if: |
-      github.ref == 'refs/heads/main' ||
-      (github.event_name == 'workflow_dispatch' && inputs.target == 'dev')
+      (github.event_name == 'push' && github.ref == 'refs/heads/main') ||
+      (github.event_name == 'workflow_dispatch' &&
+        (inputs.target == 'dev' || inputs.target == 'prod'))
     needs: build
     runs-on: ubuntu-latest
     permissions:
@@ -75,6 +81,8 @@ jobs:
       id-token: write
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
+        with:
+          ref: ${{ inputs.ref || github.ref }}
       - uses: nais/deploy/actions/deploy@849e900e3cfa7faf7ad1532bb3a3e6499c932199
         env:
           CLUSTER: dev-gcp
@@ -83,7 +91,7 @@ jobs:
 
   deploy-prod:
     if: |
-      github.ref == 'refs/heads/main' ||
+      (github.event_name == 'push' && github.ref == 'refs/heads/main') ||
       (github.event_name == 'workflow_dispatch' && inputs.target == 'prod')
     needs: [build, deploy-dev]
     runs-on: ubuntu-latest
@@ -92,6 +100,8 @@ jobs:
       id-token: write
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
+        with:
+          ref: ${{ inputs.ref || github.ref }}
       - uses: nais/deploy/actions/deploy@849e900e3cfa7faf7ad1532bb3a3e6499c932199
         env:
           CLUSTER: prod-gcp

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "verify:lumi-survey": "pnpm --filter @navikt/lumi-survey run build && node scripts/verify-lumi-survey-package.mjs",
     "verify:lumi-survey-consumer": "./scripts/verify-lumi-survey-consumer.sh",
     "check:lumi-survey-release-drift": "node scripts/check-lumi-survey-release-drift.mjs",
-    "test:release-guards": "node --test scripts/check-lumi-survey-release-drift.test.mjs scripts/verify-github-actions-pins.test.mjs scripts/verify-lumi-survey-package.test.mjs",
+    "test:release-guards": "node --test scripts/check-lumi-survey-release-drift.test.mjs scripts/verify-deploy-api-trigger.test.mjs scripts/verify-github-actions-pins.test.mjs scripts/verify-lumi-survey-package.test.mjs",
     "test": "pnpm --filter @navikt/lumi-types run test && pnpm --filter @navikt/lumi-survey run test && pnpm --filter lumi-dashboard run test",
     "e2e": "pnpm --filter lumi-dashboard run e2e",
     "e2e:full-chain": "pnpm --filter lumi-dashboard run e2e:full-chain",

--- a/scripts/verify-deploy-api-trigger.test.mjs
+++ b/scripts/verify-deploy-api-trigger.test.mjs
@@ -1,0 +1,77 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import test from "node:test";
+import { fileURLToPath } from "node:url";
+import { load } from "js-yaml";
+
+const repositoryRoot = path.resolve(
+  path.dirname(fileURLToPath(import.meta.url)),
+  "..",
+);
+
+const workflow = load(
+  readFileSync(
+    path.join(repositoryRoot, ".github", "workflows", "deploy-api.yaml"),
+    "utf8",
+  ),
+);
+
+const normalizeExpression = (expression) =>
+  expression.replace(/\s+/g, " ").trim();
+const selectedRefExpression = "$" + "{{ inputs.ref || github.ref }}";
+
+test("API push deploys run only for API changes on main", () => {
+  assert.deepEqual(workflow.on.push, {
+    branches: ["main"],
+    paths: ["apps/lumi-api/**"],
+  });
+});
+
+test("API workflow changes are validated in pull requests and manual inputs stay available", () => {
+  assert.deepEqual(workflow.on.pull_request, {
+    paths: ["apps/lumi-api/**", ".github/workflows/deploy-api.yaml"],
+  });
+  assert.deepEqual(workflow.on.workflow_dispatch.inputs, {
+    target: {
+      description: "Where to deploy",
+      type: "choice",
+      required: true,
+      options: ["dev", "prod"],
+    },
+    ref: {
+      description:
+        "Git ref to deploy (branch/tag/sha). Defaults to the ref you run the workflow from.",
+      type: "string",
+      required: false,
+    },
+  });
+});
+
+test("automatic and manual deploys follow the intended environment sequence", () => {
+  assert.equal(
+    normalizeExpression(workflow.jobs["deploy-dev"].if),
+    normalizeExpression(`
+      (github.event_name == 'push' && github.ref == 'refs/heads/main') ||
+      (github.event_name == 'workflow_dispatch' &&
+        (inputs.target == 'dev' || inputs.target == 'prod'))
+    `),
+  );
+  assert.equal(
+    normalizeExpression(workflow.jobs["deploy-prod"].if),
+    normalizeExpression(`
+      (github.event_name == 'push' && github.ref == 'refs/heads/main') ||
+      (github.event_name == 'workflow_dispatch' && inputs.target == 'prod')
+    `),
+  );
+  assert.deepEqual(workflow.jobs["deploy-prod"].needs, ["build", "deploy-dev"]);
+  assert.equal(workflow.jobs.build.steps[0].with.ref, selectedRefExpression);
+  assert.equal(
+    workflow.jobs["deploy-dev"].steps[0].with.ref,
+    selectedRefExpression,
+  );
+  assert.equal(
+    workflow.jobs["deploy-prod"].steps[0].with.ref,
+    selectedRefExpression,
+  );
+});


### PR DESCRIPTION
## Summary

- run automatic API deployments from main only when apps/lumi-api changes
- validate API and deploy-workflow changes in pull requests without publishing or deploying
- make manual dev/prod routing explicit and use the selected ref consistently
- lock the deployment trigger contract with a release-guard test

## Verification

- pnpm run test:release-guards (34/34)
- pnpm run lint
- pnpm run typecheck
- actionlint .github/workflows/deploy-api.yaml .github/workflows/ci.yaml