### PR TITLE
feat(dashboard): add explicit survey overview refresh

### DIFF
--- a/apps/lumi-api/src/main/kotlin/no/nav/lumi/config/RateLimiting.kt
+++ b/apps/lumi-api/src/main/kotlin/no/nav/lumi/config/RateLimiting.kt
@@ -28,7 +28,7 @@ import kotlin.time.Duration.Companion.minutes
  *   [UserRateLimitHashKey] in its `onCall`, which runs before the RateLimit
  *   `requestKey`. These routes are therefore keyed per caller-app and, when a
  *   user hash is present, per hashed user.
- * - Analytics/export routes: `rateLimit` is nested inside `authenticate`, so
+ * - Analytics/export/bootstrap-refresh routes: `rateLimit` is nested inside `authenticate`, so
  *   [rateLimitKey] uses the validated `BrukerPrincipal` and a pseudonymized
  *   user identifier to separate dashboard users of the shared client.
  * - Rejected export authentication: Ktor does not execute an inner rate limiter
@@ -46,9 +46,11 @@ import kotlin.time.Duration.Companion.minutes
 val SubmissionRateLimit = RateLimitName("submission")
 val UserSubmissionRateLimit = RateLimitName("user-submission")
 val AnalyticsRateLimit = RateLimitName("analytics")
+val BootstrapRefreshRateLimit = RateLimitName("bootstrap-refresh")
 val ExportRateLimit = RateLimitName("export")
 
 private const val EXPORT_REQUESTS_PER_MINUTE = 30
+private const val BOOTSTRAP_REFRESH_REQUESTS_PER_MINUTE = 6
 private val RATE_LIMIT_REFILL_PERIOD = 1.minutes
 private val defaultRateLimitSubmissionObservability = SubmissionObservability()
 
@@ -154,6 +156,17 @@ fun Application.configureRateLimiting(
         register(AnalyticsRateLimit) {
             rateLimiter(limit = 300, refillPeriod = RATE_LIMIT_REFILL_PERIOD)
             requestKey { call -> call.rateLimitKey() }
+        }
+
+        register(BootstrapRefreshRateLimit) {
+            rateLimiter(
+                limit = BOOTSTRAP_REFRESH_REQUESTS_PER_MINUTE,
+                refillPeriod = RATE_LIMIT_REFILL_PERIOD,
+            )
+            requestKey { call -> call.rateLimitKey() }
+            requestWeight { call, _ ->
+                if (call.request.queryParameters["refresh"] == "true") 1 else 0
+            }
         }
 
         register(ExportRateLimit) {

--- a/apps/lumi-api/src/main/kotlin/no/nav/lumi/routes/FilterRoutes.kt
+++ b/apps/lumi-api/src/main/kotlin/no/nav/lumi/routes/FilterRoutes.kt
@@ -2,21 +2,24 @@ package no.nav.lumi.routes
 
 import io.ktor.http.ContentType
 import io.ktor.http.HttpHeaders
+import io.ktor.server.plugins.ratelimit.rateLimit
 import io.ktor.server.resources.get
 import io.ktor.server.response.*
 import io.ktor.server.routing.*
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.encodeToString
 import kotlinx.serialization.json.Json
+import no.nav.lumi.config.BootstrapRefreshRateLimit
+import no.nav.lumi.config.auth.authorizedPrincipal
 import no.nav.lumi.config.auth.authorizedTeam
 import no.nav.lumi.config.auth.authorizedTeams
-import no.nav.lumi.config.auth.authorizedPrincipal
+import no.nav.lumi.config.exception.ApiErrorException
 import no.nav.lumi.integrations.valkey.StringCache
 import no.nav.lumi.integrations.valkey.ValkeyStringCache
 import no.nav.lumi.repository.FeedbackRepository
 import no.nav.lumi.repository.SurveyMetadataRepository
-import java.time.Instant
 import java.time.Duration
+import java.time.Instant
 
 /**
  * Response for GET /api/v1/intern/filters/bootstrap
@@ -134,67 +137,83 @@ fun Route.filterRoutes(
 ) {
     val versionedBootstrapCache = VersionedBootstrapCache(bootstrapCache)
 
-    get<ApiV1Intern.Filters.Bootstrap> {
-        val team = call.authorizedTeam
-        val teams = call.authorizedTeams
-        val principal = call.authorizedPrincipal
+    rateLimit(BootstrapRefreshRateLimit) {
+        get<ApiV1Intern.Filters.Bootstrap> { params ->
+            val team = call.authorizedTeam
+            val teams = call.authorizedTeams
+            val principal = call.authorizedPrincipal
+            val forceRefresh = when (params.refresh) {
+                null, "false" -> false
+                "true" -> true
+                else -> throw ApiErrorException.BadRequestException(
+                    "Invalid refresh: expected true or false",
+                )
+            }
 
-        // Cache is shared across users (Valkey). Include user identity to avoid leaking `availableTeams`.
-        // Team comes first so team-scoped invalidation can clear by prefix. Principals without a
-        // stable user identity are served uncached (a shared key would leak team memberships).
-        val cacheLookup = versionedBootstrapCache.lookup(team, principal)
+            // Cache is shared across users (Valkey). Include user identity to avoid leaking
+            // `availableTeams`. Team comes first so team-scoped invalidation can clear by prefix.
+            // Principals without a stable identity are served uncached.
+            val cacheLookup = versionedBootstrapCache.lookup(team, principal)
 
-        cacheLookup.value?.let { cachedJson ->
-            call.response.headers.append(HttpHeaders.CacheControl, "private, max-age=300")
-            call.respondText(cachedJson, ContentType.Application.Json)
-            return@get
-        }
+            if (!forceRefresh) {
+                cacheLookup.value?.let { cachedJson ->
+                    call.response.headers.append(HttpHeaders.CacheControl, "private, max-age=300")
+                    call.respondText(cachedJson, ContentType.Application.Json)
+                    return@get
+                }
+            }
 
-        // Each repository call manages its own transaction. Survey options and
-        // recency metadata deliberately share one aggregation/snapshot.
-        val apps = feedbackRepository.findDistinctApps(team)
-        val surveyOverview = feedbackRepository.findSurveyOverview(team)
-        val tags = feedbackRepository.findAllTags(team)
-        val archiveStates = surveyMetadataRepository.findByTeam(team).associateBy { it.surveyId }
-        val firstSubmissionBySurvey = surveyOverview.firstSubmissionBySurvey
-        val lastSubmissionBySurvey = surveyOverview.lastSubmissionBySurvey
-        val surveyMeta = (
-            archiveStates.keys + firstSubmissionBySurvey.keys + lastSubmissionBySurvey.keys
-        ).associateWith { surveyId ->
-            SurveyMetaEntry(
-                archivedAt = archiveStates[surveyId]?.archivedAt,
-                firstSubmissionAt = firstSubmissionBySurvey[surveyId],
-                lastSubmissionAt = lastSubmissionBySurvey[surveyId],
-            )
-        }
-        val surveyMetaByApp = surveyOverview.submissionBoundsByApp.mapValues { (_, boundsBySurvey) ->
-            boundsBySurvey.mapValues { (surveyId, bounds) ->
+            // Each repository call manages its own transaction. Survey options and
+            // recency metadata deliberately share one aggregation/snapshot.
+            val apps = feedbackRepository.findDistinctApps(team)
+            val surveyOverview = feedbackRepository.findSurveyOverview(team)
+            val tags = feedbackRepository.findAllTags(team)
+            val archiveStates = surveyMetadataRepository.findByTeam(team).associateBy { it.surveyId }
+            val firstSubmissionBySurvey = surveyOverview.firstSubmissionBySurvey
+            val lastSubmissionBySurvey = surveyOverview.lastSubmissionBySurvey
+            val surveyMeta = (
+                archiveStates.keys + firstSubmissionBySurvey.keys + lastSubmissionBySurvey.keys
+            ).associateWith { surveyId ->
                 SurveyMetaEntry(
                     archivedAt = archiveStates[surveyId]?.archivedAt,
-                    firstSubmissionAt = bounds.firstSubmissionAt,
-                    lastSubmissionAt = bounds.lastSubmissionAt,
+                    firstSubmissionAt = firstSubmissionBySurvey[surveyId],
+                    lastSubmissionAt = lastSubmissionBySurvey[surveyId],
                 )
+            }
+            val surveyMetaByApp = surveyOverview.submissionBoundsByApp.mapValues { (_, boundsBySurvey) ->
+                boundsBySurvey.mapValues { (surveyId, bounds) ->
+                    SurveyMetaEntry(
+                        archivedAt = archiveStates[surveyId]?.archivedAt,
+                        firstSubmissionAt = bounds.firstSubmissionAt,
+                        lastSubmissionAt = bounds.lastSubmissionAt,
+                    )
+                }.toSortedMap()
             }.toSortedMap()
-        }.toSortedMap()
 
-        val response = FilterBootstrapResponse(
-            generatedAt = Instant.now().toString(),
-            selectedTeam = team,
-            availableTeams = teams.sorted(),
-            apps = apps.sorted(),
-            surveysByApp = surveyOverview.surveysByApp.mapValues { it.value.sorted() }.toSortedMap(),
-            tags = tags.sorted(),
-            surveyMeta = surveyMeta,
-            surveyMetaByApp = surveyMetaByApp,
-        )
+            val response = FilterBootstrapResponse(
+                generatedAt = Instant.now().toString(),
+                selectedTeam = team,
+                availableTeams = teams.sorted(),
+                apps = apps.sorted(),
+                surveysByApp = surveyOverview.surveysByApp.mapValues { it.value.sorted() }.toSortedMap(),
+                tags = tags.sorted(),
+                surveyMeta = surveyMeta,
+                surveyMetaByApp = surveyMetaByApp,
+            )
 
-        versionedBootstrapCache.set(
-            cacheLookup,
-            json.encodeToString(response),
-            ttl = Duration.ofMinutes(5),
-        )
-        call.response.headers.append(HttpHeaders.CacheControl, "private, max-age=300")
+            if (!forceRefresh) {
+                versionedBootstrapCache.set(
+                    cacheLookup,
+                    json.encodeToString(response),
+                    ttl = Duration.ofMinutes(5),
+                )
+            }
+            call.response.headers.append(
+                HttpHeaders.CacheControl,
+                if (forceRefresh) "private, no-store" else "private, max-age=300",
+            )
 
-        call.respond(response)
+            call.respond(response)
+        }
     }
 }

--- a/apps/lumi-api/src/main/kotlin/no/nav/lumi/routes/Resources.kt
+++ b/apps/lumi-api/src/main/kotlin/no/nav/lumi/routes/Resources.kt
@@ -223,6 +223,8 @@ class ApiV1Intern {
             val parent: Filters = Filters(),
             /** Optional team scope. If omitted, the backend selects a default authorized team. */
             val team: String? = null,
+            /** Bypass the cached response without changing the shared cache entry. */
+            val refresh: String? = null,
         )
     }
 

--- a/apps/lumi-api/src/test/kotlin/no/nav/lumi/TestUtils.kt
+++ b/apps/lumi-api/src/test/kotlin/no/nav/lumi/TestUtils.kt
@@ -241,6 +241,7 @@ fun Application.testModule(
     feedbackService: FeedbackService = FeedbackService(),
     statsRepository: FeedbackStatsRepository = FeedbackStatsRepository(),
     bootstrapCache: StringCache = InMemoryStringCache(),
+    filterFeedbackRepository: FeedbackRepository = FeedbackRepository(),
 ) {
     // Initialize test database
     DatabaseHolder.initializeForTesting(TestDatabase.dataSource)
@@ -308,7 +309,10 @@ fun Application.testModule(
                 statsCacheInvalidator = statsCacheInvalidator,
             )
             surveyAuthoringRoutes()
-            filterRoutes(bootstrapCache = bootstrapCache)
+            filterRoutes(
+                feedbackRepository = filterFeedbackRepository,
+                bootstrapCache = bootstrapCache,
+            )
             markerRoutes()
             statsRoutes(statsService)
             exportRoutes(exportService)

--- a/apps/lumi-api/src/test/kotlin/no/nav/lumi/routes/FilterRoutesTest.kt
+++ b/apps/lumi-api/src/test/kotlin/no/nav/lumi/routes/FilterRoutesTest.kt
@@ -3,6 +3,8 @@ package no.nav.lumi.routes
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.shouldNotBe
+import io.mockk.coEvery
+import io.mockk.mockk
 import io.ktor.client.request.delete
 import io.ktor.client.request.get
 import io.ktor.client.request.header
@@ -20,6 +22,7 @@ import no.nav.lumi.config.auth.BrukerPrincipal
 import no.nav.lumi.createTestClient
 import no.nav.lumi.insertTestFeedback
 import no.nav.lumi.integrations.valkey.InMemoryStringCache
+import no.nav.lumi.repository.FeedbackRepository
 import no.nav.lumi.repository.SurveyMetadataRepository
 import no.nav.lumi.testModule
 import java.time.Duration
@@ -94,6 +97,129 @@ class FilterRoutesTest : FunSpec({
         cache.set(staleLookup, "stale", Duration.ofMinutes(5))
 
         cache.lookup("team-test", principal).value shouldBe null
+    }
+
+    test("explicit refresh bypasses cached bootstrap without evicting the shared value") {
+        val bootstrapCache = InMemoryStringCache()
+
+        testApplication {
+            application { testModule(bootstrapCache = bootstrapCache) }
+            val client = createTestClient()
+
+            suspend fun fetchBootstrap(refresh: String? = null) = client.get(
+                "/api/v1/intern/filters/bootstrap?team=team-test" +
+                    refresh?.let { "&refresh=$it" }.orEmpty(),
+            ) {
+                header(HttpHeaders.Authorization, "Bearer test-token")
+            }
+
+            insertTestFeedback(id = "cached-feedback", surveyId = "survey-cached")
+            val initial = fetchBootstrap()
+            initial.status shouldBe HttpStatusCode.OK
+            Json.parseToJsonElement(initial.bodyAsText())
+                .jsonObject["surveyMeta"]!!.jsonObject["survey-cached"] shouldNotBe null
+
+            insertTestFeedback(id = "fresh-feedback", surveyId = "survey-fresh")
+            val stillCached = fetchBootstrap(refresh = "false")
+            stillCached.status shouldBe HttpStatusCode.OK
+            Json.parseToJsonElement(stillCached.bodyAsText())
+                .jsonObject["surveyMeta"]!!.jsonObject["survey-fresh"] shouldBe null
+
+            val refreshed = fetchBootstrap(refresh = "true")
+            refreshed.status shouldBe HttpStatusCode.OK
+            refreshed.headers[HttpHeaders.CacheControl] shouldBe "private, no-store"
+            Json.parseToJsonElement(refreshed.bodyAsText())
+                .jsonObject["surveyMeta"]!!.jsonObject["survey-fresh"] shouldNotBe null
+
+            val cachedAfterRefresh = fetchBootstrap()
+            cachedAfterRefresh.status shouldBe HttpStatusCode.OK
+            Json.parseToJsonElement(cachedAfterRefresh.bodyAsText())
+                .jsonObject["surveyMeta"]!!.jsonObject["survey-fresh"] shouldBe null
+        }
+    }
+
+    test("failed refresh preserves the previously cached bootstrap") {
+        val bootstrapCache = InMemoryStringCache()
+        val cache = VersionedBootstrapCache(bootstrapCache)
+        val principal = BrukerPrincipal(
+            navIdent = "A123456",
+            name = "Test User",
+            email = "test.user@nav.no",
+            clientId = "dev-gcp:team-esyfo:lumi-dashboard",
+        )
+        cache.set(
+            cache.lookup("team-test", principal),
+            "{\"cached\":true}",
+            Duration.ofMinutes(5),
+        )
+        val failingRepository = mockk<FeedbackRepository>()
+        coEvery { failingRepository.findDistinctApps(any()) } throws
+            RuntimeException("simulated repository failure")
+
+        testApplication {
+            application {
+                testModule(
+                    bootstrapCache = bootstrapCache,
+                    filterFeedbackRepository = failingRepository,
+                )
+            }
+            val client = createTestClient()
+
+            val refresh = client.get(
+                "/api/v1/intern/filters/bootstrap?team=team-test&refresh=true",
+            ) {
+                header(HttpHeaders.Authorization, "Bearer test-token")
+            }
+            refresh.status shouldBe HttpStatusCode.InternalServerError
+
+            val cached = client.get("/api/v1/intern/filters/bootstrap?team=team-test") {
+                header(HttpHeaders.Authorization, "Bearer test-token")
+            }
+            cached.status shouldBe HttpStatusCode.OK
+            cached.bodyAsText() shouldBe "{\"cached\":true}"
+        }
+    }
+
+    test("bootstrap rejects an invalid refresh value") {
+        testApplication {
+            application { testModule() }
+
+            val response = createTestClient().get(
+                "/api/v1/intern/filters/bootstrap?team=team-test&refresh=invalid",
+            ) {
+                header(HttpHeaders.Authorization, "Bearer test-token")
+            }
+
+            response.status shouldBe HttpStatusCode.BadRequest
+        }
+    }
+
+    test("bootstrap refresh has a dedicated rate limit without blocking ordinary reads") {
+        testApplication {
+            application { testModule() }
+            val client = createTestClient()
+
+            repeat(6) {
+                val response = client.get(
+                    "/api/v1/intern/filters/bootstrap?team=team-test&refresh=true",
+                ) {
+                    header(HttpHeaders.Authorization, "Bearer test-token")
+                }
+                response.status shouldBe HttpStatusCode.OK
+            }
+
+            val limited = client.get(
+                "/api/v1/intern/filters/bootstrap?team=team-test&refresh=true",
+            ) {
+                header(HttpHeaders.Authorization, "Bearer test-token")
+            }
+            limited.status shouldBe HttpStatusCode.TooManyRequests
+
+            val ordinary = client.get("/api/v1/intern/filters/bootstrap?team=team-test") {
+                header(HttpHeaders.Authorization, "Bearer test-token")
+            }
+            ordinary.status shouldBe HttpStatusCode.OK
+        }
     }
 
     beforeTest {

--- a/apps/lumi-dashboard/app/components/shared/FilterBar/__tests__/FilterBar.archive.test.tsx
+++ b/apps/lumi-dashboard/app/components/shared/FilterBar/__tests__/FilterBar.archive.test.tsx
@@ -46,6 +46,12 @@ vi.mock("~/hooks/useFilterBootstrap", () => ({
   useFilterBootstrap: () => mockBootstrap,
 }));
 
+vi.mock("~/components/shared/RefreshSurveyOverview", () => ({
+  RefreshSurveyOverview: () => (
+    <button type="button">Oppdater surveyoversikt</button>
+  ),
+}));
+
 function loadedBootstrapData() {
   return {
     selectedTeam: "team-test",
@@ -143,6 +149,9 @@ describe("FilterBar archive state", () => {
     expect(
       screen.queryByRole("combobox", { name: "App" }),
     ).not.toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: "Oppdater surveyoversikt" }),
+    ).toBeInTheDocument();
 
     fireEvent.click(screen.getByRole("button", { name: "Prøv igjen" }));
 

--- a/apps/lumi-dashboard/app/components/shared/FilterBar/index.tsx
+++ b/apps/lumi-dashboard/app/components/shared/FilterBar/index.tsx
@@ -17,6 +17,7 @@ import dayjs from "dayjs";
 import { useEffect } from "react";
 import { PeriodSelector } from "~/components/dashboard/PeriodSelector";
 import { DataFetchBoundary } from "~/components/shared/DataFetchBoundary";
+import { RefreshSurveyOverview } from "~/components/shared/RefreshSurveyOverview";
 import { getSurveyFeatures } from "~/config/surveyConfig";
 import { useActiveFilters } from "~/hooks/useActiveFilters";
 import { useFilterBootstrap } from "~/hooks/useFilterBootstrap";
@@ -47,16 +48,21 @@ export function FilterBar({ showDetails = false }: FilterBarProps) {
   // Stats failures must not hide the controls users need to narrow the query.
   // Bootstrap failures still hide the controls because their options are unknown.
   return (
-    <DataFetchBoundary
-      title="Kunne ikke hente filtre"
-      queries={[bootstrapQuery]}
-    >
-      <FilterBarContent
-        showDetails={showDetails}
-        bootstrapQuery={bootstrapQuery}
-        statsQuery={statsQuery}
-      />
-    </DataFetchBoundary>
+    <VStack gap="space-8">
+      <HStack justify="end">
+        <RefreshSurveyOverview />
+      </HStack>
+      <DataFetchBoundary
+        title="Kunne ikke hente filtre"
+        queries={[bootstrapQuery]}
+      >
+        <FilterBarContent
+          showDetails={showDetails}
+          bootstrapQuery={bootstrapQuery}
+          statsQuery={statsQuery}
+        />
+      </DataFetchBoundary>
+    </VStack>
   );
 }
 

--- a/apps/lumi-dashboard/app/components/shared/RefreshSurveyOverview/RefreshSurveyOverview.module.css
+++ b/apps/lumi-dashboard/app/components/shared/RefreshSurveyOverview/RefreshSurveyOverview.module.css
@@ -1,0 +1,11 @@
+.srOnly {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  margin: -1px;
+  padding: 0;
+  overflow: hidden;
+  clip-path: inset(50%);
+  white-space: nowrap;
+  border: 0;
+}

--- a/apps/lumi-dashboard/app/components/shared/RefreshSurveyOverview/RefreshSurveyOverview.test.tsx
+++ b/apps/lumi-dashboard/app/components/shared/RefreshSurveyOverview/RefreshSurveyOverview.test.tsx
@@ -1,0 +1,71 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { RefreshSurveyOverview } from ".";
+
+const { mockMutation } = vi.hoisted(() => ({
+  mockMutation: {
+    mutate: vi.fn(),
+    isPending: false,
+    isError: false,
+    isSuccess: false,
+  },
+}));
+
+vi.mock("~/hooks/useRefreshSurveyOverview", () => ({
+  useRefreshSurveyOverview: () => mockMutation,
+}));
+
+describe("RefreshSurveyOverview", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockMutation.isPending = false;
+    mockMutation.isError = false;
+    mockMutation.isSuccess = false;
+  });
+
+  it("starts one explicit refresh from an accessible button", () => {
+    render(<RefreshSurveyOverview />);
+
+    const button = screen.getByRole("button", {
+      name: "Oppdater surveyoversikt",
+    });
+    expect(button).toHaveAttribute(
+      "title",
+      "Oppdaterer surveyvalg og svarperioder, men ikke statistikken.",
+    );
+    fireEvent.click(button);
+    fireEvent.click(button);
+
+    expect(mockMutation.mutate).toHaveBeenCalledOnce();
+  });
+
+  it("keeps the button in place and disables repeated clicks while refreshing", () => {
+    mockMutation.isPending = true;
+    render(<RefreshSurveyOverview />);
+
+    expect(
+      screen.getByRole("button", { name: "Oppdater surveyoversikt" }),
+    ).toBeDisabled();
+  });
+
+  it("shows a retryable error without replacing the existing page", () => {
+    mockMutation.isError = true;
+    render(<RefreshSurveyOverview />);
+
+    expect(screen.getByRole("alert")).toHaveTextContent(
+      "Kunne ikke oppdatere surveyoversikten. Prøv igjen.",
+    );
+    expect(
+      screen.getByRole("button", { name: "Oppdater surveyoversikt" }),
+    ).toBeEnabled();
+  });
+
+  it("announces a completed refresh", () => {
+    mockMutation.isSuccess = true;
+    render(<RefreshSurveyOverview />);
+
+    expect(screen.getByRole("status")).toHaveTextContent(
+      "Surveyoversikten er oppdatert.",
+    );
+  });
+});

--- a/apps/lumi-dashboard/app/components/shared/RefreshSurveyOverview/index.tsx
+++ b/apps/lumi-dashboard/app/components/shared/RefreshSurveyOverview/index.tsx
@@ -1,0 +1,53 @@
+import { ArrowCirclepathIcon } from "@navikt/aksel-icons";
+import { Alert, Button, Tooltip, VStack } from "@navikt/ds-react";
+import { useRef } from "react";
+import { useRefreshSurveyOverview } from "~/hooks/useRefreshSurveyOverview";
+import styles from "./RefreshSurveyOverview.module.css";
+
+export function RefreshSurveyOverview() {
+  const refreshMutation = useRefreshSurveyOverview();
+  const clickLocked = useRef(false);
+
+  const handleRefresh = () => {
+    if (clickLocked.current || refreshMutation.isPending) return;
+    clickLocked.current = true;
+    refreshMutation.mutate(undefined, {
+      onSettled: () => {
+        clickLocked.current = false;
+      },
+    });
+  };
+
+  return (
+    <VStack gap="space-4" align="end">
+      <Tooltip
+        content="Oppdaterer surveyvalg og svarperioder, men ikke statistikken."
+        describesChild
+      >
+        <Button
+          type="button"
+          aria-label="Oppdater surveyoversikt"
+          variant="tertiary"
+          size="small"
+          icon={<ArrowCirclepathIcon aria-hidden />}
+          loading={refreshMutation.isPending}
+          onClick={handleRefresh}
+        >
+          Oppdater surveyoversikt
+        </Button>
+      </Tooltip>
+
+      {refreshMutation.isError && (
+        <Alert variant="error" size="small" role="alert">
+          Kunne ikke oppdatere surveyoversikten. Prøv igjen.
+        </Alert>
+      )}
+
+      {refreshMutation.isSuccess && !refreshMutation.isPending && (
+        <span role="status" aria-live="polite" className={styles.srOnly}>
+          Surveyoversikten er oppdatert.
+        </span>
+      )}
+    </VStack>
+  );
+}

--- a/apps/lumi-dashboard/app/hooks/__tests__/useRefreshSurveyOverview.test.tsx
+++ b/apps/lumi-dashboard/app/hooks/__tests__/useRefreshSurveyOverview.test.tsx
@@ -1,0 +1,307 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { act, renderHook, waitFor } from "@testing-library/react";
+import type { ReactNode } from "react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { FilterBootstrapResponse } from "~/types/schemas";
+
+const { mockNavigate, mockParams, mockRefreshBootstrap } = vi.hoisted(() => ({
+  mockRefreshBootstrap: vi.fn(),
+  mockNavigate: vi.fn().mockResolvedValue(undefined),
+  mockParams: {
+    team: "team-test",
+    app: "app-a" as string | undefined,
+    surveyId: "shared-survey" as string | undefined,
+    dateMode: "auto" as "auto" | "fixed" | undefined,
+    fromDate: "2024-01-20" as string | undefined,
+    toDate: "2024-02-18" as string | undefined,
+  },
+}));
+
+vi.mock("~/server/actions", () => ({
+  fetchFilterBootstrapServerFn: vi.fn(),
+  refreshFilterBootstrapServerFn: mockRefreshBootstrap,
+}));
+
+vi.mock("~/hooks/useSearchParams", () => ({
+  useSearchParams: () => ({ params: mockParams }),
+}));
+
+vi.mock("@tanstack/react-router", async (importOriginal) => {
+  const original =
+    await importOriginal<typeof import("@tanstack/react-router")>();
+  return { ...original, useNavigate: () => mockNavigate };
+});
+
+import { filterBootstrapQueryKey } from "../useFilterBootstrap";
+import { useRefreshSurveyOverview } from "../useRefreshSurveyOverview";
+
+function createQueryClient() {
+  return new QueryClient({
+    defaultOptions: {
+      mutations: { retry: false },
+      queries: { retry: false },
+    },
+  });
+}
+
+function createWrapper(queryClient: QueryClient) {
+  return ({ children }: { children: ReactNode }) => (
+    <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+  );
+}
+
+function freshBootstrap(): FilterBootstrapResponse {
+  return {
+    generatedAt: "2026-08-23T10:00:00Z",
+    selectedTeam: "team-test",
+    availableTeams: ["team-test"],
+    deviceTypes: ["desktop"],
+    apps: ["app-a", "app-b"],
+    surveysByApp: {
+      "app-a": ["shared-survey"],
+      "app-b": ["shared-survey"],
+    },
+    tags: [],
+    surveyMeta: {
+      "shared-survey": {
+        archivedAt: null,
+        firstSubmissionAt: "2024-05-01T12:00:00Z",
+        lastSubmissionAt: "2024-05-30T12:00:00Z",
+      },
+    },
+    surveyMetaByApp: {
+      "app-a": {
+        "shared-survey": {
+          archivedAt: null,
+          firstSubmissionAt: "2024-03-01T12:00:00Z",
+          lastSubmissionAt: "2024-03-20T12:00:00Z",
+        },
+      },
+    },
+  };
+}
+
+describe("useRefreshSurveyOverview", () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockParams.team = "team-test";
+    mockParams.app = "app-a";
+    mockParams.surveyId = "shared-survey";
+    mockParams.dateMode = "auto";
+    mockParams.fromDate = "2024-01-20";
+    mockParams.toDate = "2024-02-18";
+  });
+
+  it("forces fresh bootstrap metadata before moving an automatic period and refreshing feedback", async () => {
+    const queryClient = createQueryClient();
+    const cancelSpy = vi.spyOn(queryClient, "cancelQueries");
+    const setQueryDataSpy = vi.spyOn(queryClient, "setQueryData");
+    const invalidateSpy = vi.spyOn(queryClient, "invalidateQueries");
+    const bootstrap = freshBootstrap();
+    mockRefreshBootstrap.mockResolvedValueOnce(bootstrap);
+
+    const { result } = renderHook(() => useRefreshSurveyOverview(), {
+      wrapper: createWrapper(queryClient),
+    });
+
+    await act(async () => {
+      await result.current.mutateAsync();
+    });
+
+    expect(mockRefreshBootstrap).toHaveBeenCalledWith({
+      data: { team: "team-test" },
+    });
+    expect(cancelSpy).toHaveBeenCalledTimes(2);
+    expect(cancelSpy).toHaveBeenNthCalledWith(1, {
+      queryKey: filterBootstrapQueryKey("team-test"),
+      exact: true,
+    });
+    expect(cancelSpy).toHaveBeenNthCalledWith(2, {
+      queryKey: filterBootstrapQueryKey("team-test"),
+      exact: true,
+    });
+    expect(mockNavigate).toHaveBeenCalledOnce();
+    const navigation = mockNavigate.mock.calls[0][0];
+    expect(
+      navigation.search({
+        team: "team-test",
+        app: "app-a",
+        surveyId: "shared-survey",
+        dateMode: "auto",
+        fromDate: "2024-01-20",
+        toDate: "2024-02-18",
+      }),
+    ).toMatchObject({
+      dateMode: "auto",
+      fromDate: "2024-03-01",
+      toDate: "2024-03-20",
+      page: "1",
+    });
+    expect(
+      queryClient.getQueryData(filterBootstrapQueryKey("team-test")),
+    ).toEqual(bootstrap);
+    expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: ["feedback"] });
+    expect(invalidateSpy).not.toHaveBeenCalledWith({ queryKey: ["stats"] });
+    expect(cancelSpy.mock.invocationCallOrder[0]).toBeLessThan(
+      mockRefreshBootstrap.mock.invocationCallOrder[0],
+    );
+    expect(mockRefreshBootstrap.mock.invocationCallOrder[0]).toBeLessThan(
+      cancelSpy.mock.invocationCallOrder[1],
+    );
+    expect(cancelSpy.mock.invocationCallOrder[1]).toBeLessThan(
+      setQueryDataSpy.mock.invocationCallOrder[0],
+    );
+    expect(setQueryDataSpy.mock.invocationCallOrder[0]).toBeLessThan(
+      mockNavigate.mock.invocationCallOrder[0],
+    );
+    expect(mockNavigate.mock.invocationCallOrder[0]).toBeLessThan(
+      invalidateSpy.mock.invocationCallOrder[0],
+    );
+  });
+
+  it("refreshes feedback when an automatic period is already current", async () => {
+    const queryClient = createQueryClient();
+    const invalidateSpy = vi.spyOn(queryClient, "invalidateQueries");
+    mockParams.fromDate = "2024-03-01";
+    mockParams.toDate = "2024-03-20";
+    mockRefreshBootstrap.mockResolvedValueOnce(freshBootstrap());
+
+    const { result } = renderHook(() => useRefreshSurveyOverview(), {
+      wrapper: createWrapper(queryClient),
+    });
+
+    await act(async () => {
+      await result.current.mutateAsync();
+    });
+
+    expect(mockNavigate).not.toHaveBeenCalled();
+    expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: ["feedback"] });
+  });
+
+  it("moves an unscoped automatic period to the current rolling window", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-08-23T12:00:00Z"));
+    const queryClient = createQueryClient();
+    mockParams.app = undefined;
+    mockParams.surveyId = undefined;
+    mockParams.fromDate = "2026-07-24";
+    mockParams.toDate = "2026-08-22";
+    mockRefreshBootstrap.mockResolvedValueOnce(freshBootstrap());
+
+    const { result } = renderHook(() => useRefreshSurveyOverview(), {
+      wrapper: createWrapper(queryClient),
+    });
+
+    await act(async () => {
+      await result.current.mutateAsync();
+    });
+
+    const navigation = mockNavigate.mock.calls[0][0];
+    expect(navigation.search({})).toMatchObject({
+      dateMode: "auto",
+      fromDate: "2026-07-25",
+      toDate: "2026-08-23",
+      page: "1",
+    });
+  });
+
+  it("preserves a fixed period while still refreshing metadata and feedback", async () => {
+    const queryClient = createQueryClient();
+    const invalidateSpy = vi.spyOn(queryClient, "invalidateQueries");
+    mockParams.dateMode = "fixed";
+    mockParams.fromDate = "2024-01-01";
+    mockParams.toDate = "2024-01-31";
+    mockRefreshBootstrap.mockResolvedValueOnce(freshBootstrap());
+
+    const { result } = renderHook(() => useRefreshSurveyOverview(), {
+      wrapper: createWrapper(queryClient),
+    });
+
+    await act(async () => {
+      await result.current.mutateAsync();
+    });
+
+    expect(mockNavigate).not.toHaveBeenCalled();
+    expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: ["feedback"] });
+  });
+
+  it("treats legacy explicit dates without a mode as fixed", async () => {
+    const queryClient = createQueryClient();
+    mockParams.dateMode = undefined;
+    mockParams.fromDate = "2024-01-01";
+    mockParams.toDate = "2024-01-31";
+    mockRefreshBootstrap.mockResolvedValueOnce(freshBootstrap());
+
+    const { result } = renderHook(() => useRefreshSurveyOverview(), {
+      wrapper: createWrapper(queryClient),
+    });
+
+    await act(async () => {
+      await result.current.mutateAsync();
+    });
+
+    expect(mockNavigate).not.toHaveBeenCalled();
+  });
+
+  it("keeps the existing cached overview when the forced request fails", async () => {
+    const queryClient = createQueryClient();
+    const existing = freshBootstrap();
+    existing.generatedAt = "2026-08-22T10:00:00Z";
+    queryClient.setQueryData(filterBootstrapQueryKey("team-test"), existing);
+    mockRefreshBootstrap.mockRejectedValueOnce(new Error("refresh failed"));
+
+    const { result } = renderHook(() => useRefreshSurveyOverview(), {
+      wrapper: createWrapper(queryClient),
+    });
+
+    await expect(act(async () => result.current.mutateAsync())).rejects.toThrow(
+      "refresh failed",
+    );
+
+    expect(
+      queryClient.getQueryData(filterBootstrapQueryKey("team-test")),
+    ).toEqual(existing);
+    expect(mockNavigate).not.toHaveBeenCalled();
+  });
+
+  it("does not apply a late response to a different team context", async () => {
+    const queryClient = createQueryClient();
+    let resolveRefresh: (bootstrap: FilterBootstrapResponse) => void = () =>
+      undefined;
+    mockRefreshBootstrap.mockReturnValueOnce(
+      new Promise<FilterBootstrapResponse>((resolve) => {
+        resolveRefresh = resolve;
+      }),
+    );
+
+    const { result, rerender } = renderHook(() => useRefreshSurveyOverview(), {
+      wrapper: createWrapper(queryClient),
+    });
+    let refreshPromise: Promise<unknown> | undefined;
+    act(() => {
+      refreshPromise = result.current.mutateAsync();
+    });
+    await waitFor(() => expect(mockRefreshBootstrap).toHaveBeenCalledOnce());
+
+    mockParams.team = "team-other";
+    mockParams.app = "app-b";
+    rerender();
+
+    await act(async () => {
+      resolveRefresh(freshBootstrap());
+      await refreshPromise;
+    });
+
+    expect(
+      queryClient.getQueryData(filterBootstrapQueryKey("team-test")),
+    ).toEqual(freshBootstrap());
+    expect(
+      queryClient.getQueryData(filterBootstrapQueryKey("team-other")),
+    ).toBeUndefined();
+    expect(mockNavigate).not.toHaveBeenCalled();
+  });
+});

--- a/apps/lumi-dashboard/app/hooks/useFilterBootstrap.ts
+++ b/apps/lumi-dashboard/app/hooks/useFilterBootstrap.ts
@@ -3,6 +3,9 @@ import { useSearchParams } from "~/hooks/useSearchParams";
 import { fetchFilterBootstrapServerFn } from "~/server/actions";
 import type { FilterBootstrapResponse } from "~/types/schemas";
 
+export const filterBootstrapQueryKey = (team?: string) =>
+  ["filterBootstrap", { team }] as const;
+
 /**
  * Hook to fetch filter bootstrap data.
  *
@@ -33,7 +36,7 @@ export function useFilterBootstrap() {
   const { params } = useSearchParams();
 
   return useQuery<FilterBootstrapResponse>({
-    queryKey: ["filterBootstrap", { team: params.team }],
+    queryKey: filterBootstrapQueryKey(params.team),
     queryFn: () =>
       fetchFilterBootstrapServerFn({ data: { team: params.team } }),
     staleTime: 5 * 60 * 1000, // 5 minutes - bootstrap data changes rarely

--- a/apps/lumi-dashboard/app/hooks/useRefreshSurveyOverview.ts
+++ b/apps/lumi-dashboard/app/hooks/useRefreshSurveyOverview.ts
@@ -1,0 +1,116 @@
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { useNavigate } from "@tanstack/react-router";
+import { useRef } from "react";
+import { filterBootstrapQueryKey } from "~/hooks/useFilterBootstrap";
+import { type SearchParams, useSearchParams } from "~/hooks/useSearchParams";
+import { refreshFilterBootstrapServerFn } from "~/server/actions";
+import { resolveDashboardPeriod } from "~/utils/dashboardPeriod";
+
+type RefreshContext = Pick<
+  SearchParams,
+  "team" | "app" | "surveyId" | "dateMode" | "fromDate" | "toDate"
+>;
+
+function snapshotRefreshContext(params: SearchParams): RefreshContext {
+  return {
+    team: params.team,
+    app: params.app,
+    surveyId: params.surveyId,
+    dateMode: params.dateMode,
+    fromDate: params.fromDate,
+    toDate: params.toDate,
+  };
+}
+
+function isSameRefreshContext(
+  current: RefreshContext,
+  requested: RefreshContext,
+) {
+  return (Object.keys(requested) as Array<keyof RefreshContext>).every(
+    (key) => current[key] === requested[key],
+  );
+}
+
+/**
+ * Fetches survey/filter metadata without the five-minute bootstrap cache.
+ *
+ * Feedback is also invalidated because that API is uncached. Statistics are
+ * deliberately left alone: their server-side caches have a separate contract,
+ * so this action must not imply that every dashboard card is immediately fresh.
+ */
+export function useRefreshSurveyOverview() {
+  const queryClient = useQueryClient();
+  const navigate = useNavigate();
+  const { params } = useSearchParams();
+  const latestParams = useRef(params);
+  latestParams.current = params;
+
+  return useMutation({
+    mutationFn: async () => {
+      const refreshContext = snapshotRefreshContext(latestParams.current);
+      const bootstrapQueryKey = filterBootstrapQueryKey(refreshContext.team);
+      // Ignore a late ordinary response after the forced request has returned.
+      await queryClient.cancelQueries({
+        queryKey: bootstrapQueryKey,
+        exact: true,
+      });
+      const bootstrap = await refreshFilterBootstrapServerFn({
+        data: { team: refreshContext.team },
+      });
+      return { bootstrap, bootstrapQueryKey, refreshContext };
+    },
+    onSuccess: async ({ bootstrap, bootstrapQueryKey, refreshContext }) => {
+      // Cancel an ordinary request that may have started while the forced request
+      // was running, then cache the response under the team actually requested.
+      await queryClient.cancelQueries({
+        queryKey: bootstrapQueryKey,
+        exact: true,
+      });
+      queryClient.setQueryData(bootstrapQueryKey, bootstrap);
+
+      if (
+        !isSameRefreshContext(
+          snapshotRefreshContext(latestParams.current),
+          refreshContext,
+        )
+      ) {
+        return;
+      }
+
+      const surveyMeta = refreshContext.surveyId
+        ? ((refreshContext.app
+            ? bootstrap.surveyMetaByApp?.[refreshContext.app]?.[
+                refreshContext.surveyId
+              ]
+            : undefined) ?? bootstrap.surveyMeta?.[refreshContext.surveyId])
+        : undefined;
+      const refreshedPeriod = resolveDashboardPeriod({
+        dateMode: refreshContext.dateMode,
+        fromDate: refreshContext.fromDate,
+        toDate: refreshContext.toDate,
+        surveyMeta,
+      });
+      const shouldMoveAutomaticPeriod =
+        refreshedPeriod.dateMode === "auto" &&
+        (refreshContext.dateMode !== "auto" ||
+          refreshContext.fromDate !== refreshedPeriod.fromDate ||
+          refreshContext.toDate !== refreshedPeriod.toDate);
+
+      if (shouldMoveAutomaticPeriod) {
+        await navigate({
+          // @ts-expect-error -- shared hook is used by both dashboard routes.
+          search: (previous: Record<string, string | undefined>) => ({
+            ...previous,
+            dateMode: "auto",
+            fromDate: refreshedPeriod.fromDate,
+            toDate: refreshedPeriod.toDate,
+            page: "1",
+          }),
+          replace: true,
+        });
+      }
+
+      await queryClient.invalidateQueries({ queryKey: ["feedback"] });
+    },
+  });
+}

--- a/apps/lumi-dashboard/app/server/actions/__tests__/fetchFilterBootstrap.contract.test.ts
+++ b/apps/lumi-dashboard/app/server/actions/__tests__/fetchFilterBootstrap.contract.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  buildFilterBootstrapUrl,
+  buildRefreshFilterBootstrapUrl,
+  FILTER_BOOTSTRAP_PATH,
+} from "../fetchFilterBootstrap";
+
+describe("fetchFilterBootstrap contract", () => {
+  it("forwards the explicit refresh signal to the bootstrap endpoint", () => {
+    const url = buildRefreshFilterBootstrapUrl("https://backend.example", {
+      team: "team-test",
+    });
+
+    const parsed = new URL(url);
+    expect(parsed.pathname).toBe(FILTER_BOOTSTRAP_PATH);
+    expect(parsed.searchParams.get("team")).toBe("team-test");
+    expect(parsed.searchParams.get("refresh")).toBe("true");
+  });
+
+  it("does not add a refresh signal to ordinary bootstrap requests", () => {
+    const url = buildFilterBootstrapUrl("https://backend.example", {
+      team: "team-test",
+    });
+
+    expect(new URL(url).searchParams.has("refresh")).toBe(false);
+  });
+});

--- a/apps/lumi-dashboard/app/server/actions/fetchFilterBootstrap.ts
+++ b/apps/lumi-dashboard/app/server/actions/fetchFilterBootstrap.ts
@@ -1,4 +1,5 @@
 import { createServerFn } from "@tanstack/react-start";
+import { setResponseHeader } from "@tanstack/react-start/server";
 import { zodValidator } from "@tanstack/zod-adapter";
 import { getMockFilterBootstrap } from "~/mock/mockData";
 import { authMiddleware } from "~/server/middleware/auth";
@@ -9,9 +10,59 @@ import {
   isMockMode,
   mockDelay,
 } from "~/server/utils";
-import type { FilterBootstrapResponse } from "~/types/schemas";
-import { FilterBootstrapParamsSchema } from "~/types/schemas";
+import type {
+  FilterBootstrapParams,
+  FilterBootstrapResponse,
+  RefreshFilterBootstrapParams,
+} from "~/types/schemas";
+import {
+  FilterBootstrapParamsSchema,
+  RefreshFilterBootstrapParamsSchema,
+} from "~/types/schemas";
 import { handleApiResponse } from "../fetchUtils";
+
+export const FILTER_BOOTSTRAP_PATH =
+  "/api/v1/intern/filters/bootstrap" as const;
+
+export function buildFilterBootstrapUrl(
+  backendUrl: string,
+  data: FilterBootstrapParams,
+) {
+  return buildUrl(backendUrl, FILTER_BOOTSTRAP_PATH, {
+    team: data.team,
+  });
+}
+
+export function buildRefreshFilterBootstrapUrl(
+  backendUrl: string,
+  data: RefreshFilterBootstrapParams,
+) {
+  return buildUrl(backendUrl, FILTER_BOOTSTRAP_PATH, {
+    team: data.team,
+    refresh: "true",
+  });
+}
+
+async function requestFilterBootstrap(
+  data: FilterBootstrapParams | RefreshFilterBootstrapParams,
+  context: AuthContext,
+  forceRefresh: boolean,
+): Promise<FilterBootstrapResponse> {
+  if (isMockMode()) {
+    await mockDelay();
+    return getMockFilterBootstrap(data.team);
+  }
+
+  const url = forceRefresh
+    ? buildRefreshFilterBootstrapUrl(context.backendUrl, data)
+    : buildFilterBootstrapUrl(context.backendUrl, data);
+  const response = await fetch(url, {
+    headers: getHeaders(context.oboToken),
+  });
+
+  await handleApiResponse(response);
+  return response.json() as Promise<FilterBootstrapResponse>;
+}
 
 /**
  * Server function to fetch filter bootstrap data.
@@ -28,22 +79,14 @@ export const fetchFilterBootstrapServerFn = createServerFn({ method: "GET" })
   .middleware([authMiddleware])
   .inputValidator(zodValidator(FilterBootstrapParamsSchema))
   .handler(async ({ data, context }): Promise<FilterBootstrapResponse> => {
-    const { backendUrl, oboToken } = context as AuthContext;
+    return requestFilterBootstrap(data, context as AuthContext, false);
+  });
 
-    if (isMockMode()) {
-      await mockDelay();
-      return getMockFilterBootstrap(data.team);
-    }
-
-    const url = buildUrl(backendUrl, "/api/v1/intern/filters/bootstrap", {
-      team: data.team,
-    });
-
-    const response = await fetch(url, {
-      headers: getHeaders(oboToken),
-    });
-
-    await handleApiResponse(response);
-
-    return response.json() as Promise<FilterBootstrapResponse>;
+/** Explicit, uncached refresh. POST keeps this user action out of GET caches. */
+export const refreshFilterBootstrapServerFn = createServerFn({ method: "POST" })
+  .middleware([authMiddleware])
+  .inputValidator(zodValidator(RefreshFilterBootstrapParamsSchema))
+  .handler(async ({ data, context }): Promise<FilterBootstrapResponse> => {
+    setResponseHeader("Cache-Control", "private, no-store");
+    return requestFilterBootstrap(data, context as AuthContext, true);
   });

--- a/apps/lumi-dashboard/app/server/actions/index.ts
+++ b/apps/lumi-dashboard/app/server/actions/index.ts
@@ -22,7 +22,10 @@ export { fetchDiscoveryServerFn } from "./fetchDiscovery";
 // Feedback
 export { fetchFeedbackServerFn } from "./fetchFeedback";
 // Filter Bootstrap
-export { fetchFilterBootstrapServerFn } from "./fetchFilterBootstrap";
+export {
+  fetchFilterBootstrapServerFn,
+  refreshFilterBootstrapServerFn,
+} from "./fetchFilterBootstrap";
 // Stats
 export { fetchStatsServerFn } from "./fetchStats";
 // Surveys

--- a/apps/lumi-dashboard/e2e/dashboard-period.spec.ts
+++ b/apps/lumi-dashboard/e2e/dashboard-period.spec.ts
@@ -23,6 +23,46 @@ async function expectSearchParams(
 }
 
 test.describe("Dashboard response period", () => {
+  test("manual survey overview refresh is available on every filter route", async ({
+    page,
+  }) => {
+    await page.goto("/?dateMode=fixed&fromDate=2024-01-01&toDate=2024-01-31");
+    await page.waitForLoadState("networkidle");
+
+    const refresh = page.getByRole("button", {
+      name: "Oppdater surveyoversikt",
+    });
+    await expect(refresh).toHaveCount(1);
+    const refreshResponsePromise = page.waitForResponse(
+      (response) =>
+        response.url().includes("/_serverFn/") &&
+        response.request().method() === "POST",
+    );
+    await refresh.click();
+    const refreshResponse = await refreshResponsePromise;
+    expect(refreshResponse.headers()["cache-control"]).toContain("no-store");
+    await expect(
+      page
+        .getByRole("status")
+        .filter({ hasText: "Surveyoversikten er oppdatert." }),
+    ).toHaveCount(1);
+    await expectSearchParams(page, {
+      dateMode: "fixed",
+      fromDate: "2024-01-01",
+      toDate: "2024-01-31",
+    });
+
+    await page.getByRole("link", { name: "Tilbakemeldinger" }).click();
+    await expect(
+      page.getByRole("button", { name: "Oppdater surveyoversikt" }),
+    ).toHaveCount(1);
+
+    await page.getByRole("link", { name: "Eksporter" }).click();
+    await expect(
+      page.getByRole("button", { name: "Oppdater surveyoversikt" }),
+    ).toHaveCount(1);
+  });
+
   test("selecting an old survey finds its responses and keeps the automatic period across routes", async ({
     page,
   }) => {

--- a/packages/lumi-types/src/schemas.ts
+++ b/packages/lumi-types/src/schemas.ts
@@ -194,6 +194,14 @@ export const FilterBootstrapParamsSchema = z.object({
 
 export type FilterBootstrapParams = z.infer<typeof FilterBootstrapParamsSchema>;
 
+export const RefreshFilterBootstrapParamsSchema = z.object({
+  team: z.string().optional(),
+});
+
+export type RefreshFilterBootstrapParams = z.infer<
+  typeof RefreshFilterBootstrapParamsSchema
+>;
+
 export const ArchiveSurveySchema = z.object({
   surveyId: z.string(),
   team: z.string().optional(),


### PR DESCRIPTION
## Hva

- legger til en manuell «Oppdater surveyoversikt»-handling på dashboard-, tilbakemeldings- og eksportsiden
- henter surveyvalg, tags og svarperioder utenom femminutterscachen
- oppdaterer automatisk periode fra fersk, app-spesifikk metadata og bevarer fikserte perioder
- oppdaterer tilbakemeldingslisten, som ikke har servercache, men lover ikke fersk statistikk

## Robusthet og kost

- refresh er en ren cache-bypass og endrer ikke delt bootstrap-cache
- mislykket refresh bevarer eksisterende cacheverdi
- maks seks tvungne refresh-kall per autentisert identitet per minutt
- nettleserhandlingen bruker POST med `Cache-Control: private, no-store`
- sene svar kan ikke endre periode eller cache for en ny team-/filterkontekst

## Verifisering

- lint og typecheck
- full API-testsuite
- 2 lumi-types-tester, 481 widgettester og 651 dashboardtester
- 20 Playwright-tester for periode/refresh og tilgjengelighet
- produksjonsbuild av dashboardet
- to uavhengige reviews av eksakt commit

Refs #490