### PR TITLE
Reduser cachetid for teamtilgang

### DIFF
--- a/apps/lumi-api/src/main/kotlin/no/nav/lumi/integrations/nais/NaisGraphQlClient.kt
+++ b/apps/lumi-api/src/main/kotlin/no/nav/lumi/integrations/nais/NaisGraphQlClient.kt
@@ -56,8 +56,8 @@ sealed class NaisApiResult<out T> {
  * Different TTLs based on whether user has teams or not.
  */
 object CacheTtl {
-    /** TTL when user HAS teams - team membership changes rarely */
-    val HAS_TEAMS: Duration = Duration.ofHours(12)
+    /** TTL when user HAS teams - bounds access after team membership is revoked */
+    val HAS_TEAMS: Duration = Duration.ofMinutes(10)
     
     /** TTL when user has NO teams - allow quick onboarding */
     val NO_TEAMS: Duration = Duration.ofMinutes(5)

--- a/apps/lumi-api/src/main/kotlin/no/nav/lumi/integrations/valkey/ValkeyClient.kt
+++ b/apps/lumi-api/src/main/kotlin/no/nav/lumi/integrations/valkey/ValkeyClient.kt
@@ -77,7 +77,8 @@ class InMemoryTeamCache : TeamCache {
  */
 class ValkeyTeamCache private constructor(
     private val redisClient: RedisClient,
-    private val keyPrefix: String = "teams:",
+    // Versioned so entries written with the previous 12-hour TTL are ignored after deployment.
+    private val keyPrefix: String = "teams:v2:",
     private val fallback: InMemoryTeamCache = InMemoryTeamCache()
 ) : TeamCache {
     

--- a/apps/lumi-api/src/test/kotlin/no/nav/lumi/integrations/nais/NaisGraphQlClientTest.kt
+++ b/apps/lumi-api/src/test/kotlin/no/nav/lumi/integrations/nais/NaisGraphQlClientTest.kt
@@ -526,8 +526,8 @@ class NaisGraphQlClientTest {
     }
 
     @Test
-    fun `team cache TTLs keep positive memberships warm while allowing onboarding`() {
-        assertEquals(Duration.ofHours(12), CacheTtl.HAS_TEAMS)
+    fun `team cache TTLs bound membership revocation while allowing onboarding`() {
+        assertEquals(Duration.ofMinutes(10), CacheTtl.HAS_TEAMS)
         assertEquals(Duration.ofMinutes(5), CacheTtl.NO_TEAMS)
         assertEquals(Duration.ofSeconds(30), CacheTtl.ERROR)
     }
@@ -558,12 +558,11 @@ class NaisGraphQlClientTest {
             client = mockClient
         )
         
-        // First call - caches with long TTL (because user HAS teams)
+        // First call caches the positive team lookup.
         client.getTeamSlugsForUser("test@nav.no")
         assertEquals(1, callCount)
 
-        // Even after 30 minutes, cache should still be valid
-        // (In real usage, TTL is enforced by Valkey, but InMemoryTeamCache respects the TTL)
+        // A subsequent call within the TTL should use the cache.
         client.getTeamSlugsForUser("test@nav.no")
         assertEquals(1, callCount)
     }

--- a/docs/dashboard/tilgang.md
+++ b/docs/dashboard/tilgang.md
@@ -25,7 +25,7 @@ Dashboardet viser kun data fra teamene dine. Hvilke team du tilhører hentes aut
 ::: tip Mangler du tilgang?
 Sjekk at du er lagt til som medlem i riktig NAIS-team via [NAIS Console](https://console.nav.cloud.nais.io).
 
-Lumi cacher teamoppslag som gir minst ett team i opptil 12 timer. Nye eller fjernede teamtilganger for en bruker som allerede har tilgang til andre team, kan derfor bruke opptil 12 timer på å tre i kraft. Oppslag som ikke gir noen team, caches i 5 minutter. Fjerning fra et team kan gi fortsatt tilgang til teamets data frem til den positive cachen utløper, så lenge brukeren fortsatt kan logge inn.
+Lumi cacher teamoppslag som gir minst ett team i opptil 10 minutter. Nye eller fjernede teamtilganger for en bruker som allerede har tilgang til andre team, kan derfor bruke opptil 10 minutter på å tre i kraft. Oppslag som ikke gir noen team, caches i 5 minutter. Fjerning fra et team kan gi fortsatt tilgang til teamets data frem til den positive cachen utløper, så lenge brukeren fortsatt kan logge inn.
 :::
 
 ## Se også


### PR DESCRIPTION
## Hva

- reduserer positiv team-cache fra 12 timer til 10 minutter
- versjonerer Valkey-nøklene slik at gamle 12-timersoppføringer ikke brukes etter utrulling
- beholder 5 minutter for tomme teamoppslag og 30 sekunder ved feil
- oppdaterer dokumentasjonen med faktisk maksimal revokeringstid

## Hvorfor

Fjerning fra et NAIS-team kunne tidligere gi fortsatt tilgang til teamets data i opptil 12 timer. Endringen begrenser vinduet til omtrent 10 minutter uten å innføre en invalideringsflyt som Lumi ikke har et pålitelig medlemskapssignal for.

## Validering

- ./gradlew cleanTest test
- pnpm run lint
- pnpm run typecheck

Closes #480