### PR TITLE
test: verify legacy surveys in the full chain

### DIFF
--- a/apps/lumi-dashboard/full-chain-e2e/submission.spec.ts
+++ b/apps/lumi-dashboard/full-chain-e2e/submission.spec.ts
@@ -1,9 +1,14 @@
 import { writeFile } from "node:fs/promises";
 import { resolve } from "node:path";
+import type {
+  LumiApiFeedbackSubmissionV1,
+  LumiApiFeedbackSubmissionV2,
+} from "@navikt/lumi-survey";
 import {
   expect,
   type Locator,
   type Page,
+  type Response,
   type TestInfo,
   test,
 } from "@playwright/test";
@@ -34,6 +39,7 @@ interface FullChainReport {
     controlledRoundTrip: "pending" | "passed" | "failed";
     localSubmissionProxy: "not-tested" | "passed" | "failed";
     surveyContractMatrix?: "not-tested" | "passed" | "failed";
+    legacyCompatibility?: "passed" | "failed";
     globalAzureHealth: "not-assessed";
     trygdeetatenProxy: "not-tested";
     navWideRelease: "pending";
@@ -42,6 +48,7 @@ interface FullChainReport {
     runner: "playwright";
     failures: string[];
     matrix: MatrixScenarioEvidence[];
+    legacyCompatibility: LegacyCompatibilityEvidence;
   };
 }
 
@@ -67,18 +74,6 @@ interface TransportAnswer {
   };
 }
 
-interface TransportPayload {
-  schemaVersion: number;
-  surveyId: string;
-  surveyType: string;
-  definition: {
-    surveyType: string;
-    fields: TransportFieldDefinition[];
-  };
-  context?: { tags?: Record<string, string> };
-  answers: TransportAnswer[];
-}
-
 type MatrixAction =
   | { kind: "radio"; name: string | RegExp }
   | { kind: "textbox"; name: string; suffix: string }
@@ -88,6 +83,7 @@ type MatrixAction =
 
 interface MatrixScenario {
   id: string;
+  authoringFormat: "legacy-flat" | "document-v1";
   surveyType: "rating" | "topTasks" | "discovery" | "taskPriority" | "custom";
   dashboardType:
     | "Vurdering"
@@ -106,10 +102,37 @@ interface MatrixScenarioEvidence {
   scenarioId: string;
   surveyId: string;
   surveyType: MatrixScenario["surveyType"];
+  authoringFormat: MatrixScenario["authoringFormat"];
   facets: string[];
   status: "passed" | "failed";
   receiptId: string | null;
   detail: string;
+}
+
+interface LegacySubmissionEvidence {
+  schemaVersion: 1 | 2;
+  receiptId: string | null;
+  marker: string | null;
+  readback: "not-tested" | "passed" | "failed";
+}
+
+interface LegacyCompatibilityEvidence {
+  scenarioId: "legacy-flat-rating";
+  surveyId: string;
+  status: "passed" | "failed";
+  legacySubmission: LegacySubmissionEvidence & { schemaVersion: 1 };
+  widgetSubmission: LegacySubmissionEvidence & { schemaVersion: 2 };
+  detail: string;
+}
+
+interface LocalSurveyMatrixResult {
+  matrix: MatrixScenarioEvidence[];
+  legacyCompatibility: LegacyCompatibilityEvidence;
+}
+
+interface CurrentWidgetSubmission {
+  receiptId: string;
+  response: Response;
 }
 
 class MatrixScenarioFailure extends Error {
@@ -119,6 +142,21 @@ class MatrixScenarioFailure extends Error {
   ) {
     super(message);
     this.name = "MatrixScenarioFailure";
+  }
+}
+
+class LegacyCompatibilityFailure extends MatrixScenarioFailure {
+  constructor(
+    message: string,
+    readonly legacyReceiptId: string | null,
+    widgetReceiptId: string | null,
+    readonly legacyMarker: string,
+    readonly widgetMarker: string,
+    readonly legacyReadback: "not-tested" | "passed" | "failed",
+    readonly widgetReadback: "not-tested" | "passed" | "failed",
+  ) {
+    super(message, widgetReceiptId);
+    this.name = "LegacyCompatibilityFailure";
   }
 }
 
@@ -140,6 +178,16 @@ const MATRIX_SCENARIOS: MatrixScenario[] = [
     rating: 4,
     textFieldId: "feedback",
     textPrompt: "Har du andre tilbakemeldinger?",
+  }),
+  ratingScenario({
+    id: "legacy-flat-rating",
+    authoringFormat: "legacy-flat",
+    facet: "emoji",
+    ratingFieldId: "rating",
+    ratingAction: { kind: "radio", name: "4. Bra" },
+    rating: 4,
+    textFieldId: "feedback",
+    textPrompt: "Hva bør vi forbedre?",
   }),
   ratingScenario({
     id: "rating-thumbs",
@@ -173,6 +221,7 @@ const MATRIX_SCENARIOS: MatrixScenario[] = [
   }),
   {
     id: "discovery",
+    authoringFormat: "document-v1",
     surveyType: "discovery",
     dashboardType: "Discovery",
     facets: ["text", "singleChoice", "pages", "visibleIf"],
@@ -205,6 +254,7 @@ const MATRIX_SCENARIOS: MatrixScenario[] = [
   },
   {
     id: "top-tasks",
+    authoringFormat: "document-v1",
     surveyType: "topTasks",
     dashboardType: "Top Tasks",
     facets: ["singleChoice", "text", "pages", "visibleIf"],
@@ -253,6 +303,7 @@ const MATRIX_SCENARIOS: MatrixScenario[] = [
   ]),
   {
     id: "custom-field-matrix",
+    authoringFormat: "document-v1",
     surveyType: "custom",
     dashboardType: "Custom",
     facets: ["text", "singleChoice", "multiChoice", "checkbox"],
@@ -285,6 +336,7 @@ const MATRIX_SCENARIOS: MatrixScenario[] = [
   },
   {
     id: "pages-multi-question",
+    authoringFormat: "document-v1",
     surveyType: "custom",
     dashboardType: "Custom",
     facets: ["pages", "multi-question", "visibleIf", "stars"],
@@ -330,26 +382,38 @@ test("the full chain produces one terminal release-verification report", async (
   const startedAt = new Date().toISOString();
   const failures: string[] = [];
   let matrixEvidence: MatrixScenarioEvidence[] = [];
+  let legacyCompatibility = failedLegacyCompatibilityEvidence(
+    "Kompatibilitetssporet ble ikke kjørt",
+  );
   let localProxyStatus: "passed" | "failed" = "passed";
   let controlledReport: FullChainReport | null = null;
 
   try {
-    matrixEvidence = await verifyLocalSurveyMatrix(page);
+    const matrixResult = await verifyLocalSurveyMatrix(page);
+    matrixEvidence = matrixResult.matrix;
+    legacyCompatibility = matrixResult.legacyCompatibility;
     const matrixFailures = matrixEvidence.filter(
       ({ status }) => status === "failed",
     );
     if (matrixFailures.length > 0) {
       localProxyStatus = "failed";
       failures.push(
-        ...matrixFailures.map(
-          ({ scenarioId, detail }) =>
-            `survey-contract-matrix/${scenarioId}: ${detail}`,
-        ),
+        ...matrixFailures
+          .filter(({ authoringFormat }) => authoringFormat !== "legacy-flat")
+          .map(
+            ({ scenarioId, detail }) =>
+              `survey-contract-matrix/${scenarioId}: ${detail}`,
+          ),
       );
     }
   } catch (error) {
     localProxyStatus = "failed";
     failures.push(`survey-contract-matrix: ${errorMessage(error)}`);
+  }
+
+  if (legacyCompatibility.status === "failed") {
+    localProxyStatus = "failed";
+    failures.push(`legacy-compatibility: ${legacyCompatibility.detail}`);
   }
 
   try {
@@ -362,6 +426,7 @@ test("the full chain produces one terminal release-verification report", async (
   const report = controlledReport ?? createFailedReport(startedAt, finishedAt);
   report.coverage.localSubmissionProxy = localProxyStatus;
   report.coverage.surveyContractMatrix = localProxyStatus;
+  report.coverage.legacyCompatibility = legacyCompatibility.status;
   report.checks.push({
     id: "local-submission-proxy",
     status: localProxyStatus,
@@ -380,10 +445,17 @@ test("the full chain produces one terminal release-verification report", async (
         ? `${matrixEvidence.length}/${MATRIX_SCENARIOS.length} survey- og feltvarianter er verifisert`
         : `${matrixEvidence.filter(({ status }) => status === "passed").length}/${MATRIX_SCENARIOS.length} survey- og feltvarianter er verifisert`,
   });
+  report.checks.push({
+    id: "legacy-compatibility",
+    status: legacyCompatibility.status,
+    completedAt: finishedAt,
+    detail: legacyCompatibility.detail,
+  });
   report.automation = {
     runner: "playwright",
     failures,
     matrix: matrixEvidence,
+    legacyCompatibility,
   };
   report.generatedAt = finishedAt;
   report.finishedAt = finishedAt;
@@ -398,7 +470,7 @@ test("the full chain produces one terminal release-verification report", async (
 
 async function verifyLocalSurveyMatrix(
   page: Page,
-): Promise<MatrixScenarioEvidence[]> {
+): Promise<LocalSurveyMatrixResult> {
   await page.goto(DEMO_URL);
   await expect(
     page.getByRole("heading", { name: "Full-chain testbenk" }),
@@ -406,31 +478,64 @@ async function verifyLocalSurveyMatrix(
   const scenarioSelect = page.getByRole("combobox", {
     name: "Survey- og feltvariant",
   });
-  const renderedScenarioIds = await scenarioSelect
+  const renderedScenarios = await scenarioSelect
     .locator("option")
     .evaluateAll((options) =>
-      options.map((option) => (option as HTMLOptionElement).value),
+      options.map((option) => ({
+        id: (option as HTMLOptionElement).value,
+        authoringFormat: option.getAttribute("data-authoring-format"),
+      })),
     );
-  expect(renderedScenarioIds).toEqual(MATRIX_SCENARIOS.map(({ id }) => id));
+  expect(renderedScenarios).toEqual(
+    MATRIX_SCENARIOS.map(({ id, authoringFormat }) => ({
+      id,
+      authoringFormat,
+    })),
+  );
 
   const evidence: MatrixScenarioEvidence[] = [];
+  let legacyCompatibility: LegacyCompatibilityEvidence | null = null;
   for (const scenario of MATRIX_SCENARIOS) {
     try {
-      evidence.push(await verifyMatrixScenario(page, scenario));
+      if (scenario.authoringFormat === "legacy-flat") {
+        const result = await verifyLegacyCompatibilityScenario(page, scenario);
+        evidence.push(result.matrix);
+        legacyCompatibility = result.compatibility;
+      } else {
+        evidence.push(await verifyMatrixScenario(page, scenario));
+      }
     } catch (error) {
       evidence.push({
         scenarioId: scenario.id,
         surveyId: `local-demo-${scenario.id}`,
         surveyType: scenario.surveyType,
+        authoringFormat: scenario.authoringFormat,
         facets: scenario.facets,
         status: "failed",
         receiptId:
           error instanceof MatrixScenarioFailure ? error.receiptId : null,
         detail: errorMessage(error),
       });
+      if (scenario.authoringFormat === "legacy-flat") {
+        legacyCompatibility =
+          error instanceof LegacyCompatibilityFailure
+            ? failedLegacyCompatibilityEvidence(error.message, error)
+            : failedLegacyCompatibilityEvidence(errorMessage(error));
+      }
     }
   }
-  return evidence;
+  expect(
+    legacyCompatibility,
+    "legacy-flat-scenario mangler i matrisen",
+  ).not.toBeNull();
+  return {
+    matrix: evidence,
+    legacyCompatibility:
+      legacyCompatibility ??
+      failedLegacyCompatibilityEvidence(
+        "legacy-flat-scenario mangler i matrisen",
+      ),
+  };
 }
 
 async function verifyMatrixScenario(
@@ -441,67 +546,29 @@ async function verifyMatrixScenario(
   const marker = `matrix-${scenario.id}-${Date.now()}`;
   let receiptId: string | null = null;
   try {
-    await page.goto(DEMO_URL);
-    await page
-      .getByRole("combobox", { name: "Survey- og feltvariant" })
-      .selectOption(scenario.id);
-    await expect(page.getByText(surveyId, { exact: true })).toBeVisible();
-
-    const widget = page.getByRole("complementary", {
-      name: "Tilbakemeldingspanel",
+    const widget = await openAndFillScenario(page, scenario, marker);
+    const submission = await submitCurrentWidget(page, widget);
+    receiptId = submission.receiptId;
+    await assertCurrentWidgetSubmission(
+      page,
+      submission.response,
+      scenario,
+      surveyId,
+      marker,
+    );
+    const feedbackTable = await openSurveyFeedback(page, surveyId);
+    await assertReceiptReadback(page, feedbackTable, {
+      receiptId,
+      surveyId,
+      values: scenario.dashboardValues(marker),
     });
-    for (const action of scenario.actions) {
-      await performMatrixAction(page, widget, action, marker);
-    }
-
-    const responsePromise = page.waitForResponse(
-      (response) =>
-        response.request().method() === "POST" &&
-        response.url().includes("/api/azure/v1/feedback"),
-    );
-    await widget.getByRole("button", { name: "Send", exact: true }).click();
-    const response = await responsePromise;
-    expect(response.ok()).toBe(true);
-    const receipt = (await response.json()) as { id?: string };
-    expect(receipt.id).toEqual(expect.any(String));
-    receiptId = receipt.id ?? null;
-    const payload = response.request().postDataJSON() as TransportPayload;
-    assertTransportPayload(payload, scenario, surveyId, marker);
-
-    await expect(
-      page.getByRole("heading", { name: "Signal lagret" }),
-    ).toBeVisible();
-
-    await page.goto(
-      `${DASHBOARD_URL}/feedback?team=local-dev&app=local-app&surveyId=${encodeURIComponent(surveyId)}&dateMode=auto`,
-    );
-    await expect(page.getByText(/Viser \d+ svar for/)).toBeVisible();
-    const feedbackTable = page.getByRole("table");
-    const newestRow = feedbackTable.getByRole("row").nth(1);
-    await expect(newestRow).toBeVisible();
-    await newestRow
-      .getByRole("button", { name: "Utvid rad" })
-      .click({ timeout: 5_000 });
-    const expandedRow = feedbackTable.getByRole("row").nth(2);
-    await expect(expandedRow).toBeVisible();
-    for (const value of scenario.dashboardValues(marker)) {
-      await expect(expandedRow).toContainText(value);
-    }
-
-    await page.goto(
-      `${DASHBOARD_URL}/?team=local-dev&app=local-app&surveyId=${encodeURIComponent(surveyId)}&dateMode=auto`,
-    );
-    await expect(
-      page
-        .locator("main")
-        .getByText(scenario.dashboardType, { exact: true })
-        .first(),
-    ).toBeVisible();
+    await assertDashboardType(page, scenario, surveyId);
 
     return {
       scenarioId: scenario.id,
       surveyId,
       surveyType: scenario.surveyType,
+      authoringFormat: scenario.authoringFormat,
       facets: scenario.facets,
       status: "passed",
       receiptId,
@@ -510,6 +577,340 @@ async function verifyMatrixScenario(
   } catch (error) {
     throw new MatrixScenarioFailure(errorMessage(error), receiptId);
   }
+}
+
+async function verifyLegacyCompatibilityScenario(
+  page: Page,
+  scenario: MatrixScenario,
+): Promise<{
+  matrix: MatrixScenarioEvidence;
+  compatibility: LegacyCompatibilityEvidence;
+}> {
+  const surveyId = `local-demo-${scenario.id}`;
+  const markerSeed = `${Date.now()}-${Math.random().toString(16).slice(2)}`;
+  const legacyMarker = `legacy-v1-${markerSeed}`;
+  const widgetMarker = `widget-v2-${markerSeed}`;
+  let legacyReceiptId: string | null = null;
+  let widgetReceiptId: string | null = null;
+  let legacyReadback: LegacySubmissionEvidence["readback"] = "not-tested";
+  let widgetReadback: LegacySubmissionEvidence["readback"] = "not-tested";
+
+  try {
+    const widget = await openAndFillScenario(
+      page,
+      scenario,
+      widgetMarker,
+      false,
+    );
+    legacyReceiptId = await submitLegacyV1(page, {
+      surveyId,
+      scenarioId: scenario.id,
+      marker: legacyMarker,
+    });
+
+    for (const action of scenario.actions) {
+      await performMatrixAction(page, widget, action, widgetMarker);
+    }
+    const widgetSubmission = await submitCurrentWidget(page, widget);
+    widgetReceiptId = widgetSubmission.receiptId;
+    await assertCurrentWidgetSubmission(
+      page,
+      widgetSubmission.response,
+      scenario,
+      surveyId,
+      widgetMarker,
+    );
+    expect(widgetReceiptId).not.toBe(legacyReceiptId);
+
+    const feedbackTable = await openSurveyFeedback(page, surveyId);
+    try {
+      await assertReceiptReadback(page, feedbackTable, {
+        receiptId: legacyReceiptId,
+        surveyId,
+        values: [legacyMarker, "3/5"],
+      });
+      legacyReadback = "passed";
+    } catch (error) {
+      legacyReadback = "failed";
+      throw error;
+    }
+    try {
+      await assertReceiptReadback(page, feedbackTable, {
+        receiptId: widgetReceiptId,
+        surveyId,
+        values: scenario.dashboardValues(widgetMarker),
+      });
+      widgetReadback = "passed";
+    } catch (error) {
+      widgetReadback = "failed";
+      throw error;
+    }
+    await assertDashboardType(page, scenario, surveyId);
+
+    const detail =
+      "Schema v1 og flatkonfigurert widget-schema v2 ble lagret med ulike kvitteringer og lest tilbake i dashboardet";
+    return {
+      matrix: {
+        scenarioId: scenario.id,
+        surveyId,
+        surveyType: scenario.surveyType,
+        authoringFormat: scenario.authoringFormat,
+        facets: scenario.facets,
+        status: "passed",
+        receiptId: widgetReceiptId,
+        detail,
+      },
+      compatibility: {
+        scenarioId: "legacy-flat-rating",
+        surveyId,
+        status: "passed",
+        legacySubmission: {
+          schemaVersion: 1,
+          receiptId: legacyReceiptId,
+          marker: legacyMarker,
+          readback: legacyReadback,
+        },
+        widgetSubmission: {
+          schemaVersion: 2,
+          receiptId: widgetReceiptId,
+          marker: `${widgetMarker}-emoji`,
+          readback: widgetReadback,
+        },
+        detail,
+      },
+    };
+  } catch (error) {
+    throw new LegacyCompatibilityFailure(
+      errorMessage(error),
+      legacyReceiptId,
+      widgetReceiptId,
+      legacyMarker,
+      `${widgetMarker}-emoji`,
+      legacyReadback,
+      widgetReadback,
+    );
+  }
+}
+
+async function openAndFillScenario(
+  page: Page,
+  scenario: MatrixScenario,
+  marker: string,
+  performActions = true,
+): Promise<Locator> {
+  await page.goto(DEMO_URL);
+  await page
+    .getByRole("combobox", { name: "Survey- og feltvariant" })
+    .selectOption(scenario.id);
+  await expect(
+    page.getByText(surveyIdFor(scenario), { exact: true }),
+  ).toBeVisible();
+  await expect(
+    page.getByText(scenario.authoringFormat, { exact: true }),
+  ).toBeVisible();
+
+  const widget = page.getByRole("complementary", {
+    name: "Tilbakemeldingspanel",
+  });
+  if (performActions) {
+    for (const action of scenario.actions) {
+      await performMatrixAction(page, widget, action, marker);
+    }
+  }
+  return widget;
+}
+
+async function submitCurrentWidget(
+  page: Page,
+  widget: Locator,
+): Promise<CurrentWidgetSubmission> {
+  const responsePromise = page.waitForResponse(
+    (response) =>
+      response.request().method() === "POST" &&
+      response.url().includes("/api/azure/v1/feedback"),
+  );
+  await widget.getByRole("button", { name: "Send", exact: true }).click();
+  const response = await responsePromise;
+  const responseBody = await response.text();
+  expect(response.status(), responseBody).toBe(201);
+  const receipt = JSON.parse(responseBody) as { id?: string };
+  expect(receipt.id).toEqual(expect.any(String));
+  return { receiptId: receipt.id ?? "", response };
+}
+
+async function assertCurrentWidgetSubmission(
+  page: Page,
+  response: Response,
+  scenario: MatrixScenario,
+  surveyId: string,
+  marker: string,
+): Promise<void> {
+  const payload = response
+    .request()
+    .postDataJSON() as LumiApiFeedbackSubmissionV2;
+  assertTransportPayload(payload, scenario, surveyId, marker);
+  await expect(
+    page.getByRole("heading", { name: "Signal lagret" }),
+  ).toBeVisible();
+}
+
+async function submitLegacyV1(
+  page: Page,
+  input: { surveyId: string; scenarioId: string; marker: string },
+): Promise<string> {
+  const payload: LumiApiFeedbackSubmissionV1 = {
+    schemaVersion: 1,
+    surveyId: input.surveyId,
+    surveyType: "rating",
+    submittedAt: new Date().toISOString(),
+    context: {
+      tags: {
+        environment: "local-full-chain",
+        scenario: input.scenarioId,
+        compatibilityPhase: "legacy-v1",
+      },
+    },
+    answers: [
+      {
+        fieldId: "rating",
+        fieldType: "RATING",
+        question: { label: "Hvordan var opplevelsen?" },
+        value: {
+          type: "rating",
+          rating: 3,
+          ratingVariant: "emoji",
+          ratingScale: 5,
+        },
+      },
+      {
+        fieldId: "feedback",
+        fieldType: "TEXT",
+        question: { label: "Hva bør vi forbedre?" },
+        value: { type: "text", text: input.marker },
+      },
+    ],
+  };
+  expect(payload).not.toHaveProperty("definition");
+  expect(payload).not.toHaveProperty("deduplicationKey");
+  const response = await page.evaluate(async (body) => {
+    const result = await fetch("/api/azure/v1/feedback", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(body),
+    });
+    return { status: result.status, body: await result.text() };
+  }, payload);
+  expect(response.status, response.body).toBe(201);
+  const receipt = JSON.parse(response.body) as { id?: string };
+  expect(receipt.id).toEqual(expect.any(String));
+  return receipt.id ?? "";
+}
+
+async function openSurveyFeedback(
+  page: Page,
+  surveyId: string,
+): Promise<Locator> {
+  await page.goto(
+    `${DASHBOARD_URL}/feedback?team=local-dev&app=local-app&surveyId=${encodeURIComponent(surveyId)}&dateMode=auto`,
+  );
+  await expect(page.getByText(/Viser \d+ svar for/)).toBeVisible();
+  await expect(page.getByRole("combobox", { name: "App" }).first()).toHaveValue(
+    "local-app",
+  );
+  return page.getByRole("table");
+}
+
+async function assertReceiptReadback(
+  page: Page,
+  feedbackTable: Locator,
+  input: {
+    receiptId: string;
+    surveyId: string;
+    values: string[];
+  },
+): Promise<void> {
+  const dataRows = feedbackTable.locator("tbody > tr").filter({
+    has: page.getByRole("button", { name: /^(Utvid|Minimer) rad$/ }),
+  });
+  await expect(dataRows.first()).toBeVisible();
+
+  const receipt = feedbackTable.getByText(`ID: ${input.receiptId}`, {
+    exact: true,
+  });
+  let dataRow: Locator | null = null;
+  const rowCount = await dataRows.count();
+  for (let index = 0; index < rowCount; index += 1) {
+    const candidate = dataRows.nth(index);
+    const expandButton = candidate.getByRole("button", { name: "Utvid rad" });
+    if (await expandButton.isVisible()) {
+      await expandButton.click({ timeout: 5_000 });
+    }
+    const minimizeButton = candidate.getByRole("button", {
+      name: "Minimer rad",
+    });
+    await expect(minimizeButton).toBeVisible();
+    if (await receipt.isVisible()) {
+      dataRow = candidate;
+      break;
+    }
+    await minimizeButton.click({ timeout: 5_000 });
+  }
+
+  if (dataRow === null) {
+    throw new Error(`Fant ikke feedbackrad med ID ${input.receiptId}`);
+  }
+  await expect(dataRow).toContainText(input.surveyId);
+  await expect(dataRow).toContainText("local-app");
+  await expect(receipt).toBeVisible();
+  const expandedRow = receipt.locator("xpath=ancestor::tr");
+  await expect(expandedRow).toContainText(`Survey: ${input.surveyId}`);
+  for (const value of input.values) {
+    await expect(expandedRow).toContainText(value);
+  }
+}
+
+async function assertDashboardType(
+  page: Page,
+  scenario: MatrixScenario,
+  surveyId: string,
+): Promise<void> {
+  await page.goto(
+    `${DASHBOARD_URL}/?team=local-dev&app=local-app&surveyId=${encodeURIComponent(surveyId)}&dateMode=auto`,
+  );
+  await expect(
+    page
+      .locator("main")
+      .getByText(scenario.dashboardType, { exact: true })
+      .first(),
+  ).toBeVisible();
+}
+
+function surveyIdFor(scenario: MatrixScenario): string {
+  return `local-demo-${scenario.id}`;
+}
+
+function failedLegacyCompatibilityEvidence(
+  detail: string,
+  failure?: LegacyCompatibilityFailure,
+): LegacyCompatibilityEvidence {
+  return {
+    scenarioId: "legacy-flat-rating",
+    surveyId: "local-demo-legacy-flat-rating",
+    status: "failed",
+    legacySubmission: {
+      schemaVersion: 1,
+      receiptId: failure?.legacyReceiptId ?? null,
+      marker: failure?.legacyMarker ?? null,
+      readback: failure?.legacyReadback ?? "not-tested",
+    },
+    widgetSubmission: {
+      schemaVersion: 2,
+      receiptId: failure?.receiptId ?? null,
+      marker: failure?.widgetMarker ?? null,
+      readback: failure?.widgetReadback ?? "not-tested",
+    },
+    detail,
+  };
 }
 
 async function performMatrixAction(
@@ -553,7 +954,7 @@ async function performMatrixAction(
 }
 
 function assertTransportPayload(
-  payload: TransportPayload,
+  payload: LumiApiFeedbackSubmissionV2,
   scenario: MatrixScenario,
   surveyId: string,
   marker: string,
@@ -576,7 +977,7 @@ function assertTransportPayload(
       payload.definition.fields.find(
         ({ fieldId }) => fieldId === expectedField.fieldId,
       ),
-    ).toMatchObject(expectedField);
+    ).toEqual(expect.objectContaining({ ...expectedField }));
   }
 
   const expectedAnswers = scenario.expectedAnswers(marker);
@@ -584,12 +985,13 @@ function assertTransportPayload(
   for (const expectedAnswer of expectedAnswers) {
     expect(
       payload.answers.find(({ fieldId }) => fieldId === expectedAnswer.fieldId),
-    ).toMatchObject(expectedAnswer);
+    ).toEqual(expect.objectContaining({ ...expectedAnswer }));
   }
 }
 
 function ratingScenario({
   id,
+  authoringFormat = "document-v1",
   facet,
   ratingFieldId,
   ratingAction,
@@ -598,6 +1000,7 @@ function ratingScenario({
   textPrompt,
 }: {
   id: string;
+  authoringFormat?: MatrixScenario["authoringFormat"];
   facet: "emoji" | "thumbs" | "stars" | "nps";
   ratingFieldId: string;
   ratingAction: Extract<MatrixAction, { kind: "radio" }>;
@@ -606,8 +1009,15 @@ function ratingScenario({
   textPrompt: string;
 }): MatrixScenario {
   const scale = facet === "thumbs" ? 2 : facet === "nps" ? 11 : 5;
+  const dashboardRating =
+    facet === "thumbs"
+      ? "👍 Ja"
+      : facet === "nps"
+        ? `${rating}/10`
+        : `${rating}/${scale}`;
   return {
     id,
+    authoringFormat,
     surveyType: "rating",
     dashboardType: "Vurdering",
     facets: ["rating", facet, "text", "visibleIf"],
@@ -627,7 +1037,7 @@ function ratingScenario({
       ratingAnswer(ratingFieldId, facet, scale, rating),
       textAnswer(textFieldId, `${marker}-${facet}`),
     ],
-    dashboardValues: (marker) => [`${marker}-${facet}`],
+    dashboardValues: (marker) => [`${marker}-${facet}`, dashboardRating],
   };
 }
 
@@ -638,6 +1048,7 @@ function taskPriorityScenario(
 ): MatrixScenario {
   return {
     id,
+    authoringFormat: "document-v1",
     surveyType: "taskPriority",
     dashboardType: "Task Priority",
     facets: ["multiChoice", facet],
@@ -777,6 +1188,7 @@ function createFailedReport(
     coverage: {
       controlledRoundTrip: "failed",
       localSubmissionProxy: "not-tested",
+      legacyCompatibility: "failed",
       globalAzureHealth: "not-assessed",
       trygdeetatenProxy: "not-tested",
       navWideRelease: "pending",

--- a/apps/lumi-dashboard/tsconfig.typecheck.json
+++ b/apps/lumi-dashboard/tsconfig.typecheck.json
@@ -15,5 +15,6 @@
       ],
       "@navikt/lumi-survey/*": ["../../packages/lumi-survey/dist/*"]
     }
-  }
+  },
+  "include": ["app/**/*", "*.config.ts", "full-chain-e2e/**/*.ts"]
 }

--- a/apps/lumi-local-demo/Dockerfile.local
+++ b/apps/lumi-local-demo/Dockerfile.local
@@ -13,6 +13,8 @@ RUN --mount=type=secret,id=npm_token,target=/run/secrets/npm_token \
 
 COPY apps/lumi-local-demo apps/lumi-local-demo
 COPY packages/lumi-survey packages/lumi-survey
+ARG VITE_LUMI_DASHBOARD_HOST_PORT=3000
+ENV VITE_LUMI_DASHBOARD_HOST_PORT=$VITE_LUMI_DASHBOARD_HOST_PORT
 RUN pnpm --filter @navikt/lumi-survey run build && pnpm --filter lumi-local-demo run build
 
 FROM cgr.dev/chainguard/nginx:latest

--- a/apps/lumi-local-demo/src/App.tsx
+++ b/apps/lumi-local-demo/src/App.tsx
@@ -6,9 +6,11 @@ import {
 } from "@navikt/lumi-survey";
 import { useMemo, useState } from "react";
 
-import { demoScenarios } from "./scenarios";
+import { type DemoScenarioId, demoScenarios } from "./scenarios";
 
-const DASHBOARD_URL = "http://localhost:3000/feedback";
+const DASHBOARD_HOST_PORT =
+  import.meta.env.VITE_LUMI_DASHBOARD_HOST_PORT ?? "3000";
+const DASHBOARD_URL = `http://localhost:${DASHBOARD_HOST_PORT}/feedback`;
 
 type SubmissionState =
   | { status: "idle" }
@@ -17,7 +19,9 @@ type SubmissionState =
   | { status: "error"; surveyId: string; message: string };
 
 export function App() {
-  const [scenarioId, setScenarioId] = useState(demoScenarios[0].id);
+  const [scenarioId, setScenarioId] = useState<DemoScenarioId>(
+    demoScenarios[0].id,
+  );
   const [submission, setSubmission] = useState<SubmissionState>({
     status: "idle",
   });
@@ -62,7 +66,11 @@ export function App() {
 
   const selectScenario = (nextScenarioId: string) => {
     if (isSending) return;
-    setScenarioId(nextScenarioId);
+    const nextScenario = demoScenarios.find(
+      (candidate) => candidate.id === nextScenarioId,
+    );
+    if (!nextScenario) return;
+    setScenarioId(nextScenario.id);
     setSubmission({ status: "idle" });
   };
 
@@ -97,7 +105,11 @@ export function App() {
             onChange={(event) => selectScenario(event.target.value)}
           >
             {demoScenarios.map((candidate) => (
-              <option key={candidate.id} value={candidate.id}>
+              <option
+                key={candidate.id}
+                value={candidate.id}
+                data-authoring-format={candidate.authoringFormat}
+              >
                 {candidate.title}
               </option>
             ))}
@@ -106,6 +118,9 @@ export function App() {
           <div className="scenarioReadout">
             <p>{scenario.summary}</p>
             <div className="tagRow">
+              <Tag size="small" variant="outline">
+                {scenario.authoringFormat}
+              </Tag>
               {scenario.coverage.map((item) => (
                 <Tag key={item} size="small" variant="outline">
                   {item}

--- a/apps/lumi-local-demo/src/scenarios.ts
+++ b/apps/lumi-local-demo/src/scenarios.ts
@@ -3,18 +3,33 @@ import {
   createTopTasksSurveyDocument,
   DEFAULT_DISCOVERY_SURVEY_DOCUMENT,
   DEFAULT_RATING_SURVEY_DOCUMENT,
-  type LumiSurveyDefinition,
+  type LumiSurveyConfig,
+  type LumiSurveyQuestionType,
+  type MultiChoiceVariant,
+  type RatingVariant,
   type SurveyDocumentV1,
   type SurveyQuestionV1,
+  type SurveyType,
 } from "@navikt/lumi-survey";
 
-export interface DemoScenario {
+export type SurveyAuthoringFormat = "legacy-flat" | "document-v1";
+
+interface DemoScenarioBase {
   id: string;
   title: string;
   summary: string;
   coverage: string[];
-  survey: LumiSurveyDefinition;
 }
+
+export type DemoScenario =
+  | (DemoScenarioBase & {
+      authoringFormat: "legacy-flat";
+      survey: LumiSurveyConfig;
+    })
+  | (DemoScenarioBase & {
+      authoringFormat: "document-v1";
+      survey: SurveyDocumentV1;
+    });
 
 const tasks = [
   { value: "apply", label: "Søke om en ytelse" },
@@ -37,16 +52,53 @@ function ratingDocument(
   };
 }
 
-export const demoScenarios: DemoScenario[] = [
+const legacyFlatRatingSurvey = {
+  type: "rating",
+  questions: [
+    {
+      id: "rating",
+      type: "rating",
+      variant: "emoji",
+      prompt: "Hvordan var opplevelsen?",
+      required: true,
+    },
+    {
+      id: "feedback",
+      type: "text",
+      prompt: "Hva bør vi forbedre?",
+      maxLength: 500,
+      visibleIf: { questionId: "rating", operator: "EXISTS" },
+    },
+  ],
+} satisfies LumiSurveyConfig;
+
+function defineDemoScenarios<const Id extends string>(
+  scenarios: Array<DemoScenario & { id: Id }>,
+): Array<DemoScenario & { id: Id }> {
+  return scenarios;
+}
+
+export const demoScenarios = defineDemoScenarios([
   {
     id: "rating-emoji",
+    authoringFormat: "document-v1",
     title: "Rating · emoji",
     summary: "Standard 1–5-opplevelse med progressiv fritekst.",
     coverage: ["rating", "emoji", "text", "visibleIf"],
     survey: DEFAULT_RATING_SURVEY_DOCUMENT,
   },
   {
+    id: "legacy-flat-rating",
+    authoringFormat: "legacy-flat",
+    title: "Rating · eksisterende flat konfigurasjon",
+    summary:
+      "Kompatibilitetsspor for eksisterende LumiSurveyConfig; ikke anbefalt for nye surveyer.",
+    coverage: ["rating", "emoji", "text", "visibleIf"],
+    survey: legacyFlatRatingSurvey,
+  },
+  {
     id: "rating-thumbs",
+    authoringFormat: "document-v1",
     title: "Rating · tommel",
     summary: "Binært hjelpsomhetsspørsmål med oppfølging.",
     coverage: ["rating", "thumbs", "text"],
@@ -71,6 +123,7 @@ export const demoScenarios: DemoScenario[] = [
   },
   {
     id: "rating-stars",
+    authoringFormat: "document-v1",
     title: "Rating · stjerner",
     summary: "Fem stjerner og valgfri begrunnelse.",
     coverage: ["rating", "stars", "text"],
@@ -95,6 +148,7 @@ export const demoScenarios: DemoScenario[] = [
   },
   {
     id: "rating-nps",
+    authoringFormat: "document-v1",
     title: "Rating · NPS",
     summary: "0–10-skala med endeetiketter.",
     coverage: ["rating", "nps", "text"],
@@ -122,6 +176,7 @@ export const demoScenarios: DemoScenario[] = [
   },
   {
     id: "discovery",
+    authoringFormat: "document-v1",
     title: "Discovery",
     summary: "Oppgave i fritekst, gjennomføring og eventuell hindring.",
     coverage: ["discovery", "text", "singleChoice"],
@@ -129,6 +184,7 @@ export const demoScenarios: DemoScenario[] = [
   },
   {
     id: "top-tasks",
+    authoringFormat: "document-v1",
     title: "Top Tasks",
     summary: "Sidebasert oppgavevalg med annet-felt og relevante oppfølginger.",
     coverage: ["topTasks", "singleChoice", "visibleIf", "pages", "text"],
@@ -140,6 +196,7 @@ export const demoScenarios: DemoScenario[] = [
   },
   {
     id: "task-priority-checkbox",
+    authoringFormat: "document-v1",
     title: "Task Priority · avkryssing",
     summary: "Flervalg i kompakt checkbox-variant.",
     coverage: ["taskPriority", "multiChoice", "checkbox"],
@@ -152,6 +209,7 @@ export const demoScenarios: DemoScenario[] = [
   },
   {
     id: "task-priority-combobox",
+    authoringFormat: "document-v1",
     title: "Task Priority · komboboks",
     summary: "Søkbar flervalgsliste med chips.",
     coverage: ["taskPriority", "multiChoice", "combobox"],
@@ -164,6 +222,7 @@ export const demoScenarios: DemoScenario[] = [
   },
   {
     id: "custom-field-matrix",
+    authoringFormat: "document-v1",
     title: "Custom · feltmatrise",
     summary: "Alle generiske felttyper i én eksplisitt stegflyt.",
     coverage: ["custom", "text", "singleChoice", "multiChoice"],
@@ -212,6 +271,7 @@ export const demoScenarios: DemoScenario[] = [
   },
   {
     id: "pages-multi-question",
+    authoringFormat: "document-v1",
     title: "Pages · flere spørsmål",
     summary:
       "To eksplisitte sider med samlet validering og betinget felt på siste side.",
@@ -274,4 +334,100 @@ export const demoScenarios: DemoScenario[] = [
       ],
     },
   },
-];
+]);
+
+export type DemoScenarioId = (typeof demoScenarios)[number]["id"];
+
+interface SurveyContractCoverage {
+  authoringFormats: Record<SurveyAuthoringFormat, DemoScenarioId[]>;
+  surveyTypes: Record<SurveyType, DemoScenarioId[]>;
+  questionTypes: Record<LumiSurveyQuestionType, DemoScenarioId[]>;
+  ratingVariants: Record<RatingVariant, DemoScenarioId[]>;
+  multiChoiceVariants: Record<MultiChoiceVariant, DemoScenarioId[]>;
+}
+
+/**
+ * Derived inventory for the public survey contract. The explicit empty
+ * buckets make new public union members a compile error; the runtime guard
+ * requires every member to occur in a rendered full-chain scenario.
+ */
+export const surveyContractCoverage = buildSurveyContractCoverage();
+
+function buildSurveyContractCoverage(): SurveyContractCoverage {
+  const coverage: SurveyContractCoverage = {
+    authoringFormats: { "legacy-flat": [], "document-v1": [] },
+    surveyTypes: {
+      rating: [],
+      topTasks: [],
+      discovery: [],
+      taskPriority: [],
+      custom: [],
+    },
+    questionTypes: {
+      rating: [],
+      text: [],
+      singleChoice: [],
+      multiChoice: [],
+    },
+    ratingVariants: { emoji: [], thumbs: [], stars: [], nps: [] },
+    multiChoiceVariants: { checkbox: [], combobox: [] },
+  };
+
+  for (const scenario of demoScenarios) {
+    addScenario(
+      coverage.authoringFormats[scenario.authoringFormat],
+      scenario.id,
+    );
+    addScenario(
+      coverage.surveyTypes[scenario.survey.type ?? "custom"],
+      scenario.id,
+    );
+    const questions =
+      scenario.authoringFormat === "legacy-flat"
+        ? scenario.survey.questions
+        : scenario.survey.pages.flatMap((page) => page.questions);
+
+    for (const question of questions) {
+      addScenario(coverage.questionTypes[question.type], scenario.id);
+      if (question.type === "rating") {
+        addScenario(
+          coverage.ratingVariants[question.variant ?? "emoji"],
+          scenario.id,
+        );
+      }
+      if (question.type === "multiChoice") {
+        addScenario(
+          coverage.multiChoiceVariants[question.variant ?? "checkbox"],
+          scenario.id,
+        );
+      }
+    }
+  }
+
+  assertEveryMemberCovered("authoringFormats", coverage.authoringFormats);
+  assertEveryMemberCovered("surveyTypes", coverage.surveyTypes);
+  assertEveryMemberCovered("questionTypes", coverage.questionTypes);
+  assertEveryMemberCovered("ratingVariants", coverage.ratingVariants);
+  assertEveryMemberCovered("multiChoiceVariants", coverage.multiChoiceVariants);
+  return coverage;
+}
+
+function addScenario(
+  scenarioIds: DemoScenarioId[],
+  scenarioId: DemoScenarioId,
+): void {
+  if (!scenarioIds.includes(scenarioId)) {
+    scenarioIds.push(scenarioId);
+  }
+}
+
+function assertEveryMemberCovered<Member extends string>(
+  category: string,
+  members: Record<Member, DemoScenarioId[]>,
+): void {
+  for (const member in members) {
+    if (members[member].length === 0) {
+      throw new Error(`Mangler full-chain-scenario for ${category}.${member}`);
+    }
+  }
+}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,7 +14,7 @@ services:
       POSTGRES_USER: lumi
       POSTGRES_PASSWORD: lumi
     ports:
-      - "127.0.0.1:5432:5432"
+      - "127.0.0.1:${LUMI_POSTGRES_HOST_PORT:-5432}:5432"
     volumes:
       - lumi-postgres-data:/var/lib/postgresql/data
     healthcheck:
@@ -41,7 +41,7 @@ services:
       LUMI_LOCAL_AUTH_BYPASS: "true"
       LUMI_INTERNAL_SUBMISSION_KEY: "local-full-chain-only"
     ports:
-      - "127.0.0.1:8080:8080"
+      - "127.0.0.1:${LUMI_API_HOST_PORT:-8080}:8080"
 
   submission-proxy:
     build:
@@ -55,7 +55,7 @@ services:
       LUMI_INTERNAL_SUBMISSION_KEY: "local-full-chain-only"
       LUMI_LOCAL_AUTH_BYPASS: "true"
     ports:
-      - "127.0.0.1:8081:8080"
+      - "127.0.0.1:${LUMI_SUBMISSION_PROXY_HOST_PORT:-8081}:8080"
 
   dashboard:
     build:
@@ -71,19 +71,21 @@ services:
       USE_MOCK_DATA: "false"
       LUMI_LOCAL_AUTH_BYPASS: "true"
     ports:
-      - "127.0.0.1:3000:3000"
+      - "127.0.0.1:${LUMI_DASHBOARD_HOST_PORT:-3000}:3000"
 
   demo:
     build:
       context: .
       dockerfile: apps/lumi-local-demo/Dockerfile.local
+      args:
+        VITE_LUMI_DASHBOARD_HOST_PORT: "${LUMI_DASHBOARD_HOST_PORT:-3000}"
       secrets:
         - npm_token
     container_name: lumi-local-demo
     depends_on:
       - submission-proxy
     ports:
-      - "127.0.0.1:3001:8080"
+      - "127.0.0.1:${LUMI_DEMO_HOST_PORT:-3001}:8080"
 
 volumes:
   lumi-postgres-data:

--- a/docs/runbooks/nav-wide-rollout.md
+++ b/docs/runbooks/nav-wide-rollout.md
@@ -10,7 +10,7 @@ brukes som en måte å ta produktbeslutningen på.
 | --- | --- | --- |
 | Historiske surveys i dashboardet | Klar | Automatisk periode velges fra surveyens faktiske datointervall; eksplisitt valgt periode beholdes |
 | Pakket `@navikt/lumi-survey` | Automatisert | `pnpm run verify:lumi-survey-consumer` installerer tarballen i en ren konsument og kjører typecheck + Vite-build |
-| Widget → proxy → API → Postgres → dashboard | Automatisert | `pnpm run test:full-chain` kjører alle ti stabile survey- og feltvarianter mot en isolert Compose-stack og CI laster opp én aggregert terminalrapport med receipt per scenario |
+| Widget → proxy → API → Postgres → dashboard | Automatisert | `pnpm run test:full-chain` kjører alle elleve stabile survey- og feltvarianter mot en isolert Compose-stack, inkludert legacy v1 → kompatibel widget-v2 på samme survey-ID, og CI laster opp én aggregert terminalrapport med receipt per innsending |
 | Ekte Azure OBO i dev | Selvbetjent | `/release-verification` kjører team-preflight, startprobe, 15 minutters hold og sluttprobe med eksakt receipt-readback |
 | Innsendingshelse | Instrumentert | `lumi_submissions_total` skiller kanal og utfall; prod varsler på serverfeil og rejection-spike |
 | Hvilke eksisterende surveys som skal fortsette | Avventer | Må avklares før migrering; surveys som skal stoppes migreres ikke |
@@ -28,7 +28,8 @@ beholdes og skal fortsatt være lesbare selv om en survey skrus av.
 4. Send startproben med de syntetiske valgene. Vent til siden låser opp
    sluttproben etter 15 minutter, og send den.
 5. Del rapportlenken eller last ned JSON-beviset. For den kontrollerte kjeden
-   skal `outcome` og `coverage.controlledRoundTrip` være `passed`.
+   skal `outcome` og `coverage.controlledRoundTrip` være `passed`. CI-profilen
+   krever i tillegg `coverage.legacyCompatibility: passed`.
 6. Review canary-PR-en uten å merge den.
 
 Dette gir release-evidens uten å aktivere, migrere eller sende data fra en ekte
@@ -65,6 +66,15 @@ Matrisen dekker:
 - ratingvariantene emoji, tommel, stjerner og NPS
 - tekst, enkeltvalg, flervalg med avkryssing og flervalg med komboboks
 - `SurveyDocumentV1` med flere sider, flere spørsmål per side og `visibleIf`
+- eksisterende flat `LumiSurveyConfig`: først en representativ
+  `schemaVersion: 1` uten `definition` eller `deduplicationKey`, deretter en
+  kompatibel `schemaVersion: 2` fra dagens widget på samme survey-ID
+
+Legacy-sporet krever `201` og ulike receipt-ID-er for begge innsendingene. Det
+finner deretter hver feedbackrad ved eksakt receipt-ID og kontrollerer survey,
+app og egne svar i dashboardet. Resultatet lagres separat under
+`automation.legacyCompatibility`, slik at en grønn generell matrise ikke kan
+skjule et brudd i overgangsformatet.
 
 `DATE` finnes i den bredere API-kontrakten for lagrede svar, men er ikke en
 spørsmålstype som `@navikt/lumi-survey` kan authorere eller rendre. Den er derfor

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -48,6 +48,7 @@ definisjonskontroll også testes. Testbenken dekker:
 | Scenario | Surveytype | Felt/variant |
 | --- | --- | --- |
 | Rating · emoji | `rating` | `rating/emoji`, `text`, `visibleIf` |
+| Rating · eksisterende flat konfigurasjon | `rating` | `LumiSurveyConfig`, `rating/emoji`, `text`, `visibleIf` |
 | Rating · tommel | `rating` | `rating/thumbs`, `text` |
 | Rating · stjerner | `rating` | `rating/stars`, `text` |
 | Rating · NPS | `rating` | `rating/nps`, `text` |
@@ -77,8 +78,10 @@ pnpm run local:reset  # slett også Postgres-volumet
 ### Automatisert fullkjede
 
 Den samme stakken inngår nå i merge-gaten. Playwright sender både fra den
-lokale testbenken og fra dashboardets dev-only release-rigg, og verifiserer at
-den unike teksten kan leses tilbake i dashboardet:
+lokale testbenken og fra dashboardets dev-only release-rigg. Legacy-scenarioet
+forhåndssender schema v1 gjennom samme proxy før dagens flate widget sender en
+kompatibel schema-v2 på samme survey-ID. Begge innsendingene og resten av
+matrisen bindes til eksakt receipt ved tilbake-lesing i dashboardet:
 
 ```bash
 export NPM_AUTH_TOKEN="$(gh auth token)"
@@ -87,7 +90,17 @@ pnpm run test:full-chain
 
 Kommandoen bruker Compose-prosjektet `lumi-full-chain-smoke`, oppretter et eget
 databasevolum og rydder kun dette prosjektet etter kjøringen. Ved feil skrives
-containerloggene før opprydding.
+containerloggene før opprydding. Hvis en standardport allerede er opptatt, kan
+alle host-portene overstyres uten å endre containertrafikken:
+
+```bash
+LUMI_API_HOST_PORT=18080 \
+LUMI_SUBMISSION_PROXY_HOST_PORT=18081 \
+LUMI_DASHBOARD_HOST_PORT=13000 \
+LUMI_DEMO_HOST_PORT=13001 \
+LUMI_POSTGRES_HOST_PORT=15432 \
+pnpm run test:full-chain
+```
 
 ### Verifiser den publiserbare pakken
 
@@ -141,6 +154,18 @@ cd apps/lumi-api && ./gradlew run     # Flyway migrates on boot
 ./scripts/lumi-local-smoke.sh         # in another terminal
 ```
 
+Ved portkollisjon må både den publiserte Compose-porten og API-ens
+databaseport peke på samme alternative port:
+
+```bash
+export LUMI_POSTGRES_HOST_PORT=15432
+docker compose up -d postgres
+(cd apps/lumi-api && DB_PORT="$LUMI_POSTGRES_HOST_PORT" ./gradlew run)
+
+# Fra repo-roten i et annet terminalvindu:
+LUMI_POSTGRES_HOST_PORT=15432 ./scripts/lumi-local-smoke.sh
+```
+
 Both give "local mode" (auth disabled). The API reads `DB_*` env vars, so the
 container points at the `postgres` service while the host falls back to
 `localhost:5432`.
@@ -155,8 +180,9 @@ prints the resulting DB rows:
 | Same `deduplicationKey` again | `200 OK` (deduplicated, no new row) |
 | Structural change, same `surveyId` | `409 Conflict` (immutable definition guard) |
 
-> Requires port `5432` to be free. If you already run a local Postgres, stop it
-> or change the published port in `docker-compose.yml`.
+> Krever som standard at port `5432` er ledig. Option A trenger bare
+> `LUMI_POSTGRES_HOST_PORT`; for Option B må `DB_PORT` i den host-kjørte API-en
+> ha samme verdi, som vist over.
 
 ### Manual curl
 

--- a/scripts/lumi-full-chain-e2e.sh
+++ b/scripts/lumi-full-chain-e2e.sh
@@ -1,12 +1,19 @@
 #!/usr/bin/env bash
 
 # Runs the browser-visible Lumi path against an isolated local Compose project:
-# SurveyDocumentV1 widget -> submission proxy -> API -> Postgres -> dashboard.
+# Survey widget (DocumentV1 + legacy-flat) -> proxy -> API -> Postgres -> dashboard.
 set -euo pipefail
 
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 PROJECT_NAME="lumi-full-chain-smoke"
 COMPOSE=(docker compose --project-name "$PROJECT_NAME" -f "$ROOT/docker-compose.yml")
+API_HOST_PORT="${LUMI_API_HOST_PORT:-8080}"
+SUBMISSION_PROXY_HOST_PORT="${LUMI_SUBMISSION_PROXY_HOST_PORT:-8081}"
+DASHBOARD_HOST_PORT="${LUMI_DASHBOARD_HOST_PORT:-3000}"
+DEMO_HOST_PORT="${LUMI_DEMO_HOST_PORT:-3001}"
+
+export LUMI_DASHBOARD_URL="${LUMI_DASHBOARD_URL:-http://127.0.0.1:$DASHBOARD_HOST_PORT}"
+export LUMI_DEMO_URL="${LUMI_DEMO_URL:-http://127.0.0.1:$DEMO_HOST_PORT}"
 
 if [[ -z "${NPM_AUTH_TOKEN:-}" ]]; then
   printf 'NPM_AUTH_TOKEN må være satt for å bygge workspace-imagene.\n' >&2
@@ -45,9 +52,10 @@ wait_for() {
 }
 
 "${COMPOSE[@]}" up --detach --build
-wait_for "lumi-api" "http://127.0.0.1:8080/internal/isAlive"
-wait_for "lumi-dashboard" "http://127.0.0.1:3000"
-wait_for "lumi-local-demo" "http://127.0.0.1:3001/healthz"
+wait_for "lumi-api" "http://127.0.0.1:$API_HOST_PORT/internal/isAlive"
+wait_for "lumi-submission-proxy" "http://127.0.0.1:$SUBMISSION_PROXY_HOST_PORT/internal/isReady"
+wait_for "lumi-dashboard" "$LUMI_DASHBOARD_URL"
+wait_for "lumi-local-demo" "$LUMI_DEMO_URL/healthz"
 
 cd "$ROOT"
 pnpm run e2e:full-chain


### PR DESCRIPTION
## Hva

- legger til en stabil flat `LumiSurveyConfig` i den lokale surveymatrisen
- verifiserer schema v1 og widget-generert schema v2 på samme survey-ID gjennom proxy, API og dashboard
- binder begge lagrede svar til eksakt receipt og rapporterer legacy-kompatibilitet separat
- avleder kontraktdekning fra scenarioene og feiler ved udekkede offentlige unionmedlemmer
- gjør localhost-portene overstyrbare og venter eksplisitt på submission-proxyen

## Hvorfor

Dette gir et selvstendig CI-bevis for at eksisterende flate surveykonfigurasjoner fortsatt kan tas over av dagens widgetformat, uten eksterne NAV-verktøy eller ny driftsinfrastruktur.

## Verifisering

- `pnpm run lint`
- `pnpm run typecheck`
- `pnpm test`
- `pnpm run build`
- `bash -n scripts/lumi-full-chain-e2e.sh scripts/lumi-local-smoke.sh`
- Compose-konfigurasjon med alternative localhost-porter
- `pnpm run test:full-chain` med alternative localhost-porter: 11/11 scenarioer, `legacyCompatibility: passed`, ingen rapporterte feil

Node 25 gir kun engine-advarsel lokalt; repoet krever Node 24 og CI kjører den støttede versjonen.