### PR TITLE
Dokumenter faktisk cachetid for teamtilgang

### DIFF
--- a/docs/dashboard/tilgang.md
+++ b/docs/dashboard/tilgang.md
@@ -23,7 +23,9 @@ Innlogging skjer automatisk via Microsoft Entra ID (Azure AD) første gang du å
 Dashboardet viser kun data fra teamene dine. Hvilke team du tilhører hentes automatisk fra NAIS Console.
 
 ::: tip Mangler du tilgang?
-Sjekk at du er lagt til som medlem i riktig NAIS-team via [NAIS Console](https://console.nav.cloud.nais.io). Teammedlemskap caches i opptil 1 time, så det kan ta litt tid før endringer trer i kraft.
+Sjekk at du er lagt til som medlem i riktig NAIS-team via [NAIS Console](https://console.nav.cloud.nais.io).
+
+Lumi cacher teamoppslag som gir minst ett team i opptil 12 timer. Nye eller fjernede teamtilganger for en bruker som allerede har tilgang til andre team, kan derfor bruke opptil 12 timer på å tre i kraft. Oppslag som ikke gir noen team, caches i 5 minutter. Fjerning fra et team kan gi fortsatt tilgang til teamets data frem til den positive cachen utløper, så lenge brukeren fortsatt kan logge inn.
 :::
 
 ## Se også


### PR DESCRIPTION
## Hva

- dokumenterer at positive teamoppslag caches i opptil 12 timer
- dokumenterer at oppslag uten team caches i 5 minutter
- presiserer at fjernet teamtilgang kan bestå til den positive cachen utløper når brukeren fortsatt kan logge inn

Ingen TTL-, autorisasjons- eller cacheimplementasjon endres.

## Validering

- `pnpm run docs:build`
- `pnpm run lint`
- `pnpm run typecheck`
- `git diff --check`

Relatert til #480. Issue-et beholdes åpent for et eksplisitt valg av revokerings-SLO og eventuell senere TTL-/invalideringsendring.