### PR TITLE
Automatisk retention for surveysvar

### DIFF
--- a/apps/lumi-api/docs/runbooks/automatic-retention.md
+++ b/apps/lumi-api/docs/runbooks/automatic-retention.md
@@ -1,18 +1,69 @@
 # Automatic retention
 
 Lumi deletes stored survey responses when their server-side creation timestamp is
-older than 12 months. When `LUMI_RETENTION_ENABLED=true`, every API instance starts
-the daily cleanup loop, while a PostgreSQL advisory lock ensures that only one
-instance performs cleanup at a time. The setting is fail-closed: a missing or false
-value disables deletion.
+older than 12 months. When `LUMI_RETENTION_ENABLED=true`, every API instance polls
+hourly. A PostgreSQL advisory lock and the persisted
+`feedback_retention_job_state` row allow only one global cleanup every 24 hours,
+including across pod restarts and replica changes. The setting is fail-closed: a
+missing or false value disables deletion.
 
-Each run deletes at most 500 of the oldest eligible responses. Later daily runs
-continue with the remaining rows. This limit bounds the impact of one run and must
-not be increased without checking production volume and query performance first.
+Each global run deletes at most 500 of the oldest eligible responses. Later runs
+continue with the remaining rows. The deletion and the persisted completion time
+commit in the same database transaction. This bounds deletion to 500 rows in any
+rolling 24-hour period and must not be increased without checking production volume
+and query performance first.
 
 Production is initially deployed with cleanup disabled. Enable it in a separate,
 controlled manifest change after verifying the migration, metrics, eligible-row
 count, query plan, and database recovery readiness.
+
+## Production activation
+
+Before opening the activation PR:
+
+1. Let development complete at least one global run and confirm that
+   `lumi_retention_runs_total{outcome="failed"}` does not increase.
+2. Confirm that Flyway migrations V16–V18 succeeded and inspect
+   `feedback_retention_job_state`.
+3. Count eligible rows with the same UTC calendar cutoff as the application:
+
+   ```sql
+   SELECT COUNT(*)
+   FROM feedback
+   WHERE opprettet < (
+       (now() AT TIME ZONE 'UTC' - INTERVAL '12 months') AT TIME ZONE 'UTC'
+   );
+   ```
+
+4. Run `EXPLAIN (ANALYZE, BUFFERS)` on the bounded `SELECT` from the cleanup CTE,
+   never on the `DELETE`, and confirm use of `idx_feedback_opprettet`.
+5. Verify a tested recovery path. Prefer point-in-time recovery for a destructive
+   workload. If only scheduled backups are available, explicitly accept the recovery
+   window after testing clone/restore.
+6. Change only the production `LUMI_RETENTION_ENABLED` value in a separately
+   reviewed PR. Development must already have been observed before that PR merges,
+   because the current workflow deploys production automatically after development.
+
+After deployment:
+
+1. Confirm `min(lumi_retention_enabled{app="lumi-api"}) == 1`, so every live pod has
+   the intended configuration.
+2. Confirm one executed run and no failed runs.
+3. Confirm the increase in `lumi_retention_deleted_feedback_total` is at most 500
+   over 24 hours, and compare it with the eligible-row count.
+4. Confirm that dashboard counts and filters are refreshed for affected teams.
+
+## Emergency stop
+
+Set production `LUMI_RETENTION_ENABLED` back to `false` by reverting the activation
+commit or merging an emergency manifest PR. The switch is deploy-based: a deletion
+transaction already in progress may commit up to its 500-row limit before the old pod
+terminates.
+
+After the rollout, confirm
+`max(lumi_retention_enabled{app="lumi-api"}) == 0` across all live pods. Record the
+increase in the deletion counter, recount eligible rows, and use the verified recovery
+procedure if rows outside the approved retention set were removed.
 
 ## Alerts
 

--- a/apps/lumi-api/docs/runbooks/automatic-retention.md
+++ b/apps/lumi-api/docs/runbooks/automatic-retention.md
@@ -1,0 +1,27 @@
+# Automatic retention
+
+Lumi deletes stored survey responses when their server-side creation timestamp is
+older than 12 months. Every API instance starts the daily cleanup loop, while a
+PostgreSQL advisory lock ensures that only one instance performs cleanup at a time.
+
+## Alerts
+
+`LumiRetentionCleanupFailure` means a cleanup attempt failed. Inspect the
+`lumi-api` logs for `Automatic retention failed`, confirm database availability,
+and verify that the next run completes.
+
+`LumiRetentionCleanupStale` means no instance has reported a successful cleanup
+for more than 36 hours. Check whether the application has restarted repeatedly,
+whether Prometheus is scraping `/internal/prometheus`, and whether one instance
+can acquire a database connection and the retention lock.
+
+## Metrics
+
+- `lumi_retention_runs_total{outcome}` counts executed, skipped, and failed runs.
+- `lumi_retention_deleted_feedback_total` counts deleted response rows.
+- `lumi_retention_last_success_timestamp_seconds` records the latest successful
+  run. The stale alert evaluates 36 hours of gauge history so pod restarts do
+  not erase the signal, and separately detects a missing metric series.
+
+A skipped run is expected on instances that do not acquire the lock. It is not an
+error as long as another instance reports an executed run.

--- a/apps/lumi-api/docs/runbooks/automatic-retention.md
+++ b/apps/lumi-api/docs/runbooks/automatic-retention.md
@@ -87,5 +87,7 @@ and whether one instance can acquire a database connection and the retention loc
   `0` when it is disabled. The stale alert is inactive while all instances are
   disabled.
 
-A skipped run is expected on instances that do not acquire the lock. It is not an
-error as long as another instance reports an executed run.
+A skipped poll is expected when the global 24-hour interval has not elapsed or
+another instance holds the lock. The metric combines both reasons; application logs
+distinguish them. Skips are not errors as long as a global executed run is reported
+within the stale-alert window.

--- a/apps/lumi-api/docs/runbooks/automatic-retention.md
+++ b/apps/lumi-api/docs/runbooks/automatic-retention.md
@@ -1,8 +1,18 @@
 # Automatic retention
 
 Lumi deletes stored survey responses when their server-side creation timestamp is
-older than 12 months. Every API instance starts the daily cleanup loop, while a
-PostgreSQL advisory lock ensures that only one instance performs cleanup at a time.
+older than 12 months. When `LUMI_RETENTION_ENABLED=true`, every API instance starts
+the daily cleanup loop, while a PostgreSQL advisory lock ensures that only one
+instance performs cleanup at a time. The setting is fail-closed: a missing or false
+value disables deletion.
+
+Each run deletes at most 500 of the oldest eligible responses. Later daily runs
+continue with the remaining rows. This limit bounds the impact of one run and must
+not be increased without checking production volume and query performance first.
+
+Production is initially deployed with cleanup disabled. Enable it in a separate,
+controlled manifest change after verifying the migration, metrics, eligible-row
+count, query plan, and database recovery readiness.
 
 ## Alerts
 
@@ -11,9 +21,9 @@ PostgreSQL advisory lock ensures that only one instance performs cleanup at a ti
 and verify that the next run completes.
 
 `LumiRetentionCleanupStale` means no instance has reported a successful cleanup
-for more than 36 hours. Check whether the application has restarted repeatedly,
-whether Prometheus is scraping `/internal/prometheus`, and whether one instance
-can acquire a database connection and the retention lock.
+for more than 36 hours while retention is enabled. Check whether the application
+has restarted repeatedly, whether Prometheus is scraping `/internal/prometheus`,
+and whether one instance can acquire a database connection and the retention lock.
 
 ## Metrics
 
@@ -22,6 +32,9 @@ can acquire a database connection and the retention lock.
 - `lumi_retention_last_success_timestamp_seconds` records the latest successful
   run. The stale alert evaluates 36 hours of gauge history so pod restarts do
   not erase the signal, and separately detects a missing metric series.
+- `lumi_retention_enabled` is `1` when deletion is enabled for an instance and
+  `0` when it is disabled. The stale alert is inactive while all instances are
+  disabled.
 
 A skipped run is expected on instances that do not acquire the lock. It is not an
 error as long as another instance reports an executed run.

--- a/apps/lumi-api/nais/alerts/prod.yaml
+++ b/apps/lumi-api/nais/alerts/prod.yaml
@@ -58,12 +58,16 @@ spec:
             severity: warning
             namespace: team-esyfo
         - alert: LumiRetentionCleanupStale
-          expr: (time() - max(max_over_time(lumi_retention_last_success_timestamp_seconds{app="lumi-api"}[36h])) > 129600) or on() absent_over_time(lumi_retention_last_success_timestamp_seconds{app="lumi-api"}[15m])
+          expr: >-
+            max(lumi_retention_enabled{app="lumi-api"}) == 1
+            and on()
+            ((time() - max(max_over_time(lumi_retention_last_success_timestamp_seconds{app="lumi-api"}[36h])) > 129600)
+            or on() absent_over_time(lumi_retention_last_success_timestamp_seconds{app="lumi-api"}[15m]))
           for: 15m
           annotations:
             summary: "Automatisk sletting av gamle Lumi-svar har ikke fullført"
             consequence: "Ingen API-instans har rapportert en vellykket opprydding de siste 36 timene."
-            action: "Kontroller scheduler, database og Prometheus-scraping, og kjør runbooken."
+            action: "Kontroller konfigurasjon, scheduler, database og Prometheus-scraping, og kjør runbooken."
             runbook_url: "https://github.com/navikt/lumi/blob/main/apps/lumi-api/docs/runbooks/automatic-retention.md"
           labels:
             severity: warning

--- a/apps/lumi-api/nais/alerts/prod.yaml
+++ b/apps/lumi-api/nais/alerts/prod.yaml
@@ -45,3 +45,26 @@ spec:
           labels:
             severity: warning
             namespace: team-esyfo
+    - name: lumi-api-retention
+      rules:
+        - alert: LumiRetentionCleanupFailure
+          expr: sum(increase(lumi_retention_runs_total{app="lumi-api",outcome="failed"}[15m])) > 0
+          annotations:
+            summary: "Automatisk sletting av gamle Lumi-svar feiler"
+            consequence: "Survey-svar som har passert lagringstiden kan bli liggende lenger enn 12 måneder."
+            action: "Undersøk feilen og kontroller at neste opprydding fullføres."
+            runbook_url: "https://github.com/navikt/lumi/blob/main/apps/lumi-api/docs/runbooks/automatic-retention.md"
+          labels:
+            severity: warning
+            namespace: team-esyfo
+        - alert: LumiRetentionCleanupStale
+          expr: (time() - max(max_over_time(lumi_retention_last_success_timestamp_seconds{app="lumi-api"}[36h])) > 129600) or on() absent_over_time(lumi_retention_last_success_timestamp_seconds{app="lumi-api"}[15m])
+          for: 15m
+          annotations:
+            summary: "Automatisk sletting av gamle Lumi-svar har ikke fullført"
+            consequence: "Ingen API-instans har rapportert en vellykket opprydding de siste 36 timene."
+            action: "Kontroller scheduler, database og Prometheus-scraping, og kjør runbooken."
+            runbook_url: "https://github.com/navikt/lumi/blob/main/apps/lumi-api/docs/runbooks/automatic-retention.md"
+          labels:
+            severity: warning
+            namespace: team-esyfo

--- a/apps/lumi-api/nais/app/dev.yaml
+++ b/apps/lumi-api/nais/app/dev.yaml
@@ -83,3 +83,5 @@ spec:
       value: https://lumi-dashboard.ansatt.dev.nav.no
     - name: LUMI_GLOBAL_REQUESTS_PER_SOURCE_PER_MINUTE
       value: "10000"
+    - name: LUMI_RETENTION_ENABLED
+      value: "true"

--- a/apps/lumi-api/nais/app/prod.yaml
+++ b/apps/lumi-api/nais/app/prod.yaml
@@ -86,3 +86,6 @@ spec:
       value: https://lumi-dashboard.ansatt.nav.no
     - name: LUMI_GLOBAL_REQUESTS_PER_SOURCE_PER_MINUTE
       value: "10000"
+    # Enable in a separate, controlled rollout after migration and metrics verification.
+    - name: LUMI_RETENTION_ENABLED
+      value: "false"

--- a/apps/lumi-api/src/main/kotlin/no/nav/lumi/Application.kt
+++ b/apps/lumi-api/src/main/kotlin/no/nav/lumi/Application.kt
@@ -8,6 +8,7 @@ import no.nav.lumi.config.configureDatabase
 import no.nav.lumi.config.configureSecurityHeaders
 import no.nav.lumi.config.configureMetrics
 import no.nav.lumi.config.configureRateLimiting
+import no.nav.lumi.config.configureRetentionCleanup
 import no.nav.lumi.config.configureRouting
 import no.nav.lumi.config.configureSerialization
 import no.nav.lumi.config.configureStatusPages
@@ -31,5 +32,6 @@ fun Application.module() {
     configureAuth()
     configureDatabase()
     configureMetrics()
+    configureRetentionCleanup()
     configureRouting()
 }

--- a/apps/lumi-api/src/main/kotlin/no/nav/lumi/config/RetentionCleanup.kt
+++ b/apps/lumi-api/src/main/kotlin/no/nav/lumi/config/RetentionCleanup.kt
@@ -16,7 +16,7 @@ fun Application.configureRetentionCleanup(
     config: RetentionEnv = ServerEnv.current.retention,
     observability: RetentionObservability = RetentionObservability(enabled = config.enabled),
     service: FeedbackRetentionService = FeedbackRetentionService(observability = observability),
-    interval: Duration = Duration.ofDays(1),
+    pollInterval: Duration = Duration.ofHours(1),
 ) {
     if (!ServerEnv.current.nais.isNais) {
         retentionLog.info("Automatic retention scheduler is disabled outside NAIS")
@@ -32,7 +32,7 @@ fun Application.configureRetentionCleanup(
             runCatching {
                 withContext(Dispatchers.IO) { service.runOnce() }
             }
-            delay(interval.toMillis())
+            delay(pollInterval.toMillis())
         }
     }
 }

--- a/apps/lumi-api/src/main/kotlin/no/nav/lumi/config/RetentionCleanup.kt
+++ b/apps/lumi-api/src/main/kotlin/no/nav/lumi/config/RetentionCleanup.kt
@@ -13,11 +13,17 @@ import java.time.Duration
 private val retentionLog = LoggerFactory.getLogger("RetentionCleanup")
 
 fun Application.configureRetentionCleanup(
-    service: FeedbackRetentionService = FeedbackRetentionService(),
+    config: RetentionEnv = ServerEnv.current.retention,
+    observability: RetentionObservability = RetentionObservability(enabled = config.enabled),
+    service: FeedbackRetentionService = FeedbackRetentionService(observability = observability),
     interval: Duration = Duration.ofDays(1),
 ) {
     if (!ServerEnv.current.nais.isNais) {
         retentionLog.info("Automatic retention scheduler is disabled outside NAIS")
+        return
+    }
+    if (!config.enabled) {
+        retentionLog.info("Automatic retention scheduler is disabled by configuration")
         return
     }
 

--- a/apps/lumi-api/src/main/kotlin/no/nav/lumi/config/RetentionCleanup.kt
+++ b/apps/lumi-api/src/main/kotlin/no/nav/lumi/config/RetentionCleanup.kt
@@ -1,0 +1,32 @@
+package no.nav.lumi.config
+
+import io.ktor.server.application.Application
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.isActive
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
+import no.nav.lumi.service.FeedbackRetentionService
+import org.slf4j.LoggerFactory
+import java.time.Duration
+
+private val retentionLog = LoggerFactory.getLogger("RetentionCleanup")
+
+fun Application.configureRetentionCleanup(
+    service: FeedbackRetentionService = FeedbackRetentionService(),
+    interval: Duration = Duration.ofDays(1),
+) {
+    if (!ServerEnv.current.nais.isNais) {
+        retentionLog.info("Automatic retention scheduler is disabled outside NAIS")
+        return
+    }
+
+    launch {
+        while (isActive) {
+            runCatching {
+                withContext(Dispatchers.IO) { service.runOnce() }
+            }
+            delay(interval.toMillis())
+        }
+    }
+}

--- a/apps/lumi-api/src/main/kotlin/no/nav/lumi/config/RetentionEnv.kt
+++ b/apps/lumi-api/src/main/kotlin/no/nav/lumi/config/RetentionEnv.kt
@@ -1,0 +1,21 @@
+package no.nav.lumi.config
+
+data class RetentionEnv(
+    val enabled: Boolean,
+) {
+    companion object {
+        private const val ENABLED_ENV = "LUMI_RETENTION_ENABLED"
+
+        fun fromEnvironment(
+            configuredValue: String? = System.getenv(ENABLED_ENV),
+        ): RetentionEnv = RetentionEnv(
+            enabled = when (configuredValue?.lowercase()) {
+                null, "false" -> false
+                "true" -> true
+                else -> throw IllegalStateException("$ENABLED_ENV must be 'true' or 'false'")
+            },
+        )
+
+        fun disabled(): RetentionEnv = RetentionEnv(enabled = false)
+    }
+}

--- a/apps/lumi-api/src/main/kotlin/no/nav/lumi/config/RetentionObservability.kt
+++ b/apps/lumi-api/src/main/kotlin/no/nav/lumi/config/RetentionObservability.kt
@@ -1,0 +1,59 @@
+package no.nav.lumi.config
+
+import io.micrometer.core.instrument.Counter
+import io.micrometer.core.instrument.Gauge
+import io.micrometer.core.instrument.MeterRegistry
+import java.time.Instant
+import java.util.concurrent.atomic.AtomicLong
+
+enum class RetentionRunOutcome(val metricValue: String) {
+    EXECUTED("executed"),
+    SKIPPED("skipped"),
+    FAILED("failed"),
+}
+
+class RetentionObservability(
+    meterRegistry: MeterRegistry = appMicrometerRegistry,
+) {
+    private val runCounters = RetentionRunOutcome.entries.associateWith { outcome ->
+        Counter.builder(RUNS_METRIC_NAME)
+            .description("Number of automatic retention runs by outcome")
+            .tag("outcome", outcome.metricValue)
+            .register(meterRegistry)
+    }
+    private val deletedFeedbackCounter = Counter.builder(DELETED_FEEDBACK_METRIC_NAME)
+        .description("Number of feedback rows deleted by automatic retention")
+        .register(meterRegistry)
+    private val lastSuccessTimestamp = AtomicLong(0)
+
+    init {
+        Gauge.builder(LAST_SUCCESS_METRIC_NAME, lastSuccessTimestamp) { value -> value.get().toDouble() }
+            .description("Unix timestamp of the last successful automatic retention run")
+            .baseUnit("seconds")
+            .register(meterRegistry)
+    }
+
+    fun recordExecuted(completedAt: Instant) {
+        runCounters.getValue(RetentionRunOutcome.EXECUTED).increment()
+        lastSuccessTimestamp.set(completedAt.epochSecond)
+    }
+
+    fun recordDeletedFeedback(deletedFeedback: Int) {
+        require(deletedFeedback >= 0) { "deletedFeedback cannot be negative" }
+        deletedFeedbackCounter.increment(deletedFeedback.toDouble())
+    }
+
+    fun recordSkipped() {
+        runCounters.getValue(RetentionRunOutcome.SKIPPED).increment()
+    }
+
+    fun recordFailed() {
+        runCounters.getValue(RetentionRunOutcome.FAILED).increment()
+    }
+
+    companion object {
+        const val RUNS_METRIC_NAME = "lumi_retention_runs_total"
+        const val DELETED_FEEDBACK_METRIC_NAME = "lumi_retention_deleted_feedback_total"
+        const val LAST_SUCCESS_METRIC_NAME = "lumi_retention_last_success_timestamp_seconds"
+    }
+}

--- a/apps/lumi-api/src/main/kotlin/no/nav/lumi/config/RetentionObservability.kt
+++ b/apps/lumi-api/src/main/kotlin/no/nav/lumi/config/RetentionObservability.kt
@@ -14,6 +14,7 @@ enum class RetentionRunOutcome(val metricValue: String) {
 
 class RetentionObservability(
     meterRegistry: MeterRegistry = appMicrometerRegistry,
+    enabled: Boolean = true,
 ) {
     private val runCounters = RetentionRunOutcome.entries.associateWith { outcome ->
         Counter.builder(RUNS_METRIC_NAME)
@@ -25,11 +26,15 @@ class RetentionObservability(
         .description("Number of feedback rows deleted by automatic retention")
         .register(meterRegistry)
     private val lastSuccessTimestamp = AtomicLong(0)
+    private val enabledState = AtomicLong(if (enabled) 1 else 0)
 
     init {
         Gauge.builder(LAST_SUCCESS_METRIC_NAME, lastSuccessTimestamp) { value -> value.get().toDouble() }
             .description("Unix timestamp of the last successful automatic retention run")
             .baseUnit("seconds")
+            .register(meterRegistry)
+        Gauge.builder(ENABLED_METRIC_NAME, enabledState) { value -> value.get().toDouble() }
+            .description("Whether automatic retention is enabled for this application instance")
             .register(meterRegistry)
     }
 
@@ -55,5 +60,6 @@ class RetentionObservability(
         const val RUNS_METRIC_NAME = "lumi_retention_runs_total"
         const val DELETED_FEEDBACK_METRIC_NAME = "lumi_retention_deleted_feedback_total"
         const val LAST_SUCCESS_METRIC_NAME = "lumi_retention_last_success_timestamp_seconds"
+        const val ENABLED_METRIC_NAME = "lumi_retention_enabled"
     }
 }

--- a/apps/lumi-api/src/main/kotlin/no/nav/lumi/config/ServerEnv.kt
+++ b/apps/lumi-api/src/main/kotlin/no/nav/lumi/config/ServerEnv.kt
@@ -17,6 +17,7 @@ data class ServerEnv(
     val valkey: ValkeyEnv,
     val naisApi: NaisApiEnv,
     val rateLimit: RateLimitEnv,
+    val retention: RetentionEnv,
 ) {
     /**
      * Database connection configuration.
@@ -222,6 +223,7 @@ data class ServerEnv(
                 valkey = ValkeyEnv.fromEnvironment(),
                 naisApi = NaisApiEnv.fromEnvironment(),
                 rateLimit = RateLimitEnv.fromEnvironment(),
+                retention = RetentionEnv.fromEnvironment(),
             )
         }
         
@@ -238,6 +240,7 @@ data class ServerEnv(
                 valkey = ValkeyEnv.forLocal(),
                 naisApi = NaisApiEnv.forLocal(),
                 rateLimit = RateLimitEnv.fromEnvironment(),
+                retention = RetentionEnv.disabled(),
             )
         }
         
@@ -263,6 +266,7 @@ data class ServerEnv(
                 valkey = ValkeyEnv.forLocal(),
                 naisApi = NaisApiEnv(graphqlUrl = null, tokenPath = null, staticKey = null),
                 rateLimit = RateLimitEnv.default(),
+                retention = RetentionEnv.disabled(),
             )
         }
     }

--- a/apps/lumi-api/src/main/kotlin/no/nav/lumi/repository/FeedbackRepository.kt
+++ b/apps/lumi-api/src/main/kotlin/no/nav/lumi/repository/FeedbackRepository.kt
@@ -70,6 +70,8 @@ class FeedbackRepository(
         }
     }
 
+    suspend fun <T> withTransaction(block: suspend () -> T): T = dbQuery { block() }
+
     suspend fun save(
         feedbackJson: String,
         team: String,

--- a/apps/lumi-api/src/main/kotlin/no/nav/lumi/repository/FeedbackRetentionRepository.kt
+++ b/apps/lumi-api/src/main/kotlin/no/nav/lumi/repository/FeedbackRetentionRepository.kt
@@ -25,7 +25,9 @@ class FeedbackRetentionRepository(
         batchSize: Int,
         onBatchCommitted: (FeedbackRetentionBatchResult) -> Unit = {},
     ): FeedbackRetentionResult {
-        require(batchSize > 0) { "batchSize must be greater than zero" }
+        require(batchSize in 1..MAX_DELETE_BATCH_SIZE) {
+            "batchSize must be between 1 and $MAX_DELETE_BATCH_SIZE"
+        }
 
         return dataSource.connection.use { connection ->
             connection.autoCommit = false
@@ -35,22 +37,16 @@ class FeedbackRetentionRepository(
             }
 
             try {
-                var deletedTotal = 0
-                val affectedTeams = mutableSetOf<String>()
-                do {
-                    val deletedBatch = connection.deleteExpiredBatch(cutoff, batchSize)
-                    connection.commit()
-                    deletedTotal += deletedBatch.deletedFeedback
-                    affectedTeams += deletedBatch.affectedTeams
-                    if (deletedBatch.deletedFeedback > 0) {
-                        onBatchCommitted(deletedBatch)
-                    }
-                } while (deletedBatch.deletedFeedback == batchSize)
+                val deletedBatch = connection.deleteExpiredBatch(cutoff, batchSize)
+                connection.commit()
+                if (deletedBatch.deletedFeedback > 0) {
+                    onBatchCommitted(deletedBatch)
+                }
 
                 FeedbackRetentionResult(
                     executed = true,
-                    deletedFeedback = deletedTotal,
-                    affectedTeams = affectedTeams,
+                    deletedFeedback = deletedBatch.deletedFeedback,
+                    affectedTeams = deletedBatch.affectedTeams,
                 )
             } catch (cause: Throwable) {
                 connection.rollback()
@@ -115,5 +111,6 @@ class FeedbackRetentionRepository(
 
     internal companion object {
         const val CLEANUP_LOCK_ID = 4_861_756_693_849L
+        const val MAX_DELETE_BATCH_SIZE = 500
     }
 }

--- a/apps/lumi-api/src/main/kotlin/no/nav/lumi/repository/FeedbackRetentionRepository.kt
+++ b/apps/lumi-api/src/main/kotlin/no/nav/lumi/repository/FeedbackRetentionRepository.kt
@@ -14,6 +14,7 @@ enum class FeedbackRetentionSkipReason {
 
 data class FeedbackRetentionResult(
     val executed: Boolean,
+    val cutoff: Instant? = null,
     val deletedFeedback: Int = 0,
     val affectedTeams: Set<String> = emptySet(),
     val skipReason: FeedbackRetentionSkipReason? = null,
@@ -28,7 +29,7 @@ class FeedbackRetentionRepository(
     private val dataSource: DataSource = DatabaseHolder.dataSource,
 ) {
     fun deleteExpiredFeedback(
-        cutoff: Instant,
+        retentionMonths: Int,
         minimumInterval: Duration,
         batchSize: Int,
         onBatchCommitted: (FeedbackRetentionBatchResult) -> Unit = {},
@@ -36,6 +37,7 @@ class FeedbackRetentionRepository(
         require(batchSize in 1..MAX_DELETE_BATCH_SIZE) {
             "batchSize must be between 1 and $MAX_DELETE_BATCH_SIZE"
         }
+        require(retentionMonths > 0) { "retentionMonths must be positive" }
         require(!minimumInterval.isNegative && minimumInterval.toMillis() > 0) {
             "minimumInterval must be positive"
         }
@@ -59,6 +61,7 @@ class FeedbackRetentionRepository(
                     )
                 }
 
+                val cutoff = connection.retentionCutoff(retentionMonths)
                 val deletedBatch = connection.deleteExpiredBatch(cutoff, batchSize)
                 connection.recordCleanupCompleted()
                 connection.commit()
@@ -68,6 +71,7 @@ class FeedbackRetentionRepository(
 
                 FeedbackRetentionResult(
                     executed = true,
+                    cutoff = cutoff,
                     deletedFeedback = deletedBatch.deletedFeedback,
                     affectedTeams = deletedBatch.affectedTeams,
                 )
@@ -79,6 +83,21 @@ class FeedbackRetentionRepository(
             }
         }
     }
+
+    private fun Connection.retentionCutoff(retentionMonths: Int): Instant =
+        prepareStatement(
+            """
+                SELECT (
+                    clock_timestamp() AT TIME ZONE 'UTC' - make_interval(months => ?)
+                ) AT TIME ZONE 'UTC' AS cutoff
+            """.trimIndent()
+        ).use { statement ->
+            statement.setInt(1, retentionMonths)
+            statement.executeQuery().use { result ->
+                check(result.next()) { "Retention cutoff query returned no result" }
+                result.getTimestamp("cutoff").toInstant()
+            }
+        }
 
     private fun Connection.isCleanupDue(minimumInterval: Duration): Boolean =
         prepareStatement(

--- a/apps/lumi-api/src/main/kotlin/no/nav/lumi/repository/FeedbackRetentionRepository.kt
+++ b/apps/lumi-api/src/main/kotlin/no/nav/lumi/repository/FeedbackRetentionRepository.kt
@@ -3,13 +3,20 @@ package no.nav.lumi.repository
 import no.nav.lumi.config.DatabaseHolder
 import java.sql.Connection
 import java.sql.Timestamp
+import java.time.Duration
 import java.time.Instant
 import javax.sql.DataSource
+
+enum class FeedbackRetentionSkipReason {
+    LOCK_HELD,
+    MINIMUM_INTERVAL_NOT_ELAPSED,
+}
 
 data class FeedbackRetentionResult(
     val executed: Boolean,
     val deletedFeedback: Int = 0,
     val affectedTeams: Set<String> = emptySet(),
+    val skipReason: FeedbackRetentionSkipReason? = null,
 )
 
 data class FeedbackRetentionBatchResult(
@@ -22,22 +29,38 @@ class FeedbackRetentionRepository(
 ) {
     fun deleteExpiredFeedback(
         cutoff: Instant,
+        minimumInterval: Duration,
         batchSize: Int,
         onBatchCommitted: (FeedbackRetentionBatchResult) -> Unit = {},
     ): FeedbackRetentionResult {
         require(batchSize in 1..MAX_DELETE_BATCH_SIZE) {
             "batchSize must be between 1 and $MAX_DELETE_BATCH_SIZE"
         }
+        require(!minimumInterval.isNegative && minimumInterval.toMillis() > 0) {
+            "minimumInterval must be positive"
+        }
 
         return dataSource.connection.use { connection ->
             connection.autoCommit = false
             if (!connection.tryAcquireCleanupLock()) {
                 connection.rollback()
-                return@use FeedbackRetentionResult(executed = false)
+                return@use FeedbackRetentionResult(
+                    executed = false,
+                    skipReason = FeedbackRetentionSkipReason.LOCK_HELD,
+                )
             }
 
             try {
+                if (!connection.isCleanupDue(minimumInterval)) {
+                    connection.rollback()
+                    return@use FeedbackRetentionResult(
+                        executed = false,
+                        skipReason = FeedbackRetentionSkipReason.MINIMUM_INTERVAL_NOT_ELAPSED,
+                    )
+                }
+
                 val deletedBatch = connection.deleteExpiredBatch(cutoff, batchSize)
+                connection.recordCleanupCompleted()
                 connection.commit()
                 if (deletedBatch.deletedFeedback > 0) {
                     onBatchCommitted(deletedBatch)
@@ -54,6 +77,39 @@ class FeedbackRetentionRepository(
             } finally {
                 connection.releaseCleanupLock()
             }
+        }
+    }
+
+    private fun Connection.isCleanupDue(minimumInterval: Duration): Boolean =
+        prepareStatement(
+            """
+                SELECT last_completed_at <=
+                    clock_timestamp() - (? * INTERVAL '1 millisecond') AS due
+                FROM feedback_retention_job_state
+                WHERE job_name = ?
+            """.trimIndent()
+        ).use { statement ->
+            statement.setLong(1, minimumInterval.toMillis())
+            statement.setString(2, JOB_NAME)
+            statement.executeQuery().use { result ->
+                !result.next() || result.getBoolean("due")
+            }
+        }
+
+    private fun Connection.recordCleanupCompleted() {
+        prepareStatement(
+            """
+                INSERT INTO feedback_retention_job_state (job_name, last_completed_at)
+                VALUES (?, clock_timestamp())
+                ON CONFLICT (job_name) DO UPDATE
+                SET last_completed_at = GREATEST(
+                    feedback_retention_job_state.last_completed_at,
+                    EXCLUDED.last_completed_at
+                )
+            """.trimIndent()
+        ).use { statement ->
+            statement.setString(1, JOB_NAME)
+            check(statement.executeUpdate() == 1) { "Retention job state was not updated" }
         }
     }
 
@@ -110,6 +166,7 @@ class FeedbackRetentionRepository(
     }
 
     internal companion object {
+        const val JOB_NAME = "feedback-cleanup"
         const val CLEANUP_LOCK_ID = 4_861_756_693_849L
         const val MAX_DELETE_BATCH_SIZE = 500
     }

--- a/apps/lumi-api/src/main/kotlin/no/nav/lumi/repository/FeedbackRetentionRepository.kt
+++ b/apps/lumi-api/src/main/kotlin/no/nav/lumi/repository/FeedbackRetentionRepository.kt
@@ -1,0 +1,119 @@
+package no.nav.lumi.repository
+
+import no.nav.lumi.config.DatabaseHolder
+import java.sql.Connection
+import java.sql.Timestamp
+import java.time.Instant
+import javax.sql.DataSource
+
+data class FeedbackRetentionResult(
+    val executed: Boolean,
+    val deletedFeedback: Int = 0,
+    val affectedTeams: Set<String> = emptySet(),
+)
+
+data class FeedbackRetentionBatchResult(
+    val deletedFeedback: Int,
+    val affectedTeams: Set<String>,
+)
+
+class FeedbackRetentionRepository(
+    private val dataSource: DataSource = DatabaseHolder.dataSource,
+) {
+    fun deleteExpiredFeedback(
+        cutoff: Instant,
+        batchSize: Int,
+        onBatchCommitted: (FeedbackRetentionBatchResult) -> Unit = {},
+    ): FeedbackRetentionResult {
+        require(batchSize > 0) { "batchSize must be greater than zero" }
+
+        return dataSource.connection.use { connection ->
+            connection.autoCommit = false
+            if (!connection.tryAcquireCleanupLock()) {
+                connection.rollback()
+                return@use FeedbackRetentionResult(executed = false)
+            }
+
+            try {
+                var deletedTotal = 0
+                val affectedTeams = mutableSetOf<String>()
+                do {
+                    val deletedBatch = connection.deleteExpiredBatch(cutoff, batchSize)
+                    connection.commit()
+                    deletedTotal += deletedBatch.deletedFeedback
+                    affectedTeams += deletedBatch.affectedTeams
+                    if (deletedBatch.deletedFeedback > 0) {
+                        onBatchCommitted(deletedBatch)
+                    }
+                } while (deletedBatch.deletedFeedback == batchSize)
+
+                FeedbackRetentionResult(
+                    executed = true,
+                    deletedFeedback = deletedTotal,
+                    affectedTeams = affectedTeams,
+                )
+            } catch (cause: Throwable) {
+                connection.rollback()
+                throw cause
+            } finally {
+                connection.releaseCleanupLock()
+            }
+        }
+    }
+
+    private fun Connection.tryAcquireCleanupLock(): Boolean =
+        prepareStatement("SELECT pg_try_advisory_lock(?)").use { statement ->
+            statement.setLong(1, CLEANUP_LOCK_ID)
+            statement.executeQuery().use { result ->
+                check(result.next()) { "Retention lock query returned no result" }
+                result.getBoolean(1)
+            }
+        }
+
+    private fun Connection.releaseCleanupLock() {
+        prepareStatement("SELECT pg_advisory_unlock(?)").use { statement ->
+            statement.setLong(1, CLEANUP_LOCK_ID)
+            statement.executeQuery().use { result ->
+                check(result.next() && result.getBoolean(1)) {
+                    "Retention cleanup lock was not held when release was attempted"
+                }
+            }
+        }
+        commit()
+    }
+
+    private fun Connection.deleteExpiredBatch(cutoff: Instant, batchSize: Int): FeedbackRetentionBatchResult {
+        val sql = """
+            WITH expired AS (
+                SELECT id
+                FROM feedback
+                WHERE opprettet < ?
+                ORDER BY opprettet, id
+                LIMIT ?
+                FOR UPDATE SKIP LOCKED
+            )
+            DELETE FROM feedback
+            USING expired
+            WHERE feedback.id = expired.id
+            RETURNING feedback.team
+        """.trimIndent()
+
+        return prepareStatement(sql).use { statement ->
+            statement.setTimestamp(1, Timestamp.from(cutoff))
+            statement.setInt(2, batchSize)
+            statement.executeQuery().use { result ->
+                var count = 0
+                val affectedTeams = mutableSetOf<String>()
+                while (result.next()) {
+                    count += 1
+                    affectedTeams += result.getString("team")
+                }
+                FeedbackRetentionBatchResult(count, affectedTeams)
+            }
+        }
+    }
+
+    internal companion object {
+        const val CLEANUP_LOCK_ID = 4_861_756_693_849L
+    }
+}

--- a/apps/lumi-api/src/main/kotlin/no/nav/lumi/repository/SurveyDefinitionRepository.kt
+++ b/apps/lumi-api/src/main/kotlin/no/nav/lumi/repository/SurveyDefinitionRepository.kt
@@ -11,8 +11,17 @@ data class StoredSurveyDefinition(
     val team: String,
     val surveyId: String,
     val definitionHash: String,
-    val definition: SurveyDefinition,
-    val source: String = SurveyDefinitionSource.AUTO
+    val definition: SurveyDefinition?,
+    val source: String = SurveyDefinitionSource.AUTO,
+    val lastSubmissionAt: Instant = Instant.EPOCH,
+    val definitionRetentionAt: Instant = Instant.MAX,
+    val retiredAt: Instant? = null,
+)
+
+data class SurveyRetentionCandidate(
+    val surveyId: String,
+    val lastActivityAt: Instant,
+    val scheduledFor: Instant,
 )
 
 object SurveyDefinitionSource {
@@ -27,6 +36,31 @@ class SurveyDefinitionRepository {
         return dbQuery {
             findByTeamAndSurveyIdInCurrentTransaction(team, surveyId)
         }
+    }
+
+    suspend fun findUpcomingRetentionCandidates(
+        team: String,
+        scheduledBefore: Instant,
+    ): List<SurveyRetentionCandidate> = dbQuery {
+        SurveyDefinitionTable
+            .select(
+                SurveyDefinitionTable.surveyId,
+                SurveyDefinitionTable.lastSubmissionAt,
+                SurveyDefinitionTable.definitionRetentionAt,
+            )
+            .where {
+                (SurveyDefinitionTable.team eq team) and
+                    SurveyDefinitionTable.retiredAt.isNull() and
+                    (SurveyDefinitionTable.definitionRetentionAt lessEq scheduledBefore)
+            }
+            .orderBy(SurveyDefinitionTable.definitionRetentionAt to SortOrder.ASC)
+            .map { row ->
+                SurveyRetentionCandidate(
+                    surveyId = row[SurveyDefinitionTable.surveyId],
+                    lastActivityAt = row[SurveyDefinitionTable.lastSubmissionAt],
+                    scheduledFor = row[SurveyDefinitionTable.definitionRetentionAt],
+                )
+            }
     }
 
     /**
@@ -115,8 +149,12 @@ class SurveyDefinitionRepository {
                     team = row[SurveyDefinitionTable.team],
                     surveyId = row[SurveyDefinitionTable.surveyId],
                     definitionHash = row[SurveyDefinitionTable.definitionHash],
-                    definition = json.decodeFromString(row[SurveyDefinitionTable.definition]),
-                    source = row[SurveyDefinitionTable.dbSource]
+                    definition = row[SurveyDefinitionTable.definition]
+                        ?.let { json.decodeFromString(it) },
+                    source = row[SurveyDefinitionTable.dbSource],
+                    lastSubmissionAt = row[SurveyDefinitionTable.lastSubmissionAt],
+                    definitionRetentionAt = row[SurveyDefinitionTable.definitionRetentionAt],
+                    retiredAt = row[SurveyDefinitionTable.retiredAt],
                 )
             }
     }
@@ -187,11 +225,34 @@ class SurveyDefinitionRepository {
         }) {
             it[SurveyDefinitionTable.definitionHash] = newDefinitionHash
             it[SurveyDefinitionTable.definition] = definitionJson
+            it[SurveyDefinitionTable.retiredAt] = null
             if (source != null) {
                 it[SurveyDefinitionTable.dbSource] = source
             }
             it[SurveyDefinitionTable.updatedAt] = Instant.now()
         } > 0
+    }
+
+    internal fun recordStoredSubmissionInCurrentTransaction(team: String, surveyId: String) {
+        val transaction = org.jetbrains.exposed.v1.jdbc.transactions.TransactionManager.current()
+        val conn = transaction.connection.connection as java.sql.Connection
+        conn.prepareStatement(
+            """
+                UPDATE survey_definitions
+                SET last_submission_at = GREATEST(last_submission_at, now()),
+                    definition_retention_at = GREATEST(
+                        definition_retention_at,
+                        now() + INTERVAL '18 months'
+                    )
+                WHERE team = ? AND survey_id = ?
+            """.trimIndent()
+        ).use { statement ->
+            statement.setString(1, team)
+            statement.setString(2, surveyId)
+            check(statement.executeUpdate() == 1) {
+                "Survey definition disappeared while recording stored submission"
+            }
+        }
     }
 
     internal fun updateApiDefinitionIfHashMatchesInCurrentTransaction(

--- a/apps/lumi-api/src/main/kotlin/no/nav/lumi/repository/SurveyDefinitionRepository.kt
+++ b/apps/lumi-api/src/main/kotlin/no/nav/lumi/repository/SurveyDefinitionRepository.kt
@@ -242,7 +242,7 @@ class SurveyDefinitionRepository {
                 SET last_submission_at = GREATEST(last_submission_at, now()),
                     definition_retention_at = GREATEST(
                         definition_retention_at,
-                        now() + INTERVAL '18 months'
+                        (now() AT TIME ZONE 'UTC' + INTERVAL '18 months') AT TIME ZONE 'UTC'
                     )
                 WHERE team = ? AND survey_id = ?
             """.trimIndent()

--- a/apps/lumi-api/src/main/kotlin/no/nav/lumi/repository/SurveyDefinitionTable.kt
+++ b/apps/lumi-api/src/main/kotlin/no/nav/lumi/repository/SurveyDefinitionTable.kt
@@ -7,10 +7,15 @@ object SurveyDefinitionTable : Table("survey_definitions") {
     val team = varchar("team", 255)
     val surveyId = varchar("survey_id", 255)
     val definitionHash = varchar("definition_hash", 64)
-    val definition = registerColumn<String>("definition", JsonbColumnType())
+    // Nullable in the application model so rolling deploys are prepared for
+    // the later migration that replaces inactive definitions with tombstones.
+    val definition = registerColumn<String>("definition", JsonbColumnType()).nullable()
     // Additional columns declared for schema completeness.
     // Defaults are managed by the DB (V12 migration); writes use defaults.
     val dbSource = varchar("source", 50).default("auto")
     val createdAt = timestamp("created_at")
     val updatedAt = timestamp("updated_at")
+    val lastSubmissionAt = timestamp("last_submission_at")
+    val definitionRetentionAt = timestamp("definition_retention_at")
+    val retiredAt = timestamp("retired_at").nullable()
 }

--- a/apps/lumi-api/src/main/kotlin/no/nav/lumi/routes/FeedbackRoutes.kt
+++ b/apps/lumi-api/src/main/kotlin/no/nav/lumi/routes/FeedbackRoutes.kt
@@ -19,6 +19,7 @@ import no.nav.lumi.domain.TeamsAndApps
 import no.nav.lumi.repository.FeedbackRepository
 import no.nav.lumi.service.FeedbackService
 import no.nav.lumi.service.StatsCacheInvalidator
+import no.nav.lumi.service.sharedBootstrapCache
 import no.nav.lumi.integrations.valkey.ValkeyStatsCache
 import no.nav.lumi.integrations.valkey.StringCache
 import org.slf4j.LoggerFactory

--- a/apps/lumi-api/src/main/kotlin/no/nav/lumi/routes/FilterRoutes.kt
+++ b/apps/lumi-api/src/main/kotlin/no/nav/lumi/routes/FilterRoutes.kt
@@ -15,11 +15,17 @@ import no.nav.lumi.config.auth.authorizedTeam
 import no.nav.lumi.config.auth.authorizedTeams
 import no.nav.lumi.config.exception.ApiErrorException
 import no.nav.lumi.integrations.valkey.StringCache
-import no.nav.lumi.integrations.valkey.ValkeyStringCache
+import no.nav.lumi.service.BootstrapCacheInvalidator
+import no.nav.lumi.service.bootstrapCacheGenerationKey
+import no.nav.lumi.service.bootstrapCacheTeamPrefix
+import no.nav.lumi.service.sharedBootstrapCache
 import no.nav.lumi.repository.FeedbackRepository
 import no.nav.lumi.repository.SurveyMetadataRepository
+import no.nav.lumi.repository.SurveyDefinitionRepository
+import no.nav.lumi.service.FeedbackRetentionService
 import java.time.Duration
 import java.time.Instant
+import java.time.ZoneOffset
 
 /**
  * Response for GET /api/v1/intern/filters/bootstrap
@@ -38,6 +44,14 @@ data class FilterBootstrapResponse(
     val tags: List<String>,
     val surveyMeta: Map<String, SurveyMetaEntry> = emptyMap(),
     val surveyMetaByApp: Map<String, Map<String, SurveyMetaEntry>> = emptyMap(),
+    val retentionWarnings: List<SurveyRetentionWarning> = emptyList(),
+)
+
+@Serializable
+data class SurveyRetentionWarning(
+    val surveyId: String,
+    val lastActivityAt: String,
+    val scheduledFor: String,
 )
 
 /**
@@ -56,20 +70,7 @@ data class SurveyMetaEntry(
 
 private val defaultRepository = FeedbackRepository()
 private val defaultSurveyMetadataRepository = SurveyMetadataRepository()
-
-/**
- * Shared bootstrap cache instance so mutations (e.g. survey archiving) can
- * invalidate what the bootstrap route cached. Keys start with "team=<team>&"
- * — see [bootstrapCacheTeamPrefix].
- */
-internal val sharedBootstrapCache: StringCache by lazy {
-    ValkeyStringCache.fromEnvOrFallback(keyPrefix = "filters:bootstrap:")
-}
-
-/** Cache-key prefix covering every user's bootstrap entry for a team. */
-internal fun bootstrapCacheTeamPrefix(team: String) = "team=${team.lowercase()}&"
-
-private fun bootstrapCacheGenerationKey(team: String) = "generation:team=${team.lowercase()}"
+private val defaultSurveyDefinitionRepository = SurveyDefinitionRepository()
 
 /**
  * Per-user bootstrap cache key, or null when the principal has no stable user
@@ -80,7 +81,7 @@ internal fun bootstrapCacheKey(team: String, principal: no.nav.lumi.config.auth.
     val userIdentity = stablePrincipalIdentity(principal) ?: return null
     // Version the response contract so rolling deploys cannot reuse bootstrap
     // payloads that predate newly added metadata fields.
-    return "${bootstrapCacheTeamPrefix(team)}user=${userIdentity.lowercase()}&responseVersion=2"
+    return "${bootstrapCacheTeamPrefix(team)}user=${userIdentity.lowercase()}&responseVersion=3"
 }
 
 internal fun stablePrincipalIdentity(principal: no.nav.lumi.config.auth.BrukerPrincipal): String? =
@@ -98,6 +99,8 @@ internal data class BootstrapCacheLookup(
  * advances the team generation; late writes remain on the old generation.
  */
 internal class VersionedBootstrapCache(private val cache: StringCache) {
+    private val invalidator = BootstrapCacheInvalidator(cache)
+
     fun lookup(
         team: String,
         principal: no.nav.lumi.config.auth.BrukerPrincipal,
@@ -114,8 +117,7 @@ internal class VersionedBootstrapCache(private val cache: StringCache) {
     }
 
     fun invalidate(team: String) {
-        cache.increment(bootstrapCacheGenerationKey(team))
-        cache.clearByPrefix(bootstrapCacheTeamPrefix(team))
+        invalidator.invalidateTeam(team)
     }
 }
 
@@ -133,6 +135,7 @@ private val json = Json {
 fun Route.filterRoutes(
     feedbackRepository: FeedbackRepository = defaultRepository,
     surveyMetadataRepository: SurveyMetadataRepository = defaultSurveyMetadataRepository,
+    surveyDefinitionRepository: SurveyDefinitionRepository = defaultSurveyDefinitionRepository,
     bootstrapCache: StringCache = sharedBootstrapCache,
 ) {
     val versionedBootstrapCache = VersionedBootstrapCache(bootstrapCache)
@@ -169,6 +172,19 @@ fun Route.filterRoutes(
             val surveyOverview = feedbackRepository.findSurveyOverview(team)
             val tags = feedbackRepository.findAllTags(team)
             val archiveStates = surveyMetadataRepository.findByTeam(team).associateBy { it.surveyId }
+            val now = Instant.now()
+            val scheduledBefore = now.atZone(ZoneOffset.UTC)
+                .plusMonths(FeedbackRetentionService.DEFINITION_WARNING_LEAD_MONTHS)
+                .toInstant()
+            val retentionWarnings = surveyDefinitionRepository
+                .findUpcomingRetentionCandidates(team, scheduledBefore)
+                .map { candidate ->
+                    SurveyRetentionWarning(
+                        surveyId = candidate.surveyId,
+                        lastActivityAt = candidate.lastActivityAt.toString(),
+                        scheduledFor = candidate.scheduledFor.toString(),
+                    )
+                }
             val firstSubmissionBySurvey = surveyOverview.firstSubmissionBySurvey
             val lastSubmissionBySurvey = surveyOverview.lastSubmissionBySurvey
             val surveyMeta = (
@@ -199,6 +215,7 @@ fun Route.filterRoutes(
                 tags = tags.sorted(),
                 surveyMeta = surveyMeta,
                 surveyMetaByApp = surveyMetaByApp,
+                retentionWarnings = retentionWarnings,
             )
 
             if (!forceRefresh) {

--- a/apps/lumi-api/src/main/kotlin/no/nav/lumi/routes/SurveyArchiveRoutes.kt
+++ b/apps/lumi-api/src/main/kotlin/no/nav/lumi/routes/SurveyArchiveRoutes.kt
@@ -10,6 +10,7 @@ import no.nav.lumi.config.auth.authorizedTeam
 import no.nav.lumi.integrations.valkey.StringCache
 import no.nav.lumi.repository.SurveyMetadataRepository
 import no.nav.lumi.service.StatsCacheInvalidator
+import no.nav.lumi.service.sharedBootstrapCache
 
 private val defaultSurveyMetadataRepository = SurveyMetadataRepository()
 private val defaultArchiveStatsCacheInvalidator = StatsCacheInvalidator()

--- a/apps/lumi-api/src/main/kotlin/no/nav/lumi/service/BootstrapCacheInvalidator.kt
+++ b/apps/lumi-api/src/main/kotlin/no/nav/lumi/service/BootstrapCacheInvalidator.kt
@@ -1,0 +1,21 @@
+package no.nav.lumi.service
+
+import no.nav.lumi.integrations.valkey.StringCache
+import no.nav.lumi.integrations.valkey.ValkeyStringCache
+
+internal val sharedBootstrapCache: StringCache by lazy {
+    ValkeyStringCache.fromEnvOrFallback(keyPrefix = "filters:bootstrap:")
+}
+
+internal fun bootstrapCacheTeamPrefix(team: String) = "team=${team.lowercase()}&"
+
+internal fun bootstrapCacheGenerationKey(team: String) = "generation:team=${team.lowercase()}"
+
+class BootstrapCacheInvalidator(
+    private val cache: StringCache = sharedBootstrapCache,
+) {
+    fun invalidateTeam(team: String) {
+        cache.increment(bootstrapCacheGenerationKey(team))
+        cache.clearByPrefix(bootstrapCacheTeamPrefix(team))
+    }
+}

--- a/apps/lumi-api/src/main/kotlin/no/nav/lumi/service/FeedbackRetentionService.kt
+++ b/apps/lumi-api/src/main/kotlin/no/nav/lumi/service/FeedbackRetentionService.kt
@@ -9,7 +9,6 @@ import org.slf4j.LoggerFactory
 import java.time.Clock
 import java.time.Duration
 import java.time.Instant
-import java.time.ZoneOffset
 
 class FeedbackRetentionService(
     private val repository: FeedbackRetentionRepository = FeedbackRetentionRepository(),
@@ -22,17 +21,18 @@ class FeedbackRetentionService(
     private val log = LoggerFactory.getLogger(FeedbackRetentionService::class.java)
 
     fun runOnce(): FeedbackRetentionResult {
-        val runAt = Instant.now(clock)
-        val cutoff = retentionCutoff(runAt)
         return try {
             repository.deleteExpiredFeedback(
-                cutoff = cutoff,
+                retentionMonths = RESPONSE_RETENTION_MONTHS,
                 minimumInterval = MINIMUM_RUN_INTERVAL,
                 batchSize = batchSize,
             ) { batch ->
                 publishCommittedBatch(batch)
             }.also { result ->
                 if (result.executed) {
+                    val cutoff = checkNotNull(result.cutoff) {
+                        "Executed retention result did not include the database cutoff"
+                    }
                     observability.recordExecuted(Instant.now(clock))
                     log.info(
                         "Automatic retention run completed: deletedFeedback={}, cutoff={}",
@@ -57,11 +57,6 @@ class FeedbackRetentionService(
         }
     }
 
-    internal fun retentionCutoff(now: Instant): Instant =
-        now.atZone(ZoneOffset.UTC)
-            .minusMonths(RESPONSE_RETENTION_MONTHS)
-            .toInstant()
-
     private fun publishCommittedBatch(batch: FeedbackRetentionBatchResult) {
         var invalidationFailure: Throwable? = null
         batch.affectedTeams.forEach { team ->
@@ -82,7 +77,7 @@ class FeedbackRetentionService(
         this?.also { it.addSuppressed(cause) } ?: cause
 
     companion object {
-        const val RESPONSE_RETENTION_MONTHS = 12L
+        const val RESPONSE_RETENTION_MONTHS = 12
         const val DEFINITION_WARNING_LEAD_MONTHS = 3L
         val MINIMUM_RUN_INTERVAL: Duration = Duration.ofDays(1)
     }

--- a/apps/lumi-api/src/main/kotlin/no/nav/lumi/service/FeedbackRetentionService.kt
+++ b/apps/lumi-api/src/main/kotlin/no/nav/lumi/service/FeedbackRetentionService.kt
@@ -4,8 +4,10 @@ import no.nav.lumi.config.RetentionObservability
 import no.nav.lumi.repository.FeedbackRetentionBatchResult
 import no.nav.lumi.repository.FeedbackRetentionRepository
 import no.nav.lumi.repository.FeedbackRetentionResult
+import no.nav.lumi.repository.FeedbackRetentionSkipReason
 import org.slf4j.LoggerFactory
 import java.time.Clock
+import java.time.Duration
 import java.time.Instant
 import java.time.ZoneOffset
 
@@ -20,9 +22,14 @@ class FeedbackRetentionService(
     private val log = LoggerFactory.getLogger(FeedbackRetentionService::class.java)
 
     fun runOnce(): FeedbackRetentionResult {
-        val cutoff = retentionCutoff(Instant.now(clock))
+        val runAt = Instant.now(clock)
+        val cutoff = retentionCutoff(runAt)
         return try {
-            repository.deleteExpiredFeedback(cutoff, batchSize) { batch ->
+            repository.deleteExpiredFeedback(
+                cutoff = cutoff,
+                minimumInterval = MINIMUM_RUN_INTERVAL,
+                batchSize = batchSize,
+            ) { batch ->
                 publishCommittedBatch(batch)
             }.also { result ->
                 if (result.executed) {
@@ -34,7 +41,13 @@ class FeedbackRetentionService(
                     )
                 } else {
                     observability.recordSkipped()
-                    log.info("Automatic retention skipped because another instance holds the cleanup lock")
+                    when (result.skipReason) {
+                        FeedbackRetentionSkipReason.LOCK_HELD ->
+                            log.info("Automatic retention skipped because another instance holds the cleanup lock")
+                        FeedbackRetentionSkipReason.MINIMUM_INTERVAL_NOT_ELAPSED ->
+                            log.info("Automatic retention skipped because the global run interval has not elapsed")
+                        null -> log.warn("Automatic retention skipped without a reason")
+                    }
                 }
             }
         } catch (cause: Throwable) {
@@ -71,5 +84,6 @@ class FeedbackRetentionService(
     companion object {
         const val RESPONSE_RETENTION_MONTHS = 12L
         const val DEFINITION_WARNING_LEAD_MONTHS = 3L
+        val MINIMUM_RUN_INTERVAL: Duration = Duration.ofDays(1)
     }
 }

--- a/apps/lumi-api/src/main/kotlin/no/nav/lumi/service/FeedbackRetentionService.kt
+++ b/apps/lumi-api/src/main/kotlin/no/nav/lumi/service/FeedbackRetentionService.kt
@@ -15,7 +15,7 @@ class FeedbackRetentionService(
     private val statsCacheInvalidator: StatsCacheInvalidator = StatsCacheInvalidator(),
     private val bootstrapCacheInvalidator: BootstrapCacheInvalidator = BootstrapCacheInvalidator(),
     private val clock: Clock = Clock.systemUTC(),
-    private val batchSize: Int = DEFAULT_BATCH_SIZE,
+    private val batchSize: Int = FeedbackRetentionRepository.MAX_DELETE_BATCH_SIZE,
 ) {
     private val log = LoggerFactory.getLogger(FeedbackRetentionService::class.java)
 
@@ -28,7 +28,7 @@ class FeedbackRetentionService(
                 if (result.executed) {
                     observability.recordExecuted(Instant.now(clock))
                     log.info(
-                        "Automatic retention completed: deletedFeedback={}, cutoff={}",
+                        "Automatic retention run completed: deletedFeedback={}, cutoff={}",
                         result.deletedFeedback,
                         cutoff,
                     )
@@ -71,6 +71,5 @@ class FeedbackRetentionService(
     companion object {
         const val RESPONSE_RETENTION_MONTHS = 12L
         const val DEFINITION_WARNING_LEAD_MONTHS = 3L
-        const val DEFAULT_BATCH_SIZE = 500
     }
 }

--- a/apps/lumi-api/src/main/kotlin/no/nav/lumi/service/FeedbackRetentionService.kt
+++ b/apps/lumi-api/src/main/kotlin/no/nav/lumi/service/FeedbackRetentionService.kt
@@ -1,0 +1,76 @@
+package no.nav.lumi.service
+
+import no.nav.lumi.config.RetentionObservability
+import no.nav.lumi.repository.FeedbackRetentionBatchResult
+import no.nav.lumi.repository.FeedbackRetentionRepository
+import no.nav.lumi.repository.FeedbackRetentionResult
+import org.slf4j.LoggerFactory
+import java.time.Clock
+import java.time.Instant
+import java.time.ZoneOffset
+
+class FeedbackRetentionService(
+    private val repository: FeedbackRetentionRepository = FeedbackRetentionRepository(),
+    private val observability: RetentionObservability = RetentionObservability(),
+    private val statsCacheInvalidator: StatsCacheInvalidator = StatsCacheInvalidator(),
+    private val bootstrapCacheInvalidator: BootstrapCacheInvalidator = BootstrapCacheInvalidator(),
+    private val clock: Clock = Clock.systemUTC(),
+    private val batchSize: Int = DEFAULT_BATCH_SIZE,
+) {
+    private val log = LoggerFactory.getLogger(FeedbackRetentionService::class.java)
+
+    fun runOnce(): FeedbackRetentionResult {
+        val cutoff = retentionCutoff(Instant.now(clock))
+        return try {
+            repository.deleteExpiredFeedback(cutoff, batchSize) { batch ->
+                publishCommittedBatch(batch)
+            }.also { result ->
+                if (result.executed) {
+                    observability.recordExecuted(Instant.now(clock))
+                    log.info(
+                        "Automatic retention completed: deletedFeedback={}, cutoff={}",
+                        result.deletedFeedback,
+                        cutoff,
+                    )
+                } else {
+                    observability.recordSkipped()
+                    log.info("Automatic retention skipped because another instance holds the cleanup lock")
+                }
+            }
+        } catch (cause: Throwable) {
+            observability.recordFailed()
+            log.error("Automatic retention failed", cause)
+            throw cause
+        }
+    }
+
+    internal fun retentionCutoff(now: Instant): Instant =
+        now.atZone(ZoneOffset.UTC)
+            .minusMonths(RESPONSE_RETENTION_MONTHS)
+            .toInstant()
+
+    private fun publishCommittedBatch(batch: FeedbackRetentionBatchResult) {
+        var invalidationFailure: Throwable? = null
+        batch.affectedTeams.forEach { team ->
+            runCatching { statsCacheInvalidator.invalidateTeam(team) }
+                .onFailure { cause ->
+                    invalidationFailure = invalidationFailure.append(cause)
+                }
+            runCatching { bootstrapCacheInvalidator.invalidateTeam(team) }
+                .onFailure { cause ->
+                    invalidationFailure = invalidationFailure.append(cause)
+                }
+        }
+        observability.recordDeletedFeedback(batch.deletedFeedback)
+        invalidationFailure?.let { throw it }
+    }
+
+    private fun Throwable?.append(cause: Throwable): Throwable =
+        this?.also { it.addSuppressed(cause) } ?: cause
+
+    companion object {
+        const val RESPONSE_RETENTION_MONTHS = 12L
+        const val DEFINITION_WARNING_LEAD_MONTHS = 3L
+        const val DEFAULT_BATCH_SIZE = 500
+    }
+}

--- a/apps/lumi-api/src/main/kotlin/no/nav/lumi/service/SubmissionService.kt
+++ b/apps/lumi-api/src/main/kotlin/no/nav/lumi/service/SubmissionService.kt
@@ -24,20 +24,27 @@ class SubmissionService(
         definition: SurveyDefinition? = null
     ): SubmissionOutcome {
         if (submission.deduplicationKey == null) {
-            val definitionResult = registerDefinition(
-                team = team,
-                submission = submission,
-                definition = definition,
-                inCurrentTransaction = false
-            )
-            val saveResult = feedbackService.save(
-                feedbackJson = feedbackJson,
-                team = team,
-                app = app,
-                surveyId = definitionResult.surveyId,
-                definitionHash = definitionResult.definitionHash
-            )
-            return SubmissionOutcome(saveResult, definitionResult.definitionHash)
+            val prepared = feedbackService.prepareForSave(feedbackJson, team, submission.surveyId)
+            return feedbackRepository.withTransaction {
+                val definitionResult = registerDefinition(
+                    team = team,
+                    submission = submission,
+                    definition = definition,
+                    inCurrentTransaction = true
+                )
+                val saveResult = feedbackRepository.saveInCurrentTransaction(
+                    feedbackJson = prepared.feedbackJson,
+                    team = team,
+                    app = app,
+                    surveyId = definitionResult.surveyId,
+                    definitionHash = definitionResult.definitionHash,
+                )
+                surveyDefinitionService.recordStoredSubmissionInCurrentTransaction(
+                    team,
+                    definitionResult.surveyId,
+                )
+                SubmissionOutcome(saveResult, definitionResult.definitionHash)
+            }
         }
 
         val duplicateId = feedbackService.findDuplicateSubmissionId(
@@ -80,6 +87,13 @@ class SubmissionService(
                 definitionHash = definitionResult.definitionHash,
                 deduplicationKeyHash = deduplicationKeyHash
             )
+
+            if (saveResult is SaveResult.Created) {
+                surveyDefinitionService.recordStoredSubmissionInCurrentTransaction(
+                    team,
+                    definitionResult.surveyId,
+                )
+            }
 
             SubmissionOutcome(
                 saveResult = saveResult,

--- a/apps/lumi-api/src/main/kotlin/no/nav/lumi/service/SurveyDefinitionService.kt
+++ b/apps/lumi-api/src/main/kotlin/no/nav/lumi/service/SurveyDefinitionService.kt
@@ -21,6 +21,10 @@ data class RegistrationResult(
 class SurveyDefinitionService(
     private val repository: SurveyDefinitionRepository = SurveyDefinitionRepository()
 ) {
+    internal fun recordStoredSubmissionInCurrentTransaction(team: String, surveyId: String) {
+        repository.recordStoredSubmissionInCurrentTransaction(team, surveyId)
+    }
+
     suspend fun registerOrValidate(team: String, submission: FeedbackSubmissionV1): RegistrationResult {
         return registerOrValidate(
             team = team,
@@ -188,9 +192,49 @@ class SurveyDefinitionService(
         incomingSource: String,
         updateDefinition: suspend (String, String, String, SurveyDefinition, String) -> Boolean
     ): ExistingDefinitionResult {
+        val storedDefinition = stored.definition
+        if (storedDefinition == null) {
+            if (stored.retiredAt == null) {
+                throw ApiErrorException.InternalServerErrorException(
+                    "Survey definition is missing without being retired for surveyId=${stored.surveyId}"
+                )
+            }
+            if (incomingSource == SurveyDefinitionSource.AUTO) {
+                throw ApiErrorException.DefinitionConflictException(
+                    team = team,
+                    surveyId = stored.surveyId,
+                    errorMessage = "Survey definition for surveyId=${stored.surveyId} has been retired. " +
+                        "Upgrade to schemaVersion 2 with the complete original definition, or use a new surveyId."
+                )
+            }
+
+            val incomingHash = incomingDefinition.computeHash()
+            if (incomingHash != stored.definitionHash) {
+                throw ApiErrorException.DefinitionConflictException(
+                    team = team,
+                    surveyId = stored.surveyId,
+                    errorMessage = "Survey definition conflict for retired surveyId=${stored.surveyId}. " +
+                        "Use the complete original definition or a new surveyId."
+                )
+            }
+
+            val updated = updateDefinition(
+                team,
+                stored.surveyId,
+                stored.definitionHash,
+                incomingDefinition,
+                incomingHash,
+            )
+            return if (updated) {
+                ExistingDefinitionResult.Resolved(RegistrationResult(stored.surveyId, incomingHash))
+            } else {
+                ExistingDefinitionResult.Retry
+            }
+        }
+
         if (!allowDefinitionExpansion) {
             val enrichedStoredDefinition =
-                stored.definition.withMissingMaxSelectionsFrom(incomingDefinition)
+                storedDefinition.withMissingMaxSelectionsFrom(incomingDefinition)
             val definitionDiff = diff(enrichedStoredDefinition, incomingDefinition)
             if (stored.source == SurveyDefinitionSource.AUTO && incomingSource == SurveyDefinitionSource.API) {
                 if (definitionDiff.changedFields.isNotEmpty() || definitionDiff.removedFields.isNotEmpty()) {
@@ -212,7 +256,7 @@ class SurveyDefinitionService(
                 throwDefinitionConflict(team, stored.surveyId, definitionDiff, redactIdentifiers = true)
             }
 
-            if (enrichedStoredDefinition !== stored.definition) {
+            if (enrichedStoredDefinition !== storedDefinition) {
                 val enrichedHash = enrichedStoredDefinition.computeHash()
                 val updated = updateDefinition(
                     team,
@@ -236,7 +280,7 @@ class SurveyDefinitionService(
         }
 
         if (stored.source == SurveyDefinitionSource.API) {
-            val definitionDiff = diff(stored.definition, incomingDefinition)
+            val definitionDiff = diff(storedDefinition, incomingDefinition)
             if (definitionDiff.changedFields.isNotEmpty() || definitionDiff.addedFields.isNotEmpty()) {
                 throwDefinitionConflict(team, stored.surveyId, definitionDiff)
             }
@@ -246,8 +290,8 @@ class SurveyDefinitionService(
             )
         }
 
-        val mergedDefinition = stored.definition.mergeWith(incomingDefinition)
-        val definitionDiff = diff(stored.definition, mergedDefinition)
+        val mergedDefinition = storedDefinition.mergeWith(incomingDefinition)
+        val definitionDiff = diff(storedDefinition, mergedDefinition)
         if (definitionDiff.changedFields.isNotEmpty()) {
             throwDefinitionConflict(team, stored.surveyId, definitionDiff)
         }

--- a/apps/lumi-api/src/main/resources/db/migration/V16__survey_retention_activity.sql
+++ b/apps/lumi-api/src/main/resources/db/migration/V16__survey_retention_activity.sql
@@ -1,56 +1,21 @@
--- Activity timestamps used by automatic survey retention.
--- The structural definition remains NOT NULL until all running application
--- versions can safely read retired definition rows.
+-- Add nullable activity columns and install the rolling-deploy trigger in a
+-- short migration. Backfill runs in V17 after this transaction has committed,
+-- so CREATE TRIGGER does not block feedback inserts during a full table scan.
 
 ALTER TABLE survey_definitions
-    ADD COLUMN last_submission_at TIMESTAMPTZ;
-
-WITH submission_activity AS (
-    SELECT
-        team,
-        COALESCE(survey_id, feedback_json ->> 'surveyId') AS survey_id,
-        MAX(opprettet) AS last_submission_at
-    FROM feedback
-    GROUP BY team, COALESCE(survey_id, feedback_json ->> 'surveyId')
-)
-UPDATE survey_definitions definition
-SET last_submission_at = submission_activity.last_submission_at
-FROM submission_activity
-WHERE submission_activity.team = definition.team
-  AND submission_activity.survey_id = definition.survey_id;
-
-UPDATE survey_definitions
-SET last_submission_at = created_at
-WHERE last_submission_at IS NULL;
-
-ALTER TABLE survey_definitions
-    ALTER COLUMN last_submission_at SET NOT NULL,
-    ALTER COLUMN last_submission_at SET DEFAULT now();
-
-ALTER TABLE survey_definitions
+    ADD COLUMN last_submission_at TIMESTAMPTZ,
     ADD COLUMN definition_retention_at TIMESTAMPTZ,
     ADD COLUMN retired_at TIMESTAMPTZ;
 
--- Existing definitions that are already beyond 18 months receive the same
--- three-month warning period as definitions that approach the limit later.
-UPDATE survey_definitions
-SET definition_retention_at = GREATEST(
-    last_submission_at + INTERVAL '18 months',
-    now() + INTERVAL '3 months'
-);
-
+-- Old application instances do not write the new columns explicitly. Defaults
+-- keep definitions created between V16 and V17 valid without changing existing
+-- rows, which remain NULL until the backfill.
 ALTER TABLE survey_definitions
-    ALTER COLUMN definition_retention_at SET NOT NULL,
-    ALTER COLUMN definition_retention_at SET DEFAULT (now() + INTERVAL '18 months');
+    ALTER COLUMN last_submission_at SET DEFAULT now(),
+    ALTER COLUMN definition_retention_at SET DEFAULT (
+        (now() AT TIME ZONE 'UTC' + INTERVAL '18 months') AT TIME ZONE 'UTC'
+    );
 
-CREATE INDEX idx_survey_definitions_active_retention
-    ON survey_definitions(definition_retention_at)
-    WHERE retired_at IS NULL;
-
--- Keep activity correct while old and new application versions run together.
--- The application also records activity transactionally, but the trigger covers
--- writers from before these columns existed and remains safe for retries because
--- it only runs after a feedback row has actually been inserted.
 CREATE OR REPLACE FUNCTION update_survey_definition_activity()
 RETURNS TRIGGER AS $$
 DECLARE
@@ -58,10 +23,16 @@ DECLARE
 BEGIN
     IF submitted_survey_id IS NOT NULL THEN
         UPDATE survey_definitions
-        SET last_submission_at = GREATEST(last_submission_at, NEW.opprettet),
+        SET last_submission_at = GREATEST(
+                COALESCE(last_submission_at, NEW.opprettet),
+                NEW.opprettet
+            ),
             definition_retention_at = GREATEST(
-                definition_retention_at,
-                NEW.opprettet + INTERVAL '18 months'
+                COALESCE(
+                    definition_retention_at,
+                    (NEW.opprettet AT TIME ZONE 'UTC' + INTERVAL '18 months') AT TIME ZONE 'UTC'
+                ),
+                (NEW.opprettet AT TIME ZONE 'UTC' + INTERVAL '18 months') AT TIME ZONE 'UTC'
             )
         WHERE team = NEW.team
           AND survey_id = submitted_survey_id;
@@ -75,28 +46,3 @@ CREATE TRIGGER feedback_survey_definition_activity
     AFTER INSERT ON feedback
     FOR EACH ROW
     EXECUTE FUNCTION update_survey_definition_activity();
-
--- CREATE TRIGGER takes a lock that blocks later inserts until this migration
--- commits. Repeating the activity aggregation after that lock is acquired
--- closes the gap for inserts that committed after the first backfill but before
--- the trigger existed.
-WITH submission_activity AS (
-    SELECT
-        team,
-        COALESCE(survey_id, feedback_json ->> 'surveyId') AS survey_id,
-        MAX(opprettet) AS last_submission_at
-    FROM feedback
-    GROUP BY team, COALESCE(survey_id, feedback_json ->> 'surveyId')
-)
-UPDATE survey_definitions definition
-SET last_submission_at = GREATEST(
-        definition.last_submission_at,
-        submission_activity.last_submission_at
-    ),
-    definition_retention_at = GREATEST(
-        definition.definition_retention_at,
-        submission_activity.last_submission_at + INTERVAL '18 months'
-    )
-FROM submission_activity
-WHERE submission_activity.team = definition.team
-  AND submission_activity.survey_id = definition.survey_id;

--- a/apps/lumi-api/src/main/resources/db/migration/V16__survey_retention_activity.sql
+++ b/apps/lumi-api/src/main/resources/db/migration/V16__survey_retention_activity.sql
@@ -1,0 +1,102 @@
+-- Activity timestamps used by automatic survey retention.
+-- The structural definition remains NOT NULL until all running application
+-- versions can safely read retired definition rows.
+
+ALTER TABLE survey_definitions
+    ADD COLUMN last_submission_at TIMESTAMPTZ;
+
+WITH submission_activity AS (
+    SELECT
+        team,
+        COALESCE(survey_id, feedback_json ->> 'surveyId') AS survey_id,
+        MAX(opprettet) AS last_submission_at
+    FROM feedback
+    GROUP BY team, COALESCE(survey_id, feedback_json ->> 'surveyId')
+)
+UPDATE survey_definitions definition
+SET last_submission_at = submission_activity.last_submission_at
+FROM submission_activity
+WHERE submission_activity.team = definition.team
+  AND submission_activity.survey_id = definition.survey_id;
+
+UPDATE survey_definitions
+SET last_submission_at = created_at
+WHERE last_submission_at IS NULL;
+
+ALTER TABLE survey_definitions
+    ALTER COLUMN last_submission_at SET NOT NULL,
+    ALTER COLUMN last_submission_at SET DEFAULT now();
+
+ALTER TABLE survey_definitions
+    ADD COLUMN definition_retention_at TIMESTAMPTZ,
+    ADD COLUMN retired_at TIMESTAMPTZ;
+
+-- Existing definitions that are already beyond 18 months receive the same
+-- three-month warning period as definitions that approach the limit later.
+UPDATE survey_definitions
+SET definition_retention_at = GREATEST(
+    last_submission_at + INTERVAL '18 months',
+    now() + INTERVAL '3 months'
+);
+
+ALTER TABLE survey_definitions
+    ALTER COLUMN definition_retention_at SET NOT NULL,
+    ALTER COLUMN definition_retention_at SET DEFAULT (now() + INTERVAL '18 months');
+
+CREATE INDEX idx_survey_definitions_active_retention
+    ON survey_definitions(definition_retention_at)
+    WHERE retired_at IS NULL;
+
+-- Keep activity correct while old and new application versions run together.
+-- The application also records activity transactionally, but the trigger covers
+-- writers from before these columns existed and remains safe for retries because
+-- it only runs after a feedback row has actually been inserted.
+CREATE OR REPLACE FUNCTION update_survey_definition_activity()
+RETURNS TRIGGER AS $$
+DECLARE
+    submitted_survey_id TEXT := COALESCE(NEW.survey_id, NEW.feedback_json ->> 'surveyId');
+BEGIN
+    IF submitted_survey_id IS NOT NULL THEN
+        UPDATE survey_definitions
+        SET last_submission_at = GREATEST(last_submission_at, NEW.opprettet),
+            definition_retention_at = GREATEST(
+                definition_retention_at,
+                NEW.opprettet + INTERVAL '18 months'
+            )
+        WHERE team = NEW.team
+          AND survey_id = submitted_survey_id;
+    END IF;
+
+    RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE TRIGGER feedback_survey_definition_activity
+    AFTER INSERT ON feedback
+    FOR EACH ROW
+    EXECUTE FUNCTION update_survey_definition_activity();
+
+-- CREATE TRIGGER takes a lock that blocks later inserts until this migration
+-- commits. Repeating the activity aggregation after that lock is acquired
+-- closes the gap for inserts that committed after the first backfill but before
+-- the trigger existed.
+WITH submission_activity AS (
+    SELECT
+        team,
+        COALESCE(survey_id, feedback_json ->> 'surveyId') AS survey_id,
+        MAX(opprettet) AS last_submission_at
+    FROM feedback
+    GROUP BY team, COALESCE(survey_id, feedback_json ->> 'surveyId')
+)
+UPDATE survey_definitions definition
+SET last_submission_at = GREATEST(
+        definition.last_submission_at,
+        submission_activity.last_submission_at
+    ),
+    definition_retention_at = GREATEST(
+        definition.definition_retention_at,
+        submission_activity.last_submission_at + INTERVAL '18 months'
+    )
+FROM submission_activity
+WHERE submission_activity.team = definition.team
+  AND submission_activity.survey_id = definition.survey_id;

--- a/apps/lumi-api/src/main/resources/db/migration/V17__backfill_survey_retention_activity.sql
+++ b/apps/lumi-api/src/main/resources/db/migration/V17__backfill_survey_retention_activity.sql
@@ -1,0 +1,55 @@
+-- Backfill after V16 has committed its feedback trigger. Concurrent inserts
+-- either appear in this aggregation or move the same timestamps forward via
+-- the trigger, so this migration never needs to lock feedback against writers.
+
+WITH submission_activity AS (
+    SELECT
+        team,
+        COALESCE(survey_id, feedback_json ->> 'surveyId') AS survey_id,
+        MAX(opprettet) AS last_submission_at
+    FROM feedback
+    GROUP BY team, COALESCE(survey_id, feedback_json ->> 'surveyId')
+)
+UPDATE survey_definitions definition
+SET last_submission_at = GREATEST(
+        COALESCE(definition.last_submission_at, submission_activity.last_submission_at),
+        submission_activity.last_submission_at
+    ),
+    definition_retention_at = GREATEST(
+        COALESCE(
+            definition.definition_retention_at,
+            (
+                submission_activity.last_submission_at AT TIME ZONE 'UTC' + INTERVAL '18 months'
+            ) AT TIME ZONE 'UTC'
+        ),
+        (
+            submission_activity.last_submission_at AT TIME ZONE 'UTC' + INTERVAL '18 months'
+        ) AT TIME ZONE 'UTC'
+    )
+FROM submission_activity
+WHERE submission_activity.team = definition.team
+  AND submission_activity.survey_id = definition.survey_id;
+
+UPDATE survey_definitions
+SET last_submission_at = created_at
+WHERE last_submission_at IS NULL;
+
+-- Existing definitions that are already beyond 18 months receive the same
+-- three-month warning period as definitions that approach the limit later.
+UPDATE survey_definitions
+SET definition_retention_at = GREATEST(
+    COALESCE(
+        definition_retention_at,
+        (last_submission_at AT TIME ZONE 'UTC' + INTERVAL '18 months') AT TIME ZONE 'UTC'
+    ),
+    (last_submission_at AT TIME ZONE 'UTC' + INTERVAL '18 months') AT TIME ZONE 'UTC',
+    (now() AT TIME ZONE 'UTC' + INTERVAL '3 months') AT TIME ZONE 'UTC'
+);
+
+ALTER TABLE survey_definitions
+    ALTER COLUMN last_submission_at SET NOT NULL,
+    ALTER COLUMN definition_retention_at SET NOT NULL;
+
+CREATE INDEX idx_survey_definitions_active_retention
+    ON survey_definitions(definition_retention_at)
+    WHERE retired_at IS NULL;

--- a/apps/lumi-api/src/main/resources/db/migration/V18__coordinate_feedback_retention.sql
+++ b/apps/lumi-api/src/main/resources/db/migration/V18__coordinate_feedback_retention.sql
@@ -1,0 +1,14 @@
+-- Persist the global retention cadence so pod restarts and replica changes
+-- cannot execute more than one deletion batch in a rolling 24-hour window.
+CREATE TABLE feedback_retention_job_state
+(
+    job_name         VARCHAR(100) PRIMARY KEY,
+    last_completed_at TIMESTAMPTZ NOT NULL
+);
+
+-- Retention warnings are always team-scoped and ordered by retention time.
+DROP INDEX idx_survey_definitions_active_retention;
+
+CREATE INDEX idx_survey_definitions_active_retention
+    ON survey_definitions(team, definition_retention_at)
+    WHERE retired_at IS NULL;

--- a/apps/lumi-api/src/test/kotlin/no/nav/lumi/TestDatabase.kt
+++ b/apps/lumi-api/src/test/kotlin/no/nav/lumi/TestDatabase.kt
@@ -84,7 +84,8 @@ object TestDatabase {
             conn.createStatement().use { stmt ->
                 stmt.execute(
                     "TRUNCATE TABLE rating_marker, feedback, survey_definitions, survey_metadata, " +
-                        "survey_authoring_revisions, survey_authoring_projects CASCADE"
+                        "survey_authoring_revisions, survey_authoring_projects, " +
+                        "feedback_retention_job_state CASCADE"
                 )
             }
             conn.commit()

--- a/apps/lumi-api/src/test/kotlin/no/nav/lumi/config/RetentionAlertRulesTest.kt
+++ b/apps/lumi-api/src/test/kotlin/no/nav/lumi/config/RetentionAlertRulesTest.kt
@@ -1,0 +1,17 @@
+package no.nav.lumi.config
+
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.string.shouldContain
+import java.nio.file.Files
+import java.nio.file.Path
+
+class RetentionAlertRulesTest : FunSpec({
+    test("stale alert uses absolute success history and detects missing series") {
+        val rules = Files.readString(Path.of("nais/alerts/prod.yaml"))
+
+        rules shouldContain
+            """time() - max(max_over_time(lumi_retention_last_success_timestamp_seconds{app="lumi-api"}[36h])) > 129600"""
+        rules shouldContain
+            """or on() absent_over_time(lumi_retention_last_success_timestamp_seconds{app="lumi-api"}[15m])"""
+    }
+})

--- a/apps/lumi-api/src/test/kotlin/no/nav/lumi/config/RetentionAlertRulesTest.kt
+++ b/apps/lumi-api/src/test/kotlin/no/nav/lumi/config/RetentionAlertRulesTest.kt
@@ -13,5 +13,17 @@ class RetentionAlertRulesTest : FunSpec({
             """time() - max(max_over_time(lumi_retention_last_success_timestamp_seconds{app="lumi-api"}[36h])) > 129600"""
         rules shouldContain
             """or on() absent_over_time(lumi_retention_last_success_timestamp_seconds{app="lumi-api"}[15m])"""
+        rules shouldContain
+            """max(lumi_retention_enabled{app="lumi-api"}) == 1"""
+    }
+
+    test("production retention starts disabled while development exercises cleanup") {
+        val prodManifest = Files.readString(Path.of("nais/app/prod.yaml"))
+        val devManifest = Files.readString(Path.of("nais/app/dev.yaml"))
+
+        prodManifest shouldContain """name: LUMI_RETENTION_ENABLED
+      value: "false""".trimIndent()
+        devManifest shouldContain """name: LUMI_RETENTION_ENABLED
+      value: "true""".trimIndent()
     }
 })

--- a/apps/lumi-api/src/test/kotlin/no/nav/lumi/config/RetentionEnvTest.kt
+++ b/apps/lumi-api/src/test/kotlin/no/nav/lumi/config/RetentionEnvTest.kt
@@ -1,0 +1,22 @@
+package no.nav.lumi.config
+
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+class RetentionEnvTest : FunSpec({
+    test("is fail-closed when the environment value is missing") {
+        RetentionEnv.fromEnvironment(null) shouldBe RetentionEnv(enabled = false)
+    }
+
+    test("accepts explicit boolean environment values case-insensitively") {
+        RetentionEnv.fromEnvironment("TRUE") shouldBe RetentionEnv(enabled = true)
+        RetentionEnv.fromEnvironment("false") shouldBe RetentionEnv(enabled = false)
+    }
+
+    test("rejects ambiguous environment values") {
+        shouldThrow<IllegalStateException> {
+            RetentionEnv.fromEnvironment("yes")
+        }.message shouldBe "LUMI_RETENTION_ENABLED must be 'true' or 'false'"
+    }
+})

--- a/apps/lumi-api/src/test/kotlin/no/nav/lumi/config/RetentionObservabilityTest.kt
+++ b/apps/lumi-api/src/test/kotlin/no/nav/lumi/config/RetentionObservabilityTest.kt
@@ -1,0 +1,40 @@
+package no.nav.lumi.config
+
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.doubles.shouldBeExactly
+import io.kotest.matchers.string.shouldContain
+import io.kotest.matchers.string.shouldNotContain
+import io.micrometer.prometheusmetrics.PrometheusConfig
+import io.micrometer.prometheusmetrics.PrometheusMeterRegistry
+import java.time.Instant
+
+class RetentionObservabilityTest : FunSpec({
+    test("records bounded retention metrics without team or survey labels") {
+        val registry = PrometheusMeterRegistry(PrometheusConfig.DEFAULT)
+        val observability = RetentionObservability(registry)
+
+        observability.recordDeletedFeedback(7)
+        observability.recordExecuted(Instant.parse("2026-08-26T12:00:00Z"))
+        observability.recordSkipped()
+        observability.recordFailed()
+
+        registry.get(RetentionObservability.RUNS_METRIC_NAME)
+            .tag("outcome", "executed")
+            .counter()
+            .count()
+            .shouldBeExactly(1.0)
+        registry.get(RetentionObservability.DELETED_FEEDBACK_METRIC_NAME)
+            .counter()
+            .count()
+            .shouldBeExactly(7.0)
+        registry.get(RetentionObservability.LAST_SUCCESS_METRIC_NAME)
+            .gauge()
+            .value()
+            .shouldBeExactly(1_787_745_600.0)
+        val scrape = registry.scrape()
+        scrape shouldContain "lumi_retention_runs_total{outcome=\"failed\"} 1.0"
+        scrape shouldContain "lumi_retention_last_success_timestamp_seconds 1.7877456E9"
+        scrape shouldNotContain "survey_id"
+        scrape shouldNotContain "team="
+    }
+})

--- a/apps/lumi-api/src/test/kotlin/no/nav/lumi/config/RetentionObservabilityTest.kt
+++ b/apps/lumi-api/src/test/kotlin/no/nav/lumi/config/RetentionObservabilityTest.kt
@@ -31,10 +31,25 @@ class RetentionObservabilityTest : FunSpec({
             .gauge()
             .value()
             .shouldBeExactly(1_787_745_600.0)
+        registry.get(RetentionObservability.ENABLED_METRIC_NAME)
+            .gauge()
+            .value()
+            .shouldBeExactly(1.0)
         val scrape = registry.scrape()
         scrape shouldContain "lumi_retention_runs_total{outcome=\"failed\"} 1.0"
         scrape shouldContain "lumi_retention_last_success_timestamp_seconds 1.7877456E9"
         scrape shouldNotContain "survey_id"
         scrape shouldNotContain "team="
+    }
+
+    test("reports disabled state without running cleanup") {
+        val registry = PrometheusMeterRegistry(PrometheusConfig.DEFAULT)
+
+        RetentionObservability(registry, enabled = false)
+
+        registry.get(RetentionObservability.ENABLED_METRIC_NAME)
+            .gauge()
+            .value()
+            .shouldBeExactly(0.0)
     }
 })

--- a/apps/lumi-api/src/test/kotlin/no/nav/lumi/repository/FeedbackRetentionRepositoryTest.kt
+++ b/apps/lumi-api/src/test/kotlin/no/nav/lumi/repository/FeedbackRetentionRepositoryTest.kt
@@ -5,8 +5,9 @@ import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.matchers.collections.shouldContainExactlyInAnyOrder
 import io.kotest.matchers.shouldBe
 import no.nav.lumi.TestDatabase
-import java.time.Instant
 import java.sql.Timestamp
+import java.time.Duration
+import java.time.Instant
 
 class FeedbackRetentionRepositoryTest : FunSpec({
     beforeSpec {
@@ -28,7 +29,11 @@ class FeedbackRetentionRepositoryTest : FunSpec({
 
         val repository = FeedbackRetentionRepository(TestDatabase.dataSource)
         val firstResult = repository
-            .deleteExpiredFeedback(cutoff, batchSize = 1)
+            .deleteExpiredFeedback(
+                cutoff = cutoff,
+                minimumInterval = Duration.ofDays(1),
+                batchSize = 1,
+            )
 
         firstResult shouldBe FeedbackRetentionResult(
             executed = true,
@@ -38,7 +43,29 @@ class FeedbackRetentionRepositoryTest : FunSpec({
         remainingFeedbackIds() shouldContainExactlyInAnyOrder listOf("old-2", "boundary", "new")
         remainingTagFeedbackIds() shouldContainExactlyInAnyOrder listOf("boundary")
 
-        val secondResult = repository.deleteExpiredFeedback(cutoff, batchSize = 1)
+        ageCleanupState(Duration.ofHours(23))
+
+        val restartResult = FeedbackRetentionRepository(TestDatabase.dataSource)
+            .deleteExpiredFeedback(
+                cutoff = cutoff,
+                minimumInterval = Duration.ofDays(1),
+                batchSize = 1,
+            )
+
+        restartResult shouldBe FeedbackRetentionResult(
+            executed = false,
+            skipReason = FeedbackRetentionSkipReason.MINIMUM_INTERVAL_NOT_ELAPSED,
+        )
+        remainingFeedbackIds() shouldContainExactlyInAnyOrder listOf("old-2", "boundary", "new")
+
+        ageCleanupState(Duration.ofDays(1).plusSeconds(1))
+
+        val secondResult = FeedbackRetentionRepository(TestDatabase.dataSource)
+            .deleteExpiredFeedback(
+                cutoff = cutoff,
+                minimumInterval = Duration.ofDays(1),
+                batchSize = 1,
+            )
 
         secondResult shouldBe FeedbackRetentionResult(
             executed = true,
@@ -52,6 +79,7 @@ class FeedbackRetentionRepositoryTest : FunSpec({
         shouldThrow<IllegalArgumentException> {
             FeedbackRetentionRepository(TestDatabase.dataSource).deleteExpiredFeedback(
                 cutoff = Instant.parse("2025-08-26T12:00:00Z"),
+                minimumInterval = Duration.ofDays(1),
                 batchSize = FeedbackRetentionRepository.MAX_DELETE_BATCH_SIZE + 1,
             )
         }.message shouldBe "batchSize must be between 1 and 500"
@@ -66,9 +94,16 @@ class FeedbackRetentionRepositoryTest : FunSpec({
             }
 
             val result = FeedbackRetentionRepository(TestDatabase.dataSource)
-                .deleteExpiredFeedback(Instant.parse("2025-08-26T12:00:00Z"), batchSize = 10)
+                .deleteExpiredFeedback(
+                    cutoff = Instant.parse("2025-08-26T12:00:00Z"),
+                    minimumInterval = Duration.ofDays(1),
+                    batchSize = 10,
+                )
 
-            result shouldBe FeedbackRetentionResult(executed = false)
+            result shouldBe FeedbackRetentionResult(
+                executed = false,
+                skipReason = FeedbackRetentionSkipReason.LOCK_HELD,
+            )
         } finally {
             lockConnection.prepareStatement("SELECT pg_advisory_unlock(?)").use { statement ->
                 statement.setLong(1, FeedbackRetentionRepository.CLEANUP_LOCK_ID)
@@ -87,7 +122,11 @@ class FeedbackRetentionRepositoryTest : FunSpec({
 
         shouldThrow<IllegalStateException> {
             FeedbackRetentionRepository(TestDatabase.dataSource)
-                .deleteExpiredFeedback(cutoff, batchSize = 1) { batch ->
+                .deleteExpiredFeedback(
+                    cutoff = cutoff,
+                    minimumInterval = Duration.ofDays(1),
+                    batchSize = 1,
+                ) { batch ->
                     published += batch
                     error("stop after committed batch")
                 }
@@ -98,6 +137,16 @@ class FeedbackRetentionRepositoryTest : FunSpec({
                 deletedFeedback = 1,
                 affectedTeams = setOf("team-a"),
             ),
+        )
+        remainingFeedbackIds() shouldBe listOf("second")
+
+        FeedbackRetentionRepository(TestDatabase.dataSource).deleteExpiredFeedback(
+            cutoff = cutoff,
+            minimumInterval = Duration.ofDays(1),
+            batchSize = 1,
+        ) shouldBe FeedbackRetentionResult(
+            executed = false,
+            skipReason = FeedbackRetentionSkipReason.MINIMUM_INTERVAL_NOT_ELAPSED,
         )
         remainingFeedbackIds() shouldBe listOf("second")
     }
@@ -115,6 +164,22 @@ private fun insertFeedback(id: String, createdAt: Instant, team: String) {
             statement.setTimestamp(2, Timestamp.from(createdAt))
             statement.setString(3, team)
             statement.executeUpdate()
+        }
+        connection.commit()
+    }
+}
+
+private fun ageCleanupState(age: Duration) {
+    TestDatabase.dataSource.connection.use { connection ->
+        connection.prepareStatement(
+            """
+                UPDATE feedback_retention_job_state
+                SET last_completed_at = clock_timestamp() - (? * INTERVAL '1 millisecond')
+                WHERE job_name = 'feedback-cleanup'
+            """.trimIndent()
+        ).use { statement ->
+            statement.setLong(1, age.toMillis())
+            statement.executeUpdate() shouldBe 1
         }
         connection.commit()
     }

--- a/apps/lumi-api/src/test/kotlin/no/nav/lumi/repository/FeedbackRetentionRepositoryTest.kt
+++ b/apps/lumi-api/src/test/kotlin/no/nav/lumi/repository/FeedbackRetentionRepositoryTest.kt
@@ -4,7 +4,9 @@ import io.kotest.core.spec.style.FunSpec
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.matchers.collections.shouldContainExactlyInAnyOrder
 import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
 import no.nav.lumi.TestDatabase
+import java.sql.SQLException
 import java.sql.Timestamp
 import java.time.Duration
 import java.time.Instant
@@ -19,35 +21,36 @@ class FeedbackRetentionRepositoryTest : FunSpec({
     }
 
     test("deletes only one bounded batch of feedback strictly older than cutoff") {
-        val cutoff = Instant.parse("2025-08-26T12:00:00Z")
-        insertFeedback("old-1", cutoff.minusSeconds(2), "team-a")
-        insertFeedback("old-2", cutoff.minusSeconds(1), "team-b")
-        insertFeedback("boundary", cutoff, "team-a")
-        insertFeedback("new", cutoff.plusSeconds(1), "team-a")
+        val cutoff = databaseRetentionCutoff()
+        insertFeedback("old-1", cutoff.minusSeconds(120), "team-a")
+        insertFeedback("old-2", cutoff.minusSeconds(60), "team-b")
+        insertFeedback("inside-window", cutoff.plusSeconds(60), "team-a")
+        insertFeedback("new", cutoff.plusSeconds(3600), "team-a")
         insertTag("old-1", "expired")
-        insertTag("boundary", "kept")
+        insertTag("inside-window", "kept")
 
         val repository = FeedbackRetentionRepository(TestDatabase.dataSource)
         val firstResult = repository
             .deleteExpiredFeedback(
-                cutoff = cutoff,
+                retentionMonths = 12,
                 minimumInterval = Duration.ofDays(1),
                 batchSize = 1,
             )
 
-        firstResult shouldBe FeedbackRetentionResult(
+        firstResult.cutoff shouldNotBe null
+        firstResult.copy(cutoff = null) shouldBe FeedbackRetentionResult(
             executed = true,
             deletedFeedback = 1,
             affectedTeams = setOf("team-a"),
         )
-        remainingFeedbackIds() shouldContainExactlyInAnyOrder listOf("old-2", "boundary", "new")
-        remainingTagFeedbackIds() shouldContainExactlyInAnyOrder listOf("boundary")
+        remainingFeedbackIds() shouldContainExactlyInAnyOrder listOf("old-2", "inside-window", "new")
+        remainingTagFeedbackIds() shouldContainExactlyInAnyOrder listOf("inside-window")
 
         ageCleanupState(Duration.ofHours(23))
 
         val restartResult = FeedbackRetentionRepository(TestDatabase.dataSource)
             .deleteExpiredFeedback(
-                cutoff = cutoff,
+                retentionMonths = 12,
                 minimumInterval = Duration.ofDays(1),
                 batchSize = 1,
             )
@@ -56,29 +59,30 @@ class FeedbackRetentionRepositoryTest : FunSpec({
             executed = false,
             skipReason = FeedbackRetentionSkipReason.MINIMUM_INTERVAL_NOT_ELAPSED,
         )
-        remainingFeedbackIds() shouldContainExactlyInAnyOrder listOf("old-2", "boundary", "new")
+        remainingFeedbackIds() shouldContainExactlyInAnyOrder listOf("old-2", "inside-window", "new")
 
         ageCleanupState(Duration.ofDays(1).plusSeconds(1))
 
         val secondResult = FeedbackRetentionRepository(TestDatabase.dataSource)
             .deleteExpiredFeedback(
-                cutoff = cutoff,
+                retentionMonths = 12,
                 minimumInterval = Duration.ofDays(1),
                 batchSize = 1,
             )
 
-        secondResult shouldBe FeedbackRetentionResult(
+        secondResult.cutoff shouldNotBe null
+        secondResult.copy(cutoff = null) shouldBe FeedbackRetentionResult(
             executed = true,
             deletedFeedback = 1,
             affectedTeams = setOf("team-b"),
         )
-        remainingFeedbackIds() shouldContainExactlyInAnyOrder listOf("boundary", "new")
+        remainingFeedbackIds() shouldContainExactlyInAnyOrder listOf("inside-window", "new")
     }
 
     test("rejects a batch size above the defensive per-run limit") {
         shouldThrow<IllegalArgumentException> {
             FeedbackRetentionRepository(TestDatabase.dataSource).deleteExpiredFeedback(
-                cutoff = Instant.parse("2025-08-26T12:00:00Z"),
+                retentionMonths = 12,
                 minimumInterval = Duration.ofDays(1),
                 batchSize = FeedbackRetentionRepository.MAX_DELETE_BATCH_SIZE + 1,
             )
@@ -95,7 +99,7 @@ class FeedbackRetentionRepositoryTest : FunSpec({
 
             val result = FeedbackRetentionRepository(TestDatabase.dataSource)
                 .deleteExpiredFeedback(
-                    cutoff = Instant.parse("2025-08-26T12:00:00Z"),
+                    retentionMonths = 12,
                     minimumInterval = Duration.ofDays(1),
                     batchSize = 10,
                 )
@@ -115,15 +119,15 @@ class FeedbackRetentionRepositoryTest : FunSpec({
     }
 
     test("publishes a batch only after its deletion is committed") {
-        val cutoff = Instant.parse("2025-08-26T12:00:00Z")
-        insertFeedback("first", cutoff.minusSeconds(2), "team-a")
-        insertFeedback("second", cutoff.minusSeconds(1), "team-b")
+        val cutoff = databaseRetentionCutoff()
+        insertFeedback("first", cutoff.minusSeconds(120), "team-a")
+        insertFeedback("second", cutoff.minusSeconds(60), "team-b")
         val published = mutableListOf<FeedbackRetentionBatchResult>()
 
         shouldThrow<IllegalStateException> {
             FeedbackRetentionRepository(TestDatabase.dataSource)
                 .deleteExpiredFeedback(
-                    cutoff = cutoff,
+                    retentionMonths = 12,
                     minimumInterval = Duration.ofDays(1),
                     batchSize = 1,
                 ) { batch ->
@@ -141,7 +145,7 @@ class FeedbackRetentionRepositoryTest : FunSpec({
         remainingFeedbackIds() shouldBe listOf("second")
 
         FeedbackRetentionRepository(TestDatabase.dataSource).deleteExpiredFeedback(
-            cutoff = cutoff,
+            retentionMonths = 12,
             minimumInterval = Duration.ofDays(1),
             batchSize = 1,
         ) shouldBe FeedbackRetentionResult(
@@ -150,7 +154,44 @@ class FeedbackRetentionRepositoryTest : FunSpec({
         )
         remainingFeedbackIds() shouldBe listOf("second")
     }
+
+    test("rolls back deletion when retention job state cannot be written") {
+        val cutoff = databaseRetentionCutoff()
+        insertFeedback("kept-after-rollback", cutoff.minusSeconds(60), "team-a")
+        installRejectingStateTrigger()
+
+        try {
+            shouldThrow<SQLException> {
+                FeedbackRetentionRepository(TestDatabase.dataSource).deleteExpiredFeedback(
+                    retentionMonths = 12,
+                    minimumInterval = Duration.ofDays(1),
+                    batchSize = 1,
+                )
+            }
+
+            remainingFeedbackIds() shouldBe listOf("kept-after-rollback")
+            retentionJobStateCount() shouldBe 0
+        } finally {
+            removeRejectingStateTrigger()
+        }
+    }
 })
+
+private fun databaseRetentionCutoff(): Instant =
+    TestDatabase.dataSource.connection.use { connection ->
+        connection.prepareStatement(
+            """
+                SELECT (
+                    clock_timestamp() AT TIME ZONE 'UTC' - make_interval(months => 12)
+                ) AT TIME ZONE 'UTC' AS cutoff
+            """.trimIndent()
+        ).use { statement ->
+            statement.executeQuery().use { result ->
+                check(result.next())
+                result.getTimestamp("cutoff").toInstant()
+            }
+        }
+    }
 
 private fun insertFeedback(id: String, createdAt: Instant, team: String) {
     TestDatabase.dataSource.connection.use { connection ->
@@ -184,6 +225,49 @@ private fun ageCleanupState(age: Duration) {
         connection.commit()
     }
 }
+
+private fun installRejectingStateTrigger() {
+    TestDatabase.dataSource.connection.use { connection ->
+        connection.createStatement().use { statement ->
+            statement.execute(
+                """
+                    CREATE FUNCTION reject_retention_state_write()
+                    RETURNS trigger
+                    AS 'BEGIN RAISE EXCEPTION ''forced retention state failure''; END;'
+                    LANGUAGE plpgsql
+                """.trimIndent()
+            )
+            statement.execute(
+                """
+                    CREATE TRIGGER reject_retention_state_write
+                    BEFORE INSERT OR UPDATE ON feedback_retention_job_state
+                    FOR EACH ROW EXECUTE FUNCTION reject_retention_state_write()
+                """.trimIndent()
+            )
+        }
+        connection.commit()
+    }
+}
+
+private fun removeRejectingStateTrigger() {
+    TestDatabase.dataSource.connection.use { connection ->
+        connection.createStatement().use { statement ->
+            statement.execute("DROP TRIGGER IF EXISTS reject_retention_state_write ON feedback_retention_job_state")
+            statement.execute("DROP FUNCTION IF EXISTS reject_retention_state_write()")
+        }
+        connection.commit()
+    }
+}
+
+private fun retentionJobStateCount(): Int =
+    TestDatabase.dataSource.connection.use { connection ->
+        connection.createStatement().use { statement ->
+            statement.executeQuery("SELECT COUNT(*) FROM feedback_retention_job_state").use { result ->
+                check(result.next())
+                result.getInt(1)
+            }
+        }
+    }
 
 private fun insertTag(feedbackId: String, tag: String) {
     TestDatabase.dataSource.connection.use { connection ->

--- a/apps/lumi-api/src/test/kotlin/no/nav/lumi/repository/FeedbackRetentionRepositoryTest.kt
+++ b/apps/lumi-api/src/test/kotlin/no/nav/lumi/repository/FeedbackRetentionRepositoryTest.kt
@@ -17,7 +17,7 @@ class FeedbackRetentionRepositoryTest : FunSpec({
         TestDatabase.clearAllData()
     }
 
-    test("deletes only feedback strictly older than cutoff in multiple batches") {
+    test("deletes only one bounded batch of feedback strictly older than cutoff") {
         val cutoff = Instant.parse("2025-08-26T12:00:00Z")
         insertFeedback("old-1", cutoff.minusSeconds(2), "team-a")
         insertFeedback("old-2", cutoff.minusSeconds(1), "team-b")
@@ -26,16 +26,35 @@ class FeedbackRetentionRepositoryTest : FunSpec({
         insertTag("old-1", "expired")
         insertTag("boundary", "kept")
 
-        val result = FeedbackRetentionRepository(TestDatabase.dataSource)
+        val repository = FeedbackRetentionRepository(TestDatabase.dataSource)
+        val firstResult = repository
             .deleteExpiredFeedback(cutoff, batchSize = 1)
 
-        result shouldBe FeedbackRetentionResult(
+        firstResult shouldBe FeedbackRetentionResult(
             executed = true,
-            deletedFeedback = 2,
-            affectedTeams = setOf("team-a", "team-b"),
+            deletedFeedback = 1,
+            affectedTeams = setOf("team-a"),
+        )
+        remainingFeedbackIds() shouldContainExactlyInAnyOrder listOf("old-2", "boundary", "new")
+        remainingTagFeedbackIds() shouldContainExactlyInAnyOrder listOf("boundary")
+
+        val secondResult = repository.deleteExpiredFeedback(cutoff, batchSize = 1)
+
+        secondResult shouldBe FeedbackRetentionResult(
+            executed = true,
+            deletedFeedback = 1,
+            affectedTeams = setOf("team-b"),
         )
         remainingFeedbackIds() shouldContainExactlyInAnyOrder listOf("boundary", "new")
-        remainingTagFeedbackIds() shouldContainExactlyInAnyOrder listOf("boundary")
+    }
+
+    test("rejects a batch size above the defensive per-run limit") {
+        shouldThrow<IllegalArgumentException> {
+            FeedbackRetentionRepository(TestDatabase.dataSource).deleteExpiredFeedback(
+                cutoff = Instant.parse("2025-08-26T12:00:00Z"),
+                batchSize = FeedbackRetentionRepository.MAX_DELETE_BATCH_SIZE + 1,
+            )
+        }.message shouldBe "batchSize must be between 1 and 500"
     }
 
     test("skips cleanup when another connection holds the advisory lock") {

--- a/apps/lumi-api/src/test/kotlin/no/nav/lumi/repository/FeedbackRetentionRepositoryTest.kt
+++ b/apps/lumi-api/src/test/kotlin/no/nav/lumi/repository/FeedbackRetentionRepositoryTest.kt
@@ -1,0 +1,137 @@
+package no.nav.lumi.repository
+
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.matchers.collections.shouldContainExactlyInAnyOrder
+import io.kotest.matchers.shouldBe
+import no.nav.lumi.TestDatabase
+import java.time.Instant
+import java.sql.Timestamp
+
+class FeedbackRetentionRepositoryTest : FunSpec({
+    beforeSpec {
+        TestDatabase.initialize()
+    }
+
+    beforeTest {
+        TestDatabase.clearAllData()
+    }
+
+    test("deletes only feedback strictly older than cutoff in multiple batches") {
+        val cutoff = Instant.parse("2025-08-26T12:00:00Z")
+        insertFeedback("old-1", cutoff.minusSeconds(2), "team-a")
+        insertFeedback("old-2", cutoff.minusSeconds(1), "team-b")
+        insertFeedback("boundary", cutoff, "team-a")
+        insertFeedback("new", cutoff.plusSeconds(1), "team-a")
+        insertTag("old-1", "expired")
+        insertTag("boundary", "kept")
+
+        val result = FeedbackRetentionRepository(TestDatabase.dataSource)
+            .deleteExpiredFeedback(cutoff, batchSize = 1)
+
+        result shouldBe FeedbackRetentionResult(
+            executed = true,
+            deletedFeedback = 2,
+            affectedTeams = setOf("team-a", "team-b"),
+        )
+        remainingFeedbackIds() shouldContainExactlyInAnyOrder listOf("boundary", "new")
+        remainingTagFeedbackIds() shouldContainExactlyInAnyOrder listOf("boundary")
+    }
+
+    test("skips cleanup when another connection holds the advisory lock") {
+        val lockConnection = TestDatabase.dataSource.connection
+        try {
+            lockConnection.prepareStatement("SELECT pg_advisory_lock(?)").use { statement ->
+                statement.setLong(1, FeedbackRetentionRepository.CLEANUP_LOCK_ID)
+                statement.execute()
+            }
+
+            val result = FeedbackRetentionRepository(TestDatabase.dataSource)
+                .deleteExpiredFeedback(Instant.parse("2025-08-26T12:00:00Z"), batchSize = 10)
+
+            result shouldBe FeedbackRetentionResult(executed = false)
+        } finally {
+            lockConnection.prepareStatement("SELECT pg_advisory_unlock(?)").use { statement ->
+                statement.setLong(1, FeedbackRetentionRepository.CLEANUP_LOCK_ID)
+                statement.execute()
+            }
+            lockConnection.commit()
+            lockConnection.close()
+        }
+    }
+
+    test("publishes a batch only after its deletion is committed") {
+        val cutoff = Instant.parse("2025-08-26T12:00:00Z")
+        insertFeedback("first", cutoff.minusSeconds(2), "team-a")
+        insertFeedback("second", cutoff.minusSeconds(1), "team-b")
+        val published = mutableListOf<FeedbackRetentionBatchResult>()
+
+        shouldThrow<IllegalStateException> {
+            FeedbackRetentionRepository(TestDatabase.dataSource)
+                .deleteExpiredFeedback(cutoff, batchSize = 1) { batch ->
+                    published += batch
+                    error("stop after committed batch")
+                }
+        }
+
+        published shouldBe listOf(
+            FeedbackRetentionBatchResult(
+                deletedFeedback = 1,
+                affectedTeams = setOf("team-a"),
+            ),
+        )
+        remainingFeedbackIds() shouldBe listOf("second")
+    }
+})
+
+private fun insertFeedback(id: String, createdAt: Instant, team: String) {
+    TestDatabase.dataSource.connection.use { connection ->
+        connection.prepareStatement(
+            """
+                INSERT INTO feedback (id, opprettet, feedback_json, team, app)
+                VALUES (?, ?, '{}'::jsonb, ?, 'app-a')
+            """.trimIndent()
+        ).use { statement ->
+            statement.setString(1, id)
+            statement.setTimestamp(2, Timestamp.from(createdAt))
+            statement.setString(3, team)
+            statement.executeUpdate()
+        }
+        connection.commit()
+    }
+}
+
+private fun insertTag(feedbackId: String, tag: String) {
+    TestDatabase.dataSource.connection.use { connection ->
+        connection.prepareStatement(
+            "INSERT INTO feedback_tag (feedback_id, tag) VALUES (?, ?)"
+        ).use { statement ->
+            statement.setString(1, feedbackId)
+            statement.setString(2, tag)
+            statement.executeUpdate()
+        }
+        connection.commit()
+    }
+}
+
+private fun remainingFeedbackIds(): List<String> =
+    TestDatabase.dataSource.connection.use { connection ->
+        connection.createStatement().use { statement ->
+            statement.executeQuery("SELECT id FROM feedback").use { result ->
+                buildList {
+                    while (result.next()) add(result.getString("id"))
+                }
+            }
+        }
+    }
+
+private fun remainingTagFeedbackIds(): List<String> =
+    TestDatabase.dataSource.connection.use { connection ->
+        connection.createStatement().use { statement ->
+            statement.executeQuery("SELECT feedback_id FROM feedback_tag").use { result ->
+                buildList {
+                    while (result.next()) add(result.getString("feedback_id"))
+                }
+            }
+        }
+    }

--- a/apps/lumi-api/src/test/kotlin/no/nav/lumi/repository/SurveyDefinitionRepositoryTest.kt
+++ b/apps/lumi-api/src/test/kotlin/no/nav/lumi/repository/SurveyDefinitionRepositoryTest.kt
@@ -8,6 +8,9 @@ import no.nav.lumi.TestDatabase
 import no.nav.lumi.config.DatabaseHolder
 import no.nav.lumi.domain.FieldType
 import no.nav.lumi.domain.SurveyType
+import java.sql.Timestamp
+import java.time.Instant
+import java.time.ZoneOffset
 
 class SurveyDefinitionRepositoryTest : FunSpec({
     val repository = SurveyDefinitionRepository()
@@ -57,9 +60,89 @@ class SurveyDefinitionRepositoryTest : FunSpec({
         }
 
         val stored = repository.findByTeamAndSurveyId("team-a", "survey-unknown-fields").shouldNotBeNull()
-        stored.definition.surveyType shouldBe SurveyType.RATING
-        stored.definition.fields.shouldHaveSize(1)
-        stored.definition.fields.single().fieldId shouldBe "comment"
-        stored.definition.fields.single().fieldType shouldBe FieldType.TEXT
+        val definition = stored.definition.shouldNotBeNull()
+        definition.surveyType shouldBe SurveyType.RATING
+        definition.fields.shouldHaveSize(1)
+        definition.fields.single().fieldId shouldBe "comment"
+        definition.fields.single().fieldType shouldBe FieldType.TEXT
+    }
+
+    test("stored submission moves activity and definition retention forward") {
+        val oldActivity = Instant.parse("2020-01-01T00:00:00Z")
+        TestDatabase.dataSource.connection.use { connection ->
+            connection.prepareStatement(
+                """
+                    INSERT INTO survey_definitions (
+                        team, survey_id, definition_hash, definition,
+                        last_submission_at, definition_retention_at
+                    )
+                    VALUES ('team-a', 'survey-activity', ?, ?::jsonb, ?, ?)
+                """.trimIndent()
+            ).use { statement ->
+                statement.setString(1, "a".repeat(64))
+                statement.setString(
+                    2,
+                    """{"surveyId":"survey-activity","surveyType":"custom","fields":[]}""",
+                )
+                statement.setTimestamp(3, Timestamp.from(oldActivity))
+                statement.setTimestamp(4, Timestamp.from(oldActivity))
+                statement.executeUpdate()
+            }
+            connection.commit()
+        }
+        val beforeUpdate = Instant.now().minusSeconds(1)
+
+        dbQuery {
+            repository.recordStoredSubmissionInCurrentTransaction("team-a", "survey-activity")
+        }
+
+        val stored = repository.findByTeamAndSurveyId("team-a", "survey-activity").shouldNotBeNull()
+        (stored.lastSubmissionAt >= beforeUpdate) shouldBe true
+        (
+            stored.definitionRetentionAt >= beforeUpdate.atZone(ZoneOffset.UTC)
+                .plusMonths(18)
+                .toInstant()
+        ) shouldBe true
+    }
+
+    test("feedback insert updates activity for writers from before retention tracking") {
+        val oldActivity = Instant.parse("2020-01-01T00:00:00Z")
+        val submissionTime = Instant.parse("2026-08-26T12:34:56Z")
+        TestDatabase.dataSource.connection.use { connection ->
+            connection.prepareStatement(
+                """
+                    INSERT INTO survey_definitions (
+                        team, survey_id, definition_hash, definition,
+                        last_submission_at, definition_retention_at
+                    )
+                    VALUES ('team-a', 'survey-rolling', ?, ?::jsonb, ?, ?)
+                """.trimIndent()
+            ).use { statement ->
+                statement.setString(1, "a".repeat(64))
+                statement.setString(
+                    2,
+                    """{"surveyId":"survey-rolling","surveyType":"custom","fields":[]}""",
+                )
+                statement.setTimestamp(3, Timestamp.from(oldActivity))
+                statement.setTimestamp(4, Timestamp.from(oldActivity))
+                statement.executeUpdate()
+            }
+            connection.prepareStatement(
+                """
+                    INSERT INTO feedback (id, opprettet, feedback_json, team, app, survey_id)
+                    VALUES ('rolling-feedback', ?, '{}'::jsonb, 'team-a', 'app-a', 'survey-rolling')
+                """.trimIndent()
+            ).use { statement ->
+                statement.setTimestamp(1, Timestamp.from(submissionTime))
+                statement.executeUpdate()
+            }
+            connection.commit()
+        }
+
+        val stored = repository.findByTeamAndSurveyId("team-a", "survey-rolling").shouldNotBeNull()
+        stored.lastSubmissionAt shouldBe submissionTime
+        stored.definitionRetentionAt shouldBe submissionTime.atZone(ZoneOffset.UTC)
+            .plusMonths(18)
+            .toInstant()
     }
 })

--- a/apps/lumi-api/src/test/kotlin/no/nav/lumi/repository/SurveyRetentionMigrationTest.kt
+++ b/apps/lumi-api/src/test/kotlin/no/nav/lumi/repository/SurveyRetentionMigrationTest.kt
@@ -1,0 +1,149 @@
+package no.nav.lumi.repository
+
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.string.shouldContain
+import io.kotest.matchers.string.shouldNotContain
+import no.nav.lumi.PsqlContainer
+import org.flywaydb.core.Flyway
+import org.flywaydb.core.api.MigrationVersion
+import org.testcontainers.containers.wait.strategy.HostPortWaitStrategy
+import java.nio.file.Files
+import java.nio.file.Path
+import java.sql.DriverManager
+import java.sql.Timestamp
+import java.time.Instant
+import java.time.ZoneOffset
+
+class SurveyRetentionMigrationTest : FunSpec({
+    test("keeps the feedback scan out of the trigger migration") {
+        val triggerMigration = Files.readString(
+            Path.of("src/main/resources/db/migration/V16__survey_retention_activity.sql")
+        )
+        val backfillMigration = Files.readString(
+            Path.of("src/main/resources/db/migration/V17__backfill_survey_retention_activity.sql")
+        )
+
+        triggerMigration shouldNotContain "FROM feedback"
+        backfillMigration shouldContain "FROM feedback"
+    }
+
+    test("installs the rolling writer trigger before backfilling activity") {
+        PsqlContainer().apply {
+            withDatabaseName("lumi_retention_migration_test")
+            withUsername("test")
+            withPassword("test")
+            setWaitStrategy(HostPortWaitStrategy())
+        }.use { container ->
+            container.start()
+            val dataSource = Triple(container.jdbcUrl, container.username, container.password)
+
+            migrate(dataSource, target = "15")
+
+            // Future dates keep the exact retention assertions independent of
+            // the migration's three-month warning floor.
+            val historicalActivity = Instant.parse("2089-02-01T12:00:00Z")
+            val rollingDeployActivity = Instant.parse("2090-03-01T12:00:00Z")
+            val definitionWithoutFeedbackCreatedAt = Instant.parse("2090-04-01T12:00:00Z")
+
+            DriverManager.getConnection(dataSource.first, dataSource.second, dataSource.third).use { connection ->
+                connection.autoCommit = false
+                insertDefinition(connection, "survey-with-feedback", Instant.parse("2089-01-01T12:00:00Z"), "a")
+                insertDefinition(connection, "survey-without-feedback", definitionWithoutFeedbackCreatedAt, "b")
+                insertFeedback(connection, "historical", "survey-with-feedback", historicalActivity)
+                connection.commit()
+            }
+
+            migrate(dataSource, target = "16")
+
+            // Simulates an old application instance writing after V16 has committed
+            // but before the backfill migration starts.
+            DriverManager.getConnection(dataSource.first, dataSource.second, dataSource.third).use { connection ->
+                connection.autoCommit = false
+                insertFeedback(connection, "rolling", "survey-with-feedback", rollingDeployActivity)
+                connection.commit()
+            }
+
+            migrate(dataSource)
+
+            DriverManager.getConnection(dataSource.first, dataSource.second, dataSource.third).use { connection ->
+                connection.prepareStatement(
+                    """
+                        SELECT survey_id, last_submission_at, definition_retention_at
+                        FROM survey_definitions
+                        ORDER BY survey_id
+                    """.trimIndent()
+                ).use { statement ->
+                    statement.executeQuery().use { result ->
+                        result.next() shouldBe true
+                        result.getString("survey_id") shouldBe "survey-with-feedback"
+                        result.getTimestamp("last_submission_at").toInstant() shouldBe rollingDeployActivity
+                        result.getTimestamp("definition_retention_at").toInstant() shouldBe
+                            rollingDeployActivity.atZone(ZoneOffset.UTC).plusMonths(18).toInstant()
+
+                        result.next() shouldBe true
+                        result.getString("survey_id") shouldBe "survey-without-feedback"
+                        result.getTimestamp("last_submission_at").toInstant() shouldBe definitionWithoutFeedbackCreatedAt
+                        result.getTimestamp("definition_retention_at").toInstant() shouldBe
+                            definitionWithoutFeedbackCreatedAt.atZone(ZoneOffset.UTC).plusMonths(18).toInstant()
+
+                        result.next() shouldBe false
+                    }
+                }
+            }
+        }
+    }
+})
+
+private fun migrate(dataSource: Triple<String, String, String>, target: String? = null) {
+    val configuration = Flyway.configure()
+        .dataSource(dataSource.first, dataSource.second, dataSource.third)
+        .locations("classpath:db/migration")
+    if (target != null) {
+        configuration.target(MigrationVersion.fromVersion(target))
+    }
+    configuration.load().migrate()
+}
+
+private fun insertDefinition(
+    connection: java.sql.Connection,
+    surveyId: String,
+    createdAt: Instant,
+    hashCharacter: String,
+) {
+    connection.prepareStatement(
+        """
+            INSERT INTO survey_definitions (
+                team, survey_id, definition_hash, definition, created_at, updated_at
+            )
+            VALUES ('team-a', ?, ?, ?::jsonb, ?, ?)
+        """.trimIndent()
+    ).use { statement ->
+        statement.setString(1, surveyId)
+        statement.setString(2, hashCharacter.repeat(64))
+        statement.setString(3, """{"surveyId":"$surveyId","surveyType":"rating","fields":[]}""")
+        statement.setTimestamp(4, Timestamp.from(createdAt))
+        statement.setTimestamp(5, Timestamp.from(createdAt))
+        statement.executeUpdate()
+    }
+}
+
+private fun insertFeedback(
+    connection: java.sql.Connection,
+    id: String,
+    surveyId: String,
+    createdAt: Instant,
+) {
+    connection.prepareStatement(
+        """
+            INSERT INTO feedback (id, opprettet, feedback_json, team, app, survey_id)
+            VALUES (?, ?, ?::jsonb, 'team-a', 'app-a', ?)
+        """.trimIndent()
+    ).use { statement ->
+        statement.setString(1, id)
+        statement.setTimestamp(2, Timestamp.from(createdAt))
+        statement.setString(3, """{"surveyId":"$surveyId"}""")
+        statement.setString(4, surveyId)
+        statement.executeUpdate()
+    }
+}

--- a/apps/lumi-api/src/test/kotlin/no/nav/lumi/repository/SurveyRetentionMigrationTest.kt
+++ b/apps/lumi-api/src/test/kotlin/no/nav/lumi/repository/SurveyRetentionMigrationTest.kt
@@ -90,6 +90,28 @@ class SurveyRetentionMigrationTest : FunSpec({
                         result.next() shouldBe false
                     }
                 }
+                connection.prepareStatement(
+                    """
+                        SELECT indexdef
+                        FROM pg_indexes
+                        WHERE schemaname = 'public'
+                          AND indexname = 'idx_survey_definitions_active_retention'
+                    """.trimIndent()
+                ).use { statement ->
+                    statement.executeQuery().use { result ->
+                        result.next() shouldBe true
+                        result.getString("indexdef") shouldContain
+                            "(team, definition_retention_at) WHERE (retired_at IS NULL)"
+                    }
+                }
+                connection.prepareStatement(
+                    "SELECT to_regclass('public.feedback_retention_job_state')::text"
+                ).use { statement ->
+                    statement.executeQuery().use { result ->
+                        result.next() shouldBe true
+                        result.getString(1) shouldBe "feedback_retention_job_state"
+                    }
+                }
             }
         }
     }

--- a/apps/lumi-api/src/test/kotlin/no/nav/lumi/routes/FilterRoutesTest.kt
+++ b/apps/lumi-api/src/test/kotlin/no/nav/lumi/routes/FilterRoutesTest.kt
@@ -15,6 +15,7 @@ import io.ktor.http.HttpStatusCode
 import io.ktor.server.testing.testApplication
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonNull
+import kotlinx.serialization.json.jsonArray
 import kotlinx.serialization.json.jsonObject
 import kotlinx.serialization.json.jsonPrimitive
 import no.nav.lumi.TestDatabase
@@ -25,8 +26,12 @@ import no.nav.lumi.integrations.valkey.InMemoryStringCache
 import no.nav.lumi.repository.FeedbackRepository
 import no.nav.lumi.repository.SurveyMetadataRepository
 import no.nav.lumi.testModule
+import java.sql.Timestamp
 import java.time.Duration
+import java.time.Instant
 import java.time.OffsetDateTime
+import java.time.ZoneOffset
+import java.time.temporal.ChronoUnit
 
 class FilterRoutesTest : FunSpec({
     beforeSpec {
@@ -40,7 +45,7 @@ class FilterRoutesTest : FunSpec({
             email = "test@nav.no",
             clientId = null,
         )
-        bootstrapCacheKey("Team-Test", principal) shouldBe "team=team-test&user=a123456&responseVersion=2"
+        bootstrapCacheKey("Team-Test", principal) shouldBe "team=team-test&user=a123456&responseVersion=3"
     }
 
     test("bootstrapCacheKey falls back to email when navIdent is missing") {
@@ -50,7 +55,7 @@ class FilterRoutesTest : FunSpec({
             email = "Test.User@nav.no",
             clientId = null,
         )
-        bootstrapCacheKey("team-test", principal) shouldBe "team=team-test&user=test.user@nav.no&responseVersion=2"
+        bootstrapCacheKey("team-test", principal) shouldBe "team=team-test&user=test.user@nav.no&responseVersion=3"
     }
 
     test("bootstrapCacheKey falls back to email when navIdent is blank") {
@@ -60,7 +65,7 @@ class FilterRoutesTest : FunSpec({
             email = "Test.User@nav.no",
             clientId = null,
         )
-        bootstrapCacheKey("team-test", principal) shouldBe "team=team-test&user=test.user@nav.no&responseVersion=2"
+        bootstrapCacheKey("team-test", principal) shouldBe "team=team-test&user=test.user@nav.no&responseVersion=3"
     }
 
     test("bootstrapCacheKey returns null when navIdent and email are blank") {
@@ -224,6 +229,38 @@ class FilterRoutesTest : FunSpec({
 
     beforeTest {
         TestDatabase.clearAllData()
+    }
+
+    test("bootstrap exposes team-scoped retention warnings after 15 inactive months") {
+        val lastActivity = Instant.now().atZone(ZoneOffset.UTC)
+            .minusMonths(16)
+            .toInstant()
+            .truncatedTo(ChronoUnit.MICROS)
+        insertSurveyDefinition("team-test", "survey-inactive", lastActivity)
+        insertSurveyDefinition(
+            "team-test",
+            "survey-recent",
+            Instant.now().atZone(ZoneOffset.UTC).minusMonths(14).toInstant(),
+        )
+        insertSurveyDefinition("another-team", "survey-other-team", lastActivity)
+
+        testApplication {
+            application { testModule() }
+
+            val response = createTestClient().get("/api/v1/intern/filters/bootstrap?team=team-test") {
+                header(HttpHeaders.Authorization, "Bearer test-token")
+            }
+
+            response.status shouldBe HttpStatusCode.OK
+            val warnings = Json.parseToJsonElement(response.bodyAsText())
+                .jsonObject["retentionWarnings"]!!.jsonArray
+            warnings.size shouldBe 1
+            val warning = warnings.single().jsonObject
+            warning["surveyId"]!!.jsonPrimitive.content shouldBe "survey-inactive"
+            warning["lastActivityAt"]!!.jsonPrimitive.content shouldBe lastActivity.toString()
+            warning["scheduledFor"]!!.jsonPrimitive.content shouldBe
+                lastActivity.atZone(ZoneOffset.UTC).plusMonths(18).toInstant().toString()
+        }
     }
 
     test("bootstrap exposes archive state per survey in surveyMeta") {
@@ -433,3 +470,32 @@ class FilterRoutesTest : FunSpec({
         }
     }
 })
+
+private fun insertSurveyDefinition(team: String, surveyId: String, lastActivityAt: Instant) {
+    TestDatabase.dataSource.connection.use { connection ->
+        connection.prepareStatement(
+            """
+                INSERT INTO survey_definitions (
+                    team, survey_id, definition_hash, definition,
+                    last_submission_at, definition_retention_at
+                )
+                VALUES (?, ?, ?, ?::jsonb, ?, ?)
+            """.trimIndent()
+        ).use { statement ->
+            statement.setString(1, team)
+            statement.setString(2, surveyId)
+            statement.setString(3, "a".repeat(64))
+            statement.setString(
+                4,
+                """{"surveyId":"$surveyId","surveyType":"custom","fields":[]}""",
+            )
+            statement.setTimestamp(5, Timestamp.from(lastActivityAt))
+            statement.setTimestamp(
+                6,
+                Timestamp.from(lastActivityAt.atZone(ZoneOffset.UTC).plusMonths(18).toInstant()),
+            )
+            statement.executeUpdate()
+        }
+        connection.commit()
+    }
+}

--- a/apps/lumi-api/src/test/kotlin/no/nav/lumi/routes/InternalSubmissionRoutesTest.kt
+++ b/apps/lumi-api/src/test/kotlin/no/nav/lumi/routes/InternalSubmissionRoutesTest.kt
@@ -2,6 +2,7 @@ package no.nav.lumi.routes
 
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.shouldBe
+import io.kotest.matchers.nulls.shouldNotBeNull
 import io.kotest.matchers.string.shouldNotContain
 import io.ktor.client.request.*
 import io.ktor.client.statement.*
@@ -730,7 +731,7 @@ class InternalSubmissionRoutesTest : FunSpec({
 
             val storedAfter = surveyDefinitionRepository.findByTeamAndSurveyId("teamsykefravr", "modia-dedup-extension-survey")!!
             storedAfter.definitionHash shouldBe storedBefore.definitionHash
-            storedAfter.definition.fields.map { it.fieldId } shouldBe listOf("feedback")
+            storedAfter.definition.shouldNotBeNull().fields.map { it.fieldId } shouldBe listOf("feedback")
 
             val (_, total, _) = feedbackRepository.findPaginated(FeedbackQuery(team = "teamsykefravr"))
             total shouldBe 1
@@ -852,7 +853,7 @@ class InternalSubmissionRoutesTest : FunSpec({
             duplicateBody["duplicate"]?.jsonPrimitive?.boolean shouldBe true
 
             val stored = surveyDefinitionRepository.findByTeamAndSurveyId("teamsykefravr", "modia-dedup-race-conflict-survey")!!
-            stored.definition.fields.single().optionIds shouldBe listOf("apply")
+            stored.definition.shouldNotBeNull().fields.single().optionIds shouldBe listOf("apply")
 
             val (_, total, _) = feedbackRepository.findPaginated(FeedbackQuery(team = "teamsykefravr"))
             total shouldBe 1

--- a/apps/lumi-api/src/test/kotlin/no/nav/lumi/routes/SubmissionRoutesTest.kt
+++ b/apps/lumi-api/src/test/kotlin/no/nav/lumi/routes/SubmissionRoutesTest.kt
@@ -2,6 +2,7 @@ package no.nav.lumi.routes
 
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.shouldBe
+import io.kotest.matchers.nulls.shouldNotBeNull
 import io.kotest.matchers.string.shouldNotContain
 import io.ktor.client.request.*
 import io.ktor.client.statement.*
@@ -1348,7 +1349,7 @@ class SubmissionRoutesTest : FunSpec({
 
             val storedAfter = surveyDefinitionRepository.findByTeamAndSurveyId("local-dev", "dedup-conflict-survey")!!
             storedAfter.definitionHash shouldBe storedBefore.definitionHash
-            storedAfter.definition.fields.single().optionIds shouldBe listOf("apply")
+            storedAfter.definition.shouldNotBeNull().fields.single().optionIds shouldBe listOf("apply")
 
             val (_, total, _) = feedbackRepository.findPaginated(FeedbackQuery(team = "local-dev"))
             total shouldBe 1
@@ -1482,7 +1483,7 @@ class SubmissionRoutesTest : FunSpec({
             secondResponse.status shouldBe HttpStatusCode.Created
 
             val stored = surveyDefinitionRepository.findByTeamAndSurveyId("local-dev", "dedup-extension-survey")!!
-            stored.definition.fields.map { it.fieldId } shouldBe listOf("feedback", "followup")
+            stored.definition.shouldNotBeNull().fields.map { it.fieldId } shouldBe listOf("feedback", "followup")
 
             val (_, total, _) = feedbackRepository.findPaginated(FeedbackQuery(team = "local-dev"))
             total shouldBe 2
@@ -1808,7 +1809,7 @@ class SubmissionRoutesTest : FunSpec({
             duplicateBody["duplicate"]?.jsonPrimitive?.boolean shouldBe true
 
             val stored = surveyDefinitionRepository.findByTeamAndSurveyId("local-dev", "dedup-race-conflict-survey")!!
-            stored.definition.fields.single().optionIds shouldBe listOf("apply")
+            stored.definition.shouldNotBeNull().fields.single().optionIds shouldBe listOf("apply")
 
             val (_, total, _) = feedbackRepository.findPaginated(FeedbackQuery(team = "local-dev"))
             total shouldBe 1
@@ -1923,7 +1924,7 @@ class SubmissionRoutesTest : FunSpec({
             duplicateBody["duplicate"]?.jsonPrimitive?.boolean shouldBe true
 
             val stored = surveyDefinitionRepository.findByTeamAndSurveyId("local-dev", "dedup-race-extension-survey")!!
-            stored.definition.fields.map { it.fieldId } shouldBe listOf("feedback")
+            stored.definition.shouldNotBeNull().fields.map { it.fieldId } shouldBe listOf("feedback")
 
             val saved = feedbackRepository.findRawById(createdId, "local-dev")
             saved?.feedbackJson?.contains("Første payload") shouldBe true

--- a/apps/lumi-api/src/test/kotlin/no/nav/lumi/service/FeedbackRetentionServiceTest.kt
+++ b/apps/lumi-api/src/test/kotlin/no/nav/lumi/service/FeedbackRetentionServiceTest.kt
@@ -17,7 +17,7 @@ import java.time.Instant
 import java.time.ZoneOffset
 
 class FeedbackRetentionServiceTest : FunSpec({
-    test("uses a 12 calendar month cutoff and records completion") {
+    test("requests a 12 calendar month cutoff and records completion") {
         val now = Instant.parse("2026-02-28T12:00:00Z")
         val expectedCutoff = Instant.parse("2025-02-28T12:00:00Z")
         val repository = mockk<FeedbackRetentionRepository>()
@@ -34,12 +34,13 @@ class FeedbackRetentionServiceTest : FunSpec({
         )
         val expectedResult = FeedbackRetentionResult(
             executed = true,
+            cutoff = expectedCutoff,
             deletedFeedback = 3,
             affectedTeams = setOf("team-b", "team-a"),
         )
 
         every {
-            repository.deleteExpiredFeedback(expectedCutoff, Duration.ofDays(1), 25, any())
+            repository.deleteExpiredFeedback(12, Duration.ofDays(1), 25, any())
         } answers {
             lastArg<(FeedbackRetentionBatchResult) -> Unit>().invoke(
                 FeedbackRetentionBatchResult(3, setOf("team-b", "team-a")),
@@ -54,7 +55,7 @@ class FeedbackRetentionServiceTest : FunSpec({
         service.runOnce() shouldBe expectedResult
 
         verify(exactly = 1) {
-            repository.deleteExpiredFeedback(expectedCutoff, Duration.ofDays(1), 25, any())
+            repository.deleteExpiredFeedback(12, Duration.ofDays(1), 25, any())
         }
         verify(exactly = 1) { statsCacheInvalidator.invalidateTeam("team-a") }
         verify(exactly = 1) { statsCacheInvalidator.invalidateTeam("team-b") }
@@ -66,7 +67,6 @@ class FeedbackRetentionServiceTest : FunSpec({
 
     test("publishes a committed batch before a later cleanup failure") {
         val now = Instant.parse("2026-02-28T12:00:00Z")
-        val expectedCutoff = Instant.parse("2025-02-28T12:00:00Z")
         val repository = mockk<FeedbackRetentionRepository>()
         val observability = mockk<RetentionObservability>()
         val statsCacheInvalidator = mockk<StatsCacheInvalidator>()
@@ -82,7 +82,7 @@ class FeedbackRetentionServiceTest : FunSpec({
         val failure = IllegalStateException("later batch failed")
 
         every {
-            repository.deleteExpiredFeedback(expectedCutoff, Duration.ofDays(1), 25, any())
+            repository.deleteExpiredFeedback(12, Duration.ofDays(1), 25, any())
         } answers {
             lastArg<(FeedbackRetentionBatchResult) -> Unit>().invoke(
                 FeedbackRetentionBatchResult(2, setOf("team-a")),
@@ -105,7 +105,6 @@ class FeedbackRetentionServiceTest : FunSpec({
 
     test("records a globally rate-limited attempt as skipped") {
         val now = Instant.parse("2026-02-28T12:00:00Z")
-        val expectedCutoff = Instant.parse("2025-02-28T12:00:00Z")
         val repository = mockk<FeedbackRetentionRepository>()
         val observability = mockk<RetentionObservability>()
         val service = FeedbackRetentionService(
@@ -122,7 +121,7 @@ class FeedbackRetentionServiceTest : FunSpec({
 
         every {
             repository.deleteExpiredFeedback(
-                expectedCutoff,
+                12,
                 Duration.ofDays(1),
                 FeedbackRetentionRepository.MAX_DELETE_BATCH_SIZE,
                 any(),

--- a/apps/lumi-api/src/test/kotlin/no/nav/lumi/service/FeedbackRetentionServiceTest.kt
+++ b/apps/lumi-api/src/test/kotlin/no/nav/lumi/service/FeedbackRetentionServiceTest.kt
@@ -7,10 +7,12 @@ import io.mockk.every
 import io.mockk.mockk
 import io.mockk.verify
 import no.nav.lumi.config.RetentionObservability
-import no.nav.lumi.repository.FeedbackRetentionRepository
 import no.nav.lumi.repository.FeedbackRetentionBatchResult
+import no.nav.lumi.repository.FeedbackRetentionRepository
 import no.nav.lumi.repository.FeedbackRetentionResult
+import no.nav.lumi.repository.FeedbackRetentionSkipReason
 import java.time.Clock
+import java.time.Duration
 import java.time.Instant
 import java.time.ZoneOffset
 
@@ -36,8 +38,10 @@ class FeedbackRetentionServiceTest : FunSpec({
             affectedTeams = setOf("team-b", "team-a"),
         )
 
-        every { repository.deleteExpiredFeedback(expectedCutoff, 25, any()) } answers {
-            thirdArg<(FeedbackRetentionBatchResult) -> Unit>().invoke(
+        every {
+            repository.deleteExpiredFeedback(expectedCutoff, Duration.ofDays(1), 25, any())
+        } answers {
+            lastArg<(FeedbackRetentionBatchResult) -> Unit>().invoke(
                 FeedbackRetentionBatchResult(3, setOf("team-b", "team-a")),
             )
             expectedResult
@@ -49,7 +53,9 @@ class FeedbackRetentionServiceTest : FunSpec({
 
         service.runOnce() shouldBe expectedResult
 
-        verify(exactly = 1) { repository.deleteExpiredFeedback(expectedCutoff, 25, any()) }
+        verify(exactly = 1) {
+            repository.deleteExpiredFeedback(expectedCutoff, Duration.ofDays(1), 25, any())
+        }
         verify(exactly = 1) { statsCacheInvalidator.invalidateTeam("team-a") }
         verify(exactly = 1) { statsCacheInvalidator.invalidateTeam("team-b") }
         verify(exactly = 1) { bootstrapCacheInvalidator.invalidateTeam("team-a") }
@@ -75,8 +81,10 @@ class FeedbackRetentionServiceTest : FunSpec({
         )
         val failure = IllegalStateException("later batch failed")
 
-        every { repository.deleteExpiredFeedback(expectedCutoff, 25, any()) } answers {
-            thirdArg<(FeedbackRetentionBatchResult) -> Unit>().invoke(
+        every {
+            repository.deleteExpiredFeedback(expectedCutoff, Duration.ofDays(1), 25, any())
+        } answers {
+            lastArg<(FeedbackRetentionBatchResult) -> Unit>().invoke(
                 FeedbackRetentionBatchResult(2, setOf("team-a")),
             )
             throw failure
@@ -93,5 +101,39 @@ class FeedbackRetentionServiceTest : FunSpec({
         verify(exactly = 1) { observability.recordDeletedFeedback(2) }
         verify(exactly = 1) { observability.recordFailed() }
         verify(exactly = 0) { observability.recordExecuted(any()) }
+    }
+
+    test("records a globally rate-limited attempt as skipped") {
+        val now = Instant.parse("2026-02-28T12:00:00Z")
+        val expectedCutoff = Instant.parse("2025-02-28T12:00:00Z")
+        val repository = mockk<FeedbackRetentionRepository>()
+        val observability = mockk<RetentionObservability>()
+        val service = FeedbackRetentionService(
+            repository = repository,
+            observability = observability,
+            statsCacheInvalidator = mockk(),
+            bootstrapCacheInvalidator = mockk(),
+            clock = Clock.fixed(now, ZoneOffset.UTC),
+        )
+        val expectedResult = FeedbackRetentionResult(
+            executed = false,
+            skipReason = FeedbackRetentionSkipReason.MINIMUM_INTERVAL_NOT_ELAPSED,
+        )
+
+        every {
+            repository.deleteExpiredFeedback(
+                expectedCutoff,
+                Duration.ofDays(1),
+                FeedbackRetentionRepository.MAX_DELETE_BATCH_SIZE,
+                any(),
+            )
+        } returns expectedResult
+        every { observability.recordSkipped() } returns Unit
+
+        service.runOnce() shouldBe expectedResult
+
+        verify(exactly = 1) { observability.recordSkipped() }
+        verify(exactly = 0) { observability.recordExecuted(any()) }
+        verify(exactly = 0) { observability.recordFailed() }
     }
 })

--- a/apps/lumi-api/src/test/kotlin/no/nav/lumi/service/FeedbackRetentionServiceTest.kt
+++ b/apps/lumi-api/src/test/kotlin/no/nav/lumi/service/FeedbackRetentionServiceTest.kt
@@ -1,0 +1,97 @@
+package no.nav.lumi.service
+
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.matchers.shouldBe
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import no.nav.lumi.config.RetentionObservability
+import no.nav.lumi.repository.FeedbackRetentionRepository
+import no.nav.lumi.repository.FeedbackRetentionBatchResult
+import no.nav.lumi.repository.FeedbackRetentionResult
+import java.time.Clock
+import java.time.Instant
+import java.time.ZoneOffset
+
+class FeedbackRetentionServiceTest : FunSpec({
+    test("uses a 12 calendar month cutoff and records completion") {
+        val now = Instant.parse("2026-02-28T12:00:00Z")
+        val expectedCutoff = Instant.parse("2025-02-28T12:00:00Z")
+        val repository = mockk<FeedbackRetentionRepository>()
+        val observability = mockk<RetentionObservability>()
+        val statsCacheInvalidator = mockk<StatsCacheInvalidator>()
+        val bootstrapCacheInvalidator = mockk<BootstrapCacheInvalidator>()
+        val service = FeedbackRetentionService(
+            repository = repository,
+            observability = observability,
+            statsCacheInvalidator = statsCacheInvalidator,
+            bootstrapCacheInvalidator = bootstrapCacheInvalidator,
+            clock = Clock.fixed(now, ZoneOffset.UTC),
+            batchSize = 25,
+        )
+        val expectedResult = FeedbackRetentionResult(
+            executed = true,
+            deletedFeedback = 3,
+            affectedTeams = setOf("team-b", "team-a"),
+        )
+
+        every { repository.deleteExpiredFeedback(expectedCutoff, 25, any()) } answers {
+            thirdArg<(FeedbackRetentionBatchResult) -> Unit>().invoke(
+                FeedbackRetentionBatchResult(3, setOf("team-b", "team-a")),
+            )
+            expectedResult
+        }
+        every { statsCacheInvalidator.invalidateTeam(any()) } returns Unit
+        every { bootstrapCacheInvalidator.invalidateTeam(any()) } returns Unit
+        every { observability.recordDeletedFeedback(3) } returns Unit
+        every { observability.recordExecuted(now) } returns Unit
+
+        service.runOnce() shouldBe expectedResult
+
+        verify(exactly = 1) { repository.deleteExpiredFeedback(expectedCutoff, 25, any()) }
+        verify(exactly = 1) { statsCacheInvalidator.invalidateTeam("team-a") }
+        verify(exactly = 1) { statsCacheInvalidator.invalidateTeam("team-b") }
+        verify(exactly = 1) { bootstrapCacheInvalidator.invalidateTeam("team-a") }
+        verify(exactly = 1) { bootstrapCacheInvalidator.invalidateTeam("team-b") }
+        verify(exactly = 1) { observability.recordDeletedFeedback(3) }
+        verify(exactly = 1) { observability.recordExecuted(now) }
+    }
+
+    test("publishes a committed batch before a later cleanup failure") {
+        val now = Instant.parse("2026-02-28T12:00:00Z")
+        val expectedCutoff = Instant.parse("2025-02-28T12:00:00Z")
+        val repository = mockk<FeedbackRetentionRepository>()
+        val observability = mockk<RetentionObservability>()
+        val statsCacheInvalidator = mockk<StatsCacheInvalidator>()
+        val bootstrapCacheInvalidator = mockk<BootstrapCacheInvalidator>()
+        val service = FeedbackRetentionService(
+            repository = repository,
+            observability = observability,
+            statsCacheInvalidator = statsCacheInvalidator,
+            bootstrapCacheInvalidator = bootstrapCacheInvalidator,
+            clock = Clock.fixed(now, ZoneOffset.UTC),
+            batchSize = 25,
+        )
+        val failure = IllegalStateException("later batch failed")
+
+        every { repository.deleteExpiredFeedback(expectedCutoff, 25, any()) } answers {
+            thirdArg<(FeedbackRetentionBatchResult) -> Unit>().invoke(
+                FeedbackRetentionBatchResult(2, setOf("team-a")),
+            )
+            throw failure
+        }
+        every { statsCacheInvalidator.invalidateTeam("team-a") } returns Unit
+        every { bootstrapCacheInvalidator.invalidateTeam("team-a") } returns Unit
+        every { observability.recordDeletedFeedback(2) } returns Unit
+        every { observability.recordFailed() } returns Unit
+
+        shouldThrow<IllegalStateException> { service.runOnce() } shouldBe failure
+
+        verify(exactly = 1) { statsCacheInvalidator.invalidateTeam("team-a") }
+        verify(exactly = 1) { bootstrapCacheInvalidator.invalidateTeam("team-a") }
+        verify(exactly = 1) { observability.recordDeletedFeedback(2) }
+        verify(exactly = 1) { observability.recordFailed() }
+        verify(exactly = 0) { observability.recordExecuted(any()) }
+    }
+})

--- a/apps/lumi-api/src/test/kotlin/no/nav/lumi/service/SubmissionServiceTest.kt
+++ b/apps/lumi-api/src/test/kotlin/no/nav/lumi/service/SubmissionServiceTest.kt
@@ -4,8 +4,11 @@ import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.shouldBe
 import io.mockk.coEvery
 import io.mockk.coVerify
+import io.mockk.Runs
 import io.mockk.every
+import io.mockk.just
 import io.mockk.mockk
+import io.mockk.verify
 import no.nav.lumi.domain.Answer
 import no.nav.lumi.domain.AnswerValue
 import no.nav.lumi.domain.FeedbackSubmissionV1
@@ -29,8 +32,29 @@ class SubmissionServiceTest : FunSpec({
         val registrationResult = RegistrationResult("survey-1", "definition-hash-v2")
         val saveResult = SaveResult.Created("feedback-1")
 
-        coEvery { surveyDefinitionService.registerOrValidateV2("team-a", submission, definition) } returns registrationResult
-        coEvery { feedbackService.save("{}", "team-a", "app-a", "survey-1", "definition-hash-v2") } returns saveResult
+        val prepared = FeedbackService.PreparedFeedbackSave("redacted-json", null)
+        every { feedbackService.prepareForSave("{}", "team-a", "survey-1") } returns prepared
+        coEvery {
+            feedbackRepository.withTransaction(any<suspend () -> SubmissionOutcome>())
+        } coAnswers {
+            arg<suspend () -> SubmissionOutcome>(0).invoke()
+        }
+        coEvery {
+            surveyDefinitionService.registerOrValidateV2InCurrentTransaction("team-a", submission, definition)
+        } returns registrationResult
+        every {
+            feedbackRepository.saveInCurrentTransaction(
+                "redacted-json",
+                "team-a",
+                "app-a",
+                "survey-1",
+                "definition-hash-v2",
+                null,
+            )
+        } returns saveResult
+        every {
+            surveyDefinitionService.recordStoredSubmissionInCurrentTransaction("team-a", "survey-1")
+        } just Runs
 
         val result = runSubmission {
             service.submit(
@@ -43,10 +67,15 @@ class SubmissionServiceTest : FunSpec({
         }
 
         result shouldBe SubmissionOutcome(saveResult, "definition-hash-v2")
-        coVerify(exactly = 1) { surveyDefinitionService.registerOrValidateV2("team-a", submission, definition) }
+        coVerify(exactly = 1) {
+            surveyDefinitionService.registerOrValidateV2InCurrentTransaction("team-a", submission, definition)
+        }
         coVerify(exactly = 0) { surveyDefinitionService.registerOrValidate("team-a", submission) }
         coVerify(exactly = 0) { surveyDefinitionService.registerOrValidateInCurrentTransaction(any(), any()) }
-        coVerify(exactly = 0) { surveyDefinitionService.registerOrValidateV2InCurrentTransaction(any(), any(), any()) }
+        coVerify(exactly = 0) { surveyDefinitionService.registerOrValidateV2(any(), any(), any()) }
+        verify(exactly = 1) {
+            surveyDefinitionService.recordStoredSubmissionInCurrentTransaction("team-a", "survey-1")
+        }
     }
 
     test("provided definition uses v2 registration in current transaction") {
@@ -88,6 +117,9 @@ class SubmissionServiceTest : FunSpec({
                 "dedup-hash"
             )
         } returns saveResult
+        every {
+            surveyDefinitionService.recordStoredSubmissionInCurrentTransaction("team-a", "survey-1")
+        } just Runs
 
         val result = runSubmission {
             service.submit(
@@ -106,6 +138,30 @@ class SubmissionServiceTest : FunSpec({
         coVerify(exactly = 0) { surveyDefinitionService.registerOrValidateInCurrentTransaction("team-a", submission) }
         coVerify(exactly = 0) { surveyDefinitionService.registerOrValidate("team-a", submission) }
         coVerify(exactly = 0) { surveyDefinitionService.registerOrValidateV2("team-a", submission, definition) }
+        verify(exactly = 1) {
+            surveyDefinitionService.recordStoredSubmissionInCurrentTransaction("team-a", "survey-1")
+        }
+    }
+
+    test("duplicate submission does not update retention activity") {
+        val feedbackService = mockk<FeedbackService>()
+        val surveyDefinitionService = mockk<SurveyDefinitionService>()
+        val feedbackRepository = mockk<FeedbackRepository>()
+        val service = SubmissionService(feedbackService, surveyDefinitionService, feedbackRepository)
+        val submission = ratingSubmission(deduplicationKey = "client-key-123456")
+
+        coEvery {
+            feedbackService.findDuplicateSubmissionId("team-a", "survey-1", "client-key-123456")
+        } returns "feedback-existing"
+
+        val result = runSubmission {
+            service.submit("{}", "team-a", "app-a", submission, expandedDefinition())
+        }
+
+        result shouldBe SubmissionOutcome(SaveResult.Duplicate("feedback-existing"))
+        verify(exactly = 0) {
+            surveyDefinitionService.recordStoredSubmissionInCurrentTransaction(any(), any())
+        }
     }
 })
 

--- a/apps/lumi-api/src/test/kotlin/no/nav/lumi/service/SurveyDefinitionServiceTest.kt
+++ b/apps/lumi-api/src/test/kotlin/no/nav/lumi/service/SurveyDefinitionServiceTest.kt
@@ -25,8 +25,89 @@ import no.nav.lumi.domain.computeHash
 import no.nav.lumi.repository.StoredSurveyDefinition
 import no.nav.lumi.repository.SurveyDefinitionRepository
 import no.nav.lumi.repository.SurveyDefinitionSource
+import java.time.Instant
 
 class SurveyDefinitionServiceTest : FunSpec({
+    test("legacy submission cannot reactivate a retired definition") {
+        val repository = mockk<SurveyDefinitionRepository>()
+        val service = SurveyDefinitionService(repository)
+        val submission = ratingSubmission()
+        val definition = SurveyDefinition.fromSubmission(submission)
+
+        coEvery { repository.findByTeamAndSurveyId("team-a", "survey-1") } returns
+            StoredSurveyDefinition(
+                team = "team-a",
+                surveyId = "survey-1",
+                definitionHash = definition.computeHash(),
+                definition = null,
+                retiredAt = Instant.parse("2026-01-01T00:00:00Z"),
+            )
+
+        val exception = shouldThrowConflict {
+            service.registerOrValidate("team-a", submission)
+        }
+
+        exception.message shouldContain "has been retired"
+        exception.message shouldContain "schemaVersion 2"
+        exception.message shouldContain "new surveyId"
+    }
+
+    test("schemaVersion=2 reactivates a retired matching definition") {
+        val repository = mockk<SurveyDefinitionRepository>()
+        val service = SurveyDefinitionService(repository)
+        val submission = ratingSubmission()
+        val definition = SurveyDefinition.fromSubmission(submission)
+        val definitionHash = definition.computeHash()
+
+        coEvery { repository.findByTeamAndSurveyId("team-a", "survey-1") } returns
+            StoredSurveyDefinition(
+                team = "team-a",
+                surveyId = "survey-1",
+                definitionHash = definitionHash,
+                definition = null,
+                source = SurveyDefinitionSource.API,
+                retiredAt = Instant.parse("2026-01-01T00:00:00Z"),
+            )
+        coEvery {
+            repository.updateApiDefinitionIfHashMatches(
+                "team-a",
+                "survey-1",
+                definitionHash,
+                definition,
+                definitionHash,
+            )
+        } returns true
+
+        service.registerOrValidateV2("team-a", submission, definition) shouldBe
+            RegistrationResult("survey-1", definitionHash)
+    }
+
+    test("schemaVersion=2 rejects an incompatible retired definition") {
+        val repository = mockk<SurveyDefinitionRepository>()
+        val service = SurveyDefinitionService(repository)
+        val submission = ratingSubmission()
+        val incomingDefinition = SurveyDefinition.fromSubmission(submission)
+
+        coEvery { repository.findByTeamAndSurveyId("team-a", "survey-1") } returns
+            StoredSurveyDefinition(
+                team = "team-a",
+                surveyId = "survey-1",
+                definitionHash = "a".repeat(64),
+                definition = null,
+                source = SurveyDefinitionSource.API,
+                retiredAt = Instant.parse("2026-01-01T00:00:00Z"),
+            )
+
+        val exception = shouldThrowConflict {
+            service.registerOrValidateV2("team-a", submission, incomingDefinition)
+        }
+
+        exception.message shouldContain "retired surveyId=survey-1"
+        coVerify(exactly = 0) {
+            repository.updateApiDefinitionIfHashMatches(any(), any(), any(), any(), any())
+        }
+    }
+
     test("first submission registers definition") {
         val repository = mockk<SurveyDefinitionRepository>()
         val service = SurveyDefinitionService(repository)

--- a/apps/lumi-dashboard/app/components/feedback/FeedbackTable/__tests__/FeedbackTable.recency.test.tsx
+++ b/apps/lumi-dashboard/app/components/feedback/FeedbackTable/__tests__/FeedbackTable.recency.test.tsx
@@ -1,8 +1,18 @@
 import { render, screen } from "@testing-library/react";
-import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  afterAll,
+  afterEach,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  vi,
+} from "vitest";
 import { FeedbackTable } from "../index";
 
 const DAY_MS = 24 * 60 * 60 * 1000;
+const originalTimeZone = process.env.TZ;
 
 const { mockParams, mockBootstrap } = vi.hoisted(() => ({
   mockParams: {
@@ -74,7 +84,14 @@ vi.mock("~/hooks/useArchiveSurvey", () => ({
   }),
 }));
 
-function bootstrapWith(surveyMeta: Record<string, unknown>) {
+function bootstrapWith(
+  surveyMeta: Record<string, unknown>,
+  retentionWarnings: Array<{
+    surveyId: string;
+    lastActivityAt: string;
+    scheduledFor: string;
+  }> = [],
+) {
   return {
     selectedTeam: "team-test",
     availableTeams: ["team-test"],
@@ -82,10 +99,23 @@ function bootstrapWith(surveyMeta: Record<string, unknown>) {
     surveysByApp: { "app-test": ["survey-1"] },
     tags: [],
     surveyMeta,
+    retentionWarnings,
   };
 }
 
 describe("FeedbackTable recency and badge", () => {
+  beforeAll(() => {
+    process.env.TZ = "UTC";
+  });
+
+  afterAll(() => {
+    if (originalTimeZone === undefined) {
+      delete process.env.TZ;
+    } else {
+      process.env.TZ = originalTimeZone;
+    }
+  });
+
   beforeEach(() => {
     vi.useFakeTimers();
     vi.setSystemTime(new Date("2026-08-12T12:00:00Z"));
@@ -141,6 +171,27 @@ describe("FeedbackTable recency and badge", () => {
 
     expect(
       screen.queryByText("Mottar fortsatt innsendinger"),
+    ).not.toBeInTheDocument();
+  });
+
+  it("shows an informational warning for inactive survey definitions", () => {
+    mockBootstrap.data = bootstrapWith({}, [
+      {
+        surveyId: "survey-inactive",
+        lastActivityAt: "2025-02-01T00:00:00Z",
+        scheduledFor: "2026-08-31T22:30:00Z",
+      },
+    ]);
+
+    render(<FeedbackTable />);
+
+    expect(
+      screen.getByText("En inaktiv survey nærmer seg automatisk opprydding"),
+    ).toBeInTheDocument();
+    expect(screen.getByText("survey-inactive")).toBeInTheDocument();
+    expect(screen.getByText(/1. september 2026/)).toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: /behold|slett nå/i }),
     ).not.toBeInTheDocument();
   });
 });

--- a/apps/lumi-dashboard/app/components/feedback/FeedbackTable/index.tsx
+++ b/apps/lumi-dashboard/app/components/feedback/FeedbackTable/index.tsx
@@ -4,6 +4,7 @@ import {
   TrashIcon,
 } from "@navikt/aksel-icons";
 import {
+  Alert,
   BodyShort,
   Box,
   Button,
@@ -132,6 +133,8 @@ function FeedbackTableContent({
     !!selectedSurvey && isSurveyArchived(selectedSurvey, bootstrap?.surveyMeta);
   return (
     <div className={styles.table}>
+      <RetentionWarnings warnings={bootstrap?.retentionWarnings ?? []} />
+
       {/* Toolbar with bulk actions when survey is selected. Not gated on
           totalElements: old surveys without hits in the current period are
           exactly the ones users want to archive. */}
@@ -275,6 +278,40 @@ function FeedbackTableContent({
       />
     </div>
   );
+}
+
+function RetentionWarnings({
+  warnings,
+}: {
+  warnings: Array<{ surveyId: string; scheduledFor: string }>;
+}) {
+  if (warnings.length === 0) return null;
+
+  return (
+    <Alert variant="warning" size="small" className={styles.retentionWarning}>
+      <BodyShort size="small" weight="semibold">
+        {warnings.length === 1
+          ? "En inaktiv survey nærmer seg automatisk opprydding"
+          : `${warnings.length} inaktive surveyer nærmer seg automatisk opprydding`}
+      </BodyShort>
+      <ul className={styles.retentionWarningList}>
+        {warnings.map((warning) => (
+          <li key={warning.surveyId}>
+            <strong>{warning.surveyId}</strong>: definisjonen ryddes etter{" "}
+            {formatRetentionDate(warning.scheduledFor)} hvis det ikke kommer nye
+            svar.
+          </li>
+        ))}
+      </ul>
+    </Alert>
+  );
+}
+
+function formatRetentionDate(value: string): string {
+  return new Intl.DateTimeFormat("nb-NO", {
+    dateStyle: "long",
+    timeZone: "Europe/Oslo",
+  }).format(new Date(value));
 }
 
 /**

--- a/apps/lumi-dashboard/app/components/feedback/FeedbackTable/styles.module.css
+++ b/apps/lumi-dashboard/app/components/feedback/FeedbackTable/styles.module.css
@@ -14,6 +14,16 @@
   border-bottom: 1px solid var(--ax-border-subtle);
 }
 
+.retentionWarning {
+  border-radius: 0;
+  border-width: 0 0 1px;
+}
+
+.retentionWarningList {
+  margin: 0.25rem 0 0;
+  padding-left: 1.25rem;
+}
+
 .tableWrapper {
   overflow-x: auto;
 }

--- a/packages/lumi-types/src/schemas.ts
+++ b/packages/lumi-types/src/schemas.ts
@@ -169,6 +169,16 @@ export const SurveyMetaEntrySchema = z.object({
 
 export type SurveyMetaEntry = z.infer<typeof SurveyMetaEntrySchema>;
 
+export const SurveyRetentionWarningSchema = z.object({
+  surveyId: z.string(),
+  lastActivityAt: z.string(),
+  scheduledFor: z.string(),
+});
+
+export type SurveyRetentionWarning = z.infer<
+  typeof SurveyRetentionWarningSchema
+>;
+
 export const FilterBootstrapResponseSchema = z.object({
   generatedAt: z.string(),
   selectedTeam: z.string(),
@@ -182,6 +192,8 @@ export const FilterBootstrapResponseSchema = z.object({
   surveyMetaByApp: z
     .record(z.string(), z.record(z.string(), SurveyMetaEntrySchema))
     .optional(),
+  /** Inactive survey definitions approaching automatic retirement. */
+  retentionWarnings: z.array(SurveyRetentionWarningSchema).optional(),
 });
 
 export type FilterBootstrapResponse = z.infer<


### PR DESCRIPTION
## Beskrivelse

Innfører en kontrollert første fase av automatisk retention for Lumi-surveys.

Rå surveysvar slettes når `opprettet` er eldre enn 12 kalendermåneder etter PostgreSQL-klokken. Jobben sletter globalt maksimalt 500 av de eldste kvalifiserte svarene i et rullerende 24-timersvindu, også gjennom podrestart og skalering. Surveyaktivitet spores fra faktisk lagrede svar, og dashboardet varsler teamet når en inaktiv surveydefinisjon nærmer seg 18-månedersgrensen.

Slettejobben er fail-closed og er deaktivert i prod i denne PR-en. Den aktiveres i en egen, kontrollert manifestendring etter at migrering, metrikker og query plan er kontrollert i prod.

Datamodellen og API-koden kan lese fremtidige tombstones, men selve nullingen av strukturelle definisjoner aktiveres først i en separat fase. Issue #478 forblir derfor åpen.

## Endringer

- deler schema/trigger og backfill i to Flyway-migreringer, slik at triggerlåsen committes før full skanning av `feedback`
- bruker eksplisitt UTC-kalenderaritmetikk i trigger, backfill og applikasjonskode
- legger til aktivitets- og retentionfelter med backfill og rolling-deploy-sikker database-trigger
- sletter globalt maksimalt én batch på 500 svar per 24 timer; eksisterende tag-cascade beholdes
- bruker PostgreSQL advisory lock, persistert jobbtilstand og databaseklokke for både cutoff og global 24-timersgrense på tvers av replikaer og restarter
- committer sletting og nytt fullføringstidspunkt atomisk i samme transaksjon
- bruker `FOR UPDATE SKIP LOCKED` og en indeks på `opprettet` for den avgrensede slettebatchen
- bruker en teamtilpasset retention-indeks for dashboardvarslene
- invaliderer team-skopede stats- og bootstrap-cacher etter committet batch
- legger til team-skopet dashboardvarsel uten nye handlinger
- legger til fail-closed kill switch, metrikk, alarmer og runbook for feil, manglende kjøringer og slettede rader
- gjør lesing og validering klar for tombstones og kontrollert V2-reaktivering i fase 2
- lar eksisterende «Arkiver» og «Slett survey» beholde dagens semantikk

## Utrulling

- dev: `LUMI_RETENTION_ENABLED=true`
- prod: `LUMI_RETENTION_ENABLED=false`
- en ugyldig verdi stopper applikasjonsoppstart; manglende verdi deaktiverer slettejobben
- read-only kontroll i prod viser ingen svar eldre enn 12 måneder; eldste svar er fra 28. januar 2026
- før aktivering i prod kontrolleres migrering, `EXPLAIN`, retention-metrikker og en testet backup/recovery-prosedyre; PITR er foretrukket
- runbooken beskriver dev-observasjon, etterkontroll og deploy-basert nødstans

## Issue

Relates to #478

## Validering

- [x] `pnpm run lint`
- [x] `pnpm run typecheck`
- [x] full API-testsuite (`cleanTest test`)
- [x] syntetisk merge mot dagens `main`, inkludert Flyway 13.3, med full API-testsuite
- [x] full dashboard-testsuite på Node 24, sekvensielt: 86 filer / 667 tester
- [x] full lumi-survey-testsuite: 34 filer / 481 tester
- [x] migrering fra V15 via V16/V17/V18, rolling writer mellom migreringene og eksakt UTC/DST-adferd er dekket av integrasjonstest mot PostgreSQL 17
- [x] databaseberegnet retentiongrense, global 24-timersport gjennom restart, maks batchstørrelse, atomisk jobbtilstand, rollback ved feil på jobbstatus, cascade, låsing, duplikater og cacheinvalidasjon er dekket av tester
- [x] NAIS-manifester og Prometheus-regler er validert som YAML

## Sjekkliste

- [x] Koden kompilerer og linter uten feil
- [x] Endringene er testet automatisk
- [x] Ingen sensitiv data eksponert
