### PR TITLE
Plasser CODEOWNERS riktig og sett eSyfo som eier

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,8 @@
+# GitHub only discovers CODEOWNERS in the repository root, .github/, or docs/.
+/.github/CODEOWNERS @navikt/team-esyfo
+/.github/ISSUE_TEMPLATE/access-request.yml @navikt/team-esyfo
+/.github/workflows/deploy-api.yaml @navikt/team-esyfo
+/.github/workflows/deploy-proxy.yaml @navikt/team-esyfo
+/apps/lumi-api/ @navikt/team-esyfo
+/apps/lumi-dashboard/ @navikt/team-esyfo
+/apps/lumi-submission-proxy/ @navikt/team-esyfo

--- a/apps/lumi-api/CODEOWNERS
+++ b/apps/lumi-api/CODEOWNERS
@@ -1,1 +1,0 @@
-* @navikt/flex

--- a/apps/lumi-dashboard/CODEOWNERS
+++ b/apps/lumi-dashboard/CODEOWNERS
@@ -1,1 +1,0 @@
-* @navikt/team-esyfo


### PR DESCRIPTION
## Hva

- flytter CODEOWNERS fra appmapper som GitHub ikke leser, til `.github/CODEOWNERS`
- erstatter den foreldede API-eieren `@navikt/flex` med `@navikt/team-esyfo`
- gjør eSyfo til synlig eier av API, dashboard, submission-proxy, tilgangsskjema og tilhørende deploy-workflows

## Hvorfor

Tilgangsendringer for nye Lumi-konsumenter skal vurderes av team eSyfo. Med dagens plassering finner GitHub ingen gyldig CODEOWNERS-fil, og API-et peker i tillegg på feil team.

Dette endrer ingen tilgangsregel, deploy eller runtime. Branch protection krever foreløpig ikke code-owner-review; endringen gjør riktig eier tilgjengelig for automatisk review-forespørsel, men endrer ikke repository-innstillinger.

Relates to #473

## Verifisering

- GitHub CODEOWNERS API: ingen syntaksfeil på branch
- `pnpm run lint`
- `pnpm run typecheck`
- `git diff --check`
