### PR TITLE
fix(dashboard): clarify survey deletion scope

### DIFF
--- a/apps/lumi-dashboard/app/components/dashboard/DeleteSurveyDialog.tsx
+++ b/apps/lumi-dashboard/app/components/dashboard/DeleteSurveyDialog.tsx
@@ -87,7 +87,7 @@ export function DeleteSurveyDialog({
             ) : isTotalCountError || totalCount === undefined ? (
               <>
                 Kunne ikke hente totalt antall svar. Last antallet på nytt før
-                surveyen kan slettes.
+                svar og dashboarddata kan slettes.
               </>
             ) : hasNoAnswers ? (
               <>
@@ -132,7 +132,8 @@ export function DeleteSurveyDialog({
 
           {deleteMutation.isError && (
             <Alert variant="error">
-              Kunne ikke slette survey. Prøv igjen senere.
+              Kunne ikke slette svar og fjerne surveyen fra dashboardet. Prøv
+              igjen senere.
             </Alert>
           )}
         </VStack>

--- a/apps/lumi-dashboard/app/components/dashboard/DeleteSurveyDialog.tsx
+++ b/apps/lumi-dashboard/app/components/dashboard/DeleteSurveyDialog.tsx
@@ -74,7 +74,7 @@ export function DeleteSurveyDialog({
       open={isOpen}
       onClose={handleClose}
       header={{
-        heading: "Slett hele surveyen",
+        heading: "Slett svar og fjern surveyen",
         icon: <TrashIcon aria-hidden />,
       }}
       width="small"
@@ -92,7 +92,7 @@ export function DeleteSurveyDialog({
             ) : hasNoAnswers ? (
               <>
                 Surveyen <strong>"{surveyId}"</strong> har ingen lagrede svar.
-                Du kan fortsatt slette surveyen permanent fra dashboardet.
+                Du kan fortsatt fjerne surveyen fra dashboardet.
               </>
             ) : (
               <>
@@ -113,8 +113,8 @@ export function DeleteSurveyDialog({
 
           <BodyLong>
             {hasNoAnswers
-              ? "Denne handlingen kan ikke angres. Surveyen og eventuelle markører vil bli permanent fjernet fra dashboardet."
-              : "Denne handlingen kan ikke angres. All data for denne surveyen vil bli permanent fjernet fra databasen."}
+              ? "Denne handlingen kan ikke angres. Eventuelle markører og dashboardmetadata for surveyen slettes permanent. Den registrerte surveydefinisjonen beholdes, og survey-ID-en kan ikke gjenbrukes med en annen struktur."
+              : "Denne handlingen kan ikke angres. Alle svar, eventuelle markører og dashboardmetadata for surveyen slettes permanent. Den registrerte surveydefinisjonen beholdes, og survey-ID-en kan ikke gjenbrukes med en annen struktur."}
           </BodyLong>
 
           <ConfirmationPanel
@@ -124,7 +124,7 @@ export function DeleteSurveyDialog({
               totalCountUnavailable
                 ? "Antall svar må lastes før sletting"
                 : hasNoAnswers
-                  ? "Ja, slett surveyen permanent"
+                  ? "Ja, fjern surveyen fra dashboardet"
                   : `Ja, slett permanent alle ${totalCount} svar`
             }
             disabled={totalCountUnavailable}
@@ -152,7 +152,7 @@ export function DeleteSurveyDialog({
             {totalCountUnavailable
               ? "Slett svar permanent"
               : hasNoAnswers
-                ? "Slett survey permanent"
+                ? "Fjern fra dashboardet"
                 : `Slett ${totalCount} svar permanent`}
           </Button>
         </HStack>

--- a/apps/lumi-dashboard/app/components/dashboard/DeleteSurveyDialog.tsx
+++ b/apps/lumi-dashboard/app/components/dashboard/DeleteSurveyDialog.tsx
@@ -113,8 +113,8 @@ export function DeleteSurveyDialog({
 
           <BodyLong>
             {hasNoAnswers
-              ? "Denne handlingen kan ikke angres. Eventuelle markører og dashboardmetadata for surveyen slettes permanent. Den registrerte surveydefinisjonen beholdes, og survey-ID-en kan ikke gjenbrukes med en annen struktur."
-              : "Denne handlingen kan ikke angres. Alle svar, eventuelle markører og dashboardmetadata for surveyen slettes permanent. Den registrerte surveydefinisjonen beholdes, og survey-ID-en kan ikke gjenbrukes med en annen struktur."}
+              ? "Denne handlingen kan ikke angres. Eventuelle markører og dashboardmetadata for surveyen slettes permanent. Den registrerte surveydefinisjonen beholdes. Survey-ID-en forblir knyttet til definisjonen, og en inkompatibel struktur krever en ny survey-ID. Sletting stopper ikke nye innsendinger. Fjern widgeten fra frontend-koden for å stoppe datainnsamlingen."
+              : "Denne handlingen kan ikke angres. Alle svar, eventuelle markører og dashboardmetadata for surveyen slettes permanent. Den registrerte surveydefinisjonen beholdes. Survey-ID-en forblir knyttet til definisjonen, og en inkompatibel struktur krever en ny survey-ID. Sletting stopper ikke nye innsendinger. Fjern widgeten fra frontend-koden for å stoppe datainnsamlingen."}
           </BodyLong>
 
           <ConfirmationPanel

--- a/apps/lumi-dashboard/app/components/dashboard/__tests__/DeleteSurveyDialog.test.tsx
+++ b/apps/lumi-dashboard/app/components/dashboard/__tests__/DeleteSurveyDialog.test.tsx
@@ -50,7 +50,7 @@ describe("DeleteSurveyDialog", () => {
     expect(mockMutateAsync).not.toHaveBeenCalled();
   });
 
-  it("describes permanent survey deletion without referring to zero answers", () => {
+  it("explains what is retained when an empty survey is removed", () => {
     mockUseSurveyTotalCount.mockReturnValue({
       data: 0,
       isLoading: false,
@@ -67,16 +67,67 @@ describe("DeleteSurveyDialog", () => {
       />,
     );
 
+    expect(
+      screen.getByRole("heading", {
+        name: "Slett svar og fjern surveyen",
+      }),
+    ).toBeVisible();
     expect(screen.getByText(/surveyen har ingen lagrede svar/i)).toBeVisible();
     expect(
+      screen.getByText(/den registrerte surveydefinisjonen beholdes/i),
+    ).toBeVisible();
+    expect(
+      screen.getByText(
+        /survey-ID-en kan ikke gjenbrukes med en annen struktur/i,
+      ),
+    ).toBeVisible();
+    expect(
       screen.getByRole("checkbox", {
-        name: /ja, slett surveyen permanent/i,
+        name: /ja, fjern surveyen fra dashboardet/i,
       }),
     ).toBeEnabled();
     expect(
-      screen.getByRole("button", { name: /slett survey permanent/i }),
+      screen.getByRole("button", { name: /fjern fra dashboardet/i }),
     ).toBeDisabled();
     expect(screen.queryByText(/slette alle 0 svar/i)).not.toBeInTheDocument();
+    expect(
+      screen.queryByText(/all data for denne surveyen/i),
+    ).not.toBeInTheDocument();
+  });
+
+  it("distinguishes deleted survey data from the retained definition", () => {
+    mockUseSurveyTotalCount.mockReturnValue({
+      data: 5,
+      isLoading: false,
+      isFetching: false,
+      isError: false,
+    });
+
+    render(
+      <DeleteSurveyDialog
+        surveyId="survey-with-responses"
+        filteredCount={5}
+        isOpen
+        onClose={vi.fn()}
+      />,
+    );
+
+    expect(
+      screen.getByText(
+        /alle svar, eventuelle markører og dashboardmetadata for surveyen slettes permanent/i,
+      ),
+    ).toBeVisible();
+    expect(
+      screen.getByText(/den registrerte surveydefinisjonen beholdes/i),
+    ).toBeVisible();
+    expect(
+      screen.getByText(
+        /survey-ID-en kan ikke gjenbrukes med en annen struktur/i,
+      ),
+    ).toBeVisible();
+    expect(
+      screen.queryByText(/all data for denne surveyen/i),
+    ).not.toBeInTheDocument();
   });
 
   it("blocks deletion while a cached total count is being refreshed", () => {

--- a/apps/lumi-dashboard/app/components/dashboard/__tests__/DeleteSurveyDialog.test.tsx
+++ b/apps/lumi-dashboard/app/components/dashboard/__tests__/DeleteSurveyDialog.test.tsx
@@ -77,9 +77,16 @@ describe("DeleteSurveyDialog", () => {
       screen.getByText(/den registrerte surveydefinisjonen beholdes/i),
     ).toBeVisible();
     expect(
-      screen.getByText(
-        /survey-ID-en kan ikke gjenbrukes med en annen struktur/i,
-      ),
+      screen.getByText(/survey-ID-en forblir knyttet til definisjonen/i),
+    ).toBeVisible();
+    expect(
+      screen.getByText(/en inkompatibel struktur krever en ny survey-ID/i),
+    ).toBeVisible();
+    expect(
+      screen.getByText(/sletting stopper ikke nye innsendinger/i),
+    ).toBeVisible();
+    expect(
+      screen.getByText(/fjern widgeten fra frontend-koden/i),
     ).toBeVisible();
     expect(
       screen.getByRole("checkbox", {
@@ -121,9 +128,16 @@ describe("DeleteSurveyDialog", () => {
       screen.getByText(/den registrerte surveydefinisjonen beholdes/i),
     ).toBeVisible();
     expect(
-      screen.getByText(
-        /survey-ID-en kan ikke gjenbrukes med en annen struktur/i,
-      ),
+      screen.getByText(/survey-ID-en forblir knyttet til definisjonen/i),
+    ).toBeVisible();
+    expect(
+      screen.getByText(/en inkompatibel struktur krever en ny survey-ID/i),
+    ).toBeVisible();
+    expect(
+      screen.getByText(/sletting stopper ikke nye innsendinger/i),
+    ).toBeVisible();
+    expect(
+      screen.getByText(/fjern widgeten fra frontend-koden/i),
     ).toBeVisible();
     expect(
       screen.queryByText(/all data for denne surveyen/i),

--- a/apps/lumi-dashboard/app/components/dashboard/__tests__/DeleteSurveyDialog.test.tsx
+++ b/apps/lumi-dashboard/app/components/dashboard/__tests__/DeleteSurveyDialog.test.tsx
@@ -2,17 +2,15 @@ import { fireEvent, render, screen } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { DeleteSurveyDialog } from "../DeleteSurveyDialog";
 
-const { mockMutateAsync, mockUseSurveyTotalCount } = vi.hoisted(() => ({
-  mockMutateAsync: vi.fn(),
-  mockUseSurveyTotalCount: vi.fn(),
-}));
+const { mockMutateAsync, mockUseDeleteSurvey, mockUseSurveyTotalCount } =
+  vi.hoisted(() => ({
+    mockMutateAsync: vi.fn(),
+    mockUseDeleteSurvey: vi.fn(),
+    mockUseSurveyTotalCount: vi.fn(),
+  }));
 
 vi.mock("~/hooks/useDeleteSurvey", () => ({
-  useDeleteSurvey: () => ({
-    mutateAsync: mockMutateAsync,
-    isError: false,
-    isPending: false,
-  }),
+  useDeleteSurvey: mockUseDeleteSurvey,
 }));
 
 vi.mock("~/hooks/useSurveyTotalCount", () => ({
@@ -22,6 +20,11 @@ vi.mock("~/hooks/useSurveyTotalCount", () => ({
 describe("DeleteSurveyDialog", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    mockUseDeleteSurvey.mockReturnValue({
+      mutateAsync: mockMutateAsync,
+      isError: false,
+      isPending: false,
+    });
     mockUseSurveyTotalCount.mockReturnValue({
       data: undefined,
       isLoading: false,
@@ -41,13 +44,47 @@ describe("DeleteSurveyDialog", () => {
     );
 
     expect(
-      screen.getByText(/Kunne ikke hente totalt antall svar/i),
+      screen.getByText(
+        /Kunne ikke hente totalt antall svar.*før svar og dashboarddata kan slettes/i,
+      ),
     ).toBeInTheDocument();
     expect(screen.getByRole("checkbox")).toBeDisabled();
     expect(
       screen.getByRole("button", { name: /Slett svar permanent/i }),
     ).toBeDisabled();
     expect(mockMutateAsync).not.toHaveBeenCalled();
+  });
+
+  it("describes a failed deletion without claiming the definition was deleted", () => {
+    mockUseDeleteSurvey.mockReturnValue({
+      mutateAsync: mockMutateAsync,
+      isError: true,
+      isPending: false,
+    });
+    mockUseSurveyTotalCount.mockReturnValue({
+      data: 5,
+      isLoading: false,
+      isFetching: false,
+      isError: false,
+    });
+
+    render(
+      <DeleteSurveyDialog
+        surveyId="survey-failed"
+        filteredCount={5}
+        isOpen
+        onClose={vi.fn()}
+      />,
+    );
+
+    expect(
+      screen.getByText(
+        /Kunne ikke slette svar og fjerne surveyen fra dashboardet/i,
+      ),
+    ).toBeVisible();
+    expect(
+      screen.queryByText(/Kunne ikke slette survey/i),
+    ).not.toBeInTheDocument();
   });
 
   it("explains what is retained when an empty survey is removed", () => {

--- a/apps/lumi-dashboard/app/components/feedback/FeedbackTable/__tests__/FeedbackTable.emptyState.test.tsx
+++ b/apps/lumi-dashboard/app/components/feedback/FeedbackTable/__tests__/FeedbackTable.emptyState.test.tsx
@@ -331,4 +331,17 @@ describe("FeedbackTable empty states", () => {
       screen.getByText("Ingen tilbakemeldinger funnet"),
     ).toBeInTheDocument();
   });
+
+  it("describes the selected-survey delete action without implying submissions stop", () => {
+    mockBootstrap.data = bootstrapWithData();
+    mockParams.surveyId = "survey-1";
+
+    render(<FeedbackTable />);
+
+    expect(
+      screen.getByRole("button", {
+        name: /slett alle svar og fjern surveyen fra dashboardet.*nye innsendinger stoppes ikke/i,
+      }),
+    ).toBeVisible();
+  });
 });

--- a/apps/lumi-dashboard/app/components/feedback/FeedbackTable/index.tsx
+++ b/apps/lumi-dashboard/app/components/feedback/FeedbackTable/index.tsx
@@ -341,7 +341,7 @@ function SurveyToolbar({
               </Button>
             </Tooltip>
           )}
-          <Tooltip content="Slett alle svar og fjern surveyen fra dashboardet">
+          <Tooltip content="Slett alle svar og fjern surveyen fra dashboardet — nye innsendinger stoppes ikke">
             <Button
               data-color="danger"
               variant="primary"

--- a/apps/lumi-dashboard/app/components/feedback/FeedbackTable/index.tsx
+++ b/apps/lumi-dashboard/app/components/feedback/FeedbackTable/index.tsx
@@ -341,7 +341,7 @@ function SurveyToolbar({
               </Button>
             </Tooltip>
           )}
-          <Tooltip content="Slett hele surveyen (alle svar, uavhengig av filtrering)">
+          <Tooltip content="Slett alle svar og fjern surveyen fra dashboardet">
             <Button
               data-color="danger"
               variant="primary"


### PR DESCRIPTION
## Hva

- omtaler handlingen som sletting av svar og fjerning fra dashboardet, ikke sletting av hele surveyen
- beskriver eksakt at svar, markører og dashboardmetadata slettes mens den registrerte definisjonen beholdes
- forklarer at survey-ID-en forblir knyttet til definisjonen, og at inkompatibel struktur krever ny ID
- advarer om at sletting ikke stopper aktive klienter fra å sende inn nye svar
- bruker samme presise omfang i normaltilstand og feilmeldinger
- dekker tom survey, survey med lagrede svar, feilmeldinger og slettingshandlingen i verktøylinjen

## Avgrensning

Dette endrer kun brukerorientert tekst og tester. Backendens sletteoperasjon, regler for definisjonskompatibilitet og kvotesemantikk er uendret.

Refs #483. PR-en løser copy-delen av issue-et, ikke det separate kvotespørsmålet.

## Verifisering

- `pnpm --filter lumi-dashboard exec vitest run app/components/dashboard/__tests__/DeleteSurveyDialog.test.tsx app/components/feedback/FeedbackTable/__tests__/FeedbackTable.emptyState.test.tsx` — 17 tester
- `pnpm run lint`
- `pnpm run typecheck`
- `pnpm run test` — 2 lumi-types-tester, 481 widgettester og 654 dashboardtester
