### PR TITLE
ci: skip unrelated automatic dashboard deploys

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -21,10 +21,14 @@ jobs:
     runs-on: ubuntu-latest
     if: github.event_name != 'merge_group'
     outputs:
-      node: ${{ steps.filter.outputs.node }}
+      node: ${{ steps.dashboard-scope.outputs.node || steps.filter.outputs.node }}
       api: ${{ steps.filter.outputs.api }}
       docs: ${{ steps.filter.outputs.docs }}
-      full_chain: ${{ steps.filter.outputs.full_chain }}
+      full_chain: ${{ steps.dashboard-scope.outputs.full_chain || steps.filter.outputs.full_chain }}
+      dashboard_deploy: ${{ steps.dashboard-scope.outputs.required || steps.filter.outputs.dashboard_deploy }}
+    permissions:
+      actions: read
+      contents: read
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
       - id: filter
@@ -35,6 +39,7 @@ jobs:
               - 'package.json'
               - 'pnpm-lock.yaml'
               - 'pnpm-workspace.yaml'
+              - '.npmrc'
               - 'biome.json'
               - '.dockerignore'
               - 'docker-compose.yml'
@@ -49,6 +54,7 @@ jobs:
               - 'scripts/check-lumi-survey-release-drift.mjs'
               - 'scripts/check-lumi-survey-release-drift.test.mjs'
               - 'scripts/verify-deploy-api-trigger.test.mjs'
+              - 'scripts/verify-deploy-dashboard-trigger.test.mjs'
               - 'scripts/verify-github-actions-pins.test.mjs'
               - 'scripts/verify-lumi-survey-package.mjs'
               - 'scripts/verify-lumi-survey-package.test.mjs'
@@ -78,6 +84,70 @@ jobs:
               - 'packages/lumi-survey/**'
               - 'packages/lumi-types/**'
               - 'scripts/lumi-full-chain-e2e.sh'
+            dashboard_deploy:
+              - '.github/workflows/deploy-dashboard.yaml'
+              - '.npmrc'
+              - 'package.json'
+              - 'pnpm-lock.yaml'
+              - 'pnpm-workspace.yaml'
+              - 'tsconfig*.json'
+              - 'apps/lumi-dashboard/**'
+              - 'packages/lumi-survey/**'
+              - 'packages/lumi-types/**'
+      - name: Record dashboard deployment scope
+        id: dashboard-scope
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+        env:
+          DASHBOARD_DEPLOY_REQUIRED: ${{ steps.filter.outputs.dashboard_deploy }}
+          NODE_REQUIRED: ${{ steps.filter.outputs.node }}
+          FULL_CHAIN_REQUIRED: ${{ steps.filter.outputs.full_chain }}
+          BEFORE_SHA: ${{ github.event.before }}
+          GH_TOKEN: ${{ github.token }}
+          REPOSITORY: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+          required="$DASHBOARD_DEPLOY_REQUIRED"
+          node_required="$NODE_REQUIRED"
+          full_chain_required="$FULL_CHAIN_REQUIRED"
+
+          # A newer main push can cancel the previous CI run. If that happened,
+          # validate and deploy the cumulative current head so no type of next
+          # change can hide its unvalidated predecessor.
+          previous_success_count="$(
+            gh run list \
+              --repo "$REPOSITORY" \
+              --workflow ci.yaml \
+              --commit "$BEFORE_SHA" \
+              --branch main \
+              --event push \
+              --status success \
+              --limit 1 \
+              --json databaseId \
+              --jq 'length' || true
+          )"
+          if [[ "$previous_success_count" != "1" ]]; then
+            required=true
+            node_required=true
+            full_chain_required=true
+            echo "::warning::Previous main commit has no successful CI run; validating and deploying the cumulative head"
+          fi
+
+          mkdir -p "$RUNNER_TEMP/dashboard-deploy-scope"
+          printf '%s\n' "$required" > "$RUNNER_TEMP/dashboard-deploy-scope/required"
+          {
+            echo "required=$required"
+            echo "node=$node_required"
+            echo "full_chain=$full_chain_required"
+          } >> "$GITHUB_OUTPUT"
+      - name: Publish dashboard deployment scope
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+        continue-on-error: true
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: dashboard-deploy-scope
+          path: ${{ runner.temp }}/dashboard-deploy-scope/required
+          if-no-files-found: error
+          retention-days: 1
 
   required:
     name: Merge gate

--- a/.github/workflows/deploy-dashboard.yaml
+++ b/.github/workflows/deploy-dashboard.yaml
@@ -32,6 +32,55 @@ permissions:
   packages: write
 
 jobs:
+  deployment-scope:
+    name: Read dashboard deployment scope
+    if: |
+      github.event_name == 'workflow_run' &&
+      github.event.workflow_run.event == 'push' &&
+      github.event.workflow_run.head_branch == 'main' &&
+      github.event.workflow_run.conclusion == 'success'
+    runs-on: ubuntu-latest
+    permissions:
+      actions: read
+    outputs:
+      required: ${{ steps.decision.outputs.required }}
+    steps:
+      - name: Download scope from the successful CI run
+        id: download
+        continue-on-error: true
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPOSITORY: ${{ github.repository }}
+          RUN_ID: ${{ github.event.workflow_run.id }}
+          SCOPE_DIR: ${{ runner.temp }}/dashboard-deploy-scope
+        run: |
+          set -euo pipefail
+          mkdir -p "$SCOPE_DIR"
+          gh run download "$RUN_ID" --repo "$REPOSITORY" --name dashboard-deploy-scope --dir "$SCOPE_DIR"
+          required="$(<"$SCOPE_DIR/required")"
+          case "$required" in
+            true|false) ;;
+            *)
+              echo "Invalid dashboard deployment scope: $required" >&2
+              exit 1
+              ;;
+          esac
+          echo "required=$required" >> "$GITHUB_OUTPUT"
+      - name: Resolve fail-open deployment decision
+        id: decision
+        if: always()
+        env:
+          DOWNLOAD_OUTCOME: ${{ steps.download.outcome }}
+          DOWNLOADED_REQUIRED: ${{ steps.download.outputs.required }}
+        run: |
+          required=true
+          if [[ "$DOWNLOAD_OUTCOME" == "success" && "$DOWNLOADED_REQUIRED" == "false" ]]; then
+            required=false
+          elif [[ "$DOWNLOAD_OUTCOME" != "success" ]]; then
+            echo "::warning::Could not read dashboard deployment scope; deploying to avoid a false negative"
+          fi
+          echo "required=$required" >> "$GITHUB_OUTPUT"
+
   checks:
     name: Run checks
     # CI already runs this full gate for every commit pushed to main. Keep the
@@ -73,11 +122,13 @@ jobs:
 
   build-demo:
     name: Build demo (mock data)
-    needs: checks
+    needs: [checks, deployment-scope]
     runs-on: ubuntu-latest
     if: |
       always() && (
-        (github.event_name == 'workflow_run' && github.event.workflow_run.conclusion == 'success') ||
+        (github.event_name == 'workflow_run' &&
+          github.event.workflow_run.conclusion == 'success' &&
+          needs.deployment-scope.outputs.required == 'true') ||
         (needs.checks.result == 'success' && (
           startsWith(github.ref_name, 'demo-') ||
           (github.event_name == 'workflow_dispatch' && inputs.target == 'demo')
@@ -134,11 +185,13 @@ jobs:
 
   build-production:
     name: Build production
-    needs: checks
+    needs: [checks, deployment-scope]
     runs-on: ubuntu-latest
     if: |
       always() && (
-        (github.event_name == 'workflow_run' && github.event.workflow_run.conclusion == 'success') ||
+        (github.event_name == 'workflow_run' &&
+          github.event.workflow_run.conclusion == 'success' &&
+          needs.deployment-scope.outputs.required == 'true') ||
         (needs.checks.result == 'success' &&
           github.event_name == 'workflow_dispatch' &&
           (inputs.target == 'dev' || inputs.target == 'prod'))
@@ -195,10 +248,8 @@ jobs:
     name: Deploy to dev-gcp (Demo)
     needs: build-demo
     runs-on: ubuntu-latest
-    # `checks` is skipped for workflow_run, so the build jobs only survive via
-    # always(). Without the same treatment here the skip propagates down the
-    # needs chain and every deploy is skipped — state the build result instead
-    # of relying on the implicit success().
+    # `checks` is skipped for workflow_run, so state the build result instead
+    # of relying on the implicit success() inherited through the needs chain.
     if: |
       always() && needs.build-demo.result == 'success' && (
         github.event_name == 'workflow_run' ||
@@ -225,7 +276,8 @@ jobs:
     if: |
       always() && needs.build-production.result == 'success' && (
         github.event_name == 'workflow_run' ||
-        (github.event_name == 'workflow_dispatch' && inputs.target == 'dev')
+        (github.event_name == 'workflow_dispatch' &&
+          (inputs.target == 'dev' || inputs.target == 'prod'))
       )
     environment:
       name: dev

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "verify:lumi-survey": "pnpm --filter @navikt/lumi-survey run build && node scripts/verify-lumi-survey-package.mjs",
     "verify:lumi-survey-consumer": "./scripts/verify-lumi-survey-consumer.sh",
     "check:lumi-survey-release-drift": "node scripts/check-lumi-survey-release-drift.mjs",
-    "test:release-guards": "node --test scripts/check-lumi-survey-release-drift.test.mjs scripts/verify-deploy-api-trigger.test.mjs scripts/verify-github-actions-pins.test.mjs scripts/verify-lumi-survey-package.test.mjs",
+    "test:release-guards": "node --test scripts/check-lumi-survey-release-drift.test.mjs scripts/verify-deploy-api-trigger.test.mjs scripts/verify-deploy-dashboard-trigger.test.mjs scripts/verify-github-actions-pins.test.mjs scripts/verify-lumi-survey-package.test.mjs",
     "test": "pnpm --filter @navikt/lumi-types run test && pnpm --filter @navikt/lumi-survey run test && pnpm --filter lumi-dashboard run test",
     "e2e": "pnpm --filter lumi-dashboard run e2e",
     "e2e:full-chain": "pnpm --filter lumi-dashboard run e2e:full-chain",

--- a/scripts/verify-deploy-dashboard-trigger.test.mjs
+++ b/scripts/verify-deploy-dashboard-trigger.test.mjs
@@ -1,0 +1,388 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import test from "node:test";
+import { fileURLToPath } from "node:url";
+import { load } from "js-yaml";
+
+const repositoryRoot = path.resolve(
+  path.dirname(fileURLToPath(import.meta.url)),
+  "..",
+);
+
+const readWorkflow = (filename) =>
+  load(
+    readFileSync(
+      path.join(repositoryRoot, ".github", "workflows", filename),
+      "utf8",
+    ),
+  );
+
+const workflow = readWorkflow("deploy-dashboard.yaml");
+const ciWorkflow = readWorkflow("ci.yaml");
+const normalizeExpression = (value) => value.replace(/\s+/g, " ").trim();
+const normalizeShell = (value) =>
+  normalizeExpression(value.replace(/\\\r?\n/g, " "));
+const expression = (value) => `\${{ ${value} }}`;
+const filterStep = ciWorkflow.jobs.changes.steps.find(
+  (step) => step.id === "filter",
+);
+const filters = load(filterStep.with.filters);
+const dashboardDeployPaths = filters.dashboard_deploy;
+const nodePaths = filters.node;
+
+const matchesPath = (patterns, filename) =>
+  patterns.some((pattern) => {
+    if (pattern.endsWith("/**")) {
+      return filename.startsWith(pattern.slice(0, -2));
+    }
+    if (pattern === "tsconfig*.json") {
+      return /^tsconfig[^/]*\.json$/.test(filename);
+    }
+    return filename === pattern;
+  });
+
+const requiresDashboardDeploy = (filenames) =>
+  filenames.some((filename) => matchesPath(dashboardDeployPaths, filename));
+
+const requiresNodeCI = (filenames) =>
+  filenames.some((filename) => matchesPath(nodePaths, filename));
+
+const resolveCiScope = ({
+  currentPushHasDashboardChanges,
+  currentPushNeedsNode,
+  currentPushNeedsFullChain,
+  previousMainCiSucceeded,
+}) => {
+  const recoversUnvalidatedPredecessor = !previousMainCiSucceeded;
+
+  return {
+    dashboardDeploy:
+      currentPushHasDashboardChanges || recoversUnvalidatedPredecessor,
+    node: currentPushNeedsNode || recoversUnvalidatedPredecessor,
+    fullChain: currentPushNeedsFullChain || recoversUnvalidatedPredecessor,
+  };
+};
+
+test("CI publishes dashboard deployment scope for the exact main push", () => {
+  assert.equal(
+    ciWorkflow.jobs.changes.outputs.dashboard_deploy,
+    expression(
+      "steps.dashboard-scope.outputs.required || steps.filter.outputs.dashboard_deploy",
+    ),
+  );
+  assert.equal(
+    ciWorkflow.jobs.changes.outputs.node,
+    expression(
+      "steps.dashboard-scope.outputs.node || steps.filter.outputs.node",
+    ),
+  );
+  assert.equal(
+    ciWorkflow.jobs.changes.outputs.full_chain,
+    expression(
+      "steps.dashboard-scope.outputs.full_chain || steps.filter.outputs.full_chain",
+    ),
+  );
+  assert.deepEqual(ciWorkflow.jobs.changes.permissions, {
+    actions: "read",
+    contents: "read",
+  });
+  assert.deepEqual(dashboardDeployPaths, [
+    ".github/workflows/deploy-dashboard.yaml",
+    ".npmrc",
+    "package.json",
+    "pnpm-lock.yaml",
+    "pnpm-workspace.yaml",
+    "tsconfig*.json",
+    "apps/lumi-dashboard/**",
+    "packages/lumi-survey/**",
+    "packages/lumi-types/**",
+  ]);
+
+  const recordStep = ciWorkflow.jobs.changes.steps.find(
+    (step) => step.name === "Record dashboard deployment scope",
+  );
+  const publishStep = ciWorkflow.jobs.changes.steps.find(
+    (step) => step.name === "Publish dashboard deployment scope",
+  );
+  const mainPushCondition =
+    "github.event_name == 'push' && github.ref == 'refs/heads/main'";
+
+  assert.equal(recordStep.if, mainPushCondition);
+  assert.equal(recordStep.id, "dashboard-scope");
+  assert.equal(
+    recordStep.env.DASHBOARD_DEPLOY_REQUIRED,
+    expression("steps.filter.outputs.dashboard_deploy"),
+  );
+  assert.equal(
+    recordStep.env.NODE_REQUIRED,
+    expression("steps.filter.outputs.node"),
+  );
+  assert.equal(
+    recordStep.env.FULL_CHAIN_REQUIRED,
+    expression("steps.filter.outputs.full_chain"),
+  );
+  assert.equal(recordStep.env.BEFORE_SHA, expression("github.event.before"));
+  assert.equal(recordStep.env.GH_TOKEN, expression("github.token"));
+  assert.equal(recordStep.env.REPOSITORY, expression("github.repository"));
+  assert.match(
+    normalizeShell(recordStep.run),
+    /gh run list --repo "\$REPOSITORY" --workflow ci\.yaml --commit "\$BEFORE_SHA" --branch main --event push --status success --limit 1 --json databaseId --jq 'length' \|\| true/,
+  );
+  assert.match(
+    normalizeShell(recordStep.run),
+    /required.*DASHBOARD_DEPLOY_REQUIRED.*node_required.*NODE_REQUIRED.*full_chain_required.*FULL_CHAIN_REQUIRED.*previous_success_count.*previous_success_count.*1.*required=true.*node_required=true.*full_chain_required=true/,
+  );
+  assert.match(recordStep.run, /dashboard-deploy-scope\/required/);
+  assert.match(recordStep.run, /required=\$required/);
+  assert.match(recordStep.run, /node=\$node_required/);
+  assert.match(recordStep.run, /full_chain=\$full_chain_required/);
+  assert.equal(publishStep.if, mainPushCondition);
+  assert.equal(publishStep["continue-on-error"], true);
+  assert.equal(publishStep.with.name, "dashboard-deploy-scope");
+  assert.equal(
+    publishStep.with.path,
+    `${expression("runner.temp")}/dashboard-deploy-scope/required`,
+  );
+  assert.equal(publishStep.with["retention-days"], 1);
+});
+
+test("API-only and docs-only pushes classify as unrelated to the dashboard", () => {
+  assert.equal(
+    requiresDashboardDeploy([
+      "apps/lumi-api/src/main/kotlin/no/nav/lumi/Application.kt",
+    ]),
+    false,
+  );
+  assert.equal(
+    requiresDashboardDeploy(["apps/lumi-submission-proxy/build.gradle.kts"]),
+    false,
+  );
+  assert.equal(
+    requiresDashboardDeploy(["docs/runbooks/nav-wide-rollout.md"]),
+    false,
+  );
+});
+
+test("a canceled or failed predecessor forces validation before cumulative deploy", () => {
+  assert.deepEqual(
+    resolveCiScope({
+      currentPushHasDashboardChanges: false,
+      currentPushNeedsNode: false,
+      currentPushNeedsFullChain: false,
+      previousMainCiSucceeded: true,
+    }),
+    { dashboardDeploy: false, node: false, fullChain: false },
+  );
+  assert.deepEqual(
+    resolveCiScope({
+      currentPushHasDashboardChanges: false,
+      currentPushNeedsNode: false,
+      currentPushNeedsFullChain: false,
+      previousMainCiSucceeded: false,
+    }),
+    { dashboardDeploy: true, node: true, fullChain: true },
+  );
+  assert.deepEqual(
+    resolveCiScope({
+      currentPushHasDashboardChanges: true,
+      currentPushNeedsNode: true,
+      currentPushNeedsFullChain: false,
+      previousMainCiSucceeded: false,
+    }),
+    { dashboardDeploy: true, node: true, fullChain: true },
+  );
+  assert.deepEqual(
+    resolveCiScope({
+      currentPushHasDashboardChanges: true,
+      currentPushNeedsNode: true,
+      currentPushNeedsFullChain: false,
+      previousMainCiSucceeded: true,
+    }),
+    { dashboardDeploy: true, node: true, fullChain: false },
+  );
+});
+
+test("dashboard build inputs require both Node CI and a deploy", () => {
+  const relevantFixtures = [
+    "apps/lumi-dashboard/app/routes/index.tsx",
+    "apps/lumi-dashboard/nais/prod.yaml",
+    "apps/lumi-dashboard/Dockerfile",
+    "packages/lumi-survey/src/index.ts",
+    "packages/lumi-types/src/api.ts",
+    ".github/workflows/deploy-dashboard.yaml",
+    ".npmrc",
+    "package.json",
+    "pnpm-lock.yaml",
+    "pnpm-workspace.yaml",
+    "tsconfig.shared.json",
+  ];
+
+  for (const filename of relevantFixtures) {
+    assert.equal(
+      requiresNodeCI([filename]),
+      true,
+      `${filename} must pass Node CI before deployment`,
+    );
+    assert.equal(
+      requiresDashboardDeploy([filename]),
+      true,
+      `${filename} must trigger dashboard deployment`,
+    );
+  }
+  assert.equal(
+    requiresDashboardDeploy([
+      "apps/lumi-api/src/main/kotlin/no/nav/lumi/Application.kt",
+      "packages/lumi-types/src/api.ts",
+    ]),
+    true,
+  );
+});
+
+test("automatic dashboard builds require a relevant change from the successful CI run", () => {
+  const deploymentScope = workflow.jobs["deployment-scope"];
+  assert.ok(deploymentScope);
+  assert.equal(
+    normalizeExpression(deploymentScope.if),
+    "github.event_name == 'workflow_run' && github.event.workflow_run.event == 'push' && github.event.workflow_run.head_branch == 'main' && github.event.workflow_run.conclusion == 'success'",
+  );
+  assert.equal(
+    deploymentScope.outputs.required,
+    expression("steps.decision.outputs.required"),
+  );
+
+  assert.deepEqual(workflow.jobs["build-demo"].needs, [
+    "checks",
+    "deployment-scope",
+  ]);
+  assert.equal(
+    normalizeExpression(workflow.jobs["build-demo"].if),
+    normalizeExpression(`
+      always() && (
+        (github.event_name == 'workflow_run' &&
+          github.event.workflow_run.conclusion == 'success' &&
+          needs.deployment-scope.outputs.required == 'true') ||
+        (needs.checks.result == 'success' && (
+          startsWith(github.ref_name, 'demo-') ||
+          (github.event_name == 'workflow_dispatch' && inputs.target == 'demo')
+        ))
+      )
+    `),
+  );
+
+  assert.deepEqual(workflow.jobs["build-production"].needs, [
+    "checks",
+    "deployment-scope",
+  ]);
+  assert.equal(
+    normalizeExpression(workflow.jobs["build-production"].if),
+    normalizeExpression(`
+      always() && (
+        (github.event_name == 'workflow_run' &&
+          github.event.workflow_run.conclusion == 'success' &&
+          needs.deployment-scope.outputs.required == 'true') ||
+        (needs.checks.result == 'success' &&
+          github.event_name == 'workflow_dispatch' &&
+          (inputs.target == 'dev' || inputs.target == 'prod'))
+      )
+    `),
+  );
+});
+
+test("missing or invalid CI scope fails open to deployment", () => {
+  const deploymentScope = workflow.jobs["deployment-scope"];
+  assert.equal(workflow.permissions.actions, undefined);
+  assert.deepEqual(deploymentScope.permissions, { actions: "read" });
+
+  const scopeSteps = deploymentScope.steps;
+  const downloadStep = scopeSteps.find((step) => step.id === "download");
+  const decisionStep = scopeSteps.find((step) => step.id === "decision");
+
+  assert.equal(downloadStep["continue-on-error"], true);
+  assert.equal(
+    downloadStep.env.RUN_ID,
+    expression("github.event.workflow_run.id"),
+  );
+  assert.equal(
+    downloadStep.env.SCOPE_DIR,
+    `${expression("runner.temp")}/dashboard-deploy-scope`,
+  );
+  assert.match(
+    normalizeExpression(downloadStep.run),
+    /gh run download "\$RUN_ID" --repo "\$REPOSITORY" --name dashboard-deploy-scope --dir "\$SCOPE_DIR"/,
+  );
+  assert.match(downloadStep.run, /"\$SCOPE_DIR\/required"/);
+  assert.match(downloadStep.run, /true\|false/);
+  assert.equal(decisionStep.if, "always()");
+  assert.match(decisionStep.run, /required=true/);
+  assert.match(
+    normalizeExpression(decisionStep.run),
+    /DOWNLOAD_OUTCOME.*success.*DOWNLOADED_REQUIRED.*false.*required=false/,
+  );
+  assert.match(decisionStep.run, /::warning::/);
+});
+
+test("manual and demo deployments follow the complete routes with one exact ref", () => {
+  assert.deepEqual(workflow.on.push, { branches: ["demo-*"] });
+  assert.deepEqual(workflow.on.workflow_run, {
+    workflows: ["CI"],
+    types: ["completed"],
+    branches: ["main"],
+  });
+  assert.deepEqual(workflow.on.workflow_dispatch.inputs.target.options, [
+    "demo",
+    "dev",
+    "prod",
+  ]);
+
+  assert.equal(workflow.jobs["deploy-demo"].needs, "build-demo");
+  assert.equal(
+    normalizeExpression(workflow.jobs["deploy-demo"].if),
+    normalizeExpression(`
+      always() && needs.build-demo.result == 'success' && (
+        github.event_name == 'workflow_run' ||
+        startsWith(github.ref_name, 'demo-') ||
+        (github.event_name == 'workflow_dispatch' && inputs.target == 'demo')
+      )
+    `),
+  );
+  assert.equal(workflow.jobs["deploy-dev"].needs, "build-production");
+  assert.equal(
+    normalizeExpression(workflow.jobs["deploy-dev"].if),
+    normalizeExpression(`
+      always() && needs.build-production.result == 'success' && (
+        github.event_name == 'workflow_run' ||
+        (github.event_name == 'workflow_dispatch' &&
+          (inputs.target == 'dev' || inputs.target == 'prod'))
+      )
+    `),
+  );
+  assert.deepEqual(workflow.jobs["deploy-prod"].needs, [
+    "build-production",
+    "deploy-dev",
+  ]);
+  assert.equal(
+    normalizeExpression(workflow.jobs["deploy-prod"].if),
+    normalizeExpression(`
+      always() &&
+      needs.build-production.result == 'success' &&
+      needs.deploy-dev.result == 'success' && (
+        github.event_name == 'workflow_run' ||
+        (github.event_name == 'workflow_dispatch' && inputs.target == 'prod')
+      )
+    `),
+  );
+
+  const selectedRef = expression(
+    "inputs.ref || github.event.workflow_run.head_sha || github.ref",
+  );
+  for (const jobName of [
+    "build-demo",
+    "build-production",
+    "deploy-demo",
+    "deploy-dev",
+    "deploy-prod",
+  ]) {
+    assert.equal(workflow.jobs[jobName].steps[0].with.ref, selectedRef);
+  }
+});


### PR DESCRIPTION
## Beskrivelse

Automatisk dashboard-deploy kjører i dag etter enhver vellykket main-CI, også når committen bare endrer API eller dokumentasjon. Det bygger og laster opp både demo- og produksjonsimage og deployer demo, dev og prod uten at dashboardet er endret.

Denne PR-en sender dashboard-scope fra den eksakte CI-kjøringen videre til deploy-workflowen. Urelaterte commits stopper etter en liten scope-jobb. Manglende scope eller en feilet/kansellert forgjenger feiler åpent: Node og full-chain kjøres på den kumulative headen før den eventuelt deployes.

Selve denne workflow-endringen er dashboard-relevant og vil derfor med hensikt gi én full dashboard-deploy når PR-en senere merges.

## Endringer

- legger til en konservativ path-gate for dashboard, NAIS/Docker-input, delte pakker og workspace/build-konfig
- overfører beslutningen som en kortlivet artifact knyttet til eksakt CI run-ID
- begrenser den privilegerte automatiske ruten til vellykket `push` på `main`, med jobblokal `actions: read`
- gjenoppretter manuell `prod`-flyt via dev før prod
- legger til kontrakttester for paths, kansellering/recovery, permissions, artifact, SHA og demo/dev/prod-ruting

## Issue

Ikke knyttet til et eget issue.

## Verifisering

- `pnpm run lint`
- `pnpm run typecheck`
- `pnpm test` — 1 121 tester
- `pnpm run e2e` — 61 tester
- `pnpm run test:release-guards` — 41 tester
- `actionlint .github/workflows/ci.yaml .github/workflows/deploy-dashboard.yaml`

## Sjekkliste

- [x] Koden kompilerer og linter uten feil
- [x] Endringene er testet automatisk
- [x] Ingen sensitiv data eksponert (tokens, credentials, PII)
