### PR TITLE
Aktiver automatisk retention i produksjon

### DIFF
--- a/apps/lumi-api/nais/app/prod.yaml
+++ b/apps/lumi-api/nais/app/prod.yaml
@@ -87,4 +87,4 @@ spec:
       value: "10000"
     # Enable in a separate, controlled rollout after migration and metrics verification.
     - name: LUMI_RETENTION_ENABLED
-      value: "false"
+      value: "true"

--- a/apps/lumi-api/src/test/kotlin/no/nav/lumi/config/RetentionAlertRulesTest.kt
+++ b/apps/lumi-api/src/test/kotlin/no/nav/lumi/config/RetentionAlertRulesTest.kt
@@ -16,14 +16,4 @@ class RetentionAlertRulesTest : FunSpec({
         rules shouldContain
             """max(lumi_retention_enabled{app="lumi-api"}) == 1"""
     }
-
-    test("production retention starts disabled while development exercises cleanup") {
-        val prodManifest = Files.readString(Path.of("nais/app/prod.yaml"))
-        val devManifest = Files.readString(Path.of("nais/app/dev.yaml"))
-
-        prodManifest shouldContain """name: LUMI_RETENTION_ENABLED
-      value: "false""".trimIndent()
-        devManifest shouldContain """name: LUMI_RETENTION_ENABLED
-      value: "true""".trimIndent()
-    }
 })


### PR DESCRIPTION
## Hva

- aktiverer automatisk retention av surveysvar i produksjon
- fjerner den midlertidige overgangstesten som låste produksjonsflagget til `false`
- beholder verifikasjonen av retention-alertene

## Hvorfor

Selve retention-mekanismen ble levert deaktivert i produksjon i #552, slik at utrullingen kunne verifiseres før aktivering. Følgende er nå kontrollert:

- Flyway V16–V18 er migrert i dev og prod
- dev har gjennomført en vellykket global kjøring uten slettinger
- read-only preflight i prod viser ingen surveysvar eldre enn 12 måneder
- de sju siste automatiske Cloud SQL-backupene er vellykkede
- retention er fortsatt begrenset til maksimalt 500 rader per global 24-timersperiode

## Rollback

Sett `LUMI_RETENTION_ENABLED` tilbake til `false` og deploy manifestet på nytt. En transaksjon som allerede kjører kan fullføre den avgrensede batchen på maksimalt 500 rader.

## Verifisering

- `nais validate apps/lumi-api/nais/app/prod.yaml`
- `pnpm run lint`
- `pnpm run typecheck`
- `pnpm run api:test`
- `pnpm run test:release-guards`
