### PR TITLE
fix(api): fail closed on unresolved user teams

### DIFF
--- a/apps/lumi-api/src/main/kotlin/no/nav/lumi/config/auth/TeamAuthorizationPlugin.kt
+++ b/apps/lumi-api/src/main/kotlin/no/nav/lumi/config/auth/TeamAuthorizationPlugin.kt
@@ -3,44 +3,24 @@ package no.nav.lumi.config.auth
 import io.ktor.server.application.*
 import io.ktor.server.auth.*
 import io.ktor.server.routing.*
-import io.micrometer.core.instrument.Counter
 import no.nav.lumi.config.ServerEnv
-import no.nav.lumi.config.appMicrometerRegistry
 import no.nav.lumi.config.exception.ApiErrorException
 import no.nav.lumi.integrations.nais.NaisApiResult
 import no.nav.lumi.integrations.nais.NaisGraphQlClient
 import org.slf4j.LoggerFactory
 
 private val log = LoggerFactory.getLogger("no.nav.lumi.config.auth.TeamAuthorizationPlugin")
-private val viewerFallbackMissingEmailCounter = Counter.builder("team_authorization_viewer_fallback_total")
-    .description("Number of times TeamAuthorization falls back to NAIS viewer lookup")
-    .tag("reason", "missing_email_claim")
-    .register(appMicrometerRegistry)
-private val viewerFallbackEmptyUserLookupCounter = Counter.builder("team_authorization_viewer_fallback_total")
-    .description("Number of times TeamAuthorization falls back to NAIS viewer lookup")
-    .tag("reason", "empty_user_lookup")
-    .register(appMicrometerRegistry)
 
 /**
  * Minimal abstraction so TeamAuthorizationPlugin can be tested without calling the real NAIS API.
  */
 interface NaisTeamLookup {
     suspend fun getTeamSlugsForUserResult(email: String): NaisApiResult<Set<String>>
-    suspend fun getTeamSlugsForViewerResult(): NaisApiResult<Set<String>>
-
-    suspend fun getTeamSlugsForUser(email: String): Set<String> =
-        getTeamSlugsForUserResult(email).getOrDefault(emptySet())
-
-    suspend fun getTeamSlugsForViewer(): Set<String> =
-        getTeamSlugsForViewerResult().getOrDefault(emptySet())
 }
 
 private class NaisGraphQlTeamLookup(private val client: NaisGraphQlClient) : NaisTeamLookup {
     override suspend fun getTeamSlugsForUserResult(email: String): NaisApiResult<Set<String>> =
         client.getTeamSlugsForUserResult(email)
-
-    override suspend fun getTeamSlugsForViewerResult(): NaisApiResult<Set<String>> =
-        client.getTeamSlugsForViewerResult()
 }
 
 class TeamAuthorizationConfig {
@@ -165,24 +145,16 @@ private suspend fun resolveAuthorizedTeams(
 ): NaisApiResult<Set<String>> {
     val email = principal.email
 
-    val teamsByEmailResult: NaisApiResult<Set<String>> = if (!email.isNullOrBlank()) {
-        naisLookup.getTeamSlugsForUserResult(email)
-    } else {
-        // Some tokens may not include email; try viewer query instead.
-        viewerFallbackMissingEmailCounter.increment()
-        val userId = pseudonymizeIdentifier(principal.navIdent)
-        if (ServerEnv.current.nais.isNais) {
-            log.warn(
-                "User {} is missing email claim; falling back to NAIS viewer lookup. Verify token claims from identity provider.",
-                userId
-            )
-        } else {
-            log.debug("User {} has no email claim, falling back to NAIS viewer lookup", userId)
-        }
-        naisLookup.getTeamSlugsForViewerResult()
+    if (email.isNullOrBlank()) {
+        log.warn(
+            "TeamAuthorization: User {} is missing email claim; denying team access",
+            pseudonymizeIdentifier(principal.navIdent),
+        )
+        return NaisApiResult.Success(emptySet())
     }
 
-    val resolvedTeamsResult: NaisApiResult<Set<String>> = when (teamsByEmailResult) {
+    val teamsByEmailResult = naisLookup.getTeamSlugsForUserResult(email)
+    return when (teamsByEmailResult) {
         is NaisApiResult.Success -> {
             if (teamsByEmailResult.value.isNotEmpty()) {
                 log.debug(
@@ -190,30 +162,11 @@ private suspend fun resolveAuthorizedTeams(
                     pseudonymizeIdentifier(principal.navIdent),
                     teamsByEmailResult.value.size
                 )
-                teamsByEmailResult
-            } else {
-                // Matches NAIS Console behavior: `me { ... on User { teams { ... }}}`.
-                // Depending on NAIS API auth configuration, `me` might not be a User.
-                viewerFallbackEmptyUserLookupCounter.increment()
-                log.warn(
-                    "NAIS user lookup returned no teams for {}; falling back to viewer query for diagnostics/compatibility",
-                    pseudonymizeIdentifier(principal.navIdent)
-                )
-                val viewerTeamsResult = naisLookup.getTeamSlugsForViewerResult()
-                if (viewerTeamsResult is NaisApiResult.Success && viewerTeamsResult.value.isNotEmpty()) {
-                    log.warn(
-                        "Resolved teams from NAIS API (viewer query) for {} (count={}). Verify NAIS_API_KEY identity type.",
-                        pseudonymizeIdentifier(principal.navIdent),
-                        viewerTeamsResult.value.size
-                    )
-                }
-                viewerTeamsResult
             }
+            teamsByEmailResult
         }
         is NaisApiResult.Error -> teamsByEmailResult
     }
-
-    return resolvedTeamsResult
 }
 
 /**

--- a/apps/lumi-api/src/main/kotlin/no/nav/lumi/integrations/nais/NaisGraphQlClient.kt
+++ b/apps/lumi-api/src/main/kotlin/no/nav/lumi/integrations/nais/NaisGraphQlClient.kt
@@ -234,15 +234,16 @@ class NaisGraphQlClient private constructor(
     }
 
     /**
-     * Get team slugs for the current "viewer" (authenticated API key owner).
-     * This is a fallback when email lookup doesn't work.
+     * Get team slugs for the current "viewer" (authenticated token owner).
+     * This is diagnostic information and must not authorize another user.
      */
     suspend fun getTeamSlugsForViewer(): Set<String> {
         return getTeamSlugsForViewerResult().getOrDefault(emptySet())
     }
     
     /**
-     * Get team slugs for viewer with detailed result.
+     * Get diagnostic team slugs for the current viewer with detailed result.
+     * Must not be used to authorize another user.
      */
     suspend fun getTeamSlugsForViewerResult(): NaisApiResult<Set<String>> {
         val viewerCacheKey = "__viewer__"

--- a/apps/lumi-api/src/test/kotlin/no/nav/lumi/TestUtils.kt
+++ b/apps/lumi-api/src/test/kotlin/no/nav/lumi/TestUtils.kt
@@ -279,9 +279,6 @@ fun Application.testModule(
 
         override suspend fun getTeamSlugsForUserResult(email: String): NaisApiResult<Set<String>> =
             NaisApiResult.Success(teams)
-
-        override suspend fun getTeamSlugsForViewerResult(): NaisApiResult<Set<String>> =
-            NaisApiResult.Success(teams)
     }
     
     // Create services with the injected repositories/services

--- a/apps/lumi-api/src/test/kotlin/no/nav/lumi/config/auth/TeamAuthorizationPluginTest.kt
+++ b/apps/lumi-api/src/test/kotlin/no/nav/lumi/config/auth/TeamAuthorizationPluginTest.kt
@@ -26,22 +26,20 @@ import java.util.concurrent.atomic.AtomicBoolean
 
 private class FakeNaisTeamLookup(
     private val teamsByEmail: Set<String> = emptySet(),
-    private val teamsByViewer: Set<String> = emptySet(),
 ) : NaisTeamLookup {
-    override suspend fun getTeamSlugsForUserResult(email: String): NaisApiResult<Set<String>> =
-        NaisApiResult.Success(teamsByEmail)
+    var userLookupCount: Int = 0
+        private set
 
-    override suspend fun getTeamSlugsForViewerResult(): NaisApiResult<Set<String>> =
-        NaisApiResult.Success(teamsByViewer)
+    override suspend fun getTeamSlugsForUserResult(email: String): NaisApiResult<Set<String>> {
+        userLookupCount++
+        return NaisApiResult.Success(teamsByEmail)
+    }
 }
 
 private class ErroringNaisTeamLookup(
     private val message: String = "NAIS API unavailable"
 ) : NaisTeamLookup {
     override suspend fun getTeamSlugsForUserResult(email: String): NaisApiResult<Set<String>> =
-        NaisApiResult.Error(message)
-
-    override suspend fun getTeamSlugsForViewerResult(): NaisApiResult<Set<String>> =
         NaisApiResult.Error(message)
 }
 
@@ -230,7 +228,7 @@ class TeamAuthorizationPluginTest {
             routing {
                 authenticate(AZURE_REALM) {
                     install(TeamAuthorizationPlugin) {
-                        naisTeamLookupProvider = { FakeNaisTeamLookup(teamsByEmail = emptySet(), teamsByViewer = emptySet()) }
+                        naisTeamLookupProvider = { FakeNaisTeamLookup(teamsByEmail = emptySet()) }
                     }
 
                     get("/team") {
@@ -294,7 +292,10 @@ class TeamAuthorizationPluginTest {
     }
 
     @Test
-    fun `falls back to viewer teams when email lookup is empty`() = testApplication {
+    fun `does not authorize requested team when email lookup is empty`() = testApplication {
+        val handlerInvoked = AtomicBoolean(false)
+        val lookup = FakeNaisTeamLookup(teamsByEmail = emptySet())
+
         application {
             install(ContentNegotiation) {
                 json()
@@ -317,27 +318,75 @@ class TeamAuthorizationPluginTest {
             routing {
                 authenticate(AZURE_REALM) {
                     install(TeamAuthorizationPlugin) {
-                        naisTeamLookupProvider = {
-                            FakeNaisTeamLookup(
-                                teamsByEmail = emptySet(),
-                                teamsByViewer = setOf("team-esyfo"),
-                            )
-                        }
+                        naisTeamLookupProvider = { lookup }
                     }
 
                     get("/team") {
-                        call.respondText(call.authorizedTeam)
+                        handlerInvoked.set(true)
+                        call.respondText("ok")
                     }
                 }
             }
         }
 
-        val response = client.get("/team") {
+        val response = client.get("/team?team=team-esyfo") {
             header(HttpHeaders.Authorization, "Bearer whatever")
         }
 
-        assertEquals(HttpStatusCode.OK, response.status)
-        assertEquals("team-esyfo", response.bodyAsText())
+        assertEquals(HttpStatusCode.Forbidden, response.status)
+        assertFalse(handlerInvoked.get())
+        assertEquals(1, lookup.userLookupCount)
+    }
+
+    @Test
+    fun `does not authorize when email claim is missing or blank`() {
+        listOf<String?>(null, "", "   ").forEach { email ->
+            testApplication {
+                val handlerInvoked = AtomicBoolean(false)
+                val lookup = FakeNaisTeamLookup()
+
+                application {
+                    install(ContentNegotiation) {
+                        json()
+                    }
+                    configureStatusPages()
+                    install(Authentication) {
+                        bearer(AZURE_REALM) {
+                            authenticate { _ ->
+                                BrukerPrincipal(
+                                    navIdent = "Z123456",
+                                    name = "Test User",
+                                    email = email,
+                                    clientId = "client",
+                                    groups = emptyList(),
+                                )
+                            }
+                        }
+                    }
+
+                    routing {
+                        authenticate(AZURE_REALM) {
+                            install(TeamAuthorizationPlugin) {
+                                naisTeamLookupProvider = { lookup }
+                            }
+
+                            get("/team") {
+                                handlerInvoked.set(true)
+                                call.respondText("ok")
+                            }
+                        }
+                    }
+                }
+
+                val response = client.get("/team") {
+                    header(HttpHeaders.Authorization, "Bearer whatever")
+                }
+
+                assertEquals(HttpStatusCode.Forbidden, response.status, "email=$email")
+                assertFalse(handlerInvoked.get(), "email=$email")
+                assertEquals(0, lookup.userLookupCount, "email=$email")
+            }
+        }
     }
 
     @Test
@@ -460,7 +509,7 @@ class TeamAuthorizationPluginTest {
             routing {
                 authenticate(AZURE_REALM) {
                     install(TeamAuthorizationPlugin) {
-                        naisTeamLookupProvider = { FakeNaisTeamLookup(teamsByEmail = emptySet(), teamsByViewer = emptySet()) }
+                        naisTeamLookupProvider = { FakeNaisTeamLookup(teamsByEmail = emptySet()) }
                     }
 
                     get("/team") {

--- a/apps/lumi-api/src/test/kotlin/no/nav/lumi/routes/AnalyticsAuthBoundaryTest.kt
+++ b/apps/lumi-api/src/test/kotlin/no/nav/lumi/routes/AnalyticsAuthBoundaryTest.kt
@@ -23,9 +23,6 @@ private class FixedTeamLookup(
 ) : NaisTeamLookup {
     override suspend fun getTeamSlugsForUserResult(email: String): NaisApiResult<Set<String>> =
         NaisApiResult.Success(teams)
-
-    override suspend fun getTeamSlugsForViewerResult(): NaisApiResult<Set<String>> =
-        NaisApiResult.Success(teams)
 }
 
 private fun Application.boundaryTestModule(


### PR DESCRIPTION
Closes #479

## Summary
- authorize dashboard access only from the authenticated user email lookup
- deny access when the email claim is missing or blank, or when the user lookup returns no teams
- preserve temporary lookup failures as service unavailable and keep the explicit local development fallback
- narrow the authorization lookup interface so viewer diagnostics cannot grant user access

## Verification
- pnpm run api:test (750 tests, 0 failures)
- pnpm run lint
- pnpm run typecheck