### PR TITLE
Publiser @navikt/lumi-survey til npmjs med trusted publishing

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -53,6 +53,8 @@ jobs:
               - 'packages/**'
               - 'scripts/check-lumi-survey-release-drift.mjs'
               - 'scripts/check-lumi-survey-release-drift.test.mjs'
+              - 'scripts/publish-lumi-survey-registry.mjs'
+              - 'scripts/publish-lumi-survey-registry.test.mjs'
               - 'scripts/verify-deploy-api-trigger.test.mjs'
               - 'scripts/verify-deploy-dashboard-trigger.test.mjs'
               - 'scripts/verify-github-actions-pins.test.mjs'

--- a/.github/workflows/publish-lumi-survey.yaml
+++ b/.github/workflows/publish-lumi-survey.yaml
@@ -23,6 +23,8 @@ permissions:
 jobs:
   verify:
     runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.release.outputs.version }}
     permissions:
       contents: read
       packages: read
@@ -58,9 +60,6 @@ jobs:
 
       - name: Unit tests
         run: pnpm --filter @navikt/lumi-survey test
-
-      - name: Pack (dry-run)
-        run: pnpm --filter @navikt/lumi-survey pack --dry-run
 
       - name: Verify packed consumer
         run: pnpm run verify:lumi-survey-consumer
@@ -120,72 +119,131 @@ jobs:
       - name: Guard against empty release (no meaningful changes)
         run: node scripts/check-lumi-survey-release-drift.mjs --require-meaningful-change
 
-  publish:
-    needs: verify
-    if: ${{ inputs.dry_run == 'false' && github.ref_type == 'branch' && github.ref_name == 'main' }}
-    runs-on: ubuntu-latest
-    permissions:
-      contents: write
-      id-token: write
-      packages: write
-    steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
-        with:
-          fetch-depth: 0
-          persist-credentials: false
-
-      - uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6.0.10
-      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020
-        with:
-          node-version-file: package.json
-          cache: pnpm
-
-      # This job can only run for the already-verified main commit. The write
-      # token is therefore never exposed to branch-controlled verification.
-      - name: Install publish dependencies
-        run: pnpm install --frozen-lockfile
-        env:
-          NPM_AUTH_TOKEN: ${{ github.token }}
-          NODE_AUTH_TOKEN: ${{ github.token }}
-
-      - name: Use npm with trusted publishing support
-        run: npm install --global npm@11.19.0
-
       - name: Pack release artifact once
-        id: pack
+        id: release
         run: |
           set -euo pipefail
           VERSION=$(node -p "require('./packages/lumi-survey/package.json').version")
-          TARBALL="${RUNNER_TEMP}/navikt-lumi-survey-${VERSION}.tgz"
-          pnpm --filter @navikt/lumi-survey pack --pack-destination "${RUNNER_TEMP}"
-          test -f "${TARBALL}"
-          echo "tarball=${TARBALL}" >> "${GITHUB_OUTPUT}"
+          ARTIFACT_DIRECTORY="${RUNNER_TEMP}/lumi-survey-release"
+          PACKED_TARBALL="${ARTIFACT_DIRECTORY}/navikt-lumi-survey-${VERSION}.tgz"
+          mkdir -p "${ARTIFACT_DIRECTORY}"
+          pnpm --filter @navikt/lumi-survey pack --pack-destination "${ARTIFACT_DIRECTORY}"
+          test -f "${PACKED_TARBALL}"
+          mv "${PACKED_TARBALL}" "${ARTIFACT_DIRECTORY}/lumi-survey.tgz"
+          echo "version=${VERSION}" >> "${GITHUB_OUTPUT}"
+
+      # Check both immutable registries before the first write. Each publish
+      # job repeats its own check to keep retries fail-closed.
+      - name: Preflight npmjs
+        run: node scripts/publish-lumi-survey-registry.mjs --mode=check --tarball="${TARBALL}" --registry=https://registry.npmjs.org
+        env:
+          TARBALL: ${{ runner.temp }}/lumi-survey-release/lumi-survey.tgz
+
+      - name: Preflight GitHub Packages
+        run: node scripts/publish-lumi-survey-registry.mjs --mode=check --tarball="${TARBALL}" --registry=https://npm.pkg.github.com
+        env:
+          NODE_AUTH_TOKEN: ${{ github.token }}
+          TARBALL: ${{ runner.temp }}/lumi-survey-release/lumi-survey.tgz
+
+      - name: Upload verified release artifact
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: lumi-survey-release-${{ github.sha }}
+          path: ${{ runner.temp }}/lumi-survey-release/lumi-survey.tgz
+          if-no-files-found: error
+          retention-days: 7
+          compression-level: 0
+          overwrite: true
+
+  publish_npmjs:
+    needs: verify
+    if: ${{ inputs.dry_run == 'false' && github.ref_type == 'branch' && github.ref_name == 'main' }}
+    runs-on: ubuntu-latest
+    environment: npm-publish
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
+        with:
+          persist-credentials: false
+
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020
+        with:
+          node-version-file: package.json
+          package-manager-cache: false
+
+      - name: Require npm with trusted publishing support
+        run: |
+          NPM_VERSION="$(npm --version)"
+          export NPM_VERSION
+          node -e '
+            const current = process.env.NPM_VERSION.split(".").map(Number);
+            const minimum = [11, 5, 1];
+            const comparison = current.findIndex((part, index) => part !== minimum[index]);
+            if (
+              current.length < minimum.length ||
+              current.some(Number.isNaN) ||
+              (comparison !== -1 && current[comparison] < minimum[comparison])
+            ) {
+              console.error("npm " + process.env.NPM_VERSION + " is too old; expected at least 11.5.1.");
+              process.exit(1);
+            }
+          '
+
+      - name: Download verified release artifact
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: lumi-survey-release-${{ github.sha }}
+          path: ${{ runner.temp }}/lumi-survey-release
 
       # npmjs is first so a missing or incorrect trusted-publisher setup cannot
       # create a GitHub Packages-only release. Trusted publishing adds provenance.
       - name: Publish to npmjs
         run: node scripts/publish-lumi-survey-registry.mjs --tarball="${TARBALL}" --registry=https://registry.npmjs.org
         env:
-          TARBALL: ${{ steps.pack.outputs.tarball }}
+          TARBALL: ${{ runner.temp }}/lumi-survey-release/lumi-survey.tgz
 
-      - name: Configure GitHub Packages authentication
-        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020
+  publish_github_packages:
+    needs: [verify, publish_npmjs]
+    if: ${{ inputs.dry_run == 'false' && github.ref_type == 'branch' && github.ref_name == 'main' }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
+        with:
+          persist-credentials: false
+
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020
         with:
           node-version-file: package.json
-          registry-url: https://npm.pkg.github.com
-          scope: "@navikt"
+          package-manager-cache: false
+
+      - name: Download verified release artifact
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: lumi-survey-release-${{ github.sha }}
+          path: ${{ runner.temp }}/lumi-survey-release
 
       - name: Publish compatibility mirror to GitHub Packages
         run: node scripts/publish-lumi-survey-registry.mjs --tarball="${TARBALL}" --registry=https://npm.pkg.github.com
         env:
           NPM_AUTH_TOKEN: ${{ github.token }}
           NODE_AUTH_TOKEN: ${{ github.token }}
-          TARBALL: ${{ steps.pack.outputs.tarball }}
+          TARBALL: ${{ runner.temp }}/lumi-survey-release/lumi-survey.tgz
 
+  tag_release:
+    needs: [verify, publish_github_packages]
+    if: ${{ inputs.dry_run == 'false' && github.ref_type == 'branch' && github.ref_name == 'main' }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
       - name: Tag release
         run: |
           set -euo pipefail
-          VERSION=$(node -p "require('./packages/lumi-survey/package.json').version")
           TAG="lumi-survey-v${VERSION}"
           TAG_OBJECT_SHA="$(
             gh api \
@@ -204,3 +262,4 @@ jobs:
             -f "sha=${TAG_OBJECT_SHA}"
         env:
           GH_TOKEN: ${{ github.token }}
+          VERSION: ${{ needs.verify.outputs.version }}

--- a/.github/workflows/publish-lumi-survey.yaml
+++ b/.github/workflows/publish-lumi-survey.yaml
@@ -1,4 +1,4 @@
-name: Publish @navikt/lumi-survey (GitHub Packages)
+name: Publish @navikt/lumi-survey (npmjs + GitHub Packages)
 
 on:
   workflow_dispatch:
@@ -30,6 +30,7 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6.0.10
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020
@@ -96,7 +97,7 @@ jobs:
           node - <<'NODE'
           const pkg = require('./packages/lumi-survey/package.json');
           if (pkg.private) {
-            console.error('packages/lumi-survey/package.json has private=true. pnpm publish will refuse.');
+            console.error('packages/lumi-survey/package.json has private=true. Publishing is not allowed.');
             process.exit(1);
           }
           NODE
@@ -125,11 +126,13 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
+      id-token: write
       packages: write
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6.0.10
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020
@@ -145,20 +148,59 @@ jobs:
           NPM_AUTH_TOKEN: ${{ github.token }}
           NODE_AUTH_TOKEN: ${{ github.token }}
 
-      - name: Publish
-        run: pnpm --filter @navikt/lumi-survey publish --publish-branch main
+      - name: Use npm with trusted publishing support
+        run: npm install --global npm@11.19.0
+
+      - name: Pack release artifact once
+        id: pack
+        run: |
+          set -euo pipefail
+          VERSION=$(node -p "require('./packages/lumi-survey/package.json').version")
+          TARBALL="${RUNNER_TEMP}/navikt-lumi-survey-${VERSION}.tgz"
+          pnpm --filter @navikt/lumi-survey pack --pack-destination "${RUNNER_TEMP}"
+          test -f "${TARBALL}"
+          echo "tarball=${TARBALL}" >> "${GITHUB_OUTPUT}"
+
+      # npmjs is first so a missing or incorrect trusted-publisher setup cannot
+      # create a GitHub Packages-only release. Trusted publishing adds provenance.
+      - name: Publish to npmjs
+        run: node scripts/publish-lumi-survey-registry.mjs --tarball="${TARBALL}" --registry=https://registry.npmjs.org
+        env:
+          TARBALL: ${{ steps.pack.outputs.tarball }}
+
+      - name: Configure GitHub Packages authentication
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020
+        with:
+          node-version-file: package.json
+          registry-url: https://npm.pkg.github.com
+          scope: "@navikt"
+
+      - name: Publish compatibility mirror to GitHub Packages
+        run: node scripts/publish-lumi-survey-registry.mjs --tarball="${TARBALL}" --registry=https://npm.pkg.github.com
         env:
           NPM_AUTH_TOKEN: ${{ github.token }}
           NODE_AUTH_TOKEN: ${{ github.token }}
+          TARBALL: ${{ steps.pack.outputs.tarball }}
 
       - name: Tag release
         run: |
           set -euo pipefail
           VERSION=$(node -p "require('./packages/lumi-survey/package.json').version")
           TAG="lumi-survey-v${VERSION}"
-
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
-
-          git tag -a "${TAG}" -m "@navikt/lumi-survey ${VERSION}"
-          git push origin "${TAG}"
+          TAG_OBJECT_SHA="$(
+            gh api \
+              --method POST \
+              "repos/${GITHUB_REPOSITORY}/git/tags" \
+              -f "tag=${TAG}" \
+              -f "message=@navikt/lumi-survey ${VERSION}" \
+              -f "object=${GITHUB_SHA}" \
+              -f "type=commit" \
+              --jq '.sha'
+          )"
+          gh api \
+            --method POST \
+            "repos/${GITHUB_REPOSITORY}/git/refs" \
+            -f "ref=refs/tags/${TAG}" \
+            -f "sha=${TAG_OBJECT_SHA}"
+        env:
+          GH_TOKEN: ${{ github.token }}

--- a/docs/adr/0005-offentlig-npm-distribusjon.md
+++ b/docs/adr/0005-offentlig-npm-distribusjon.md
@@ -39,12 +39,16 @@ del av widgetens registerbytte.
    en kortlivet identitet; ingen langlivet npm-hemmelighet lagres i repoet.
    Offentlige releaser får provenance som knytter pakken til workflowen og
    kildekoden i `navikt/lumi`. Trusted publisher bindes også til GitHub
-   Actions-environmentet `npm-publish`, som bare tillater branch `main`. Dette
-   hindrer at en endret kopi av workflowen publiserer fra en feature-branch.
+   Actions-environmentet `npm-publish`, som bare tillater beskyttede branches.
+   `main` er repoets eneste beskyttede branch. Sammen med workflowens eksplisitte
+   `main`-sjekk hindrer dette at en endret kopi av workflowen publiserer fra en
+   feature-branch. Hvis repoet får flere beskyttede branches, skal environmentet
+   strammes inn til en eksplisitt `main`-regel.
 4. **Førstegangspublisering er en kontrollert bootstrap.** npm krever at en
-   pakke allerede finnes før trusted publisher kan konfigureres. En npm-admin
-   publiserer derfor den eksisterende `2.1.0`-tarballen fra GitHub Packages én
-   gang og konfigurerer deretter `navikt/lumi`,
+   pakke allerede finnes før trusted publisher kan konfigureres. En bruker som
+   npm-administratorene har gitt publiseringstilgang, publiserer derfor den
+   eksisterende `2.1.0`-tarballen fra GitHub Packages én gang og konfigurerer
+   deretter `navikt/lumi`,
    `publish-lumi-survey.yaml` og `npm-publish` som trusted publisher. Tarballen
    bygges ikke på nytt, og digestene verifiseres i begge registre.
 5. **Publisering tåler omkjøring.** npmjs publiseres før speilet. Hvis en
@@ -59,6 +63,13 @@ del av widgetens registerbytte.
    npmjs-jobben får bare `id-token: write`, speiljobben får bare
    `packages: write`, og taggjobben får bare `contents: write`. Det samme
    verifiserte workflow-artefaktet brukes i begge registre.
+8. **npmjs er et bevisst unntak fra Navs hovedregel.** Nav anbefaler GitHub
+   Packages for interne pakker fordi npmjs ikke har SSO. Lumi Survey er derimot
+   en offentlig, MIT-lisensiert konsumentpakke der anonym installasjon er et
+   eksplisitt mål. Konsumenter trenger ingen npm-konto. Menneskelig tilgang til
+   `@navikt` på npmjs begrenses til npm-administratorer og de få Lumi-
+   maintainerne som trenger å forvalte pakkeoppsettet. Ordinær publisering skjer
+   med trusted publishing, ikke med personlige eller langlivede tokens.
 
 ## Konsekvenser
 
@@ -76,9 +87,15 @@ del av widgetens registerbytte.
 
 - To registre må publiseres og overvåkes per release.
 - Den første npmjs-publiseringen og trusted-publisher-oppsettet krever en
-  manuell npm-adminhandling.
+  manuell handling fra en bruker som npm-administratorene har gitt tilgang.
+- npmjs mangler SSO. Medlemskap, rolleendringer og fjerning av menneskelig
+  tilgang må derfor fortsatt forvaltes manuelt sammen med npm-administratorene.
 - Lumi-repoet beholder GitHub Packages-autentisering selv om widgetkonsumentene
   ikke trenger den.
+
+Denne kostnaden holdes avgrenset ved at konsumenter aldri trenger medlemskap,
+at antallet maintainere holdes lavt, og at releaser ikke er avhengige av en
+persons npm-token.
 
 ## Vurderte alternativer
 

--- a/docs/adr/0005-offentlig-npm-distribusjon.md
+++ b/docs/adr/0005-offentlig-npm-distribusjon.md
@@ -38,11 +38,15 @@ del av widgetens registerbytte.
    `id-token: write`-permission lar npm verifisere akkurat denne workflowen med
    en kortlivet identitet; ingen langlivet npm-hemmelighet lagres i repoet.
    Offentlige releaser får provenance som knytter pakken til workflowen og
-   kildekoden i `navikt/lumi`.
+   kildekoden i `navikt/lumi`. Trusted publisher bindes også til GitHub
+   Actions-environmentet `npm-publish`, som bare tillater branch `main`. Dette
+   hindrer at en endret kopi av workflowen publiserer fra en feature-branch.
 4. **Førstegangspublisering er en kontrollert bootstrap.** npm krever at en
    pakke allerede finnes før trusted publisher kan konfigureres. En npm-admin
-   publiserer derfor en eksisterende release én gang og konfigurerer deretter
-   `navikt/lumi` og `publish-lumi-survey.yaml` som trusted publisher.
+   publiserer derfor den eksisterende `2.1.0`-tarballen fra GitHub Packages én
+   gang og konfigurerer deretter `navikt/lumi`,
+   `publish-lumi-survey.yaml` og `npm-publish` som trusted publisher. Tarballen
+   bygges ikke på nytt, og digestene verifiseres i begge registre.
 5. **Publisering tåler omkjøring.** npmjs publiseres før speilet. Hvis en
    versjon allerede finnes, hoppes den bare over når registerets SHA-1- og
    SHA-512-digester er identiske med den lokale tarballen. Et avvik stopper
@@ -51,6 +55,10 @@ del av widgetens registerbytte.
    tilhørende installasjonsoppsett er fortsatt nødvendig for interne
    `@navikt`-avhengigheter. Konsumentdokumentasjonen skal ikke arve dette
    interne behovet.
+7. **Release-rettigheter separeres.** Pakking og preflight skjer read-only.
+   npmjs-jobben får bare `id-token: write`, speiljobben får bare
+   `packages: write`, og taggjobben får bare `contents: write`. Det samme
+   verifiserte workflow-artefaktet brukes i begge registre.
 
 ## Konsekvenser
 

--- a/docs/adr/0005-offentlig-npm-distribusjon.md
+++ b/docs/adr/0005-offentlig-npm-distribusjon.md
@@ -1,0 +1,90 @@
+---
+title: "ADR 0005: Lumi Survey distribueres offentlig via npmjs"
+status: Akseptert
+date: 2026-08-27
+---
+
+# ADR 0005: Lumi Survey distribueres offentlig via npmjs
+
+- **Status:** Akseptert
+- **Dato:** 2026-08-27
+- **Berører:** #471, `@navikt/lumi-survey`
+
+## Kontekst
+
+`@navikt/lumi-survey` er en offentlig MIT-lisensiert widget som skal kunne tas
+i bruk av team i hele Nav. GitHub Packages krever autentisering også ved lesing
+av offentlige npm-pakker. Konsumenter måtte derfor konfigurere hele
+`@navikt`-scopet mot GitHub Packages og håndtere et GitHub-token lokalt, i CI og
+i containerbygg bare for å installere widgeten.
+
+Scope-konfigurasjonen flytter samtidig offentlige Aksel-pakker fra npmjs til
+GitHub Packages. Det gjør konsumentene avhengige av et speil de ikke ellers
+trenger.
+
+Lumi-monorepoet har et annet behov enn widgetkonsumentene. Dashboardet bruker
+blant annet `@navikt/oasis` og `@navikt/pino-logger`, som ikke distribueres på
+npmjs. Repoets egen GitHub Packages-konfigurasjon kan derfor ikke fjernes som
+del av widgetens registerbytte.
+
+## Beslutning
+
+1. **npmjs er widgetens primære register.** Konsumenter installerer
+   `@navikt/lumi-survey` anonymt uten `.npmrc` eller GitHub-token.
+2. **GitHub Packages beholdes som kompatibilitetsspeil.** Hver release
+   publiserer samme tarball og versjon til begge registre, slik at eksisterende
+   konsumenter ikke må migrere samtidig.
+3. **npmjs-publisering bruker trusted publishing.** GitHubs
+   `id-token: write`-permission lar npm verifisere akkurat denne workflowen med
+   en kortlivet identitet; ingen langlivet npm-hemmelighet lagres i repoet.
+   Offentlige releaser får provenance som knytter pakken til workflowen og
+   kildekoden i `navikt/lumi`.
+4. **Førstegangspublisering er en kontrollert bootstrap.** npm krever at en
+   pakke allerede finnes før trusted publisher kan konfigureres. En npm-admin
+   publiserer derfor en eksisterende release én gang og konfigurerer deretter
+   `navikt/lumi` og `publish-lumi-survey.yaml` som trusted publisher.
+5. **Publisering tåler omkjøring.** npmjs publiseres før speilet. Hvis en
+   versjon allerede finnes, hoppes den bare over når registerets SHA-1- og
+   SHA-512-digester er identiske med den lokale tarballen. Et avvik stopper
+   releasen. Release-tag opprettes først etter begge registre.
+6. **Monorepoets registry-oppsett beholdes.** `.npmrc`, `READER_TOKEN` og
+   tilhørende installasjonsoppsett er fortsatt nødvendig for interne
+   `@navikt`-avhengigheter. Konsumentdokumentasjonen skal ikke arve dette
+   interne behovet.
+
+## Konsekvenser
+
+### Positivt
+
+- Nye konsumenter kan installere widgeten med en vanlig package-manager-kommando.
+- Ingen npm-publiseringstoken må lagres eller roteres i GitHub.
+- Provenance gjør koblingen mellom pakke, kildekode og release-workflow
+  etterprøvbar.
+- Eksisterende GitHub Packages-konsumenter fortsetter å fungere.
+- Delvis feilslåtte releaser kan kjøres på nytt uten å overskrive eller skjule
+  en versjon med annet innhold.
+
+### Kostnad
+
+- To registre må publiseres og overvåkes per release.
+- Den første npmjs-publiseringen og trusted-publisher-oppsettet krever en
+  manuell npm-adminhandling.
+- Lumi-repoet beholder GitHub Packages-autentisering selv om widgetkonsumentene
+  ikke trenger den.
+
+## Vurderte alternativer
+
+### Kun GitHub Packages
+
+Forkastet fordi alle konsumenter da må håndtere autentisering for en offentlig
+pakke og samtidig flytte hele `@navikt`-scopet til GitHub Packages.
+
+### Hard overgang til kun npmjs
+
+Forkastet fordi eksisterende konsumenter kan ha låst registry-oppsett og fordi
+monorepoet fortsatt trenger GitHub Packages for interne avhengigheter.
+
+### Langlivet npm-token i GitHub Actions
+
+Forkastet fordi trusted publishing støttes av npmjs og gir kortlivede,
+workflow-avgrensede credentials og automatisk provenance.

--- a/docs/kom-i-gang/installer-widget.md
+++ b/docs/kom-i-gang/installer-widget.md
@@ -6,15 +6,10 @@ title: Installer widget
 
 Denne siden viser deg hvordan du installerer `@navikt/lumi-survey` og får widgeten til å rendre i appen din.
 
-## 1. Konfigurer registry
+## 1. Installer pakken
 
-`@navikt/lumi-survey` publiseres til GitHub Packages. Legg til en `.npmrc`-fil i roten av prosjektet ditt (ved siden av `package.json`). Denne konfigurasjonen brukes av npm-kompatible package managere som pnpm, npm og Yarn:
-
-```properties
-@navikt:registry=https://npm.pkg.github.com
-```
-
-## 2. Installer pakken
+`@navikt/lumi-survey` publiseres offentlig på npmjs. Installasjonen krever
+verken `.npmrc` eller GitHub-token:
 
 ```sh
 pnpm add @navikt/lumi-survey @navikt/ds-react @navikt/ds-css
@@ -34,7 +29,7 @@ pnpm add @navikt/lumi-survey
 ```
 :::
 
-## 3. Importer CSS
+## 2. Importer CSS
 
 Importer stilarkene i appens entry-punkt (f.eks. `main.tsx`, `App.tsx` eller layout-filen din):
 
@@ -47,7 +42,7 @@ import "@navikt/lumi-survey/styles.css";
 `@navikt/ds-css` **må** importeres **før** `@navikt/lumi-survey/styles.css` for at styling skal fungere korrekt.
 :::
 
-## 4. Rendre widgeten
+## 3. Rendre widgeten
 
 Her er et minimalt eksempel som viser en survey-widget i appen din:
 

--- a/docs/referanse/miljoer.md
+++ b/docs/referanse/miljoer.md
@@ -21,7 +21,8 @@ Demo-miljøet er åpent for alle og viser testdata. Dev og prod krever Nav-innlo
 | Ressurs | URL |
 | :--- | :--- |
 | Storybook | https://navikt.github.io/lumi/storybook/ |
-| `@navikt/lumi-survey` | [GitHub Packages](https://github.com/navikt/lumi/packages) |
+| `@navikt/lumi-survey` (primær) | [npmjs](https://www.npmjs.com/package/@navikt/lumi-survey) |
+| `@navikt/lumi-survey` (speil) | [GitHub Packages](https://github.com/navikt/lumi/packages) |
 
 Storybook viser survey-widgeten med interaktive eksempler. Bruk den til å utforske spørsmålstyper og visuell tilpasning.
 

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "verify:lumi-survey": "pnpm --filter @navikt/lumi-survey run build && node scripts/verify-lumi-survey-package.mjs",
     "verify:lumi-survey-consumer": "./scripts/verify-lumi-survey-consumer.sh",
     "check:lumi-survey-release-drift": "node scripts/check-lumi-survey-release-drift.mjs",
-    "test:release-guards": "node --test scripts/check-lumi-survey-release-drift.test.mjs scripts/verify-deploy-api-trigger.test.mjs scripts/verify-deploy-dashboard-trigger.test.mjs scripts/verify-github-actions-pins.test.mjs scripts/verify-lumi-survey-package.test.mjs",
+    "test:release-guards": "node --test scripts/check-lumi-survey-release-drift.test.mjs scripts/publish-lumi-survey-registry.test.mjs scripts/verify-deploy-api-trigger.test.mjs scripts/verify-deploy-dashboard-trigger.test.mjs scripts/verify-github-actions-pins.test.mjs scripts/verify-lumi-survey-package.test.mjs",
     "test": "pnpm --filter @navikt/lumi-types run test && pnpm --filter @navikt/lumi-survey run test && pnpm --filter lumi-dashboard run test",
     "e2e": "pnpm --filter lumi-dashboard run e2e",
     "e2e:full-chain": "pnpm --filter lumi-dashboard run e2e:full-chain",

--- a/packages/lumi-survey/CHANGELOG.md
+++ b/packages/lumi-survey/CHANGELOG.md
@@ -6,6 +6,16 @@ This project follows SemVer.
 
 ## [Unreleased]
 
+## [2.1.1] - 2026-08-27
+
+### Distribution
+
+- The package is now published to npmjs as the primary, anonymously readable
+  registry and to GitHub Packages as a compatibility mirror. Consumers no
+  longer need registry configuration or a GitHub token to install it.
+- Published metadata now declares the MIT license and the package's source
+  directory in `navikt/lumi`.
+
 ### Fixed
 
 - `validateSurveyDocumentV1` and `buildCanonicalSurvey` now reject `visibleIf`
@@ -18,7 +28,6 @@ This project follows SemVer.
   single-choice answers so existing code-authored V1 documents keep working;
   the workshop continues to offer exact equality for that type. METADATA
   conditions and legacy flat surveys are unaffected.
-
 - Focus now follows dock transitions: opening targets the active heading,
   closing targets the minimized trigger, and successful submission targets the
   receipt heading. The minimized trigger no longer references an unmounted
@@ -28,15 +37,10 @@ This project follows SemVer.
   grace period while a late persisted dismissal can still be applied.
 - Rating questions now expose exactly one named group to assistive
   technology. The prompt is the fieldset legend (a level 3 heading when
-  visible), the fieldset itself carries `role="radiogroup"`, and the
-  visually hidden legend copy no longer duplicates an external prompt
-  heading. Screen readers previously announced the question up to three
-  times per rating group.
-
-## [2.1.1] - 2026-08-22
-
-### Fixed
-
+  visible), the fieldset itself carries `role="radiogroup"`, and the visually
+  hidden legend copy no longer duplicates an external prompt heading. Screen
+  readers previously announced the question up to three times per rating
+  group.
 - The published stylesheet now contains only `lumi-`-namespaced selectors.
   Unused CSS Module output previously leaked generic selectors such as
   `.container`, `.header`, `.panel` and `.active` into consumer applications.

--- a/packages/lumi-survey/CONTRIBUTING.md
+++ b/packages/lumi-survey/CONTRIBUTING.md
@@ -105,8 +105,10 @@ npm krever at pakken finnes før trusted publisher kan konfigureres. Følg denne
 engangsprosedyren før PR-en som innfører workflowen merges:
 
 1. Opprett GitHub Actions-environmentet `npm-publish` i repo-innstillingene.
-   Velg bare branch `main` under deployment branches. Environmentet trenger
-   ingen secrets eller required reviewers.
+   Tillat bare beskyttede branches og kontroller at `main` er repoets eneste
+   beskyttede branch. Hvis repoet senere får flere beskyttede branches, skal
+   regelen endres til eksplisitt `main`. Environmentet trenger ingen secrets
+   eller required reviewers.
 2. Last ned **den allerede publiserte** `2.1.0`-tarballen fra GitHub Packages.
    Ikke bygg den på nytt. Fra repo-roten, med `NPM_AUTH_TOKEN` satt til et
    GitHub-token med `read:packages`:
@@ -137,9 +139,10 @@ engangsprosedyren før PR-en som innfører workflowen merges:
        --registry=https://npm.pkg.github.com
    ```
 
-4. En npm-admin publiserer nøyaktig denne filen som offentlig pakke. Begge
-   registry-flaggene er nødvendige fordi repoets `.npmrc` peker hele
-   `@navikt`-scopet mot GitHub Packages:
+4. En bruker som npm-administratorene har gitt publiseringstilgang, publiserer
+   nøyaktig denne filen som offentlig pakke. Begge registry-flaggene er
+   nødvendige fordi repoets `.npmrc` peker hele `@navikt`-scopet mot GitHub
+   Packages:
 
    ```bash
    unset NPM_AUTH_TOKEN NODE_AUTH_TOKEN
@@ -173,6 +176,9 @@ engangsprosedyren før PR-en som innfører workflowen merges:
 Ikke legg et npm-token i workflowen for å omgå bootstrapen. Etter at trusted
 publishing er verifisert, skal pakken settes til å kreve tofaktor og avvise
 tokenbasert publisering. Eventuelle gamle publiseringstokener tilbakekalles.
+Kun npm-administratorer og de få Lumi-maintainerne som må forvalte
+pakkeoppsettet, skal ha menneskelig npm-tilgang. Konsumenter trenger ingen
+npm-konto.
 
 Monorepoets `.npmrc` beholdes fordi repoet også installerer interne
 `@navikt`-pakker som bare finnes i GitHub Packages. Konsumenter av

--- a/packages/lumi-survey/CONTRIBUTING.md
+++ b/packages/lumi-survey/CONTRIBUTING.md
@@ -60,7 +60,7 @@ Prinsipp:
 - Skriv kort og konkret (1–6 bullets). Tenk: "hva trenger en konsument å vite?".
 - Interne refactors som ikke påvirker konsumenter kan stå under "Changed" eller utelates.
 
-## Publisering til GitHub Packages (anbefalt)
+## Publisering til npmjs og GitHub Packages
 
 Publisering er en “to-trinns” prosess:
 
@@ -83,20 +83,38 @@ Publisering er en “to-trinns” prosess:
    - `pnpm --filter @navikt/lumi-survey pack --dry-run`
 5. Commit og push PR-en. Få PR-en merget til `main`.
 6. Publiser:
-   - GitHub → Actions → `Publish @navikt/lumi-survey (GitHub Packages)`
+   - GitHub → Actions → `Publish @navikt/lumi-survey (npmjs + GitHub Packages)`
    - Kjør først gjerne med `dry_run=true` (verifiserer alt uten publish)
    - Kjør deretter med `dry_run=false` for faktisk publisering
 
+Workflowen pakker én tarball og publiserer den først til npmjs og deretter til
+GitHub Packages. En omkjøring hopper bare over en eksisterende versjon når
+tarballens digester er identiske. Release-taggen opprettes etter at begge
+registrene er verifisert.
+
+Publisering til npmjs bruker trusted publishing og krever ikke et langlivet
+npm-token. Trusted publisher for pakken skal peke på GitHub-repoet
+`navikt/lumi`, workflowfilen `publish-lumi-survey.yaml` og tillate
+`npm publish`. GitHub Packages bruker workflowens kortlivede `GITHUB_TOKEN`.
+
+**Første publisering til npmjs:**
+
+npm krever at pakken finnes før trusted publisher kan konfigureres. En
+npm-admin må derfor bootstrap-publisere en eksisterende release som offentlig
+pakke og deretter konfigurere trusted publisher før den første kjøringen som
+publiserer til begge registre. Ikke legg et npm-token i workflowen for å omgå
+bootstrapen.
+
+Monorepoets `.npmrc` beholdes fordi repoet også installerer interne
+`@navikt`-pakker som bare finnes i GitHub Packages. Konsumenter av
+`@navikt/lumi-survey` trenger ikke denne konfigurasjonen.
+
 ### Publisering (manuelt)
 
-Dette er normalt ikke nødvendig. Anbefalt flyt er å publisere fra `main` via workflowen over.
+Dette er normalt ikke nødvendig. Anbefalt flyt er å publisere fra `main` via
+workflowen over.
 
-Bruk manuell publisering kun hvis du må debugge/rette opp et publish-problem, og gjør det med samme krav som workflowen (lint/typecheck/verify/tests + `pack --dry-run`).
-
-Per i dag publiserer vi til GitHub Packages (se `publishConfig.registry` i `packages/lumi-survey/package.json`).
-
-For å publisere manuelt må du ha en token som kan skrive til GitHub Packages og en `.npmrc`/miljøvariabel som gir auth (samme mekanisme som i CI).
-
-Publiser fra repo root:
-
-- `pnpm --filter @navikt/lumi-survey publish --publish-branch main`
+Bruk manuell publisering kun sammen med en npm-admin for bootstrap eller for å
+rette opp en konkret publiseringsfeil. Den ordinære flyten skal alltid gå via
+workflowen, slik at npmjs-publiseringen får provenance og begge registre
+mottar samme tarball.

--- a/packages/lumi-survey/CONTRIBUTING.md
+++ b/packages/lumi-survey/CONTRIBUTING.md
@@ -90,20 +90,89 @@ Publisering er en “to-trinns” prosess:
 Workflowen pakker én tarball og publiserer den først til npmjs og deretter til
 GitHub Packages. En omkjøring hopper bare over en eksisterende versjon når
 tarballens digester er identiske. Release-taggen opprettes etter at begge
-registrene er verifisert.
+registrene er verifisert. Pakking skjer i en read-only jobb; npmjs-publisering,
+GitHub Packages-publisering og tagging har separate minimumsrettigheter.
 
 Publisering til npmjs bruker trusted publishing og krever ikke et langlivet
 npm-token. Trusted publisher for pakken skal peke på GitHub-repoet
-`navikt/lumi`, workflowfilen `publish-lumi-survey.yaml` og tillate
-`npm publish`. GitHub Packages bruker workflowens kortlivede `GITHUB_TOKEN`.
+`navikt/lumi`, workflowfilen `publish-lumi-survey.yaml`, environmentet
+`npm-publish` og tillate `npm publish`. GitHub Packages bruker workflowens
+kortlivede `GITHUB_TOKEN`.
 
 **Første publisering til npmjs:**
 
-npm krever at pakken finnes før trusted publisher kan konfigureres. En
-npm-admin må derfor bootstrap-publisere en eksisterende release som offentlig
-pakke og deretter konfigurere trusted publisher før den første kjøringen som
-publiserer til begge registre. Ikke legg et npm-token i workflowen for å omgå
-bootstrapen.
+npm krever at pakken finnes før trusted publisher kan konfigureres. Følg denne
+engangsprosedyren før PR-en som innfører workflowen merges:
+
+1. Opprett GitHub Actions-environmentet `npm-publish` i repo-innstillingene.
+   Velg bare branch `main` under deployment branches. Environmentet trenger
+   ingen secrets eller required reviewers.
+2. Last ned **den allerede publiserte** `2.1.0`-tarballen fra GitHub Packages.
+   Ikke bygg den på nytt. Fra repo-roten, med `NPM_AUTH_TOKEN` satt til et
+   GitHub-token med `read:packages`:
+
+   ```bash
+   BOOTSTRAP_DIRECTORY="$(mktemp -d)"
+   npm pack @navikt/lumi-survey@2.1.0 \
+     --pack-destination="${BOOTSTRAP_DIRECTORY}" \
+     --registry=https://npm.pkg.github.com \
+     --@navikt:registry=https://npm.pkg.github.com
+   ```
+
+3. Verifiser tarballen før publisering:
+
+   ```text
+   SHA-1:   cfbbe9c392ae19a3792cd9053e29944a56e84738
+   SHA-512: sha512-CZiEu/tTQur7R5BqEMDpysvkVijKwhYnw8Ujf+Yb/S9MZ2yl6tYA50WrkgagvkE+oaxKLeVvlObnydZl9BK87g==
+   ```
+
+   Denne kommandoen beregner lokale digester og sammenligner dem med GitHub
+   Packages-metadata. Den skal rapportere at tarballen er identisk:
+
+   ```bash
+   NODE_AUTH_TOKEN="${NPM_AUTH_TOKEN}" \
+     node scripts/publish-lumi-survey-registry.mjs \
+       --mode=verify \
+       --tarball="${BOOTSTRAP_DIRECTORY}/navikt-lumi-survey-2.1.0.tgz" \
+       --registry=https://npm.pkg.github.com
+   ```
+
+4. En npm-admin publiserer nøyaktig denne filen som offentlig pakke. Begge
+   registry-flaggene er nødvendige fordi repoets `.npmrc` peker hele
+   `@navikt`-scopet mot GitHub Packages:
+
+   ```bash
+   unset NPM_AUTH_TOKEN NODE_AUTH_TOKEN
+   npm publish "${BOOTSTRAP_DIRECTORY}/navikt-lumi-survey-2.1.0.tgz" \
+     --registry=https://registry.npmjs.org \
+     --@navikt:registry=https://registry.npmjs.org \
+     --access=public \
+     --ignore-scripts
+   ```
+
+5. Kontroller at npmjs viser de samme SHA-1- og SHA-512-digestene:
+
+   ```bash
+   node scripts/publish-lumi-survey-registry.mjs \
+     --mode=verify \
+     --tarball="${BOOTSTRAP_DIRECTORY}/navikt-lumi-survey-2.1.0.tgz" \
+     --registry=https://registry.npmjs.org
+   ```
+
+   Kommandoen skal rapportere at tarballen er identisk. Konfigurer deretter
+   trusted publisher i npmjs-grensesnittet, eller med:
+
+   ```bash
+   npm trust github @navikt/lumi-survey \
+     --repo navikt/lumi \
+     --file publish-lumi-survey.yaml \
+     --env npm-publish \
+     --allow-publish
+   ```
+
+Ikke legg et npm-token i workflowen for å omgå bootstrapen. Etter at trusted
+publishing er verifisert, skal pakken settes til å kreve tofaktor og avvise
+tokenbasert publisering. Eventuelle gamle publiseringstokener tilbakekalles.
 
 Monorepoets `.npmrc` beholdes fordi repoet også installerer interne
 `@navikt`-pakker som bare finnes i GitHub Packages. Konsumenter av
@@ -118,3 +187,8 @@ Bruk manuell publisering kun sammen med en npm-admin for bootstrap eller for å
 rette opp en konkret publiseringsfeil. Den ordinære flyten skal alltid gå via
 workflowen, slik at npmjs-publiseringen får provenance og begge registre
 mottar samme tarball.
+
+Hvis registrene er oppdatert, men taggsteget feiler, må operatøren kontrollere
+at begge registry-digestene matcher tarballen og at `lumi-survey-v<versjon>`
+peker på riktig commit. Feil innhold skal aldri avpubliseres og publiseres på
+nytt med samme versjon; rettelsen gis en ny patch-versjon.

--- a/packages/lumi-survey/LICENSE
+++ b/packages/lumi-survey/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Nav IT
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/lumi-survey/README.md
+++ b/packages/lumi-survey/README.md
@@ -8,13 +8,8 @@ Aksel-basert React-widget for å samle inn brukertilbakemeldinger via Lumi.
 
 ## Installer
 
-Pakken publiseres til GitHub Packages. Legg dette i prosjektets `.npmrc`:
-
-```properties
-@navikt:registry=https://npm.pkg.github.com
-```
-
-Installer pakken og Aksel 8 eller nyere:
+Pakken publiseres offentlig på npmjs og kan installeres uten `.npmrc` eller
+GitHub-token. Installer pakken og Aksel 8 eller nyere:
 
 ```sh
 pnpm add @navikt/lumi-survey @navikt/ds-react @navikt/ds-css

--- a/packages/lumi-survey/package.json
+++ b/packages/lumi-survey/package.json
@@ -3,11 +3,17 @@
   "version": "2.1.1",
   "private": false,
   "description": "Aksel-based React widget for configurable NAV Lumi surveys.",
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/navikt/lumi.git",
+    "directory": "packages/lumi-survey"
+  },
   "type": "module",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "publishConfig": {
-    "registry": "https://npm.pkg.github.com"
+    "access": "public"
   },
   "exports": {
     ".": {

--- a/scripts/check-lumi-survey-release-drift.test.mjs
+++ b/scripts/check-lumi-survey-release-drift.test.mjs
@@ -185,24 +185,24 @@ test("publish verification is read-only and write access is main-only", () => {
     "utf8",
   );
   const verifyStart = workflow.indexOf("\n  verify:\n");
-  const publishStart = workflow.indexOf("\n  publish:\n");
+  const publishStart = workflow.indexOf("\n  publish_npmjs:\n");
 
   assert.notEqual(verifyStart, -1, "expected a separate verify job");
-  assert.notEqual(publishStart, -1, "expected a separate publish job");
+  assert.notEqual(publishStart, -1, "expected separate publish jobs");
   assert.ok(verifyStart < publishStart, "verify must run before publish");
 
   const verifyJob = workflow.slice(verifyStart, publishStart);
-  const publishJob = workflow.slice(publishStart);
+  const publishJobs = workflow.slice(publishStart);
   assert.match(verifyJob, /permissions:\n\s+contents: read\n\s+packages: read/);
   assert.doesNotMatch(verifyJob, /contents: write|packages: write/);
   assert.match(
-    publishJob,
+    publishJobs,
     /if:.*inputs\.dry_run == 'false'.*github\.ref_name == 'main'/,
   );
-  assert.match(
-    publishJob,
-    /permissions:\n\s+contents: write\n\s+id-token: write\n\s+packages: write/,
-  );
+  assert.equal((publishJobs.match(/id-token: write/g) ?? []).length, 1);
+  assert.equal((publishJobs.match(/packages: write/g) ?? []).length, 1);
+  assert.equal((publishJobs.match(/contents: write/g) ?? []).length, 1);
+  assert.match(publishJobs, /environment: npm-publish/);
 });
 
 test("publish mode rejects a version-only release", () => {

--- a/scripts/check-lumi-survey-release-drift.test.mjs
+++ b/scripts/check-lumi-survey-release-drift.test.mjs
@@ -201,7 +201,7 @@ test("publish verification is read-only and write access is main-only", () => {
   );
   assert.match(
     publishJob,
-    /permissions:\n\s+contents: write\n\s+packages: write/,
+    /permissions:\n\s+contents: write\n\s+id-token: write\n\s+packages: write/,
   );
 });
 

--- a/scripts/publish-lumi-survey-registry.mjs
+++ b/scripts/publish-lumi-survey-registry.mjs
@@ -1,0 +1,204 @@
+import { execFileSync, spawnSync } from "node:child_process";
+import { createHash } from "node:crypto";
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const PACKAGE_NAME = "@navikt/lumi-survey";
+const NPMJS_REGISTRY = "https://registry.npmjs.org";
+const GITHUB_REGISTRY = "https://npm.pkg.github.com";
+const ALLOWED_REGISTRIES = new Set([NPMJS_REGISTRY, GITHUB_REGISTRY]);
+
+function fail(message) {
+  throw new Error(`[publish:lumi-survey] ${message}`);
+}
+
+export function normalizeRegistryUrl(registryUrl) {
+  const normalized = registryUrl.replace(/\/+$/, "");
+  if (!ALLOWED_REGISTRIES.has(normalized)) {
+    fail(`Unsupported registry: ${registryUrl}`);
+  }
+  return normalized;
+}
+
+export function registryPackageUrl(registryUrl, name) {
+  return `${normalizeRegistryUrl(registryUrl)}/${encodeURIComponent(name)}`;
+}
+
+export function publicationDecision(localDigests, publishedDigests) {
+  if (publishedDigests === undefined) return "publish";
+  if (
+    publishedDigests.shasum === localDigests.shasum &&
+    publishedDigests.integrity === localDigests.integrity
+  ) {
+    return "skip";
+  }
+  fail(
+    "Version already exists with a different tarball digest. Refusing to continue.",
+  );
+}
+
+export function publishedVersionDigests(metadata, version) {
+  const publishedVersion = metadata?.versions?.[version];
+  if (publishedVersion === undefined) return undefined;
+
+  const shasum = publishedVersion?.dist?.shasum;
+  if (typeof shasum !== "string" || !/^[0-9a-f]{40}$/i.test(shasum)) {
+    fail(`Registry metadata for version ${version} has no valid dist.shasum.`);
+  }
+  const integrity = publishedVersion?.dist?.integrity;
+  if (
+    typeof integrity !== "string" ||
+    !/^sha512-[A-Za-z0-9+/]+={0,2}$/.test(integrity)
+  ) {
+    fail(
+      `Registry metadata for version ${version} has no valid dist.integrity.`,
+    );
+  }
+  return { shasum: shasum.toLowerCase(), integrity };
+}
+
+export function readPackedManifest(tarballPath) {
+  let manifest;
+  try {
+    manifest = execFileSync(
+      "tar",
+      ["-xOf", tarballPath, "package/package.json"],
+      { encoding: "utf8" },
+    );
+  } catch (error) {
+    const details = error instanceof Error ? error.message : String(error);
+    fail(`Could not read package/package.json from ${tarballPath}: ${details}`);
+  }
+
+  let parsed;
+  try {
+    parsed = JSON.parse(manifest);
+  } catch {
+    fail(`${tarballPath} contains an invalid package.json.`);
+  }
+
+  if (parsed.name !== PACKAGE_NAME) {
+    fail(`Expected ${PACKAGE_NAME}, found ${String(parsed.name)}.`);
+  }
+  if (typeof parsed.version !== "string" || parsed.version.length === 0) {
+    fail(`${tarballPath} does not contain a valid package version.`);
+  }
+
+  return { name: parsed.name, version: parsed.version };
+}
+
+export function tarballDigests(tarballPath) {
+  const tarball = readFileSync(tarballPath);
+  return {
+    shasum: createHash("sha1").update(tarball).digest("hex"),
+    integrity: `sha512-${createHash("sha512").update(tarball).digest("base64")}`,
+  };
+}
+
+export function buildPublishArguments(tarballPath, registryUrl) {
+  const normalizedRegistryUrl = normalizeRegistryUrl(registryUrl);
+  const publishArguments = [
+    "publish",
+    tarballPath,
+    `--registry=${normalizedRegistryUrl}`,
+    `--@navikt:registry=${normalizedRegistryUrl}`,
+    "--access=public",
+    "--ignore-scripts",
+  ];
+  if (normalizedRegistryUrl === NPMJS_REGISTRY) {
+    publishArguments.push("--provenance");
+  }
+  return publishArguments;
+}
+
+async function publishedDigests({ registryUrl, name, version, token }) {
+  const headers = { accept: "application/json" };
+  if (token) headers.authorization = `Bearer ${token}`;
+
+  const response = await fetch(registryPackageUrl(registryUrl, name), {
+    headers,
+  });
+  if (response.status === 404) return undefined;
+  if (!response.ok) {
+    fail(
+      `Registry lookup failed with HTTP ${response.status} ${response.statusText}.`,
+    );
+  }
+
+  const metadata = await response.json();
+  return publishedVersionDigests(metadata, version);
+}
+
+function parseArguments(arguments_) {
+  const values = new Map();
+  for (const argument of arguments_) {
+    const separator = argument.indexOf("=");
+    if (!argument.startsWith("--") || separator === -1) {
+      fail(`Unknown argument: ${argument}`);
+    }
+    values.set(argument.slice(2, separator), argument.slice(separator + 1));
+  }
+
+  const tarballPath = values.get("tarball");
+  const registryUrl = values.get("registry");
+  if (!tarballPath || !registryUrl || values.size !== 2) {
+    fail("Usage: --tarball=<path> --registry=<url>");
+  }
+  return {
+    tarballPath: path.resolve(tarballPath),
+    registryUrl: normalizeRegistryUrl(registryUrl),
+  };
+}
+
+async function main() {
+  const { tarballPath, registryUrl } = parseArguments(process.argv.slice(2));
+  const { name, version } = readPackedManifest(tarballPath);
+  const localDigests = tarballDigests(tarballPath);
+  const isGitHubPackages = registryUrl === GITHUB_REGISTRY;
+  const readToken = isGitHubPackages ? process.env.NODE_AUTH_TOKEN : undefined;
+
+  if (isGitHubPackages && !readToken) {
+    fail("NODE_AUTH_TOKEN is required for GitHub Packages.");
+  }
+
+  const remoteDigests = await publishedDigests({
+    registryUrl,
+    name,
+    version,
+    token: readToken,
+  });
+  const decision = publicationDecision(localDigests, remoteDigests);
+  if (decision === "skip") {
+    console.log(
+      `[publish:lumi-survey] ${name}@${version} already exists in ${registryUrl} with the same tarball; skipping.`,
+    );
+    return;
+  }
+
+  const result = spawnSync(
+    "npm",
+    buildPublishArguments(tarballPath, registryUrl),
+    {
+      env: process.env,
+      stdio: "inherit",
+    },
+  );
+  if (result.error)
+    fail(`Could not start npm publish: ${result.error.message}`);
+  if (result.status !== 0) {
+    fail(`npm publish exited with status ${String(result.status)}.`);
+  }
+}
+
+if (
+  process.argv[1] &&
+  path.resolve(process.argv[1]) === fileURLToPath(import.meta.url)
+) {
+  try {
+    await main();
+  } catch (error) {
+    console.error(error instanceof Error ? error.message : String(error));
+    process.exit(1);
+  }
+}

--- a/scripts/publish-lumi-survey-registry.mjs
+++ b/scripts/publish-lumi-survey-registry.mjs
@@ -1,6 +1,6 @@
 import { execFileSync, spawnSync } from "node:child_process";
 import { createHash } from "node:crypto";
-import { readFileSync } from "node:fs";
+import { readFileSync, realpathSync } from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 
@@ -8,6 +8,7 @@ const PACKAGE_NAME = "@navikt/lumi-survey";
 const NPMJS_REGISTRY = "https://registry.npmjs.org";
 const GITHUB_REGISTRY = "https://npm.pkg.github.com";
 const ALLOWED_REGISTRIES = new Set([NPMJS_REGISTRY, GITHUB_REGISTRY]);
+const ALLOWED_MODES = new Set(["check", "publish", "verify"]);
 
 function fail(message) {
   throw new Error(`[publish:lumi-survey] ${message}`);
@@ -112,13 +113,20 @@ export function buildPublishArguments(tarballPath, registryUrl) {
   return publishArguments;
 }
 
-async function publishedDigests({ registryUrl, name, version, token }) {
+async function publishedDigests({
+  registryUrl,
+  name,
+  version,
+  token,
+  fetchImplementation = fetch,
+}) {
   const headers = { accept: "application/json" };
   if (token) headers.authorization = `Bearer ${token}`;
 
-  const response = await fetch(registryPackageUrl(registryUrl, name), {
-    headers,
-  });
+  const response = await fetchImplementation(
+    registryPackageUrl(registryUrl, name),
+    { headers },
+  );
   if (response.status === 404) return undefined;
   if (!response.ok) {
     fail(
@@ -130,7 +138,7 @@ async function publishedDigests({ registryUrl, name, version, token }) {
   return publishedVersionDigests(metadata, version);
 }
 
-function parseArguments(arguments_) {
+export function parseArguments(arguments_) {
   const values = new Map();
   for (const argument of arguments_) {
     const separator = argument.indexOf("=");
@@ -142,45 +150,90 @@ function parseArguments(arguments_) {
 
   const tarballPath = values.get("tarball");
   const registryUrl = values.get("registry");
-  if (!tarballPath || !registryUrl || values.size !== 2) {
-    fail("Usage: --tarball=<path> --registry=<url>");
+  const mode = values.get("mode") ?? "publish";
+  const hasUnknownKey = [...values.keys()].some(
+    (key) => !["tarball", "registry", "mode"].includes(key),
+  );
+  if (
+    !tarballPath ||
+    !registryUrl ||
+    hasUnknownKey ||
+    !ALLOWED_MODES.has(mode) ||
+    values.size < 2 ||
+    values.size > 3
+  ) {
+    fail(
+      "Usage: --tarball=<path> --registry=<url> [--mode=check|publish|verify]",
+    );
   }
   return {
     tarballPath: path.resolve(tarballPath),
     registryUrl: normalizeRegistryUrl(registryUrl),
+    mode,
   };
 }
 
-async function main() {
-  const { tarballPath, registryUrl } = parseArguments(process.argv.slice(2));
+export async function runPublication({
+  tarballPath,
+  registryUrl,
+  mode = "publish",
+  environment = process.env,
+  fetchImplementation = fetch,
+  spawnImplementation = spawnSync,
+}) {
+  if (!ALLOWED_MODES.has(mode)) {
+    fail(`Unsupported mode: ${mode}`);
+  }
+
+  const normalizedRegistryUrl = normalizeRegistryUrl(registryUrl);
   const { name, version } = readPackedManifest(tarballPath);
   const localDigests = tarballDigests(tarballPath);
-  const isGitHubPackages = registryUrl === GITHUB_REGISTRY;
-  const readToken = isGitHubPackages ? process.env.NODE_AUTH_TOKEN : undefined;
+  const isGitHubPackages = normalizedRegistryUrl === GITHUB_REGISTRY;
+  const readToken = isGitHubPackages ? environment.NODE_AUTH_TOKEN : undefined;
 
   if (isGitHubPackages && !readToken) {
     fail("NODE_AUTH_TOKEN is required for GitHub Packages.");
   }
 
   const remoteDigests = await publishedDigests({
-    registryUrl,
+    registryUrl: normalizedRegistryUrl,
     name,
     version,
     token: readToken,
+    fetchImplementation,
   });
   const decision = publicationDecision(localDigests, remoteDigests);
   if (decision === "skip") {
     console.log(
-      `[publish:lumi-survey] ${name}@${version} already exists in ${registryUrl} with the same tarball; skipping.`,
+      `[publish:lumi-survey] ${name}@${version} already exists in ${normalizedRegistryUrl} with the same tarball; skipping.`,
     );
-    return;
+    return decision;
   }
 
-  const result = spawnSync(
+  if (mode === "verify") {
+    fail(
+      `${name}@${version} is not published in ${normalizedRegistryUrl}; expected an identical published version.`,
+    );
+  }
+
+  if (mode === "check") {
+    console.log(
+      `[publish:lumi-survey] ${name}@${version} is not published in ${normalizedRegistryUrl}; preflight passed.`,
+    );
+    return decision;
+  }
+
+  const publishEnvironment = { ...environment };
+  if (!isGitHubPackages) {
+    delete publishEnvironment.NODE_AUTH_TOKEN;
+    delete publishEnvironment.NPM_AUTH_TOKEN;
+  }
+
+  const result = spawnImplementation(
     "npm",
-    buildPublishArguments(tarballPath, registryUrl),
+    buildPublishArguments(tarballPath, normalizedRegistryUrl),
     {
-      env: process.env,
+      env: publishEnvironment,
       stdio: "inherit",
     },
   );
@@ -189,11 +242,18 @@ async function main() {
   if (result.status !== 0) {
     fail(`npm publish exited with status ${String(result.status)}.`);
   }
+  return decision;
+}
+
+async function main() {
+  const arguments_ = parseArguments(process.argv.slice(2));
+  await runPublication(arguments_);
 }
 
 if (
   process.argv[1] &&
-  path.resolve(process.argv[1]) === fileURLToPath(import.meta.url)
+  realpathSync(path.resolve(process.argv[1])) ===
+    realpathSync(fileURLToPath(import.meta.url))
 ) {
   try {
     await main();

--- a/scripts/publish-lumi-survey-registry.test.mjs
+++ b/scripts/publish-lumi-survey-registry.test.mjs
@@ -1,5 +1,5 @@
 import assert from "node:assert/strict";
-import { execFileSync } from "node:child_process";
+import { execFileSync, spawnSync } from "node:child_process";
 import { mkdirSync, mkdtempSync, readFileSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
@@ -8,10 +8,12 @@ import { fileURLToPath } from "node:url";
 import {
   buildPublishArguments,
   normalizeRegistryUrl,
+  parseArguments,
   publicationDecision,
   publishedVersionDigests,
   readPackedManifest,
   registryPackageUrl,
+  runPublication,
   tarballDigests,
 } from "./publish-lumi-survey-registry.mjs";
 
@@ -19,6 +21,32 @@ const repositoryRoot = path.resolve(
   path.dirname(fileURLToPath(import.meta.url)),
   "..",
 );
+
+function createTarball() {
+  const temporaryDirectory = mkdtempSync(
+    path.join(tmpdir(), "lumi-registry-publish-"),
+  );
+  const packageDirectory = path.join(temporaryDirectory, "package");
+  const tarballPath = path.join(temporaryDirectory, "lumi-survey.tgz");
+  mkdirSync(packageDirectory);
+  writeFileSync(
+    path.join(packageDirectory, "package.json"),
+    `${JSON.stringify({ name: "@navikt/lumi-survey", version: "2.1.1" })}\n`,
+  );
+  execFileSync("tar", ["-czf", tarballPath, "package"], {
+    cwd: temporaryDirectory,
+  });
+  return tarballPath;
+}
+
+function registryResponse(status, metadata) {
+  return {
+    status,
+    statusText: status === 404 ? "Not Found" : "OK",
+    ok: status >= 200 && status < 300,
+    json: async () => metadata,
+  };
+}
 
 test("allows only the two intended registries", () => {
   assert.equal(
@@ -64,6 +92,53 @@ test("builds explicit trusted-publish and mirror commands", () => {
   );
 });
 
+test("parses only the documented CLI contract", () => {
+  assert.deepEqual(
+    parseArguments([
+      "--mode=check",
+      "--tarball=relative.tgz",
+      "--registry=https://registry.npmjs.org",
+    ]),
+    {
+      mode: "check",
+      tarballPath: path.resolve("relative.tgz"),
+      registryUrl: "https://registry.npmjs.org",
+    },
+  );
+  assert.throws(
+    () =>
+      parseArguments([
+        "--tarball=relative.tgz",
+        "--registry=https://registry.npmjs.org",
+        "--unexpected=true",
+      ]),
+    /usage/i,
+  );
+});
+
+test("CLI entrypoint runs when the script path crosses a filesystem symlink", () => {
+  const canonicalScriptPath = path.join(
+    repositoryRoot,
+    "scripts/publish-lumi-survey-registry.mjs",
+  );
+  const symlinkedScriptPath = canonicalScriptPath.replace(
+    /^\/private\/tmp\//,
+    "/tmp/",
+  );
+  const result = spawnSync(
+    process.execPath,
+    [
+      symlinkedScriptPath,
+      "--tarball=missing.tgz",
+      "--registry=https://registry.example.invalid",
+    ],
+    { encoding: "utf8" },
+  );
+
+  assert.equal(result.status, 1);
+  assert.match(result.stderr, /unsupported registry/i);
+});
+
 test("publishes missing versions and skips only byte-identical versions", () => {
   const digests = {
     shasum: "a".repeat(40),
@@ -100,19 +175,7 @@ test("reads version digests from full registry metadata", () => {
 });
 
 test("reads package identity and hashes the packed tarball", () => {
-  const temporaryDirectory = mkdtempSync(
-    path.join(tmpdir(), "lumi-registry-publish-"),
-  );
-  const packageDirectory = path.join(temporaryDirectory, "package");
-  const tarballPath = path.join(temporaryDirectory, "lumi-survey.tgz");
-  mkdirSync(packageDirectory);
-  writeFileSync(
-    path.join(packageDirectory, "package.json"),
-    `${JSON.stringify({ name: "@navikt/lumi-survey", version: "2.1.1" })}\n`,
-  );
-  execFileSync("tar", ["-czf", tarballPath, "package"], {
-    cwd: temporaryDirectory,
-  });
+  const tarballPath = createTarball();
 
   assert.deepEqual(readPackedManifest(tarballPath), {
     name: "@navikt/lumi-survey",
@@ -122,38 +185,214 @@ test("reads package identity and hashes the packed tarball", () => {
   assert.match(tarballDigests(tarballPath).integrity, /^sha512-/);
 });
 
-test("release workflow publishes npmjs first and tags after both registries", () => {
+test("check mode performs a read-only preflight", async () => {
+  const tarballPath = createTarball();
+  let requestedUrl;
+  let requestedOptions;
+
+  const decision = await runPublication({
+    tarballPath,
+    registryUrl: "https://registry.npmjs.org",
+    mode: "check",
+    environment: {
+      NODE_AUTH_TOKEN: "must-not-be-sent-to-npmjs",
+      NPM_AUTH_TOKEN: "must-not-be-sent-to-npmjs",
+    },
+    fetchImplementation: async (url, options) => {
+      requestedUrl = url;
+      requestedOptions = options;
+      return registryResponse(404);
+    },
+    spawnImplementation: () => {
+      throw new Error("preflight must not invoke npm");
+    },
+  });
+
+  assert.equal(decision, "publish");
+  assert.equal(
+    requestedUrl,
+    "https://registry.npmjs.org/%40navikt%2Flumi-survey",
+  );
+  assert.deepEqual(requestedOptions.headers, { accept: "application/json" });
+});
+
+test("verify mode requires an identical published version", async () => {
+  const tarballPath = createTarball();
+  const localDigests = tarballDigests(tarballPath);
+  const unexpectedSpawn = () => {
+    throw new Error("verify mode must never invoke npm");
+  };
+
+  await assert.rejects(
+    runPublication({
+      tarballPath,
+      registryUrl: "https://registry.npmjs.org",
+      mode: "verify",
+      fetchImplementation: async () => registryResponse(404),
+      spawnImplementation: unexpectedSpawn,
+    }),
+    /expected an identical published version/i,
+  );
+
+  assert.equal(
+    await runPublication({
+      tarballPath,
+      registryUrl: "https://registry.npmjs.org",
+      mode: "verify",
+      fetchImplementation: async () =>
+        registryResponse(200, {
+          versions: { "2.1.1": { dist: localDigests } },
+        }),
+      spawnImplementation: unexpectedSpawn,
+    }),
+    "skip",
+  );
+});
+
+test("orchestration skips identical versions and blocks digest mismatches", async () => {
+  const tarballPath = createTarball();
+  const localDigests = tarballDigests(tarballPath);
+  let spawnCount = 0;
+  const spawnImplementation = () => {
+    spawnCount += 1;
+    return { status: 0 };
+  };
+
+  const metadataResponse = (digests) =>
+    registryResponse(200, {
+      versions: { "2.1.1": { dist: digests } },
+    });
+
+  assert.equal(
+    await runPublication({
+      tarballPath,
+      registryUrl: "https://registry.npmjs.org",
+      fetchImplementation: async () => metadataResponse(localDigests),
+      spawnImplementation,
+    }),
+    "skip",
+  );
+  assert.equal(spawnCount, 0);
+
+  await assert.rejects(
+    runPublication({
+      tarballPath,
+      registryUrl: "https://registry.npmjs.org",
+      fetchImplementation: async () =>
+        metadataResponse({
+          ...localDigests,
+          shasum: "b".repeat(40),
+        }),
+      spawnImplementation,
+    }),
+    /different tarball digest/i,
+  );
+  assert.equal(spawnCount, 0);
+});
+
+test("publishing scopes credentials to GitHub Packages", async () => {
+  const tarballPath = createTarball();
+  const invocations = [];
+  const requestedHeaders = [];
+  const environment = {
+    NODE_AUTH_TOKEN: "github-package-token",
+    NPM_AUTH_TOKEN: "github-package-token",
+    SAFE_VALUE: "preserved",
+  };
+  const fetchImplementation = async (_url, options) => {
+    requestedHeaders.push(options.headers);
+    return registryResponse(404);
+  };
+  const spawnImplementation = (command, args, options) => {
+    invocations.push({ command, args, options });
+    return { status: 0 };
+  };
+
+  await runPublication({
+    tarballPath,
+    registryUrl: "https://registry.npmjs.org",
+    environment,
+    fetchImplementation,
+    spawnImplementation,
+  });
+  await runPublication({
+    tarballPath,
+    registryUrl: "https://npm.pkg.github.com",
+    environment,
+    fetchImplementation,
+    spawnImplementation,
+  });
+
+  assert.deepEqual(requestedHeaders, [
+    { accept: "application/json" },
+    {
+      accept: "application/json",
+      authorization: "Bearer github-package-token",
+    },
+  ]);
+  assert.equal(invocations.length, 2);
+  assert.equal(invocations[0].command, "npm");
+  assert.equal(invocations[0].options.env.NODE_AUTH_TOKEN, undefined);
+  assert.equal(invocations[0].options.env.NPM_AUTH_TOKEN, undefined);
+  assert.equal(invocations[0].options.env.SAFE_VALUE, "preserved");
+  assert.equal(
+    invocations[1].options.env.NODE_AUTH_TOKEN,
+    "github-package-token",
+  );
+});
+
+test("release workflow preflights once and separates publish privileges", () => {
   const workflow = readFileSync(
     path.join(repositoryRoot, ".github/workflows/publish-lumi-survey.yaml"),
     "utf8",
   );
-  const publishJob = workflow.slice(workflow.indexOf("\n  publish:\n"));
-  const npmjsPublish = publishJob.indexOf(
-    "--registry=https://registry.npmjs.org",
-  );
-  const githubPublish = publishJob.indexOf(
-    "--registry=https://npm.pkg.github.com",
-  );
-  const releaseTag = publishJob.indexOf("- name: Tag release");
+  const npmjsJobStart = workflow.indexOf("\n  publish_npmjs:\n");
+  const githubJobStart = workflow.indexOf("\n  publish_github_packages:\n");
+  const tagJobStart = workflow.indexOf("\n  tag_release:\n");
+  const verifyJob = workflow.slice(0, npmjsJobStart);
+  const npmjsJob = workflow.slice(npmjsJobStart, githubJobStart);
+  const githubJob = workflow.slice(githubJobStart, tagJobStart);
+  const tagJob = workflow.slice(tagJobStart);
 
+  assert.ok(npmjsJobStart > -1, "expected npmjs publish job");
+  assert.ok(githubJobStart > npmjsJobStart, "expected mirror after npmjs");
+  assert.ok(tagJobStart > githubJobStart, "expected tag job last");
   assert.match(
-    publishJob,
-    /permissions:\n\s+contents: write\n\s+id-token: write\n\s+packages: write/,
+    verifyJob,
+    /--mode=check[^\n]+registry\.npmjs\.org[\s\S]+--mode=check[^\n]+npm\.pkg\.github\.com/,
   );
-  assert.match(publishJob, /npm install --global npm@11\.19\.0/);
-  assert.ok(npmjsPublish > -1, "expected npmjs publication");
-  assert.ok(githubPublish > npmjsPublish, "npmjs must be published first");
-  assert.ok(releaseTag > githubPublish, "tag must be created last");
-  assert.doesNotMatch(publishJob, /secrets\.NPM[^\s}]*/);
-  assert.doesNotMatch(publishJob, /--tarball=\$\{\{/);
+  assert.match(verifyJob, /actions\/upload-artifact@[0-9a-f]{40}/);
+  assert.match(verifyJob, /overwrite: true/);
   assert.match(
-    publishJob,
-    /TARBALL: \$\{\{ steps\.pack\.outputs\.tarball \}\}/,
+    npmjsJob,
+    /environment: npm-publish[\s\S]+permissions:\n\s+contents: read\n\s+id-token: write/,
   );
-  assert.match(publishJob, /repos\/\$\{GITHUB_REPOSITORY\}\/git\/tags/);
+  assert.match(
+    githubJob,
+    /needs: \[verify, publish_npmjs\][\s\S]+permissions:\n\s+contents: read\n\s+packages: write/,
+  );
+  assert.match(
+    tagJob,
+    /needs: \[verify, publish_github_packages\][\s\S]+permissions:\n\s+contents: write/,
+  );
+  assert.match(npmjsJob, /actions\/download-artifact@[0-9a-f]{40}/);
+  assert.match(githubJob, /actions\/download-artifact@[0-9a-f]{40}/);
+  assert.match(npmjsJob, /--registry=https:\/\/registry\.npmjs\.org/);
+  assert.match(githubJob, /--registry=https:\/\/npm\.pkg\.github\.com/);
+  assert.doesNotMatch(npmjsJob, /NPM_AUTH_TOKEN|NODE_AUTH_TOKEN/);
+  assert.doesNotMatch(npmjsJob, /pnpm install|npm install/);
+  assert.match(npmjsJob, /expected at least 11\.5\.1/);
+  assert.doesNotMatch(githubJob, /pnpm install|npm install/);
+  assert.doesNotMatch(workflow, /secrets\.NPM[^\s}]*/);
+  assert.doesNotMatch(workflow, /--tarball=\$\{\{/);
+  assert.match(workflow, /lumi-survey-release\/lumi-survey\.tgz/g);
+  assert.match(tagJob, /repos\/\$\{GITHUB_REPOSITORY\}\/git\/tags/);
+  assert.equal((workflow.match(/id-token: write/g) ?? []).length, 1);
+  assert.equal((workflow.match(/packages: write/g) ?? []).length, 1);
+  assert.equal((workflow.match(/contents: write/g) ?? []).length, 1);
 
   const workflowCheckoutHardening = workflow.match(
     /persist-credentials: false/g,
   );
-  assert.equal(workflowCheckoutHardening?.length, 2);
+  assert.equal(workflowCheckoutHardening?.length, 3);
 });

--- a/scripts/publish-lumi-survey-registry.test.mjs
+++ b/scripts/publish-lumi-survey-registry.test.mjs
@@ -1,0 +1,159 @@
+import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import { mkdirSync, mkdtempSync, readFileSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import test from "node:test";
+import { fileURLToPath } from "node:url";
+import {
+  buildPublishArguments,
+  normalizeRegistryUrl,
+  publicationDecision,
+  publishedVersionDigests,
+  readPackedManifest,
+  registryPackageUrl,
+  tarballDigests,
+} from "./publish-lumi-survey-registry.mjs";
+
+const repositoryRoot = path.resolve(
+  path.dirname(fileURLToPath(import.meta.url)),
+  "..",
+);
+
+test("allows only the two intended registries", () => {
+  assert.equal(
+    normalizeRegistryUrl("https://registry.npmjs.org/"),
+    "https://registry.npmjs.org",
+  );
+  assert.equal(
+    normalizeRegistryUrl("https://npm.pkg.github.com"),
+    "https://npm.pkg.github.com",
+  );
+  assert.throws(
+    () => normalizeRegistryUrl("https://registry.example.invalid"),
+    /unsupported registry/i,
+  );
+});
+
+test("encodes scoped package metadata lookups", () => {
+  assert.equal(
+    registryPackageUrl("https://registry.npmjs.org", "@navikt/lumi-survey"),
+    "https://registry.npmjs.org/%40navikt%2Flumi-survey",
+  );
+});
+
+test("builds explicit trusted-publish and mirror commands", () => {
+  assert.deepEqual(
+    buildPublishArguments("/tmp/lumi-survey.tgz", "https://registry.npmjs.org"),
+    [
+      "publish",
+      "/tmp/lumi-survey.tgz",
+      "--registry=https://registry.npmjs.org",
+      "--@navikt:registry=https://registry.npmjs.org",
+      "--access=public",
+      "--ignore-scripts",
+      "--provenance",
+    ],
+  );
+  assert.doesNotMatch(
+    buildPublishArguments(
+      "/tmp/lumi-survey.tgz",
+      "https://npm.pkg.github.com",
+    ).join(" "),
+    /--provenance/,
+  );
+});
+
+test("publishes missing versions and skips only byte-identical versions", () => {
+  const digests = {
+    shasum: "a".repeat(40),
+    integrity: `sha512-${"A".repeat(86)}==`,
+  };
+  assert.equal(publicationDecision(digests, undefined), "publish");
+  assert.equal(publicationDecision(digests, digests), "skip");
+  assert.throws(
+    () =>
+      publicationDecision(digests, {
+        ...digests,
+        integrity: `sha512-${"B".repeat(86)}==`,
+      }),
+    /different tarball digest/i,
+  );
+});
+
+test("reads version digests from full registry metadata", () => {
+  const shasum = "A".repeat(40);
+  const integrity = `sha512-${"B".repeat(86)}==`;
+  const metadata = {
+    versions: { "2.1.0": { dist: { shasum, integrity } } },
+  };
+
+  assert.deepEqual(publishedVersionDigests(metadata, "2.1.0"), {
+    shasum: shasum.toLowerCase(),
+    integrity,
+  });
+  assert.equal(publishedVersionDigests(metadata, "2.1.1"), undefined);
+  assert.throws(
+    () => publishedVersionDigests({ versions: { "2.1.0": {} } }, "2.1.0"),
+    /no valid dist\.shasum/i,
+  );
+});
+
+test("reads package identity and hashes the packed tarball", () => {
+  const temporaryDirectory = mkdtempSync(
+    path.join(tmpdir(), "lumi-registry-publish-"),
+  );
+  const packageDirectory = path.join(temporaryDirectory, "package");
+  const tarballPath = path.join(temporaryDirectory, "lumi-survey.tgz");
+  mkdirSync(packageDirectory);
+  writeFileSync(
+    path.join(packageDirectory, "package.json"),
+    `${JSON.stringify({ name: "@navikt/lumi-survey", version: "2.1.1" })}\n`,
+  );
+  execFileSync("tar", ["-czf", tarballPath, "package"], {
+    cwd: temporaryDirectory,
+  });
+
+  assert.deepEqual(readPackedManifest(tarballPath), {
+    name: "@navikt/lumi-survey",
+    version: "2.1.1",
+  });
+  assert.match(tarballDigests(tarballPath).shasum, /^[0-9a-f]{40}$/);
+  assert.match(tarballDigests(tarballPath).integrity, /^sha512-/);
+});
+
+test("release workflow publishes npmjs first and tags after both registries", () => {
+  const workflow = readFileSync(
+    path.join(repositoryRoot, ".github/workflows/publish-lumi-survey.yaml"),
+    "utf8",
+  );
+  const publishJob = workflow.slice(workflow.indexOf("\n  publish:\n"));
+  const npmjsPublish = publishJob.indexOf(
+    "--registry=https://registry.npmjs.org",
+  );
+  const githubPublish = publishJob.indexOf(
+    "--registry=https://npm.pkg.github.com",
+  );
+  const releaseTag = publishJob.indexOf("- name: Tag release");
+
+  assert.match(
+    publishJob,
+    /permissions:\n\s+contents: write\n\s+id-token: write\n\s+packages: write/,
+  );
+  assert.match(publishJob, /npm install --global npm@11\.19\.0/);
+  assert.ok(npmjsPublish > -1, "expected npmjs publication");
+  assert.ok(githubPublish > npmjsPublish, "npmjs must be published first");
+  assert.ok(releaseTag > githubPublish, "tag must be created last");
+  assert.doesNotMatch(publishJob, /secrets\.NPM[^\s}]*/);
+  assert.doesNotMatch(publishJob, /--tarball=\$\{\{/);
+  assert.match(
+    publishJob,
+    /TARBALL: \$\{\{ steps\.pack\.outputs\.tarball \}\}/,
+  );
+  assert.match(publishJob, /repos\/\$\{GITHUB_REPOSITORY\}\/git\/tags/);
+
+  const workflowCheckoutHardening = workflow.match(
+    /persist-credentials: false/g,
+  );
+  assert.equal(workflowCheckoutHardening?.length, 2);
+});

--- a/scripts/verify-lumi-survey-consumer.sh
+++ b/scripts/verify-lumi-survey-consumer.sh
@@ -26,9 +26,8 @@ if [[ ${#archives[@]} -ne 1 || ! -f "${archives[0]}" ]]; then
 fi
 mv -- "${archives[0]}" "$CONSUMER_DIR/lumi-survey.tgz"
 
-# Reuse the authenticated workspace install for GitHub Packages, while still
-# allowing public transitive packages that are not present in pnpm's store to
-# be downloaded without passing a package token to this script.
+# Install as an external consumer without registry configuration or a package
+# token. The tarball and its public peer dependencies must resolve from npmjs.
 pnpm --dir "$CONSUMER_DIR" install --prefer-offline --lockfile=false
 pnpm --dir "$CONSUMER_DIR" run typecheck
 pnpm --dir "$CONSUMER_DIR" run build

--- a/scripts/verify-lumi-survey-package.mjs
+++ b/scripts/verify-lumi-survey-package.mjs
@@ -121,6 +121,8 @@ async function scanDirRecursive(dirPath, predicate) {
 async function main() {
   const packageDir = path.join(repoRoot, "packages", "lumi-survey");
   const packageJsonPath = path.join(packageDir, "package.json");
+  const packageLicensePath = path.join(packageDir, "LICENSE");
+  const rootLicensePath = path.join(repoRoot, "LICENSE");
   const typecheckTsconfigPath = path.join(
     packageDir,
     "tsconfig.typecheck.json",
@@ -144,6 +146,34 @@ async function main() {
   }
   if ("zod" in deps) {
     fail("packages/lumi-survey/package.json must not depend on zod");
+  }
+  if (pkg.license !== "MIT") {
+    fail("packages/lumi-survey/package.json must declare license=MIT");
+  }
+  if (
+    pkg.repository?.type !== "git" ||
+    pkg.repository?.url !== "git+https://github.com/navikt/lumi.git" ||
+    pkg.repository?.directory !== "packages/lumi-survey"
+  ) {
+    fail(
+      "packages/lumi-survey/package.json must identify its source directory in navikt/lumi",
+    );
+  }
+  if (pkg.publishConfig?.registry) {
+    fail(
+      "packages/lumi-survey/package.json must not pin one registry; the release workflow dual-publishes explicitly",
+    );
+  }
+  if (pkg.publishConfig?.access !== "public") {
+    fail(
+      "packages/lumi-survey/package.json must publish the scoped package with public access",
+    );
+  }
+
+  const rootLicense = await readText(rootLicensePath);
+  const packageLicense = await readText(packageLicensePath);
+  if (packageLicense !== rootLicense) {
+    fail("packages/lumi-survey/LICENSE must match the repository LICENSE");
   }
 
   // 2) typecheck config must not map internal workspace paths.


### PR DESCRIPTION
## Sammendrag

- gjør npmjs til primær distribusjon for `@navikt/lumi-survey`, med GitHub Packages som kompatibilitetsspeil
- bruker npm trusted publishing med provenance og uten langlivet npm-hemmelighet
- bygger og verifiserer én tarball i en read-only jobb og bruker samme workflow-artefakt i begge registre
- skiller OIDC-, GitHub Packages- og taggrettigheter i tre små jobber
- preflighter begge registre før første write og stopper ved SHA-1- eller SHA-512-avvik
- legger til MIT-lisens, repository-metadata, ADR og tokenfri konsumentdokumentasjon
- dokumenterer npmjs som et bevisst unntak fra Navs GitHub Packages-hovedregel, med begrenset menneskelig npm-tilgang
- beholder repoets `.npmrc`, siden interne pakker fortsatt krever GitHub Packages

## Forutsetninger før merge

PR-en skal ikke merges før alle engangsstegene er utført:

- [x] GitHub Actions-environmentet `npm-publish` er opprettet uten secrets eller required reviewers. Det tillater bare beskyttede branches, og `main` er bekreftet som repoets eneste beskyttede branch.
- [ ] Bootstrap-publiser den eksisterende `2.1.0`-tarballen fra GitHub Packages som offentlig pakke på npmjs. Tarballen er lastet ned og verifisert mot GitHub Packages uten ny build:
  - SHA-1 `cfbbe9c392ae19a3792cd9053e29944a56e84738`
  - SHA-512 `sha512-CZiEu/tTQur7R5BqEMDpysvkVijKwhYnw8Ujf+Yb/S9MZ2yl6tYA50WrkgagvkE+oaxKLeVvlObnydZl9BK87g==`
- [ ] Konfigurer npm trusted publisher med organisasjon `navikt`, repository `lumi`, workflow `publish-lumi-survey.yaml`, environment `npm-publish` og tillatelsen `npm publish`.

De to siste stegene venter på at en separat NAV-arbeidskonto får tilgang fra npm-administratorene. Privat npm-konto skal ikke brukes. Den eksakte bootstrap- og verifikasjonsprosedyren står i `packages/lumi-survey/CONTRIBUTING.md`. Det skal ikke legges et npm-token i workflowen.

## Etter merge

1. Kjør workflowen med `dry_run=true`.
2. Kjør deretter `dry_run=false` for å publisere `2.1.1` til begge registre.
3. Verifiser anonym installasjon, MIT-metadata og provenance på npmjs.
4. Sett pakken til å kreve tofaktor og avvise tokenbasert publisering.
5. Lukk #471 først etter verifiseringen.

## Verifisering

Kjørt på Node 24.19.0 med mindre annet er oppgitt:

- `pnpm run lint`
- `pnpm run typecheck`
- `pnpm run test:release-guards` — 57 tester, også kjørt etter siste dokumentasjonsendring
- `pnpm run verify:lumi-survey`
- `pnpm run verify:lumi-survey-consumer` — ren ekstern installasjon og bygg
- `pnpm run test` — 2 type-tester, 481 widgettester og 667 dashboardtester
- `pnpm --filter lumi-docs build` — også kjørt etter siste dokumentasjonsendring
- `pnpm audit --prod --audit-level=high` — ingen high eller critical
- `actionlint` — ingen funn
- `zizmor .github/workflows/publish-lumi-survey.yaml` — ingen funn
- read-only live-preflight bekrefter at `2.1.1` ennå ikke finnes i noen av registrene
- tre uavhengige rereviews og en ekstra security-rereview av environment-/SSO-endringen uten gjenværende P0–P2-funn

Del av #471.
