### PR TITLE
Gjenbruk API-image ved rene manifestendringer

### DIFF
--- a/.github/workflows/deploy-api.yaml
+++ b/.github/workflows/deploy-api.yaml
@@ -32,6 +32,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     permissions:
+      actions: read
       contents: read
       id-token: write
     outputs:
@@ -39,25 +40,49 @@ jobs:
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
         with:
+          fetch-depth: 0
           ref: ${{ inputs.ref || github.ref }}
 
+      - name: Determine whether the workload image changed
+        if: github.event_name != 'workflow_dispatch'
+        id: what-changed
+        uses: nais/what-changed@e253615426610a2e873ada19749ca58896f3679f
+        with:
+          # List every input that can change app.jar or the production container.
+          # Using image inputs (rather than manifests) avoids false rebuilds from
+          # unrelated commits between path-filtered workflow runs in this monorepo.
+          files: >-
+            .github/workflows/deploy-api.yaml,
+            apps/lumi-api/Dockerfile,
+            apps/lumi-api/build.gradle.kts,
+            apps/lumi-api/gradle.properties,
+            apps/lumi-api/gradle/**,
+            apps/lumi-api/gradlew,
+            apps/lumi-api/gradlew.bat,
+            apps/lumi-api/settings.gradle.kts,
+            apps/lumi-api/src/main/**
+
       - name: Setup Java
+        if: github.event_name == 'workflow_dispatch' || steps.what-changed.outputs.changed != 'non-inputs'
         uses: actions/setup-java@b6effb05e454b25005698d916606bdc6ffcbf961
         with:
           distribution: temurin
           java-version: 21
 
       - name: Setup Gradle
+        if: github.event_name == 'workflow_dispatch' || steps.what-changed.outputs.changed != 'non-inputs'
         uses: gradle/actions/setup-gradle@9c971963bec38e04b3d30dcc455b5382be2fdbfb
         with:
           cache-read-only: ${{ github.ref != 'refs/heads/main' }}
           cache-overwrite-existing: true
 
       - name: Build with Gradle
+        if: github.event_name == 'workflow_dispatch' || steps.what-changed.outputs.changed != 'non-inputs'
         working-directory: apps/lumi-api
         run: ./gradlew shadowJar
 
       - name: Push docker image to GAR
+        if: github.event_name == 'workflow_dispatch' || steps.what-changed.outputs.changed != 'non-inputs'
         uses: nais/docker-build-push@8e41f1f58749b9248e376c25d33bfbdd2b1163c0
         id: docker-build-push
         with:
@@ -87,7 +112,7 @@ jobs:
         env:
           CLUSTER: dev-gcp
           RESOURCE: apps/lumi-api/nais/app/dev.yaml
-          VAR: image=${{ needs.build.outputs.image }}
+          WORKLOAD_IMAGE: ${{ needs.build.outputs.image }}
 
   deploy-prod:
     if: |
@@ -106,4 +131,4 @@ jobs:
         env:
           CLUSTER: prod-gcp
           RESOURCE: apps/lumi-api/nais/app/prod.yaml,apps/lumi-api/nais/alerts/prod.yaml
-          VAR: image=${{ needs.build.outputs.image }}
+          WORKLOAD_IMAGE: ${{ needs.build.outputs.image }}

--- a/apps/lumi-api/nais/app/dev.yaml
+++ b/apps/lumi-api/nais/app/dev.yaml
@@ -6,7 +6,6 @@ metadata:
   labels:
     team: team-esyfo
 spec:
-  image: {{image}}
   port: 8080
   replicas:
     min: 1

--- a/apps/lumi-api/nais/app/prod.yaml
+++ b/apps/lumi-api/nais/app/prod.yaml
@@ -6,7 +6,6 @@ metadata:
   labels:
     team: team-esyfo
 spec:
-  image: {{image}}
   port: 8080
   replicas:
     min: 2

--- a/scripts/verify-deploy-api-trigger.test.mjs
+++ b/scripts/verify-deploy-api-trigger.test.mjs
@@ -10,16 +10,46 @@ const repositoryRoot = path.resolve(
   "..",
 );
 
-const workflow = load(
-  readFileSync(
-    path.join(repositoryRoot, ".github", "workflows", "deploy-api.yaml"),
-    "utf8",
-  ),
-);
+const readYaml = (...segments) =>
+  load(readFileSync(path.join(repositoryRoot, ...segments), "utf8"));
+
+const workflow = readYaml(".github", "workflows", "deploy-api.yaml");
+const devManifest = readYaml("apps", "lumi-api", "nais", "app", "dev.yaml");
+const prodManifest = readYaml("apps", "lumi-api", "nais", "app", "prod.yaml");
 
 const normalizeExpression = (expression) =>
   expression.replace(/\s+/g, " ").trim();
 const selectedRefExpression = "$" + "{{ inputs.ref || github.ref }}";
+const buildImageExpression = normalizeExpression(
+  "github.event_name == 'workflow_dispatch' || steps.what-changed.outputs.changed != 'non-inputs'",
+);
+
+const findStep = (job, predicate) => job.steps.find(predicate);
+const buildJob = workflow.jobs.build;
+const checkoutStep = findStep(buildJob, (step) =>
+  step.uses?.startsWith("actions/checkout@"),
+);
+const whatChangedStep = findStep(
+  buildJob,
+  (step) => step.id === "what-changed",
+);
+const imageBuildSteps = buildJob.steps.filter((step) =>
+  [
+    "Setup Java",
+    "Setup Gradle",
+    "Build with Gradle",
+    "Push docker image to GAR",
+  ].includes(step.name),
+);
+const imageBuildInputs = whatChangedStep.with.files
+  .split(",")
+  .map((input) => input.trim());
+
+const shouldBuildImage = (changedFiles, eventName = "push") =>
+  eventName === "workflow_dispatch" ||
+  changedFiles.some((file) =>
+    imageBuildInputs.some((pattern) => path.matchesGlob(file, pattern)),
+  );
 
 test("API push deploys run only for API changes on main", () => {
   assert.deepEqual(workflow.on.push, {
@@ -65,7 +95,8 @@ test("automatic and manual deploys follow the intended environment sequence", ()
     `),
   );
   assert.deepEqual(workflow.jobs["deploy-prod"].needs, ["build", "deploy-dev"]);
-  assert.equal(workflow.jobs.build.steps[0].with.ref, selectedRefExpression);
+  assert.equal(checkoutStep.with.ref, selectedRefExpression);
+  assert.equal(checkoutStep.with["fetch-depth"], 0);
   assert.equal(
     workflow.jobs["deploy-dev"].steps[0].with.ref,
     selectedRefExpression,
@@ -74,4 +105,72 @@ test("automatic and manual deploys follow the intended environment sequence", ()
     workflow.jobs["deploy-prod"].steps[0].with.ref,
     selectedRefExpression,
   );
+});
+
+test("API image builds use the pinned monorepo-aware change detector", () => {
+  assert.equal(buildJob.permissions.actions, "read");
+  assert.equal(
+    whatChangedStep.uses,
+    "nais/what-changed@e253615426610a2e873ada19749ca58896f3679f",
+  );
+  assert.equal(whatChangedStep.if, "github.event_name != 'workflow_dispatch'");
+  assert.deepEqual(imageBuildInputs, [
+    ".github/workflows/deploy-api.yaml",
+    "apps/lumi-api/Dockerfile",
+    "apps/lumi-api/build.gradle.kts",
+    "apps/lumi-api/gradle.properties",
+    "apps/lumi-api/gradle/**",
+    "apps/lumi-api/gradlew",
+    "apps/lumi-api/gradlew.bat",
+    "apps/lumi-api/settings.gradle.kts",
+    "apps/lumi-api/src/main/**",
+  ]);
+  assert.equal(imageBuildSteps.length, 4);
+  for (const step of imageBuildSteps) {
+    assert.equal(normalizeExpression(step.if), buildImageExpression);
+  }
+});
+
+test("API image build classification covers manifest, code, mixed, and manual changes", () => {
+  assert.equal(shouldBuildImage(["apps/lumi-api/nais/app/prod.yaml"]), false);
+  assert.equal(
+    shouldBuildImage([
+      "apps/lumi-api/nais/app/prod.yaml",
+      "docs/dashboard/tilgang.md",
+    ]),
+    false,
+  );
+  assert.equal(
+    shouldBuildImage([
+      "apps/lumi-api/src/main/kotlin/no/nav/lumi/Application.kt",
+    ]),
+    true,
+  );
+  assert.equal(
+    shouldBuildImage([
+      "apps/lumi-api/nais/app/prod.yaml",
+      "apps/lumi-api/src/main/resources/logback.xml",
+    ]),
+    true,
+  );
+  assert.equal(
+    shouldBuildImage(["apps/lumi-api/nais/app/prod.yaml"], "workflow_dispatch"),
+    true,
+  );
+});
+
+test("API deploys use WORKLOAD_IMAGE and manifests do not template an image", () => {
+  assert.equal(devManifest.spec.image, undefined);
+  assert.equal(prodManifest.spec.image, undefined);
+
+  for (const jobName of ["deploy-dev", "deploy-prod"]) {
+    const deployStep = findStep(workflow.jobs[jobName], (step) =>
+      step.uses?.startsWith("nais/deploy/actions/deploy@"),
+    );
+    assert.equal(
+      deployStep.env.WORKLOAD_IMAGE,
+      "$" + "{{ needs.build.outputs.image }}",
+    );
+    assert.equal(deployStep.env.VAR, undefined);
+  }
 });


### PR DESCRIPTION
## Hva\n\n- migrerer API-deploy til NAIS WORKLOAD_IMAGE\n- hopper over Gradle- og Docker-bygg ved rene manifestendringer\n- bygger fortsatt ved kode-, image-input- og workflowendringer, samt ved manuell deploy\n- beholder eksisterende dev-til-prod-rekkefølge og øvrig deploysemantikk\n\n## Sikker overgang\n\nOvergangscommiten endrer både workflow og manifester. Den klassifiseres derfor som en image-endring og bygger et nytt image. En eventuell revert tar tilbake den gamle image-templaten og workflowen, som bygger igjen.\n\n## Validering\n\n- pnpm run test:release-guards\n- pnpm run lint\n- pnpm run typecheck\n\nRelates to #473