### PR TITLE
chore(ci): upgrade upload-artifact to v7

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -142,7 +142,7 @@ jobs:
       - name: Publish dashboard deployment scope
         if: github.event_name == 'push' && github.ref == 'refs/heads/main'
         continue-on-error: true
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: dashboard-deploy-scope
           path: ${{ runner.temp }}/dashboard-deploy-scope/required
@@ -310,7 +310,7 @@ jobs:
           NPM_AUTH_TOKEN: ${{ github.token }}
       - name: Upload full-chain evidence
         if: always()
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: full-chain-release-verification-${{ github.run_id }}
           path: apps/lumi-dashboard/test-results/full-chain


### PR DESCRIPTION
## Summary

- Upgrade both actions/upload-artifact uses to v7.0.1 at immutable commit 043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
- Move artifact uploads to the supported Node 24 runtime
- Keep deployment-scope and full-chain artifact settings unchanged

## Verification

- pnpm run test:release-guards (41/41)
- pnpm run lint
- pnpm run typecheck
- actionlint .github/workflows/ci.yaml

## Post-merge check

This CI-only change should publish dashboard_deploy=false and make Deploy dashboard skip both builds and all environments. Verify that run before continuing rollout work.