### PR TITLE
fix(api): keep pre-auth traffic out of submission health

### DIFF
--- a/apps/lumi-api/src/main/kotlin/no/nav/lumi/config/RateLimiting.kt
+++ b/apps/lumi-api/src/main/kotlin/no/nav/lumi/config/RateLimiting.kt
@@ -12,6 +12,7 @@ import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import no.nav.lumi.config.auth.AuthorizationAttributes
 import no.nav.lumi.config.auth.CallerIdentityKey
+import no.nav.lumi.config.auth.InternalSubmissionAuthenticatedKey
 import no.nav.lumi.config.auth.UserRateLimitHashKey
 import no.nav.lumi.config.auth.pseudonymizeIdentifier
 import no.nav.lumi.config.exception.ApiErrorException
@@ -28,6 +29,10 @@ import kotlin.time.Duration.Companion.minutes
  *   [UserRateLimitHashKey] in its `onCall`, which runs before the RateLimit
  *   `requestKey`. These routes are therefore keyed per caller-app and, when a
  *   user hash is present, per hashed user.
+ * - Internal proxy submissions: PSK authentication runs before the named
+ *   submission limit and sets [InternalSubmissionAuthenticatedKey]. The proxy
+ *   remains keyed by its trusted socket peer because the forwarded caller
+ *   identity is validated inside the handler.
  * - Analytics/export/bootstrap-refresh routes: `rateLimit` is nested inside `authenticate`, so
  *   [rateLimitKey] uses the validated `BrukerPrincipal` and a pseudonymized
  *   user identifier to separate dashboard users of the shared client.
@@ -180,9 +185,8 @@ fun Application.configureRateLimiting(
             requestWeight { call, _ ->
                 if (call.request.path().startsWith("/internal/")) 0 else 1
             }
-            modifyResponse { call, state ->
-                recordRejectedSubmissionWhenExhausted(call, state, submissionObservability)
-            }
+            // This guard runs before route authentication. Its 429 responses are
+            // perimeter traffic, not authenticated submission outcomes.
         }
     }
 }
@@ -198,9 +202,18 @@ private fun recordRejectedSubmissionWhenExhausted(
         "/api/tokenx/v1/feedback" -> SubmissionChannel.TOKENX
         "/api/azure/v1/feedback" -> SubmissionChannel.AZURE
         "/api/internal/v1/feedback" -> SubmissionChannel.INTERNAL_PROXY
-        else -> null
+        else -> return
     }
-    if (channel != null) {
+    // A matching path is caller-controlled. Require the channel's trusted auth
+    // marker before treating a limiter response as a submission outcome.
+    val isAuthenticated = when (channel) {
+        SubmissionChannel.TOKENX,
+        SubmissionChannel.AZURE -> call.attributes.getOrNull(CallerIdentityKey) != null
+
+        SubmissionChannel.INTERNAL_PROXY ->
+            call.attributes.getOrNull(InternalSubmissionAuthenticatedKey) != null
+    }
+    if (isAuthenticated) {
         submissionObservability.record(channel, SubmissionMetricOutcome.REJECTED)
     }
 }

--- a/apps/lumi-api/src/main/kotlin/no/nav/lumi/config/Routing.kt
+++ b/apps/lumi-api/src/main/kotlin/no/nav/lumi/config/Routing.kt
@@ -27,9 +27,7 @@ fun Application.configureRouting() {
         internalRoutes()
         
         // Internal proxy-forwarded submissions (dev only, PSK-protected)
-        rateLimit(SubmissionRateLimit) {
-            internalSubmissionRoutes()
-        }
+        internalSubmissionRoutes()
         
         // Public submission API - issuer-specific endpoints (/api/tokenx/* and /api/azure/*)
         submissionRoutes()

--- a/apps/lumi-api/src/main/kotlin/no/nav/lumi/config/auth/InternalSubmissionAuthPlugin.kt
+++ b/apps/lumi-api/src/main/kotlin/no/nav/lumi/config/auth/InternalSubmissionAuthPlugin.kt
@@ -1,0 +1,36 @@
+package no.nav.lumi.config.auth
+
+import io.ktor.server.application.*
+import io.ktor.server.request.*
+import io.ktor.util.AttributeKey
+import no.nav.lumi.config.exception.ApiErrorException
+import org.slf4j.LoggerFactory
+import java.security.MessageDigest
+
+internal const val INTERNAL_SUBMISSION_KEY_HEADER = "X-Lumi-Submission-Key"
+
+internal val InternalSubmissionAuthenticatedKey =
+    AttributeKey<Unit>("InternalSubmissionAuthenticated")
+
+internal class InternalSubmissionAuthPluginConfig {
+    lateinit var expectedKey: String
+}
+
+private val log = LoggerFactory.getLogger("InternalSubmissionAuthPlugin")
+
+internal val InternalSubmissionAuthPlugin = createRouteScopedPlugin(
+    name = "InternalSubmissionAuthPlugin",
+    createConfiguration = ::InternalSubmissionAuthPluginConfig,
+) {
+    val expectedKey = pluginConfig.expectedKey.toByteArray()
+
+    onCall { call ->
+        val providedKey = call.request.header(INTERNAL_SUBMISSION_KEY_HEADER)
+        if (providedKey == null || !MessageDigest.isEqual(providedKey.toByteArray(), expectedKey)) {
+            log.warn("Internal submission: invalid or missing $INTERNAL_SUBMISSION_KEY_HEADER")
+            throw ApiErrorException.UnauthorizedException("Invalid submission key")
+        }
+
+        call.attributes.put(InternalSubmissionAuthenticatedKey, Unit)
+    }
+}

--- a/apps/lumi-api/src/main/kotlin/no/nav/lumi/routes/InternalSubmissionRoutes.kt
+++ b/apps/lumi-api/src/main/kotlin/no/nav/lumi/routes/InternalSubmissionRoutes.kt
@@ -1,6 +1,8 @@
 package no.nav.lumi.routes
 
 import io.ktor.http.*
+import io.ktor.server.application.*
+import io.ktor.server.plugins.ratelimit.*
 import io.ktor.server.request.*
 import io.ktor.server.response.*
 import io.ktor.server.routing.*
@@ -9,20 +11,21 @@ import kotlinx.serialization.json.put
 import no.nav.lumi.config.SubmissionChannel
 import no.nav.lumi.config.SubmissionMetricOutcome
 import no.nav.lumi.config.SubmissionObservability
+import no.nav.lumi.config.SubmissionRateLimit
 import no.nav.lumi.config.auth.CallerIdentityKey
+import no.nav.lumi.config.auth.INTERNAL_SUBMISSION_KEY_HEADER
+import no.nav.lumi.config.auth.InternalSubmissionAuthPlugin
 import no.nav.lumi.config.auth.parseCallerIdentity
 import no.nav.lumi.config.exception.ApiErrorException
+import no.nav.lumi.domain.SaveResult
 import no.nav.lumi.service.FeedbackService
 import no.nav.lumi.service.SubmissionService
 import no.nav.lumi.service.SurveyDefinitionService
 import org.slf4j.LoggerFactory
-import no.nav.lumi.domain.SaveResult
-import java.security.MessageDigest
 
 private val log = LoggerFactory.getLogger("InternalSubmissionRoutes")
 private val defaultInternalSubmissionObservability = SubmissionObservability()
 
-private const val SUBMISSION_KEY_HEADER = "X-Lumi-Submission-Key"
 private const val CALLER_IDENTITY_HEADER = "X-Lumi-Caller-Identity"
 
 /**
@@ -49,70 +52,79 @@ fun Route.internalSubmissionRoutes(
     log.info("Internal submission routes enabled (proxy forwarding)")
 
     route("/api/internal/v1") {
-        post("/feedback") {
-            submissionObservability.observeAttempt(SubmissionChannel.INTERNAL_PROXY) {
-                val providedKey = call.request.header(SUBMISSION_KEY_HEADER)
-                if (providedKey == null || !MessageDigest.isEqual(providedKey.toByteArray(), expectedKey.toByteArray())) {
-                    log.warn("Internal submission: invalid or missing $SUBMISSION_KEY_HEADER")
-                    throw ApiErrorException.UnauthorizedException("Invalid submission key")
-                }
+        install(InternalSubmissionAuthPlugin) {
+            this.expectedKey = expectedKey
+        }
+        withSubmissionRateLimitIfConfigured {
+            post("/feedback") {
+                submissionObservability.observeAttempt(SubmissionChannel.INTERNAL_PROXY) {
+                    val callerIdRaw = call.request.header(CALLER_IDENTITY_HEADER)
+                    if (callerIdRaw.isNullOrBlank()) {
+                        log.warn("Internal submission: missing $CALLER_IDENTITY_HEADER header")
+                        throw ApiErrorException.BadRequestException("Missing $CALLER_IDENTITY_HEADER header")
+                    }
 
-                val callerIdRaw = call.request.header(CALLER_IDENTITY_HEADER)
-                if (callerIdRaw.isNullOrBlank()) {
-                    log.warn("Internal submission: missing $CALLER_IDENTITY_HEADER header")
-                    throw ApiErrorException.BadRequestException("Missing $CALLER_IDENTITY_HEADER header")
-                }
+                    val identity = parseCallerIdentity(callerIdRaw)
+                        ?: throw ApiErrorException.BadRequestException("Invalid caller identity format: expected cluster:namespace:app")
 
-                val identity = parseCallerIdentity(callerIdRaw)
-                    ?: throw ApiErrorException.BadRequestException("Invalid caller identity format: expected cluster:namespace:app")
+                    call.attributes.put(CallerIdentityKey, identity)
 
-                call.attributes.put(CallerIdentityKey, identity)
+                    val body = receiveTextWithLimit(call)
 
-                val body = receiveTextWithLimit(call)
+                    val jsonElement = try {
+                        strictSubmissionJson.parseToJsonElement(body)
+                    } catch (e: Exception) {
+                        log.warn(
+                            "Internal submission: invalid JSON from ${identity.team}/${identity.app} parseErrorType=${e::class.simpleName}"
+                        )
+                        throw ApiErrorException.BadRequestException("Invalid JSON")
+                    }
 
-                val jsonElement = try {
-                    strictSubmissionJson.parseToJsonElement(body)
-                } catch (e: Exception) {
-                    log.warn(
-                        "Internal submission: invalid JSON from ${identity.team}/${identity.app} parseErrorType=${e::class.simpleName}"
+                    val parsedSubmission = decodeValidatedSubmission(jsonElement)
+                    val submission = parsedSubmission.submission
+                    val submissionOutcome = submissionService.submit(
+                        feedbackJson = body,
+                        team = identity.team,
+                        app = identity.app,
+                        submission = submission,
+                        definition = parsedSubmission.definition
                     )
-                    throw ApiErrorException.BadRequestException("Invalid JSON")
-                }
 
-                val parsedSubmission = decodeValidatedSubmission(jsonElement)
-                val submission = parsedSubmission.submission
-                val submissionOutcome = submissionService.submit(
-                    feedbackJson = body,
-                    team = identity.team,
-                    app = identity.app,
-                    submission = submission,
-                    definition = parsedSubmission.definition
-                )
-
-                val metricOutcome = when (val saveResult = submissionOutcome.saveResult) {
-                    is SaveResult.Created -> {
-                        log.info(
-                            "Internal submission: saved feedback id=${saveResult.id} team=${identity.team} app=${identity.app} surveyId=${submission.surveyId} definitionHash=${submissionOutcome.definitionHash}"
-                        )
-                        call.respond(HttpStatusCode.Created, mapOf("id" to saveResult.id))
-                        SubmissionMetricOutcome.CREATED
+                    val metricOutcome = when (val saveResult = submissionOutcome.saveResult) {
+                        is SaveResult.Created -> {
+                            log.info(
+                                "Internal submission: saved feedback id=${saveResult.id} team=${identity.team} app=${identity.app} surveyId=${submission.surveyId} definitionHash=${submissionOutcome.definitionHash}"
+                            )
+                            call.respond(HttpStatusCode.Created, mapOf("id" to saveResult.id))
+                            SubmissionMetricOutcome.CREATED
+                        }
+                        is SaveResult.Duplicate -> {
+                            log.info(
+                                "Internal submission: deduplicated feedback id=${saveResult.id} team=${identity.team} app=${identity.app} surveyId=${submission.surveyId}"
+                            )
+                            call.respond(
+                                HttpStatusCode.OK,
+                                buildJsonObject {
+                                    put("id", saveResult.id)
+                                    put("duplicate", true)
+                                }
+                            )
+                            SubmissionMetricOutcome.DUPLICATE
+                        }
                     }
-                    is SaveResult.Duplicate -> {
-                        log.info(
-                            "Internal submission: deduplicated feedback id=${saveResult.id} team=${identity.team} app=${identity.app} surveyId=${submission.surveyId}"
-                        )
-                        call.respond(
-                            HttpStatusCode.OK,
-                            buildJsonObject {
-                                put("id", saveResult.id)
-                                put("duplicate", true)
-                            }
-                        )
-                        SubmissionMetricOutcome.DUPLICATE
-                    }
+                    submissionObservability.record(SubmissionChannel.INTERNAL_PROXY, metricOutcome)
                 }
-                submissionObservability.record(SubmissionChannel.INTERNAL_PROXY, metricOutcome)
             }
+        }
+    }
+}
+
+private fun Route.withSubmissionRateLimitIfConfigured(build: Route.() -> Unit) {
+    if (application.pluginOrNull(RateLimit) == null) {
+        build()
+    } else {
+        rateLimit(SubmissionRateLimit) {
+            build()
         }
     }
 }

--- a/apps/lumi-api/src/test/kotlin/no/nav/lumi/config/GlobalRateLimitingTest.kt
+++ b/apps/lumi-api/src/test/kotlin/no/nav/lumi/config/GlobalRateLimitingTest.kt
@@ -3,12 +3,16 @@ package no.nav.lumi.config
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.shouldBe
 import io.ktor.client.request.get
+import io.ktor.client.request.post
 import io.ktor.http.HttpStatusCode
 import io.ktor.server.application.call
 import io.ktor.server.response.respond
 import io.ktor.server.routing.get
+import io.ktor.server.routing.post
 import io.ktor.server.routing.routing
 import io.ktor.server.testing.testApplication
+import io.micrometer.prometheusmetrics.PrometheusConfig
+import io.micrometer.prometheusmetrics.PrometheusMeterRegistry
 
 class GlobalRateLimitingTest : FunSpec({
     test("an exhausted global bucket never blocks internal health routes") {
@@ -96,6 +100,34 @@ class GlobalRateLimitingTest : FunSpec({
             client.get("/load") {
                 headers.append("X-Test-Source", "source-b")
             }.status shouldBe HttpStatusCode.OK
+        }
+    }
+
+    test("a pre-auth global rejection is not recorded as a submission") {
+        val meterRegistry = PrometheusMeterRegistry(PrometheusConfig.DEFAULT)
+        val submissionObservability = SubmissionObservability(meterRegistry)
+
+        testApplication {
+            application {
+                configureRateLimiting(
+                    submissionObservability = submissionObservability,
+                    globalRequestsPerMinute = 1,
+                )
+                routing {
+                    post("/api/tokenx/v1/feedback") {
+                        call.respond(HttpStatusCode.Unauthorized)
+                    }
+                }
+            }
+
+            client.post("/api/tokenx/v1/feedback").status shouldBe HttpStatusCode.Unauthorized
+            client.post("/api/tokenx/v1/feedback").status shouldBe HttpStatusCode.TooManyRequests
+
+            meterRegistry.get(SubmissionObservability.METRIC_NAME)
+                .tag("channel", "tokenx")
+                .tag("outcome", "rejected")
+                .counter()
+                .count() shouldBe 0.0
         }
     }
 

--- a/apps/lumi-api/src/test/kotlin/no/nav/lumi/config/RateLimitingKeyingTest.kt
+++ b/apps/lumi-api/src/test/kotlin/no/nav/lumi/config/RateLimitingKeyingTest.kt
@@ -10,6 +10,8 @@ import io.ktor.server.plugins.ratelimit.*
 import io.ktor.server.response.*
 import io.ktor.server.routing.*
 import io.ktor.server.testing.*
+import io.micrometer.prometheusmetrics.PrometheusConfig
+import io.micrometer.prometheusmetrics.PrometheusMeterRegistry
 import no.nav.lumi.config.auth.BrukerPrincipal
 import no.nav.lumi.config.auth.CallerIdentity
 import no.nav.lumi.config.auth.CallerIdentityKey
@@ -505,6 +507,45 @@ class RateLimitingKeyingTest : FunSpec({
                 header("X-Test-User-Hash", "user:team-esyfo:app-a:hash-user-new")
             }
             blockedResponse.status shouldBe HttpStatusCode.TooManyRequests
+        }
+    }
+
+    test("an authenticated app-level rejection is recorded once") {
+        val meterRegistry = PrometheusMeterRegistry(PrometheusConfig.DEFAULT)
+        val submissionObservability = SubmissionObservability(meterRegistry)
+
+        testApplication {
+            application {
+                configureRateLimiting(submissionObservability)
+                routing {
+                    route("/api/tokenx/v1") {
+                        install(HeaderCallerIdentityPlugin)
+                        rateLimit(SubmissionRateLimit) {
+                            rateLimit(UserSubmissionRateLimit) {
+                                post("/feedback") {
+                                    call.respond(HttpStatusCode.Created)
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+
+            repeat(100) {
+                client.post("/api/tokenx/v1/feedback") {
+                    header("X-Test-Caller", "team-esyfo:app-a")
+                }.status shouldBe HttpStatusCode.Created
+            }
+
+            client.post("/api/tokenx/v1/feedback") {
+                header("X-Test-Caller", "team-esyfo:app-a")
+            }.status shouldBe HttpStatusCode.TooManyRequests
+
+            meterRegistry.get(SubmissionObservability.METRIC_NAME)
+                .tag("channel", "tokenx")
+                .tag("outcome", "rejected")
+                .counter()
+                .count() shouldBe 1.0
         }
     }
 })

--- a/apps/lumi-api/src/test/kotlin/no/nav/lumi/routes/InternalSubmissionRoutesTest.kt
+++ b/apps/lumi-api/src/test/kotlin/no/nav/lumi/routes/InternalSubmissionRoutesTest.kt
@@ -25,6 +25,7 @@ import kotlinx.serialization.json.jsonPrimitive
 import no.nav.lumi.TestDatabase
 import no.nav.lumi.config.DatabaseHolder
 import no.nav.lumi.config.SubmissionObservability
+import no.nav.lumi.config.configureRateLimiting
 import no.nav.lumi.config.configureSerialization
 import no.nav.lumi.config.configureStatusPages
 import no.nav.lumi.domain.FeedbackQuery
@@ -227,6 +228,57 @@ class InternalSubmissionRoutesTest : FunSpec({
         }
     }
 
+    test("should rate limit only authenticated proxy submissions and record the rejection") {
+        val meterRegistry = PrometheusMeterRegistry(PrometheusConfig.DEFAULT)
+        val submissionObservability = SubmissionObservability(meterRegistry)
+        val submissionService = mockk<SubmissionService>()
+        coEvery {
+            submissionService.submit(any(), any(), any(), any(), any())
+        } returns SubmissionOutcome(SaveResult.Created("created-proxy"), "hash-proxy")
+
+        testApplication {
+            application {
+                configureSerialization()
+                configureStatusPages()
+                configureRateLimiting(submissionObservability)
+                routing {
+                    internalSubmissionRoutes(
+                        submissionService = submissionService,
+                        submissionKey = TEST_PSK,
+                        submissionObservability = submissionObservability,
+                    )
+                }
+            }
+
+            suspend fun submit(psk: String) = client.post("/api/internal/v1/feedback") {
+                contentType(ContentType.Application.Json)
+                header("X-Lumi-Submission-Key", psk)
+                header("X-Lumi-Caller-Identity", VALID_IDENTITY)
+                setBody(validPayload)
+            }
+
+            repeat(100) {
+                submit("wrong-key").status shouldBe HttpStatusCode.Unauthorized
+            }
+            meterRegistry.get(SubmissionObservability.METRIC_NAME)
+                .tag("channel", "internal_proxy")
+                .tag("outcome", "rejected")
+                .counter()
+                .count() shouldBe 0.0
+
+            repeat(100) {
+                submit(TEST_PSK).status shouldBe HttpStatusCode.Created
+            }
+            submit(TEST_PSK).status shouldBe HttpStatusCode.TooManyRequests
+
+            meterRegistry.get(SubmissionObservability.METRIC_NAME)
+                .tag("channel", "internal_proxy")
+                .tag("outcome", "rejected")
+                .counter()
+                .count() shouldBe 1.0
+        }
+    }
+
     test("should apply immutable definition validation on internal route") {
         testApplication {
             application {
@@ -304,6 +356,9 @@ class InternalSubmissionRoutesTest : FunSpec({
     }
 
     test("should return 401 when PSK is missing") {
+        val meterRegistry = PrometheusMeterRegistry(PrometheusConfig.DEFAULT)
+        val submissionObservability = SubmissionObservability(meterRegistry)
+
         testApplication {
             application {
                 configureSerialization()
@@ -311,7 +366,8 @@ class InternalSubmissionRoutesTest : FunSpec({
                 routing {
                     internalSubmissionRoutes(
                         feedbackService = FeedbackService(),
-                        submissionKey = TEST_PSK
+                        submissionKey = TEST_PSK,
+                        submissionObservability = submissionObservability,
                     )
                 }
             }
@@ -323,10 +379,18 @@ class InternalSubmissionRoutesTest : FunSpec({
             }
 
             response.status shouldBe HttpStatusCode.Unauthorized
+            meterRegistry.get(SubmissionObservability.METRIC_NAME)
+                .tag("channel", "internal_proxy")
+                .tag("outcome", "rejected")
+                .counter()
+                .count() shouldBe 0.0
         }
     }
 
     test("should return 401 when PSK is incorrect") {
+        val meterRegistry = PrometheusMeterRegistry(PrometheusConfig.DEFAULT)
+        val submissionObservability = SubmissionObservability(meterRegistry)
+
         testApplication {
             application {
                 configureSerialization()
@@ -334,7 +398,8 @@ class InternalSubmissionRoutesTest : FunSpec({
                 routing {
                     internalSubmissionRoutes(
                         feedbackService = FeedbackService(),
-                        submissionKey = TEST_PSK
+                        submissionKey = TEST_PSK,
+                        submissionObservability = submissionObservability,
                     )
                 }
             }
@@ -347,6 +412,11 @@ class InternalSubmissionRoutesTest : FunSpec({
             }
 
             response.status shouldBe HttpStatusCode.Unauthorized
+            meterRegistry.get(SubmissionObservability.METRIC_NAME)
+                .tag("channel", "internal_proxy")
+                .tag("outcome", "rejected")
+                .counter()
+                .count() shouldBe 0.0
         }
     }
 
@@ -398,6 +468,9 @@ class InternalSubmissionRoutesTest : FunSpec({
     }
 
     test("should return 400 for invalid JSON body") {
+        val meterRegistry = PrometheusMeterRegistry(PrometheusConfig.DEFAULT)
+        val submissionObservability = SubmissionObservability(meterRegistry)
+
         testApplication {
             application {
                 configureSerialization()
@@ -405,7 +478,8 @@ class InternalSubmissionRoutesTest : FunSpec({
                 routing {
                     internalSubmissionRoutes(
                         feedbackService = FeedbackService(),
-                        submissionKey = TEST_PSK
+                        submissionKey = TEST_PSK,
+                        submissionObservability = submissionObservability,
                     )
                 }
             }
@@ -418,6 +492,11 @@ class InternalSubmissionRoutesTest : FunSpec({
             }
 
             response.status shouldBe HttpStatusCode.BadRequest
+            meterRegistry.get(SubmissionObservability.METRIC_NAME)
+                .tag("channel", "internal_proxy")
+                .tag("outcome", "rejected")
+                .counter()
+                .count() shouldBe 1.0
         }
     }
 

--- a/apps/lumi-api/src/test/kotlin/no/nav/lumi/routes/SubmissionV2RoutesTest.kt
+++ b/apps/lumi-api/src/test/kotlin/no/nav/lumi/routes/SubmissionV2RoutesTest.kt
@@ -221,39 +221,44 @@ class SubmissionV2RoutesTest : FunSpec({
         }
     }
 
-    test("records a user rate-limited TokenX submission as rejected") {
-        val meterRegistry = PrometheusMeterRegistry(PrometheusConfig.DEFAULT)
-        val submissionObservability = SubmissionObservability(meterRegistry)
-        val submissionService = mockk<SubmissionService>()
-        coEvery {
-            submissionService.submit(any(), any(), any(), any(), any())
-        } returns SubmissionOutcome(SaveResult.Created("created-v2"), "hash-v2")
+    listOf(
+        Triple("TokenX", "/api/tokenx/v1/feedback", "tokenx"),
+        Triple("Azure", "/api/azure/v1/feedback", "azure"),
+    ).forEach { (issuer, path, channel) ->
+        test("records a user rate-limited $issuer submission as rejected") {
+            val meterRegistry = PrometheusMeterRegistry(PrometheusConfig.DEFAULT)
+            val submissionObservability = SubmissionObservability(meterRegistry)
+            val submissionService = mockk<SubmissionService>()
+            coEvery {
+                submissionService.submit(any(), any(), any(), any(), any())
+            } returns SubmissionOutcome(SaveResult.Created("created-v2"), "hash-v2")
 
-        testApplication {
-            application {
-                submissionRoutesTestModule(submissionService, submissionObservability)
-            }
-            val client = createTestClient()
+            testApplication {
+                application {
+                    submissionRoutesTestModule(submissionService, submissionObservability)
+                }
+                val client = createTestClient()
 
-            repeat(15) {
-                val response = client.post("/api/tokenx/v1/feedback") {
+                repeat(15) {
+                    val response = client.post(path) {
+                        contentType(ContentType.Application.Json)
+                        setBody(submissionPayloadV2())
+                    }
+                    response.status shouldBe HttpStatusCode.Created
+                }
+
+                val blockedResponse = client.post(path) {
                     contentType(ContentType.Application.Json)
                     setBody(submissionPayloadV2())
                 }
-                response.status shouldBe HttpStatusCode.Created
-            }
 
-            val blockedResponse = client.post("/api/tokenx/v1/feedback") {
-                contentType(ContentType.Application.Json)
-                setBody(submissionPayloadV2())
+                blockedResponse.status shouldBe HttpStatusCode.TooManyRequests
+                meterRegistry.get(SubmissionObservability.METRIC_NAME)
+                    .tag("channel", channel)
+                    .tag("outcome", "rejected")
+                    .counter()
+                    .count() shouldBe 1.0
             }
-
-            blockedResponse.status shouldBe HttpStatusCode.TooManyRequests
-            meterRegistry.get(SubmissionObservability.METRIC_NAME)
-                .tag("channel", "tokenx")
-                .tag("outcome", "rejected")
-                .counter()
-                .count() shouldBe 1.0
         }
     }
 


### PR DESCRIPTION
## Hva

- holder globale 429-svar før autentisering utenfor submission-health-metrikken
- teller TokenX/Azure-rate-limit bare med validert caller-identitet
- validerer intern PSK før den interne submission-grensen og bruker en avgrenset trusted-markør
- registrerer gyldig intern-proxy-429, men lar ugyldig PSK være perimetertrafikk
- dekker TokenX, Azure, appgrense, brukergrense og positive/negative intern-proxy-tilfeller

## Hvorfor

Submission-health-alarmen skal uttrykke utfallet av autentiserte innsendinger. Tidligere kunne perimetertrafikk og ugyldig intern PSK øke rejected og gi et misvisende utrullingssignal.

## Verifisering

- pnpm run lint
- pnpm run typecheck
- pnpm run api:test
- målrettede tester for GlobalRateLimitingTest, RateLimitingKeyingTest, InternalSubmissionRoutesTest og SubmissionV2RoutesTest