### PR TITLE
fix(dashboard): debounce feedback search

### DIFF
--- a/apps/lumi-dashboard/app/components/feedback/FeedbackTable/__tests__/FeedbackTable.emptyState.test.tsx
+++ b/apps/lumi-dashboard/app/components/feedback/FeedbackTable/__tests__/FeedbackTable.emptyState.test.tsx
@@ -201,14 +201,16 @@ describe("FeedbackTable empty states", () => {
   it("offers a reset action when active filters exclude everything", () => {
     mockBootstrap.data = bootstrapWithData();
     mockParams.query = "finnesikke";
+    const onResetFilters = vi.fn();
 
-    render(<FeedbackTable />);
+    render(<FeedbackTable onResetFilters={onResetFilters} />);
 
     expect(
       screen.getByText("Ingen treff med gjeldende filtre"),
     ).toBeInTheDocument();
 
     fireEvent.click(screen.getByRole("button", { name: /nullstill filtre/i }));
+    expect(onResetFilters).toHaveBeenCalledOnce();
     expect(mockResetParams).toHaveBeenCalled();
   });
 

--- a/apps/lumi-dashboard/app/components/feedback/FeedbackTable/index.tsx
+++ b/apps/lumi-dashboard/app/components/feedback/FeedbackTable/index.tsx
@@ -47,7 +47,11 @@ import styles from "./styles.module.css";
  * Shows table on desktop, card grid on mobile.
  * Supports expand/collapse for detailed view, deletion, and filtering.
  */
-export function FeedbackTable() {
+interface FeedbackTableProps {
+  onResetFilters?: () => void;
+}
+
+export function FeedbackTable({ onResetFilters }: FeedbackTableProps = {}) {
   const feedbackQuery = useFeedback();
 
   return (
@@ -55,15 +59,20 @@ export function FeedbackTable() {
       title="Kunne ikke hente tilbakemeldinger"
       queries={[feedbackQuery]}
     >
-      <FeedbackTableContent feedbackQuery={feedbackQuery} />
+      <FeedbackTableContent
+        feedbackQuery={feedbackQuery}
+        onResetFilters={onResetFilters}
+      />
     </DataFetchBoundary>
   );
 }
 
 function FeedbackTableContent({
   feedbackQuery,
+  onResetFilters,
 }: {
   feedbackQuery: ReturnType<typeof useFeedback>;
+  onResetFilters?: () => void;
 }) {
   const { params, setParam, setParams } = useSearchParams();
   const page = Number.parseInt(params.page || "1", 10);
@@ -85,6 +94,10 @@ function FeedbackTableContent({
     feedbackList.length === 0 &&
     totalElements > 0 &&
     page > totalPages;
+  const handleResetFilters = () => {
+    onResetFilters?.();
+    resetFilters();
+  };
 
   useEffect(() => {
     if (hasOutOfRangePage) {
@@ -141,7 +154,7 @@ function FeedbackTableContent({
         <FeedbackEmptyState
           hasAnyData={bootstrap ? bootstrap.apps.length > 0 : undefined}
           hasActiveNonPeriodFilters={hasActiveNonPeriodFilters}
-          onResetFilters={resetFilters}
+          onResetFilters={handleResetFilters}
           periodFromDate={params.fromDate}
           periodToDate={params.toDate}
           fullPeriod={getTeamSubmissionPeriod(bootstrap?.surveyMeta, {

--- a/apps/lumi-dashboard/app/components/shared/FilterBar/__tests__/FilterBar.archive.test.tsx
+++ b/apps/lumi-dashboard/app/components/shared/FilterBar/__tests__/FilterBar.archive.test.tsx
@@ -1,7 +1,14 @@
-import { fireEvent, render, screen, waitFor } from "@testing-library/react";
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  act,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { resolveDashboardPeriod } from "~/utils/dashboardPeriod";
 import { FilterBar } from "../index";
+import { SEARCH_QUERY_DEBOUNCE_MS } from "../useDebouncedSearchQuery";
 
 const { mockParams, mockSetParams, mockResetParams, mockBootstrap, mockStats } =
   vi.hoisted(() => ({
@@ -549,5 +556,340 @@ describe("FilterBar archive state", () => {
         page: "1",
       }),
     );
+  });
+});
+
+describe("FilterBar search", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    mockParams.app = undefined;
+    mockParams.surveyId = undefined;
+    mockParams.showArchived = undefined;
+    mockParams.dateMode = "auto";
+    mockParams.fromDate = "2026-07-23";
+    mockParams.toDate = "2026-08-21";
+    mockParams.query = undefined;
+    mockBootstrap.data = loadedBootstrapData();
+    mockBootstrap.isPending = false;
+    mockBootstrap.isError = false;
+    mockBootstrap.isFetching = false;
+    mockStats.data = undefined;
+    mockStats.isPending = false;
+    mockStats.isError = false;
+    mockStats.isFetching = false;
+    mockSetParams.mockClear();
+    mockResetParams.mockClear();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("updates the field immediately and commits only the final query", () => {
+    render(<FilterBar showDetails />);
+    const searchFields = screen.getAllByRole("textbox", { name: "Søk" });
+
+    fireEvent.change(searchFields[0], { target: { value: "s" } });
+    fireEvent.change(searchFields[0], { target: { value: "sø" } });
+    fireEvent.change(searchFields[0], { target: { value: "søk" } });
+
+    expect(searchFields[0]).toHaveValue("søk");
+    expect(searchFields[1]).toHaveValue("søk");
+    expect(mockSetParams).not.toHaveBeenCalled();
+
+    act(() => {
+      vi.advanceTimersByTime(SEARCH_QUERY_DEBOUNCE_MS - 1);
+    });
+    expect(mockSetParams).not.toHaveBeenCalled();
+
+    act(() => {
+      vi.advanceTimersByTime(1);
+    });
+    expect(mockSetParams).toHaveBeenCalledOnce();
+    expect(mockSetParams).toHaveBeenCalledWith({
+      query: "søk",
+      phrase: undefined,
+      page: "1",
+    });
+  });
+
+  it("removes an empty query after the debounce period", () => {
+    mockParams.query = "gammelt søk";
+    render(<FilterBar showDetails />);
+
+    fireEvent.change(screen.getAllByRole("textbox", { name: "Søk" })[0], {
+      target: { value: "" },
+    });
+
+    act(() => {
+      vi.advanceTimersByTime(SEARCH_QUERY_DEBOUNCE_MS);
+    });
+    expect(mockSetParams).toHaveBeenCalledWith({
+      query: undefined,
+      phrase: undefined,
+      page: "1",
+    });
+  });
+
+  it("uses a newer URL query and cancels the pending draft", () => {
+    mockParams.query = "første";
+    const { rerender } = render(<FilterBar showDetails />);
+
+    fireEvent.change(screen.getAllByRole("textbox", { name: "Søk" })[0], {
+      target: { value: "ventende" },
+    });
+    mockParams.query = "fra-url";
+    rerender(<FilterBar showDetails />);
+
+    for (const field of screen.getAllByRole("textbox", { name: "Søk" })) {
+      expect(field).toHaveValue("fra-url");
+    }
+
+    act(() => {
+      vi.advanceTimersByTime(SEARCH_QUERY_DEBOUNCE_MS);
+    });
+    expect(mockSetParams).not.toHaveBeenCalled();
+  });
+
+  it("keeps newer typing when the router acknowledges an earlier query", () => {
+    const { rerender } = render(<FilterBar showDetails />);
+    const searchField = screen.getAllByRole("textbox", { name: "Søk" })[0];
+
+    fireEvent.change(searchField, { target: { value: "første" } });
+    act(() => {
+      vi.advanceTimersByTime(SEARCH_QUERY_DEBOUNCE_MS);
+    });
+    expect(mockSetParams).toHaveBeenCalledTimes(1);
+
+    fireEvent.change(searchField, { target: { value: "nyere" } });
+    mockParams.query = "første";
+    rerender(<FilterBar showDetails />);
+
+    for (const field of screen.getAllByRole("textbox", { name: "Søk" })) {
+      expect(field).toHaveValue("nyere");
+    }
+
+    act(() => {
+      vi.advanceTimersByTime(SEARCH_QUERY_DEBOUNCE_MS);
+    });
+    expect(mockSetParams).toHaveBeenLastCalledWith({
+      query: "nyere",
+      phrase: undefined,
+      page: "1",
+    });
+    expect(mockSetParams).toHaveBeenCalledTimes(2);
+  });
+
+  it("commits a revert after an earlier query is acknowledged", () => {
+    const { rerender } = render(<FilterBar showDetails />);
+    const searchField = screen.getAllByRole("textbox", { name: "Søk" })[0];
+
+    fireEvent.change(searchField, { target: { value: "første" } });
+    act(() => {
+      vi.advanceTimersByTime(SEARCH_QUERY_DEBOUNCE_MS);
+    });
+    expect(mockSetParams).toHaveBeenCalledTimes(1);
+
+    fireEvent.change(searchField, { target: { value: "" } });
+    act(() => {
+      vi.advanceTimersByTime(SEARCH_QUERY_DEBOUNCE_MS);
+    });
+    expect(mockSetParams).toHaveBeenCalledTimes(1);
+
+    mockParams.query = "første";
+    rerender(<FilterBar showDetails />);
+
+    expect(mockSetParams).toHaveBeenLastCalledWith({
+      query: undefined,
+      phrase: undefined,
+      page: "1",
+    });
+    expect(mockSetParams).toHaveBeenCalledTimes(2);
+  });
+
+  it("keeps a pending query across an ordinary URL filter change", () => {
+    const { rerender } = render(<FilterBar showDetails />);
+
+    fireEvent.change(screen.getAllByRole("textbox", { name: "Søk" })[0], {
+      target: { value: "ventende" },
+    });
+    mockParams.app = "app-test";
+    rerender(<FilterBar showDetails />);
+
+    for (const field of screen.getAllByRole("textbox", { name: "Søk" })) {
+      expect(field).toHaveValue("ventende");
+    }
+
+    act(() => {
+      vi.advanceTimersByTime(SEARCH_QUERY_DEBOUNCE_MS);
+    });
+    expect(mockSetParams).toHaveBeenCalledWith({
+      query: "ventende",
+      phrase: undefined,
+      page: "1",
+    });
+  });
+
+  it("cancels a pending query when filters are reset outside FilterBar", () => {
+    mockParams.app = "app-test";
+    const { rerender } = render(
+      <FilterBar showDetails filterResetVersion={0} />,
+    );
+
+    fireEvent.change(screen.getAllByRole("textbox", { name: "Søk" })[0], {
+      target: { value: "ventende" },
+    });
+
+    // The feedback empty state owns a separate reset action. Model its URL
+    // update without calling FilterBar's local reset handler.
+    mockParams.app = undefined;
+    rerender(<FilterBar showDetails filterResetVersion={1} />);
+
+    for (const field of screen.getAllByRole("textbox", { name: "Søk" })) {
+      expect(field).toHaveValue("");
+    }
+
+    act(() => {
+      vi.advanceTimersByTime(SEARCH_QUERY_DEBOUNCE_MS);
+    });
+    expect(mockSetParams).not.toHaveBeenCalled();
+  });
+
+  it("reasserts an external reset after an in-flight query is acknowledged", () => {
+    const { rerender } = render(
+      <FilterBar showDetails filterResetVersion={0} />,
+    );
+
+    fireEvent.change(screen.getAllByRole("textbox", { name: "Søk" })[0], {
+      target: { value: "på vei" },
+    });
+    act(() => {
+      vi.advanceTimersByTime(SEARCH_QUERY_DEBOUNCE_MS);
+    });
+    expect(mockSetParams).toHaveBeenCalledTimes(1);
+
+    rerender(<FilterBar showDetails filterResetVersion={1} />);
+    mockParams.query = "på vei";
+    rerender(<FilterBar showDetails filterResetVersion={1} />);
+
+    expect(mockSetParams).toHaveBeenLastCalledWith({
+      query: undefined,
+      phrase: undefined,
+      page: "1",
+    });
+    expect(mockSetParams).toHaveBeenCalledTimes(2);
+  });
+
+  it("allows a new query when reset cancels an in-flight navigation", () => {
+    const { rerender } = render(
+      <FilterBar showDetails filterResetVersion={0} />,
+    );
+
+    fireEvent.change(screen.getAllByRole("textbox", { name: "Søk" })[0], {
+      target: { value: "kansellert" },
+    });
+    act(() => {
+      vi.advanceTimersByTime(SEARCH_QUERY_DEBOUNCE_MS);
+    });
+    expect(mockSetParams).toHaveBeenCalledTimes(1);
+
+    rerender(<FilterBar showDetails filterResetVersion={1} />);
+    fireEvent.change(screen.getAllByRole("textbox", { name: "Søk" })[0], {
+      target: { value: "nytt søk" },
+    });
+    act(() => {
+      vi.advanceTimersByTime(SEARCH_QUERY_DEBOUNCE_MS);
+    });
+
+    expect(mockSetParams).toHaveBeenLastCalledWith({
+      query: "nytt søk",
+      phrase: undefined,
+      page: "1",
+    });
+    expect(mockSetParams).toHaveBeenCalledTimes(2);
+  });
+
+  it("ignores a discarded acknowledgement while a newer query is in flight", () => {
+    const { rerender } = render(
+      <FilterBar showDetails filterResetVersion={0} />,
+    );
+    const searchField = screen.getAllByRole("textbox", { name: "Søk" })[0];
+
+    fireEvent.change(searchField, { target: { value: "kansellert" } });
+    act(() => {
+      vi.advanceTimersByTime(SEARCH_QUERY_DEBOUNCE_MS);
+    });
+    rerender(<FilterBar showDetails filterResetVersion={1} />);
+
+    fireEvent.change(searchField, { target: { value: "nyeste" } });
+    act(() => {
+      vi.advanceTimersByTime(SEARCH_QUERY_DEBOUNCE_MS);
+    });
+    expect(mockSetParams).toHaveBeenCalledTimes(2);
+
+    mockParams.query = "kansellert";
+    rerender(<FilterBar showDetails filterResetVersion={1} />);
+    for (const field of screen.getAllByRole("textbox", { name: "Søk" })) {
+      expect(field).toHaveValue("nyeste");
+    }
+
+    mockParams.query = "nyeste";
+    rerender(<FilterBar showDetails filterResetVersion={1} />);
+    expect(mockSetParams).toHaveBeenCalledTimes(2);
+  });
+
+  it("treats the same query as external after a canceled navigation settles", async () => {
+    let settleNavigation: (() => void) | undefined;
+    mockSetParams.mockReturnValueOnce(
+      new Promise<void>((resolve) => {
+        settleNavigation = resolve;
+      }),
+    );
+    const { rerender } = render(
+      <FilterBar showDetails filterResetVersion={0} />,
+    );
+
+    fireEvent.change(screen.getAllByRole("textbox", { name: "Søk" })[0], {
+      target: { value: "kansellert" },
+    });
+    act(() => {
+      vi.advanceTimersByTime(SEARCH_QUERY_DEBOUNCE_MS);
+    });
+    rerender(<FilterBar showDetails filterResetVersion={1} />);
+
+    await act(async () => {
+      settleNavigation?.();
+    });
+    mockParams.query = "kansellert";
+    rerender(<FilterBar showDetails filterResetVersion={1} />);
+
+    for (const field of screen.getAllByRole("textbox", { name: "Søk" })) {
+      expect(field).toHaveValue("kansellert");
+    }
+    expect(mockSetParams).toHaveBeenCalledOnce();
+  });
+
+  it("cancels a pending query when all filters are reset", () => {
+    mockParams.app = "app-test";
+    render(<FilterBar showDetails />);
+
+    fireEvent.change(screen.getAllByRole("textbox", { name: "Søk" })[0], {
+      target: { value: "ventende" },
+    });
+    fireEvent.click(
+      screen.getAllByRole("button", {
+        name: "Nullstill alle filtre til standard (siste 30 dager)",
+      })[0],
+    );
+
+    for (const field of screen.getAllByRole("textbox", { name: "Søk" })) {
+      expect(field).toHaveValue("");
+    }
+    expect(mockResetParams).toHaveBeenCalledOnce();
+
+    act(() => {
+      vi.advanceTimersByTime(SEARCH_QUERY_DEBOUNCE_MS);
+    });
+    expect(mockSetParams).not.toHaveBeenCalled();
   });
 });

--- a/apps/lumi-dashboard/app/components/shared/FilterBar/index.tsx
+++ b/apps/lumi-dashboard/app/components/shared/FilterBar/index.tsx
@@ -14,7 +14,7 @@ import {
   VStack,
 } from "@navikt/ds-react";
 import dayjs from "dayjs";
-import { useEffect } from "react";
+import { useCallback, useEffect } from "react";
 import { PeriodSelector } from "~/components/dashboard/PeriodSelector";
 import { DataFetchBoundary } from "~/components/shared/DataFetchBoundary";
 import { RefreshSurveyOverview } from "~/components/shared/RefreshSurveyOverview";
@@ -36,12 +36,17 @@ import {
 import styles from "./FilterBar.module.css";
 import { FilterMenu } from "./FilterMenu";
 import { Skeleton as FilterBarSkeleton } from "./Skeleton";
+import { useDebouncedSearchQuery } from "./useDebouncedSearchQuery";
 
 interface FilterBarProps {
   showDetails?: boolean;
+  filterResetVersion?: number;
 }
 
-export function FilterBar({ showDetails = false }: FilterBarProps) {
+export function FilterBar({
+  showDetails = false,
+  filterResetVersion = 0,
+}: FilterBarProps) {
   const bootstrapQuery = useFilterBootstrap();
   const statsQuery = useStats();
 
@@ -58,6 +63,7 @@ export function FilterBar({ showDetails = false }: FilterBarProps) {
       >
         <FilterBarContent
           showDetails={showDetails}
+          filterResetVersion={filterResetVersion}
           bootstrapQuery={bootstrapQuery}
           statsQuery={statsQuery}
         />
@@ -68,6 +74,7 @@ export function FilterBar({ showDetails = false }: FilterBarProps) {
 
 function FilterBarContent({
   showDetails,
+  filterResetVersion,
   bootstrapQuery,
   statsQuery,
 }: Required<FilterBarProps> & {
@@ -78,6 +85,21 @@ function FilterBarContent({
   const { data: bootstrap, isPending: isPendingBootstrap } = bootstrapQuery;
   const { data: stats, isPending: isPendingStats } = statsQuery;
   const { themes } = useThemes();
+  const commitSearchQuery = useCallback(
+    (query: string) =>
+      setParams({
+        query: query || undefined,
+        phrase: undefined,
+        page: "1",
+      }),
+    [setParams],
+  );
+  const { queryDraft, updateQueryDraft, clearQueryDraft } =
+    useDebouncedSearchQuery({
+      query: params.query,
+      resetVersion: filterResetVersion,
+      onCommit: commitSearchQuery,
+    });
 
   const features = getSurveyFeatures(stats?.surveyType);
   const { themeLabel } = getFilterLabels({
@@ -91,7 +113,12 @@ function FilterBarContent({
     toDate: params.toDate,
   });
   const rollingAutomaticPeriod = resolveDashboardPeriod({ dateMode: "auto" });
-  const { hasActiveFilters, resetFilters: handleReset } = useActiveFilters();
+  const { hasActiveFilters, resetFilters } = useActiveFilters();
+
+  const handleReset = () => {
+    clearQueryDraft();
+    resetFilters();
+  };
 
   const selectedTags = params.tag
     ? params.tag
@@ -347,6 +374,7 @@ function FilterBarContent({
   ]);
 
   const handleTeamChange = (newTeam: string) => {
+    clearQueryDraft();
     setParams({
       team: newTeam,
       fromDate: params.fromDate,
@@ -454,14 +482,8 @@ function FilterBarContent({
                   label="Søk"
                   hideLabel
                   size="small"
-                  value={params.query || ""}
-                  onChange={(e) =>
-                    setParams({
-                      query: e.target.value || undefined,
-                      phrase: undefined,
-                      page: "1",
-                    })
-                  }
+                  value={queryDraft}
+                  onChange={(e) => updateQueryDraft(e.target.value)}
                   placeholder="Søk i tekst..."
                   className={styles.desktopSearch}
                 />
@@ -587,14 +609,8 @@ function FilterBarContent({
                 label="Søk"
                 hideLabel
                 size="small"
-                value={params.query || ""}
-                onChange={(e) =>
-                  setParams({
-                    query: e.target.value || undefined,
-                    phrase: undefined,
-                    page: "1",
-                  })
-                }
+                value={queryDraft}
+                onChange={(e) => updateQueryDraft(e.target.value)}
                 placeholder="Søk i tekst..."
                 className={styles.mobileSearch}
               />

--- a/apps/lumi-dashboard/app/components/shared/FilterBar/useDebouncedSearchQuery.ts
+++ b/apps/lumi-dashboard/app/components/shared/FilterBar/useDebouncedSearchQuery.ts
@@ -1,0 +1,154 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+
+export const SEARCH_QUERY_DEBOUNCE_MS = 400;
+
+interface UseDebouncedSearchQueryOptions {
+  query?: string;
+  resetVersion?: number;
+  onCommit: (query: string) => void | Promise<void>;
+}
+
+export function useDebouncedSearchQuery({
+  query,
+  resetVersion = 0,
+  onCommit,
+}: UseDebouncedSearchQueryOptions) {
+  const committedQuery = query ?? "";
+  const committedQueryRef = useRef(committedQuery);
+  const queryDraftRef = useRef(committedQuery);
+  const inFlightQueryRef = useRef<{ query: string } | undefined>(undefined);
+  const discardedQueryRef = useRef<{ query: string } | undefined>(undefined);
+  const resetVersionRef = useRef(resetVersion);
+  const timeoutRef = useRef<ReturnType<typeof setTimeout> | undefined>(
+    undefined,
+  );
+  const [queryDraft, setQueryDraft] = useState(committedQuery);
+
+  const cancelPendingQuery = useCallback(() => {
+    if (timeoutRef.current !== undefined) {
+      clearTimeout(timeoutRef.current);
+      timeoutRef.current = undefined;
+    }
+  }, []);
+
+  const startQueryCommit = useCallback(
+    (nextQuery: string) => {
+      const request = { query: nextQuery };
+      inFlightQueryRef.current = request;
+      const navigation = onCommit(nextQuery);
+
+      if (navigation) {
+        const clearDiscardedRequest = () => {
+          if (discardedQueryRef.current === request) {
+            discardedQueryRef.current = undefined;
+          }
+        };
+        void navigation.then(clearDiscardedRequest, clearDiscardedRequest);
+      }
+    },
+    [onCommit],
+  );
+
+  useEffect(() => {
+    const queryChanged = committedQueryRef.current !== committedQuery;
+    if (!queryChanged) {
+      return;
+    }
+
+    const isOwnCommit = inFlightQueryRef.current?.query === committedQuery;
+    const isDiscardedCommit =
+      !isOwnCommit && discardedQueryRef.current?.query === committedQuery;
+    committedQueryRef.current = committedQuery;
+
+    if (isDiscardedCommit) {
+      discardedQueryRef.current = undefined;
+      if (
+        queryDraftRef.current !== committedQuery &&
+        inFlightQueryRef.current === undefined &&
+        timeoutRef.current === undefined
+      ) {
+        const latestQuery = queryDraftRef.current;
+        startQueryCommit(latestQuery);
+      }
+      return;
+    }
+
+    discardedQueryRef.current = undefined;
+
+    if (!isOwnCommit) {
+      inFlightQueryRef.current = undefined;
+      cancelPendingQuery();
+      queryDraftRef.current = committedQuery;
+      setQueryDraft(committedQuery);
+      return;
+    }
+
+    inFlightQueryRef.current = undefined;
+    if (queryDraftRef.current === committedQuery) {
+      cancelPendingQuery();
+      return;
+    }
+
+    // A newer draft can outlive the request it was typed after. If its timer
+    // already elapsed while navigation was in flight, commit it now that the
+    // router has acknowledged the previous value.
+    if (timeoutRef.current === undefined) {
+      const latestQuery = queryDraftRef.current;
+      startQueryCommit(latestQuery);
+    }
+  }, [cancelPendingQuery, committedQuery, startQueryCommit]);
+
+  useEffect(() => cancelPendingQuery, [cancelPendingQuery]);
+
+  useEffect(() => {
+    if (resetVersionRef.current === resetVersion) {
+      return;
+    }
+
+    resetVersionRef.current = resetVersion;
+    cancelPendingQuery();
+    discardedQueryRef.current = inFlightQueryRef.current;
+    inFlightQueryRef.current = undefined;
+    queryDraftRef.current = "";
+    setQueryDraft("");
+  }, [cancelPendingQuery, resetVersion]);
+
+  const updateQueryDraft = useCallback(
+    (nextQuery: string) => {
+      queryDraftRef.current = nextQuery;
+      setQueryDraft(nextQuery);
+      cancelPendingQuery();
+
+      const effectiveQuery =
+        inFlightQueryRef.current?.query ?? committedQueryRef.current;
+      if (nextQuery === effectiveQuery) {
+        return;
+      }
+
+      timeoutRef.current = setTimeout(() => {
+        timeoutRef.current = undefined;
+        if (
+          inFlightQueryRef.current === undefined &&
+          nextQuery !== committedQueryRef.current
+        ) {
+          startQueryCommit(nextQuery);
+        }
+      }, SEARCH_QUERY_DEBOUNCE_MS);
+    },
+    [cancelPendingQuery, startQueryCommit],
+  );
+
+  const clearQueryDraft = useCallback(() => {
+    cancelPendingQuery();
+    discardedQueryRef.current = inFlightQueryRef.current;
+    inFlightQueryRef.current = undefined;
+    queryDraftRef.current = "";
+    setQueryDraft("");
+  }, [cancelPendingQuery]);
+
+  return {
+    queryDraft,
+    updateQueryDraft,
+    clearQueryDraft,
+  };
+}

--- a/apps/lumi-dashboard/app/hooks/useSearchParams.ts
+++ b/apps/lumi-dashboard/app/hooks/useSearchParams.ts
@@ -29,7 +29,7 @@ export function useSearchParams() {
 
   const setParams = useCallback(
     (newParams: Partial<SearchParams>) => {
-      void navigate({
+      return navigate({
         // @ts-expect-error -- shared hook used across routes; strict typing not feasible
         search: (prev: Record<string, string | undefined>) => {
           const next = { ...prev };

--- a/apps/lumi-dashboard/app/routes/feedback.tsx
+++ b/apps/lumi-dashboard/app/routes/feedback.tsx
@@ -1,6 +1,7 @@
 import { Box, Heading, VStack } from "@navikt/ds-react";
 import { createFileRoute, redirect } from "@tanstack/react-router";
 import { zodValidator } from "@tanstack/zod-adapter";
+import { useState } from "react";
 import { FeedbackTable } from "~/components/feedback/FeedbackTable";
 import { ActiveFiltersChips } from "~/components/shared/ActiveFiltersChips";
 import { FilterBar } from "~/components/shared/FilterBar";
@@ -27,6 +28,8 @@ export const Route = createFileRoute("/feedback")({
 });
 
 function FeedbackPage() {
+  const [filterResetVersion, setFilterResetVersion] = useState(0);
+
   return (
     <>
       <Header />
@@ -41,9 +44,13 @@ function FeedbackPage() {
           <Heading size="large" level="1">
             Tilbakemeldinger
           </Heading>
-          <FilterBar showDetails />
+          <FilterBar showDetails filterResetVersion={filterResetVersion} />
           <ActiveFiltersChips />
-          <FeedbackTable />
+          <FeedbackTable
+            onResetFilters={() =>
+              setFilterResetVersion((version) => version + 1)
+            }
+          />
         </VStack>
       </Box>
     </>


### PR DESCRIPTION
## Oppsummering

- holder søkefeltet responsivt med en lokal kladd
- oppdaterer URL og henter data én gang etter 400 ms uten nye tastetrykk
- bevarer side-nullstilling og phrase-prioritet ved commit
- synkroniserer back/forward og eksterne URL-endringer uten å overskrive nyere typing
- avbryter ventende søk ved nullstilling og teambytte

## Verifisering

- pnpm run lint
- pnpm run typecheck
- pnpm run test
- fokusert FilterBar-suite: 25 tester grønt

Refs #497. Issuet holdes åpent for representativ måling og en separat indeksbeslutning.