### PR TITLE
Dokumenter databaseberedskap og recovery-mål

### DIFF
--- a/apps/lumi-api/docs/runbooks/automatic-retention.md
+++ b/apps/lumi-api/docs/runbooks/automatic-retention.md
@@ -37,9 +37,9 @@ Before opening the activation PR:
 
 4. Run `EXPLAIN (ANALYZE, BUFFERS)` on the bounded `SELECT` from the cleanup CTE,
    never on the `DELETE`, and confirm use of `idx_feedback_opprettet`.
-5. Verify a tested recovery path. Prefer point-in-time recovery for a destructive
-   workload. If only scheduled backups are available, explicitly accept the recovery
-   window after testing clone/restore.
+5. Follow the [database recovery runbook](./database-recovery.md). Confirm the
+   latest successful backup and explicitly accept the recovery window from
+   [ADR 0005](../../../../docs/adr/0005-database-recovery-og-kapasitet.md).
 6. Change only the production `LUMI_RETENTION_ENABLED` value in a separately
    reviewed PR. Development must already have been observed before that PR merges,
    because the current workflow deploys production automatically after development.

--- a/apps/lumi-api/docs/runbooks/database-recovery.md
+++ b/apps/lumi-api/docs/runbooks/database-recovery.md
@@ -98,9 +98,13 @@ Før trafikk eller migrering fortsetter:
    reviewet NAIS-endring. Bekreft `/internal/isReady` og vanlige
    databaseavhengige lesekall.
 5. Hold automatisk retention avslått til radomfanget er kontrollert.
-6. Kjør én syntetisk innsending gjennom `/release-verification`, og bekreft den
-   eksakte receipt-raden i dashboardet. Ikke bruk en ekte survey eller ekte
-   respondentdata som test.
+6. Dersom en kontrollert produksjonssurvey allerede er tilgjengelig: avtal én
+   syntetisk innsending uten personopplysninger med survey-eieren, og bekreft
+   den eksakte receipt-raden i dashboardet. Ikke opprett eller reaktiver en
+   survey bare for recovery-testen. Hvis ingen egnet survey finnes, følg den
+   første forventede innsendingen via receipt-ID og metrikker uten å kopiere
+   svarinnhold. `/release-verification` er bare aktiv i dev og er derfor ikke
+   bevis på at produksjonsdatabasen er gjenopprettet.
 7. Kontroller `LumiSubmissionFailure`,
    `LumiSubmissionRejectionSpike` og applikasjonslogger før hendelsen lukkes.
 

--- a/apps/lumi-api/docs/runbooks/database-recovery.md
+++ b/apps/lumi-api/docs/runbooks/database-recovery.md
@@ -1,0 +1,130 @@
+# Database recovery
+
+Denne runbooken brukes når `lumi-api` ikke når produksjonsdatabasen, når data
+kan være korrupte, eller når en destruktiv operasjon kan ha fjernet feil rader.
+Den operasjonelle beslutningen og de aksepterte målene er dokumentert i
+[ADR 0005](../../../../docs/adr/0005-database-recovery-og-kapasitet.md).
+
+## Mål og begrensninger
+
+- Mål-RPO er høyst 24 timer fra siste vellykkede planlagte backup.
+- Mål-RTO er høyst én arbeidsdag fra beslutningen om restore.
+- Målene er interne og ikke en garanti fra NAIS eller Google Cloud.
+- Uten PITR kan data skrevet etter valgt backup gå tapt.
+- Restore til en eksisterende instans overskriver data og bryter aktive
+  forbindelser. Ikke start en restore før kilde, mål og recovery-tidspunkt er
+  kontrollert av to personer.
+
+Cloud SQL tar normalt nattlig backup og beholder syv automatiske backups. NAIS
+har i tillegg en daglig katastrofekopi til on-prem. Backupstatus og tidspunkt
+skal likevel verifiseres i den konkrete hendelsen; dokumentert standard er ikke
+bevis på at siste kjøring lyktes.
+
+## Første respons
+
+1. Opprett eller oppdater hendelsen med starttid, ansvarlig og berørte flater.
+2. Stans nye utrullinger og survey-migreringer.
+3. Avklar om dette er utilgjengelighet eller mulig datatap. Ikke restore data
+   ved et midlertidig databaseutfall som kan løses uten overskriving.
+4. Ved mistanke om feil i automatisk retention: sett
+   `LUMI_RETENTION_ENABLED=false` i en separat nødendring og bekreft
+   `max(lumi_retention_enabled{app="lumi-api"}) == 0`. En transaksjon som
+   allerede kjører kan fortsatt slette opptil 500 rader.
+5. Noter tidspunktet for siste bekreftet korrekte data og første observerte
+   feil. Ikke kopier surveyinnhold eller respondentdata til hendelsesloggen.
+
+## Verifiser backup og omfang
+
+1. Finn den faktiske Cloud SQL-instansen via NAIS Console. Ikke anta
+   instansnavn eller prosjekt.
+2. Åpne backupoversikten i Google Cloud Console og bekreft:
+   - riktig kildeinstans og PostgreSQL-versjon
+   - status `SUCCESSFUL`
+   - backupens start- og sluttidspunkt
+   - at backupen er eldre enn den første observerte korrupsjonen dersom
+     recovery gjelder feilaktige data
+3. Sammenlign backupens tidspunkt med hendelsens siste kjente gode tidspunkt.
+   Beregn forventet datatap før restore godkjennes.
+4. Ta en read-only tilstandsmåling når databasen er tilgjengelig:
+
+   ```sql
+   SELECT
+       COUNT(*) AS feedback_rows,
+       MIN(opprettet) AS oldest_feedback,
+       MAX(opprettet) AS newest_feedback,
+       pg_size_pretty(pg_database_size(current_database())) AS database_size,
+       pg_size_pretty(pg_total_relation_size('feedback')) AS feedback_size
+   FROM feedback;
+   ```
+
+5. Ved retention-hendelser: noter økningen i
+   `lumi_retention_deleted_feedback_total` og tell rader som er kvalifisert med
+   den samme UTC-grensen som i
+   [retention-runbooken](./automatic-retention.md).
+
+## Velg recovery-strategi
+
+| Situasjon | Foretrukket handling |
+| --- | --- |
+| Kortvarig Cloud SQL-/nettverksutfall uten tegn til datatap | Vent på eller eskaler plattformfeilen; ikke restore |
+| Mistanke om korrupsjon eller feilaktig sletting | Restore valgt backup til en ny instans og valider før eventuell cutover |
+| Kjent omfattende datatap der produksjonsinstansen må tilbakeføres | Overskriv eksisterende instans først etter to-personers kontroll og eksplisitt hendelsesbeslutning |
+| Katastrofe der vanlige GCP-backups ikke er tilgjengelige | Eskaler til NAIS for bruk av katastrofekopien |
+
+Cloud SQL-instansen forvaltes deklarativt av NAIS. Koordiner opprettelse,
+tilkobling og eventuell cutover med NAIS før en ny eller gjenopprettet instans
+tas i bruk. Ikke legg inn ad hoc credentials eller en udokumentert manuell
+tilkobling som varig løsning.
+
+Følg den offisielle
+[Cloud SQL-prosedyren for restore](https://docs.cloud.google.com/sql/docs/postgres/backup-recovery/restoring).
+Ved restore til eksisterende instans skal hendelsesloggen inneholde:
+
+- eksakt kildeinstans og backup-ID
+- eksakt mål-instans
+- backupens tidspunkt og forventet RPO
+- navn på de to som kontrollerte operasjonen
+- eksplisitt bekreftelse på at nyere data på målet blir overskrevet
+
+## Valider gjenopprettingen
+
+Før trafikk eller migrering fortsetter:
+
+1. Bekreft at Cloud SQL-operasjonen er fullført uten feil.
+2. Bekreft at Flyway-tabellen ikke har feilede migreringer og at forventet
+   skjema finnes.
+3. Kjør read-only tilstandsmålingen over og sammenlign med forventet backup.
+4. Start eller pek applikasjonen mot den gjenopprettede databasen gjennom en
+   reviewet NAIS-endring. Bekreft `/internal/isReady` og vanlige
+   databaseavhengige lesekall.
+5. Hold automatisk retention avslått til radomfanget er kontrollert.
+6. Kjør én syntetisk innsending gjennom `/release-verification`, og bekreft den
+   eksakte receipt-raden i dashboardet. Ikke bruk en ekte survey eller ekte
+   respondentdata som test.
+7. Kontroller `LumiSubmissionFailure`,
+   `LumiSubmissionRejectionSpike` og applikasjonslogger før hendelsen lukkes.
+
+## Etterarbeid
+
+Dokumenter:
+
+- tidspunkt for siste gjenopprettede data og første tapte data
+- faktisk RPO og RTO
+- antall tapte eller gjenopprettede rader, uten surveyinnhold
+- om målene i ADR 0005 ble brutt
+- om PITR, HA, ny tier, kø/buffering eller endret retention-begrensning skal
+  vurderes
+
+Aktivering av retention etter en recovery skal skje som en separat, reviewet
+manifestendring etter kontroll av kvalifisert radantall og query plan.
+
+## Løpende beredskap
+
+Før hver større onboarding-batch og minst månedlig under gradvis utrulling:
+
+1. Bekreft minst én vellykket planlagt backup siste 24 timer og forventet
+   backuphistorikk i Cloud SQL Console.
+2. Kontroller de siste syv døgnene med CPU, forbindelser og dyre spørringer i
+   Cloud SQL/Query Insights.
+3. Mål radantall og databasestørrelse med read-only-spørringen over.
+4. Stopp videre utrulling dersom en terskel i ADR 0005 er nådd.

--- a/docs/adr/0005-database-recovery-og-kapasitet.md
+++ b/docs/adr/0005-database-recovery-og-kapasitet.md
@@ -1,0 +1,144 @@
+---
+title: "ADR 0005: Akseptert databaseberedskap og kapasitetsgrenser"
+status: Akseptert
+date: 2026-08-28
+---
+
+# ADR 0005: Akseptert databaseberedskap og kapasitetsgrenser
+
+- **Status:** Akseptert
+- **Dato:** 2026-08-28
+- **Berører:** #484 (databaseberedskap), #507 (utrullingsklarhet) og #478 (automatisk retention)
+
+## Kontekst
+
+Lumi bruker én Cloud SQL-instans med PostgreSQL 17. Produksjonsmanifestet har
+`tier: db-custom-1-3840`, automatisk diskvekst, `highAvailability: false` og
+ingen eksplisitt `pointInTimeRecovery`. Innsendinger, analyser og eksport deler
+den samme databasen. Innsendinger bufres ikke dersom databasen er utilgjengelig.
+
+NAIS dokumenterer at Cloud SQL-instansen som standard sikkerhetskopieres hver
+natt, at syv automatiske sikkerhetskopier beholdes, og at det i tillegg tas en
+daglig katastrofekopi fra GCP til et on-prem-miljø. Point-in-time recovery (PITR)
+er ikke aktivert som standard for denne ressursmodellen.
+
+En read-only produksjonsmåling 28. august 2026 viste:
+
+- 27 571 lagrede feedbackrader
+- eldste rad fra 28. januar 2026 og nyeste rad fra 27. august 2026
+- omtrent 50 MB database og 11 MB i feedbacktabellen
+
+Automatisk retention sletter svar eldre enn 12 måneder. Jobben kan slette
+maksimalt 500 av de eldste kvalifiserte radene per global 24-timersperiode.
+Dette begrenser både datavekst og konsekvensen av en feil i slettejobben, men
+erstatter ikke en recovery-beslutning.
+
+Surveydata er nyttige analyse- og forbedringsdata, men ikke autoritative
+saksbehandlings-, vedtaks- eller ytelsesdata. Tap er uønsket, men fører ikke til
+feil utbetaling eller tap av en brukers rettigheter. Denne klassifiseringen er
+avgjørende for beslutningen; endres den, skal ADR-en revurderes.
+
+## Beslutning
+
+### Dagens databaseoppsett beholdes
+
+Produksjon beholder dagens tier uten HA og PITR. Det innføres ingen skjult
+kostnadsøkning som del av utrullingen. Tier skal skaleres på bakgrunn av målte
+kapasitetsbehov, PITR på bakgrunn av et strengere RPO-behov, og HA på bakgrunn
+av et strengere tilgjengelighets- eller RTO-behov.
+
+### Recovery-mål
+
+- **Mål-RPO: høyst 24 timer.** Ved recovery fra en vellykket planlagt backup
+  aksepteres tap av data skrevet etter den valgte backupen. Faktisk RPO skal
+  beregnes og registreres i hendelsen.
+- **Mål-RTO: høyst én arbeidsdag fra beslutningen om restore.** Dette er et
+  internt mål, ikke en garanti fra NAIS eller Google Cloud. Faktisk RTO avhenger
+  av tilgang, backupstatus, restorevarighet og nødvendig verifikasjon.
+- Innsendinger som skjer mens databasen er utilgjengelig, eller etter siste
+  gjenopprettede backup, kan gå tapt. Denne residualrisikoen aksepteres for Lumi
+  så lenge dataklassifiseringen over er uendret.
+
+Restore følger
+[database-recovery-runbooken](https://github.com/navikt/lumi/blob/main/apps/lumi-api/docs/runbooks/database-recovery.md).
+Ved mistanke om datakorrupsjon eller feilaktig sletting foretrekkes restore til
+en ny instans for kontroll. Overskriving av produksjonsinstansen krever en
+eksplisitt to-personers kontroll fordi all nyere data på mål-instansen erstattes.
+
+### Målte stoppterskler
+
+Før hver større onboarding-batch og minst månedlig under gradvis utrulling skal
+teamet kontrollere de siste syv døgnene i Cloud SQL/Query Insights. Videre
+utrulling stoppes og databasevalget revurderes dersom minst én av disse
+tersklene nås:
+
+- CPU er over 60 prosent sammenhengende i 30 minutter
+- databaseforbindelser er over 70 prosent av instansens kapasitet i 15 minutter
+- lagret radantall eller databasestørrelse overstiger ti ganger målingen over
+  (275 710 rader eller 500 MB)
+- en databasefeil gir tap som bryter mål-RPO eller mål-RTO
+- databaseutfall gir en bruker- eller driftskonsekvens som teamet ikke lenger
+  aksepterer
+- dataklassifiseringen endres slik at surveydata blir forretningskritiske
+
+En terskel betyr ikke automatisk at HA er riktig tiltak. Teamet skal først
+skille mellom utilstrekkelig tier, dyre spørringer, for mange forbindelser og
+et faktisk behov for sonefailover eller finmasket recovery.
+
+## Konsekvenser
+
+### Positivt
+
+- Dagens lave volum utløser ikke en udokumentert dobling av databasekostnaden.
+- RPO, RTO og akseptert datatap er eksplisitt i stedet for implisitt.
+- Gradvis utrulling får målbare stoppkriterier før én vCPU blir en flaskehals.
+- Retention-jobben har en konkret recovery-prosedyre dersom feil data slettes.
+
+### Negativt og residualrisiko
+
+- En sonefeil eller vedlikehold kan gjøre hele Lumi utilgjengelig til instansen
+  er tilbake; det finnes ingen standby-instans for automatisk failover.
+- En planlagt backup kan være opptil ett døgn gammel. Uten PITR kan teamet ikke
+  velge et vilkårlig tidspunkt mellom backupene.
+- Restore er en manuell og potensielt destruktiv operasjon. Målet om én
+  arbeidsdag er ikke verifisert som en plattformgaranti.
+- Konsumentene har ingen varig kø. Innsendinger under et databaseutfall kan
+  derfor forsvinne i stedet for å bli forsinket.
+
+## Vurderte alternativer
+
+### HA og PITR nå
+
+Forkastet for dagens skala. HA oppretter en standby-instans og øker
+instanskostnaden vesentlig. PITR gir bedre presisjon ved feilaktig sletting, men
+krever WAL-lagring og omstart ved aktivering. Dagens datakritikalitet,
+backupfrekvens, lave volum og begrensede retention-batcher begrunner ikke disse
+tiltakene nå.
+
+### Bare PITR
+
+Forkastet nå, men er første alternativ dersom mål-RPO strammes inn eller en
+recovery-hendelse viser at døgnbackup ikke er tilstrekkelig. PITR skal vurderes
+uavhengig av HA; behov for mer presis recovery betyr ikke automatisk behov for
+en standby-instans.
+
+### Større tier før målt behov
+
+Forkastet. Databasen er liten, disk vokser automatisk, og det foreligger ikke
+målinger som viser CPU- eller forbindelsespress. Dyre spørringer skal
+undersøkes før tier oppgraderes.
+
+## Oppfølging
+
+- Bruk recovery-runbooken ved databasehendelser og registrer faktisk RPO/RTO.
+- Kontroller backupstatus og kapasitetsmålinger før større onboarding-batcher.
+- Revurder ADR-en når en stoppterskel nås, etter en faktisk restore, eller når
+  dataenes kritikalitet endres.
+- En manifestendring som aktiverer HA, PITR eller ny tier skal være en separat,
+  kostnadssynlig og reviewet beslutning.
+
+## Kilder
+
+- [NAIS: Cloud SQL/Postgres-reference](https://docs.nais.io/persistence/cloudsql/reference/)
+- [NAIS: kostnadsoptimalisering for Cloud SQL](https://doc.nais.io/workloads/how-to/cost-optimization/)
+- [Google Cloud: restore av PostgreSQL fra backup](https://docs.cloud.google.com/sql/docs/postgres/backup-recovery/restoring)

--- a/docs/runbooks/nav-wide-rollout.md
+++ b/docs/runbooks/nav-wide-rollout.md
@@ -130,9 +130,10 @@ I tillegg til en grønn canary må disse varige gatene være lukket:
    dokumentert.
 5. Surveylisten og målingskontinuiteten er avklart etter beslutningstabellen
    over.
-6. Kapasitets- og recovery-valg bygger på avtalte RPO-/RTO-krav eller målte
-   terskler. HA, PITR og oppskalering skal ikke innføres som skjulte
-   standardvalg.
+6. Kapasitets- og recovery-valget følger
+   [ADR 0005](../adr/0005-database-recovery-og-kapasitet.md): dagens database
+   beholdes med eksplisitt RPO/RTO og målte stoppterskler. HA, PITR og
+   oppskalering skal ikke innføres som skjulte standardvalg.
 
 ## Stoppkriterier
 


### PR DESCRIPTION
## Beskrivelse

Dokumenterer den eksplisitte risiko- og kostnadsbeslutningen for Lumi sin produksjonsdatabase. Dagens Cloud SQL-tier beholdes uten HA og PITR, basert på nåværende volum, datakritikalitet, automatiske backups og begrenset retention-batch.

## Endringer

- legger til akseptert ADR med mål-RPO på 24 timer og mål-RTO på én arbeidsdag
- dokumenterer residualrisikoen for nedetid og tap av ferske surveyinnsendinger
- setter målte stoppterskler for CPU, forbindelser, volum og recovery-avvik
- legger til database-recovery-runbook med to-personers kontroll før destruktiv restore
- kobler retention- og utrullingsrunbookene til beslutningen

Produksjonsmanifest, database-tier, HA og PITR endres ikke.

## Validering

- `pnpm run docs:build`
- `pnpm run lint`
- `pnpm run typecheck`
- `git diff --cached --check`

Closes #484
