### PR TITLE
Dokumenter kontrakt og sikkerhetsgater for analyseprodukter

### DIFF
--- a/docs/adr/0006-teamavgrensede-analyseprodukter.md
+++ b/docs/adr/0006-teamavgrensede-analyseprodukter.md
@@ -1,0 +1,341 @@
+---
+title: "ADR 0006: Teamavgrensede analyseprodukter"
+status: Akseptert
+date: 2026-08-29
+---
+
+# ADR 0006: Teamavgrensede analyseprodukter
+
+- **Status:** Akseptert
+- **Dato:** 2026-08-29
+- **Berører:** #482, #507, #550, #551 og ADR 0005
+
+## Kontekst
+
+Team som bruker Lumi trenger å analysere strukturerte surveysvar i BigQuery,
+Datamarkedsplassen, Metabase og datafortellinger. Den første konkrete
+kandidaten er iSyfo/eSyfo, men løsningen skal fungere for minst 50 team uten
+databasebruker, håndskrevet SQL, kodegren eller deploy per team.
+
+Dagens brede `esyfo-analyse`-tilgang til Lumi-Postgres er en intern snarvei.
+Den eksponerer en lagringsmodell med nøstet rådata og gir en tilgangsflate som
+ikke skalerer til andre team. En generell eksport av `feedback_json` ville
+flyttet både personvernrisiko, skjemaustabilitet og Lumi-spesifikk parsing til
+hver konsument.
+
+Analysebehovet er samtidig mer enn en nedlasting. Et team trenger et varig,
+forståelig dataprodukt med eksplisitt formål, dataeierskap, kontrakt,
+retensjon, tilgangsgrense og livsløp.
+
+## Beslutning
+
+### Lumi eier et kontrollplan for analyseprodukter
+
+Et team kan opprette flere analyseprodukter. Ett produkt kan inneholde flere
+surveys fra samme team når formål, tilgang og livsløp er felles. Produktet har
+egen stabil `product_id`; team avledes alltid fra eksisterende autorisasjon og
+kan ikke oppgis eller overstyres i request-body.
+
+Hvert produkt har ett muterbart utkast og én aktiv, immutable release.
+Validering er knyttet til eksakt draft-revisjon og kildekatalog. Publisering
+lager en ny nummerert release med full konfigurasjon, aktør, tidspunkt og
+base-`schema_digest`. Hvert aktivt snapshot har i tillegg effektiv
+`schema_digest` fra releasen minus eventuelle auditerte
+sikkerhetstilbakekallinger. Brudd i kontrakten lager en ny major-versjon; en
+gammel major kan aldri bevare felt, dimensjoner eller retensjon som ikke lenger
+er tillatt.
+
+Releasen pinner også en separat `flow_hash`: normalisert `visibleIf`-graf,
+eventuell eldre `logic`, predicate-avhengigheter og evaluatorversjoner. Dagens
+strukturelle `definition_hash` inneholder ikke dette og kan ikke brukes til å
+rekonstruere historisk synlighet. Rader uten en registrert, ingest-matchet
+flytrevisjon får `flow_status=UNPINNED` og aldri en oppdiktet eksakt
+applicability. Eldre `logic` gir ikke eksakt applicability i V1 selv når
+flytrevisjonen kan identifiseres.
+
+Lumi oppretter en lukket publiseringsflate, men gir aldri menneskelig
+lesetilgang. Personer og grupper søker om og får tilgang gjennom
+Datamarkedsplassen.
+
+### Den offentlige kontrakten er flat og minimert
+
+Et publisert produkt har alltid:
+
+- én `responses_<app>_<survey>_wide_vN` per valgt kilde, med én rad per
+  innsending
+- én produktomfattende `answers_long_vN`, med én rad per publisert verdiatom
+- én produktomfattende `field_catalog_vN`, med versjonert felt- og
+  alternativmetadata
+- én `product_manifest_v1`, med aktiv release/snapshot og én rad per offentlig
+  ressurs
+
+Den lange visningen er fasit for publiserte svarverdier. Den
+surveyspesifikke wide-visningen er fasit for hele populasjonen og dermed for
+totaler. Feltspesifikke denominatorer avledes fra eksplisitte
+`<field>__applicable`-kolonner i wide, ikke fra fravær av long-rader.
+`product_snapshot_id` finnes i alle viewtypene, slik at
+konsumenten kan oppdage et pointerbytte mellom separate spørringer. Kontrakten
+er nærmere spesifisert i
+[V1-datakontrakten](../analyseprodukter/datakontrakt-v1.md).
+
+Rått eller nøstet format er ikke et valg. Verken privat eller offentlig
+eksportlag kan inneholde rå `feedback_json`, tekstsvar, datosvar, intern UUID,
+vilkårlig context, URL, pathname, user-agent, debug, eller kolonner med typene
+`JSON`, `STRUCT` eller `ARRAY`. Bare strukturerte svarfelt og dimensjoner fra et
+sentralt klassifisert register kan velges.
+
+Spørsmåls- og alternativetiketter i en innsending er klientstyrt metadata og
+er ikke en godkjent tekstkilde. Offentlige etiketter kommer bare fra en
+teamkontrollert, versjonert metadataregistrering eller et eksplisitt
+produktalias. Legacy-data uten godkjent metadata får `NULL`/`UNKNOWN`; en
+observert etikett eksporteres aldri.
+
+Applicability for et betinget felt kan røpe utfallet av predicate-input. V1
+tillater derfor bare feltet i en ny release når alle svar- og
+metadataavhengigheter selv er eksplisitt valgt, klassifisert og offentlig i
+samme produkt. Preview viser både avhengigheten og inferensen før release.
+Historiske rader med ufullstendig eller unpinned flyt får `NULL` med
+kvalitetsvarsel og får ingen offentlig verdi for det aktuelle feltet; dette
+brukes ikke som en omvei for nye scopes. En kildeverdi ved bevist
+`applicable=FALSE` fryser produktet før aktivering, enten `FALSE` skyldes
+strukturelt fravær eller usann predicate.
+
+Offentlige `response_key` og `answer_key` er stabile, nøkkelbaserte og
+produktspesifikke pseudonymer. Samme kilderad får ulike nøkler i ulike
+produkter. Nøklene er ikke anonymisering, og nøkkelmateriale skal aldri være
+tilgjengelig for konsumenter.
+
+### Eksporten bruker ett autoritativt fullsnapshot
+
+V1 starter med én Lumi-eid Cloud SQL-connection og én planlagt federated query
+til en versjonert, read-only `analytics_export_v1`-kontrakt. Hver kjøring leser
+kilden én gang til unik staging, validerer source-globale invarianter og flytter
+en monoton source-snapshot-pointer atomisk. Delvise, feilende eller eldre
+kildelesninger kan aldri bli aktive.
+
+Hvert produkt materialiseres deretter fra den aktive source-kandidaten og får
+sin egen atomiske produktpointer. Produktet flyttes bare når release-,
+isolasjon-, kontrakt- og retensjonskontrollene er grønne. Et produktlokalt
+kontraktsbrudd stopper dermed ikke andre produkter. Berørt produkt fryser
+inntaket ved siste trygge `data_cutoff_at`, går til `Må vurderes` og fortsetter
+å lage purge-only snapshots fra dagens kilde, slik at slettede og utløpte rader
+fortsatt forsvinner uten at nye, uvaliderte svar delpubliseres.
+
+Maintenance-snapshots er monotont informasjonsreduserende fra forrige aktive
+produktsnapshot. `PURGE_ONLY` kan bare fjerne nøkler som ikke lenger finnes i
+en validert source-membership eller som har falt utenfor effektiv retensjon.
+`SECURITY_REDACTION` kan i tillegg nullstille en tilbakekalt label, fjerne
+katalog-/viewbeskrivelse og flytte referansen til en deterministisk
+`UNKNOWN`-metadatahash som ble forhåndsmaterialisert av fullsnapshotet for
+feltet/optionen. Ingen av dem kan legge til nøkler,
+erstatte labelen med ny tekst, endre andre overlevende verdier/release/cutoff
+eller rekonstruere data fra en uvalidert payload. En godkjent erstatningslabel
+krever ny validert release.
+
+Kompilatorens autoritative input er en `EffectivePublicationSpec`: den
+immutable releasen minus et auditert sett med sikkerhetstilbakekallinger.
+Tilbakekallingssettet kan bare fjerne godkjent metadata eller velge en
+`UNKNOWN`-fallback som allerede finnes i fullsnapshotet; det kan aldri legge
+til scope, felt, alternativ, dimensjon eller tekst. Samme effective spec og
+digest er trusted desired state for kompilator, boundary-FQN, binder,
+reconciler og alias-publisher. En redaksjon beholder `product_release`, men får
+ny `product_snapshot_id`, `snapshot_mode=SECURITY_REDACTION` og ny digest når
+den offentlige definisjonen endres.
+
+Fjerning av publisert katalog-/viewbeskrivelse endrer digest og kan ikke mutere
+et bundet view. Redaksjonen oppretter derfor en ny immutable boundary-FQN,
+validerer og binder den, deauthorizerer gammel FQN før aliaset flyttes, og
+verifiserer deretter at den gamle FQN-en ikke kan leses. Kortvarig
+utilgjengelighet er akseptabelt i dette fail-closed-sikkerhetsløpet; gammel
+metadata er det ikke. Den gamle ressursen slettes først etter verifisert
+revokering.
+
+Monotonikontrollen sammenligner forretningspayload og logiske nøkler, ikke
+aktiveringsmetadata. Ny `product_snapshot_id`, publiseringstid og
+`snapshot_mode` forventes å endres ved en ny maintenance-aktivering.
+
+Replay betyr et nytt fullsnapshot fra dagens kilde; tidligere snapshots kan
+ikke brukes til rollback fordi de kan gjeninnføre slettede data. Run-scopede
+artefakter har hard TTL på maksimalt 24 timer.
+
+Det private, kanoniske snapshotet inneholder bare unionen som trengs av aktive
+releaser, pausede releaser og deprecated majors frem til avtalt slettedato.
+Utkast og ferdig avviklede releaser materialiseres aldri. Nyeste release er
+alltid øvre allowlist for produktet, slik at en gammel major ikke kan holde et
+fjernet felt eller en fjernet dimensjon i privatlaget.
+
+En sentral NAIS Job er eksplisitt fallback dersom en spike ikke beviser én
+konsistent eksternlesning, akseptabel Cloud SQL-last, atomisk aktivering,
+observability og slettesynk. Datastream og Airflow innføres ikke i V1.
+
+### Hvert produkt får en isolert publiseringsflate
+
+Målbildet er et dedikert Lumi-analyseprosjekt uten arvet menneskelig eller
+default lesetilgang. Hvert analyseprodukt får et separat BigQuery-datasett
+eller en tilsvarende isolert publiseringsflate. Konsumenter kan aldri lese
+Lumi-Postgres, privat staging eller kanonisk snapshot.
+
+Identitetene for Cloud SQL-eksport, BigQuery-connection, scheduled query,
+kontraktkompilator, view-publisher, cross-dataset-binder, Lumi API og
+konsumenter holdes atskilt og får minste privilegium. Publisher får bare
+rettighetene BigQuery faktisk krever for å opprette eksakt
+effective-spec-kompilert view, og kan ikke kjøre vilkårlige spørringsjobber
+eller endre datasettilgang.
+En separat binder eller NADA-mekanisme autoriserer bare et immutable,
+release-scopet boundary-view mot privatlaget. FQN inkluderer produkt, major,
+release og digest. Publisher oppretter ressursen, binder leser faktisk SQL og
+reberegner digest mot trusted effective spec før binding, og ingen identitet kan
+mutere viewet så lenge bindingen er aktiv. Endring oppretter en ny FQN;
+offboarding revokerer binding før ressursen slettes.
+
+De stabile offentlige V1-navnene kan være aliases over den aktive, bundne
+releaseressursen. En separat alias-publisher har ingen canonical-tilgang og kan
+bare velge en aktiv, bundet, ikke-tilbakekalt boundary-FQN med samme
+`product_id`, major, release og digest som trusted desired state. Forsøk på å
+peke produkt A til produkt B eller en gammel/revokert release avvises og
+auditeres. Hvis plattformen ikke kan håndheve immutable binding, må flyten være
+`deauthorize -> update -> revalidate -> authorize`, eller produktet må
+materialiseres fysisk. Drift på en bundet ressurs gir umiddelbar deauthorization
+før reparasjon. Et digestfelt alene er ikke en sikkerhetsgrense fordi BigQuery
+autoriserer FQN, ikke SQL-innholdet.
+
+BigQuery-rettigheten som kan endre en dataset-ACL kan teknisk også være sterk
+nok til å gi mennesketilgang. Det kan derfor ikke bare hevdes at binder «ikke
+kan» gjøre dette. Før produksjon må NADA eie bindingen, eller en separat,
+auditert sikkerhetsport må begrense og godkjenne eksakte resource bindings.
+Datamarkedsplassen forvalter fortsatt person- og gruppetilgang. Lumi API har
+ikke databasecredential eller direkte publiseringsprivilegier.
+
+Per-view authorization, authorized datasets, sharding og materialiserte
+produktkopier har ulike kvote- og privilegiekonsekvenser. Endelig
+publiseringstopologi velges først når spiken har bevist isolasjon og et
+ressursbudsjett for opptil 500 aktive produkter, flere surveys og parallelle
+majors. En løsning som gir fremtidige, ukontrollerte views implisitt
+source-tilgang blir ikke godkjent bare fordi den holder seg under en kvote.
+
+### Retensjon og sletting er del av kontrakten
+
+Produktet velger 30, 90 eller 180 dager, eller kildens maksimum. Effektiv
+retensjon er alltid den korteste av produktvalget og kildens faktiske
+retensjon. Kildesletting og manuell sletting skal være borte fra alle aktive og
+deprecated eksportressurser ved neste vellykkede fullsnapshot. Mål-SLO er
+høyst 36 timer. Kjøringen skjer minst daglig og får automatiske retryforsøk
+innenfor de neste seks timene; 36 timer uten slettesynk er et SLO-brudd med
+operatørvarsel og runbook, ikke en påstand om at plattformutfall er umulige.
+
+Pause fryser en immutable `data_cutoff_at` og stopper nye svar i produktet,
+men stopper aldri innsamling i Lumi, retensjon eller slettesynk. Offboarding
+stenger tilgang, fjerner markedsplassbindinger, views, data og grants, og
+verifiserer tomhet før produktet kan få status `Slettet`.
+
+Hvert produkt har obligatorisk vurderingsdato maksimalt 12 måneder frem.
+Eierne varsles 30 og 7 dager før. Manglende fornyelse fører først til
+`Må vurderes`, deretter pause og kontrollert offboarding; mislykket varsling kan
+aldri forlenge dataretensjonen.
+
+### Eksterne plattformgrenser må bevises før produksjon
+
+Før produksjon må NADA-/plattformkontrakten bekrefte prosjektarv, minste IAM,
+authorized views, programmatisk livsløp i Datamarkedsplassen, servicekontoer,
+region, credentialrotasjon og registrering av flere views som ett dataprodukt.
+Hvis teammedlemmer arver lesetilgang, krever aktivering en eksisterende ekstern
+godkjenningsport. Lumi skal ikke bygge en egen IAM- eller godkjenningsmotor.
+
+Lumi-kontrollplanet og BigQuery-discovery er teamisolert. Et eksplisitt
+godkjent sett med navn, formål, eier og kontraktmetadata kan derimot være
+synlig på tvers av team i Datamarkedsplassen, fordi discovery er dens formål.
+Operasjonell metadata, preview-statistikk og ikke-publiserte navn er aldri del
+av dette unntaket.
+
+Kravene og evidensen som må foreligge før dev, shadow og produksjon er
+spesifisert i
+[trussel- og verifikasjonsmodellen](../analyseprodukter/trusselmodell-v1.md).
+
+## Første pilot
+
+iSyfo/eSyfo går gjennom samme UI, API, eksport og provisioning som andre team.
+Første release inneholder bare de avtalte strukturerte feltene fra Bro og
+Modia, ingen tags, fritekst eller datosvar. Piloten må bevise:
+
+- samme totalpopulasjon som kilden, og samme svarmål som dagens Quarto for en
+  periode der radene har ingest-matchet `flow_hash`, med samme filtre
+- faktisk bruk i Metabase og datafortelling/notebook
+- minst to vellykkede planlagte snapshots før cutover
+- at et syntetisk eller reelt team B kan onboardes uten kode eller deploy
+- at team B aldri kan se data eller operasjonell metadata fra team A, utenom
+  eksplisitt godkjent katalogmetadata i Datamarkedsplassen
+
+Den brede `esyfo-analyse`-tilgangen fjernes kontrollert først etter bevist
+paritet og cutover. V1 lager ikke en antatt historisk flow for eksisterende
+rader. Eldre `UNPINNED` svarverdier er derfor ikke med i answer-pariteten.
+Cutover krever at dataeier aksepterer den pinnede perioden; et behov for eldre
+svarhistorikk krever en separat, sikkerhetsreviewet backfillbeslutning.
+
+## Konsekvenser
+
+### Positivt
+
+- Data scientists får en flat, relasjonell kontrakt i stedet for Lumi-intern
+  råstruktur.
+- Teamet kan se eksakt schema, syntetiske eksempelrader og eksklusjoner før
+  publisering.
+- Ett sentralt kontrollplan kan støtte mange team uten transport eller deploy
+  per produkt.
+- Produktisolasjon, retensjon, sletting og offboarding er innebygde
+  kontraktskrav fremfor driftsrutiner hos hver konsument.
+
+### Kostnad og residualrisiko
+
+- Lumi får et nytt kontrollplan, kontraktkompilator, publisher/reconciler og
+  operasjonelt ansvar for snapshots og slettesynk.
+- Wide-visninger må håndtere kolonnegrenser og Metabase-synk; long er derfor
+  nødvendig som stabil analytisk fasit.
+- Produktspesifikke pseudonymer reduserer koblingsmulighet på tvers av
+  produkter, men eliminerer ikke personvernrisiko i små eller særpregede
+  datasett.
+- Produksjonsaktivering avhenger av avklaringer og støttede mekanismer hos NADA
+  og Datamarkedsplassen.
+- Eksisterende svarhistorikk mangler ingest-matchet flow. V1 undertrykker disse
+  feltverdiene fremfor å gjette historisk synlighet, så piloten bygger et nytt
+  verifiserbart analysevindu fra aktiveringstidspunktet.
+
+## Forkastede alternativer
+
+### Gi hvert team database- eller rådatatilgang
+
+Forkastet fordi det skalerer privilegier og Lumi-spesifikk parsing, eksponerer
+for mye data og gjør sletting og kontraktsendringer vanskelige å håndheve.
+
+### Publisere bare wide eller bare long
+
+Forkastet. Bare wide gir ustabilt schema og dårlig støtte for flere surveys;
+bare long mister en enkel og komplett response-populasjon for Metabase.
+
+### Inkrementell transport eller CDC fra dag én
+
+Forkastet for dagens målte volum. Fullsnapshot gir enklere, mer beviselig
+idempotens, sletting og replay. Valget revurderes ved målte kapasitetsbehov.
+
+### Bygge tilgangsgodkjenning og dashboardbygger i Lumi
+
+Forkastet fordi Datamarkedsplassen og Metabase allerede eier disse
+ansvarsområdene. Lumi skal publisere en trygg datakontrakt og vise ærlig
+plattformstatus.
+
+## Oppfølging
+
+Implementeringen deles i små vertikale steg fra #482. Ingen produksjonsdata,
+databasegrants, eksportjobber eller IAM-endringer aktiveres av denne ADR-en.
+ADR 0005 sine kapasitets- og recoverygrenser gjelder også for analyseeksporten.
+
+## Kilder
+
+- [NADA: dataprodukter](https://docs.knada.io/dataprodukter/dele/dataprodukt/)
+- [NADA: dataoverføring](https://docs.knada.io/dataprodukter/dele/dataoverf%C3%B8ring/)
+- [NADA: tilgangsstyring og authorized views](https://docs.knada.io/dataprodukter/tilgangsstyring/)
+- [NADA: Metabase](https://docs.knada.io/analyse/metabase/)
+- [NADA: datafortellinger](https://docs.knada.io/analyse/datafortellinger/)
+- [NAIS: BigQuery](https://doc.nais.io/persistence/bigquery/)
+- [Google Cloud: BigQuery authorized views](https://docs.cloud.google.com/bigquery/docs/authorized-views)
+- [Google Cloud: administrere BigQuery-views](https://docs.cloud.google.com/bigquery/docs/managing-views)
+- [Google Cloud: BigQuery quotas and limits](https://docs.cloud.google.com/bigquery/quotas)

--- a/docs/analyseprodukter/datakontrakt-v1.md
+++ b/docs/analyseprodukter/datakontrakt-v1.md
@@ -1,0 +1,567 @@
+# Datakontrakt V1 for analyseprodukter
+
+Denne kontrakten er den normative grensen mellom Lumi og konsumenter av et
+publisert analyseprodukt. Den beskriver hva kolonnene betyr og hvilke
+invarianter som må være sanne. Fysiske prosjekt- og datasettnavn fastsettes av
+plattformintegrasjonen.
+
+V1 publiserer tre analytiske viewtyper og en teknisk manifest-view. Det finnes
+ingen konfigurasjon for å velge rått, nøstet, wide eller long format: wide,
+long, feltkatalog og manifest publiseres som én samlet kontrakt.
+
+## Felles identitet og tid
+
+- `product_id` er stabil identitet for ett analyseprodukt.
+- `product_release` er den aktive immutable releasen som styrer radens
+  nåværende allowlist og retensjon. Dette gjelder også i en deprecated
+  major-view; majoren identifiseres av viewnavnet.
+- `product_snapshot_id` er en ugjennomsiktig identitet for det atomisk aktive
+  produktsnapshotet. Alle rader i alle viewtyper fra samme aktivering har samme
+  verdi.
+- Kildeidentitet er alltid `(team_slug, app, survey_id)`. `survey_id` alene er
+  ikke globalt unik.
+- `team_slug` kommer fra autorisert teamkontekst og kan aldri overstyres av en
+  klient.
+- `submitted_date` beregnes fra serverens lagringstid i `Europe/Oslo`.
+- `submitted_hour` er et UTC-timestamp trunkert til hel time og finnes bare når
+  det er eksplisitt valgt.
+- Klientens eksakte `submittedAt` eller `startedAt` publiseres aldri.
+
+`response_key` og `answer_key` er nøkkelbaserte, produktspesifikke
+pseudonymer. De er stabile gjennom releaser og major-visninger i samme produkt,
+men forskjellige mellom produkter. Intern Lumi-ID og privat `source_row_key`
+finnes aldri i kontrakten. Nøkkelrotasjon er en breaking endring og krever ny
+major-versjon og kontrollert parallellperiode.
+
+## Release-pinnet kildekontrakt
+
+En release pinner kildekatalogrevisjonen og eksakt tillatt kombinasjon av:
+
+- `(team_slug, app, survey_id)`
+- `definition_status` og tillatte `definition_hash`-verdier, med eksplisitt
+  legacy-regel for `NULL`
+- tillatte `flow_hash`-verdier med normalisert `visibleIf`, eventuell eldre
+  `logic`, eksplisitte avhengigheter og evaluatorversjoner; manglende historisk
+  flow må være eksplisitt tillatt som `UNPINNED`
+- `field_id`, `field_type`, ratingvariant/-skala og `max_selections`
+- tillatte `option_id`-er
+- godkjente metadatarevisjoner og dimensjoner
+
+En ukjent definisjon, ikke-null flow-hash, felttype eller option blir aldri
+automatisk publisert eller droppet fra en ellers publisert innsending. Bare
+berørt produkt går til `Må vurderes`, fryser nye data ved siste trygge
+`data_cutoff_at` og fortsetter purge-only refresh for retensjon og
+kildesletting. Andre produkter fra samme source-snapshot fortsetter uavhengig.
+`UNPINNED` godtas bare når releasen eksplisitt har tillatt historiske rader med
+manglende flow; det er ikke det samme som å godta en ukjent hash.
+
+Kildeendringen tas inn gjennom et nytt utkast, ny preview og ny validert
+release. En ny flervalgsoption er kompatibel når releasen legger til en
+nullable wide-kolonne og Metabase-/katalogsynk er planlagt. En ny
+enkeltvalgsoption utvider domenet i eksisterende `<field>__option_id` og
+katalogen, uten ny svarkolonne. Endret felttype, betydning eller ratingkontrakt
+er breaking. Labelendring alene endrer ikke strukturell identitet, men følger
+reglene for godkjent metadata nedenfor.
+
+## `responses_<app>_<survey>_wide_v1`
+
+Det publiseres én wide-view per valgt `(app, survey_id)`. Den har én rad per
+innsending og er fasit for total response-populasjon og applicability-baserte
+denominatorer. En
+innsending er med selv om ingen av de valgte svarfeltene ble besvart.
+
+Viewnavn og dynamiske kolonnenavn avledes deterministisk fra stabil ID,
+kollisjonssikker slug og kort hash. Brukeren kan ikke skrive SQL-identifikatorer.
+
+### Faste kolonner
+
+```text
+response_key       STRING NOT NULL
+product_id         STRING NOT NULL
+product_release    INT64 NOT NULL
+product_snapshot_id STRING NOT NULL
+team_slug          STRING NOT NULL
+app                STRING NOT NULL
+survey_id          STRING NOT NULL
+survey_type        STRING NOT NULL
+submitted_date     DATE NOT NULL
+submitted_hour     TIMESTAMP NULL     -- bare når eksplisitt valgt
+definition_hash    STRING NULL
+definition_status  STRING NOT NULL    -- REGISTERED | LEGACY_DERIVED
+flow_hash          STRING NULL
+flow_status        STRING NOT NULL    -- PINNED | UNPINNED
+```
+
+Lumi fabrikerer aldri en `definition_hash`. Legacy-rader uten registrert hash
+har `definition_hash=NULL` og `definition_status=LEGACY_DERIVED`.
+
+`flow_hash` er hash av hele den normaliserte flytdefinisjonen: `visibleIf`-
+grafen, eventuell eldre `logic`, dependency-identitetene og evaluatorenes
+semantikkversjoner. `PINNED` krever en ikke-null hash som ble registrert og
+matchet ved ingest; en klientoppgitt, ukjent hash er aldri tilstrekkelig. Samme
+`definition_hash` med endret flyt skal gi ulik `flow_hash`. Eksisterende rader
+uten en entydig historisk flytrevisjon får `flow_hash=NULL` og
+`flow_status=UNPINNED`; Lumi rekonstruerer dem aldri med dagens betingelser.
+V1 beregner bare eksakt applicability for den kanoniske `visibleIf`-modellen.
+Eldre `logic` som kan påvirke eksponering gir `NULL` og kvalitetsvarsel selv om
+flytrevisjonen kan identifiseres.
+
+`flow_status=PINNED` krever både `definition_status=REGISTERED` og ikke-null
+`flow_hash`. `flow_status=UNPINNED` krever `flow_hash=NULL`. Brudd på denne
+invarianten stopper produktpubliseringen.
+
+### Dynamiske kolonner
+
+```text
+alle felt:       <field>__applicable BOOL
+rating:          <field>__rating INT64
+enkeltvalg:      <field>__option_id STRING
+flervalg:        <field>__selection_count INT64
+                 <field>__<option>__selected BOOL
+dimensjon:       dim_<key>_<hash> STRING|BOOL|FLOAT64
+```
+
+`<field>__applicable` beskriver om feltet var relevant for innsendingen:
+
+- `TRUE` krever `flow_status=PINNED` og betyr at feltet fantes og var
+  ubetinget, eller at release-pinnet `visibleIf` fra radens `flow_hash` kunne
+  evalueres deterministisk til sann.
+- `FALSE` betyr at en registrert, fullstendig definisjon beviser at feltet ikke
+  fantes, eller at en pinnet og sikkert evaluerbar `visibleIf` var usann.
+- `NULL` betyr at feltet finnes, men relevans ikke kan fastslås, blant annet
+  ved `flow_status=UNPINNED`, `LEGACY_DERIVED` eller eldre `logic`.
+
+Prioriteten er normativ: strukturelt bevist fravær i en registrert definisjon
+gir `FALSE` selv om raden mangler flow. Når feltet finnes, gir `UNPINNED`
+derimot alltid `NULL`; dagens predicate kan aldri brukes. For
+`LEGACY_DERIVED` kan heller ikke strukturelt fravær bevises, og resultatet er
+`NULL`.
+
+Alle answer- og metadataavhengigheter i en predicate må selv være eksplisitt
+valgt, klassifisert og offentlig i samme produkt før det betingede feltet kan
+inngå i en release. Preview viser avhengigheten og hvilken inferens både
+answer-tilstedeværelse og applicability røper. En bare allowlistet, men uvalgt
+avhengighet blokkerer releasen; det finnes ingen skjult «evaluation-only»-omvei
+i V1. `NULL` er en konservativ fallback for allerede publiserte historiske
+rader med unpinned/ukomplett flyt, ikke en måte å godkjenne et nytt ufullstendig
+scope på. En betinget gren kan aldri merkes `TRUE` bare fordi feltet finnes i
+definisjonen. `NULL` gir kvalitetsvarsel og utelates fra eksakte feltrater. Et
+ubesvart, men bevist tilgjengelig felt har derimot `applicable=TRUE` og `NULL` i
+svarverdien.
+
+En offentlig svarverdi kan bare finnes når feltets applicability er `TRUE`.
+`FALSE` eller `NULL` gir alltid `NULL` i alle wide-svarkolonner og ingen
+tilsvarende long-rad. For `UNPINNED` historikk undertrykkes en eventuell
+kildeverdi med `PASSED_WITH_WARNINGS`. Manifestet viser bare kvalitetsstatus;
+team-scope preview kan vise et personverntersklet antall uten verdiinnhold.
+Dette er en eksplisitt legacyregel og kan ikke aktiveres for en ukjent
+ikke-null flow-hash.
+
+Hvis applicability er `FALSE`, men kildekandidaten likevel har et svar, er det
+et kontraktsbrudd. Produktet fryser før aktivering og fortsetter bare
+purge-only; verdien undertrykkes ikke lydløst. Det gjelder både strukturelt
+fravær og usann pinnet `visibleIf`, for rating, enkeltvalg, flervalg og
+`EMPTY_SELECTION`.
+
+For et felt introdusert i D2 får registrerte D1-rader `FALSE` og pinnede,
+ubetingede D2-rader `TRUE`; historiske rader blir ikke feilaktig regnet som
+manglende svar. Når nyeste allowlist fjerner et felt, blir både svar- og
+applicability-kolonnene `NULL` i deprecated majors. Det finnes da ikke lenger
+et publisert grunnlag for en feltrate.
+
+Flervalg bruker treverdisemantikk:
+
+- `TRUE` betyr at alternativet ble valgt
+- `FALSE` betyr at spørsmålet ble besvart, alternativet fantes i radens
+  release-pinnede definisjon, men ble ikke valgt
+- `NULL` betyr at spørsmålet ikke ble besvart, eller at alternativet ikke
+  fantes i radens definisjon
+
+`selection_count` skiller tilfellene: `NULL` betyr ubesvart; en ikke-null count
+sammen med `NULL` option-bool betyr at optionen ikke var tilgjengelig i denne
+definitionen. En D1→D2-utvidelse med ny option skal derfor aldri omskrive
+historiske D1-rader til `FALSE`.
+
+V1 varsler ved 80 genererte svar-, applicability- og dimensjonskolonner og har
+hard grense på 120 per wide-view. JSON eller arrays kan ikke brukes for å omgå
+grensen. Over grensen må feltutvalget reduseres eller flyttes til et annet
+produkt.
+
+## `answers_long_v1`
+
+Den produktomfattende long-viewen er fasit for publiserte svarverdier og har én
+rad per verdiatom:
+
+- rating gir én rad
+- enkeltvalg gir én rad for valgt alternativ
+- flervalg gir én rad per valgt alternativ
+- eksplisitt besvart, registrert og pinnet flervalg uten valg gir én
+  `EMPTY_SELECTION`-rad
+- ubesvart spørsmål gir ingen rad
+
+```text
+response_key         STRING NOT NULL
+answer_key           STRING NOT NULL
+product_id           STRING NOT NULL
+product_release      INT64 NOT NULL
+product_snapshot_id  STRING NOT NULL
+team_slug            STRING NOT NULL
+app                  STRING NOT NULL
+survey_id             STRING NOT NULL
+survey_type           STRING NOT NULL
+submitted_date        DATE NOT NULL
+submitted_hour        TIMESTAMP NULL
+definition_hash       STRING NULL
+definition_status     STRING NOT NULL
+flow_hash             STRING NULL
+flow_status           STRING NOT NULL
+
+field_id              STRING NOT NULL
+field_type            STRING NOT NULL    -- RATING | SINGLE_CHOICE | MULTI_CHOICE
+field_metadata_hash   STRING NOT NULL
+value_kind            STRING NOT NULL    -- RATING | OPTION | EMPTY_SELECTION
+rating_value          INT64 NULL
+option_id             STRING NULL
+option_metadata_hash  STRING NULL
+selection_count       INT64 NULL
+dim_<key>_<hash>      STRING|BOOL|FLOAT64 NULL
+```
+
+### Radinvarianter
+
+| `field_type` | `value_kind` | Påkrevde verdier | Kardinalitet |
+| --- | --- | --- | --- |
+| `RATING` | `RATING` | `rating_value` innen godkjent `rating_min..rating_max`; `option_id` og `option_metadata_hash` er `NULL` | nøyaktig én rad per besvart felt |
+| `SINGLE_CHOICE` | `OPTION` | `option_id`, `option_metadata_hash`, `selection_count=1` | nøyaktig én rad per besvart felt |
+| `MULTI_CHOICE` | `OPTION` | unik `option_id`, ikke-null `option_metadata_hash`, `selection_count=N` | N rader med samme `answer_key` |
+| `MULTI_CHOICE` | `EMPTY_SELECTION` | `option_id=NULL`, `option_metadata_hash=NULL`, `selection_count=0` | én rad for eksplisitt registrert/pinnet tomvalg |
+
+For et flervalg er N `COUNT(DISTINCT option_id)`. Alle N radene har samme
+`answer_key` og `selection_count=N`, og det finnes maksimalt én rad per
+`(answer_key, option_id)`. `answer_key` identifiserer dermed det logiske svaret,
+mens raden representerer ett verdiatom.
+
+Duplisert option-ID i en registrert definisjon eller duplisert valgt option i
+et registrert/pinnet svar er et kontraktsbrudd og fryser produktet. Wide sin
+`selection_count` og long sin N beregnes fra samme validerte option-sett og er
+dermed identiske. `LEGACY_DERIVED`/`UNPINNED` publiserer ingen svarverdier og
+har derfor ingen offentlig dedupliseringssemantikk.
+
+Ratingvariant, skala og min/max skal være innbyrdes konsistente med den
+release-pinnede kildedefinisjonen. NPS har intervallet `0..10`; verdien `0` er
+et gyldig svar og kan aldri behandles som `NULL`, falsy eller manglende.
+
+Korrekte tellinger er:
+
+```sql
+-- Besvarte spørsmål i long
+COUNT(DISTINCT answer_key)
+
+-- Innsendinger med minst én publisert svarverdi
+COUNT(DISTINCT response_key)
+```
+
+Totalt antall innsendinger er alle rader i relevant wide-view. For en
+feltspesifikk svarrate er nevneren
+`COUNTIF(<field>__applicable IS TRUE)`. Telleren begrenses til samme rader og
+bruker ikke-null rating/enkeltvalg eller ikke-null `selection_count` for
+flervalg. `FALSE` og `NULL` inngår ikke i nevneren. Legacy-rader med ukjent
+applicability kan derfor ikke gis en eksakt feltrate; preview og manifest viser
+et kvalitetsvarsel. Ingen denominator skal utledes fra long.
+
+En option-rate må i tillegg avgrenses til definisjoner der optionen fantes.
+Nevneren bruker `applicable=TRUE`, `definition_status=REGISTERED` og en
+`EXISTS` mot nøyaktig produkt/release/snapshot, kilde, `definition_hash`,
+`field_id`, `option_id` og `entry_kind=OPTION` i `field_catalog_v1`. Dette
+gjelder både enkelt- og flervalg; fravær av en ny option i D1 er ikke et
+historisk nullvalg. En rate blant besvarte bruker samme nevnerfilter og krever
+i tillegg ikke-null svarverdi/`selection_count`. Preview og generert
+Metabase-metadata skal navngi om raten bruker alle eligible eller bare besvarte
+innsendinger.
+
+```sql
+WHERE wide.<field>__applicable IS TRUE
+  AND wide.definition_status = 'REGISTERED'
+  AND EXISTS (
+    SELECT 1
+    FROM field_catalog_v1 AS option_catalog
+    WHERE option_catalog.product_id = wide.product_id
+      AND option_catalog.product_release = wide.product_release
+      AND option_catalog.product_snapshot_id = wide.product_snapshot_id
+      AND option_catalog.team_slug = wide.team_slug
+      AND option_catalog.app = wide.app
+      AND option_catalog.survey_id = wide.survey_id
+      AND option_catalog.definition_hash = wide.definition_hash
+      AND option_catalog.field_id = '<field_id>'
+      AND option_catalog.option_id = '<option_id>'
+      AND option_catalog.entry_kind = 'OPTION'
+  )
+```
+
+## `field_catalog_v1`
+
+Feltkatalogen gjør etiketter og strukturell metadata tilgjengelig uten å bruke
+tekst som fysisk identitet:
+
+```text
+metadata_hash        STRING NOT NULL
+entry_kind           STRING NOT NULL    -- FIELD | OPTION
+product_id           STRING NOT NULL
+product_release      INT64 NOT NULL
+product_snapshot_id  STRING NOT NULL
+team_slug            STRING NOT NULL
+app                  STRING NOT NULL
+survey_id            STRING NOT NULL
+definition_hash      STRING NULL
+
+field_id             STRING NOT NULL
+field_type           STRING NOT NULL
+rating_variant       STRING NULL
+rating_scale         INT64 NULL
+rating_min           INT64 NULL
+rating_max           INT64 NULL
+max_selections       INT64 NULL
+
+option_id            STRING NULL
+option_ordinal       INT64 NULL
+display_label        STRING NULL
+label_source         STRING NOT NULL    -- REGISTERED_METADATA | PRODUCT_ALIAS | UNKNOWN
+metadata_revision    STRING NULL
+first_observed_date  DATE NULL
+last_observed_date   DATE NULL
+is_current_label     BOOL NOT NULL
+```
+
+Spørsmåls- og alternativetiketter i en innsending er klientstyrt metadata. De
+kan inneholde fritekst eller personopplysninger og brukes aldri som offentlig
+etikett, som hashinput eller som kilde til katalogkardinalitet.
+
+En offentlig etikett må komme fra teamkontrollert, versjonert metadata som er
+registrert gjennom en autentisert Lumi-flyt, eller fra et eksplisitt
+produktalias som valideres og publiseres med releasen. Registrering og alias
+normaliseres til ren tekst, lengdebegrenses, kontrolleres for forbudt innhold og
+persondata og auditeres som offentlig katalogmetadata. Legacy-felt uten slik
+metadata får `display_label=NULL`, `label_source=UNKNOWN` til eieren registrerer
+et alias. Derfor gjelder følgende:
+
+- `field_metadata_hash` inkluderer godkjent feltstruktur, etikett, kilde og
+  metadatarevisjon.
+- `option_metadata_hash` inkluderer felt-/option-ID og tilsvarende godkjent
+  alternativmetadata.
+- En long-rad peker til metadatarevisjonen som den aktuelle view-majoren
+  anvender, ikke til en upålitelig etikett fra innsendingen.
+- `first_observed_date`/`last_observed_date` beskriver når den strukturelle
+  felt-/option-ID-en først og sist finnes i dataene, beregnet fra serverens
+  lagringstid i `Europe/Oslo`. De er ikke gyldighetsperiode for etiketten.
+- Manglende eller konfliktende registrert metadata er kvalitetsavvik. Lumi
+  velger aldri en tilfeldig «siste etikett».
+- Hvert tillatt felt og hver tillatt option får alltid en deterministisk
+  `UNKNOWN`-fallbackrad i et vanlig fullsnapshot. Den er ikke current når
+  godkjent metadata finnes, men gjør sikkerhetsredaksjon mulig uten å opprette
+  en ny metadataidentitet fra et fryst produkt.
+
+Katalogradene har disse invariantene:
+
+| `entry_kind` / `label_source` | Påkrevd | Skal være `NULL` |
+| --- | --- | --- |
+| `FIELD` | `field_id`, `field_type`, `metadata_hash` | `option_id`, `option_ordinal` |
+| `OPTION` | `field_id`, choice-`field_type`, `option_id`, `metadata_hash` | ratingmetadata |
+| `REGISTERED_METADATA` | ikke-tom `display_label`, `metadata_revision` | – |
+| `PRODUCT_ALIAS` | ikke-tom `display_label`, `metadata_revision` | – |
+| `UNKNOWN` | – | `display_label`, `metadata_revision` |
+
+`option_ordinal` er enten `NULL` eller et ikke-negativt, unikt ordinal innen
+samme `(product_id, app, survey_id, definition_hash, field_id,
+metadata_revision)`. Ratingfelter krever konsistent variant/scale/min/max;
+choice-felter har disse ratingkolonnene som `NULL`. En malformed katalograd er
+et kontraktsbrudd selv om ingen answer-rad peker til den.
+
+`metadata_hash` beregnes deterministisk over `entry_kind`, full kildeidentitet,
+`definition_hash` med eksplisitt nullmarkør, felt-/option-ID, strukturell
+metadata, `display_label`, `label_source` og `metadata_revision`.
+
+Feltmetadata joines med følgende komplette predikat:
+
+```sql
+answers.product_id = field_catalog.product_id
+AND answers.product_release = field_catalog.product_release
+AND answers.product_snapshot_id = field_catalog.product_snapshot_id
+AND answers.team_slug = field_catalog.team_slug
+AND answers.app = field_catalog.app
+AND answers.survey_id = field_catalog.survey_id
+AND (
+  answers.definition_hash = field_catalog.definition_hash
+  OR (answers.definition_hash IS NULL AND field_catalog.definition_hash IS NULL)
+)
+AND answers.field_id = field_catalog.field_id
+AND answers.field_metadata_hash = field_catalog.metadata_hash
+AND field_catalog.entry_kind = 'FIELD'
+```
+
+Optionmetadata bruker en egen katalogalias med dette komplette predikatet:
+
+```sql
+answers.product_id = option_catalog.product_id
+AND answers.product_release = option_catalog.product_release
+AND answers.product_snapshot_id = option_catalog.product_snapshot_id
+AND answers.team_slug = option_catalog.team_slug
+AND answers.app = option_catalog.app
+AND answers.survey_id = option_catalog.survey_id
+AND (
+  answers.definition_hash = option_catalog.definition_hash
+  OR (answers.definition_hash IS NULL AND option_catalog.definition_hash IS NULL)
+)
+AND answers.field_id = option_catalog.field_id
+AND answers.option_id = option_catalog.option_id
+AND answers.option_metadata_hash = option_catalog.metadata_hash
+AND option_catalog.entry_kind = 'OPTION'
+```
+
+Hver `field_metadata_hash` skal matche nøyaktig én FIELD-rad. Hver
+`value_kind=OPTION` skal ha ikke-null `option_metadata_hash` som matcher
+nøyaktig én OPTION-rad. Rating og `EMPTY_SELECTION` skal ha
+`option_metadata_hash=NULL`. En `OPTION`-rad matcher ikke samtidig FIELD-joinet;
+konsumenten bruker to aliaser av katalogen.
+
+`is_current_label` vurderes innen eksakt `(product_id, app, survey_id,
+definition_hash, field_id[, option_id])`. Ved uløst konflikt er ingen kandidat
+current, og refresh blokkeres.
+
+Wide grupperer bevisst etter stabil felt-/option-ID og har ikke metadatahash
+per svar. Kolonnebeskrivelsen er derfor displaymetadata for aktiv release, ikke
+historisk fasit for ordlyden i gamle innsendinger. Preview varsler når Lumi har
+registrert flere godkjente etiketter for samme stabile ID. Analyse per
+metadatarevisjon bruker long; V1 hevder aldri historisk labelnøyaktighet fra
+klientleverte innsendinger. Endret semantisk betydning under samme ID er
+breaking og skal normalt løses med ny felt-ID; allerede sammenblandede data
+blokkeres fremfor å gis en oppdiktet historikk.
+
+Hvis en tidligere godkjent etikett tilbakekalles fordi den inneholder
+persondata eller forbudt innhold, undertrykkes revisjonen i alle aktive og
+deprecated majors ved neste snapshot. En `SECURITY_REDACTION`-aktivering fjerner
+gammel label, katalograd og view-/kolonnebeskrivelse og flytter refererende hash
+til deterministisk `UNKNOWN`. Den kan ikke introdusere erstatningstekst; en
+godkjent erstatning krever ny validert release. Sikkerhetstilbakekalling kan
+utløse ekstra refresh og følger samme 36-timers mål-SLO som kildesletting.
+
+Den effektive publiseringsspesifikasjonen for en redaksjon er den immutable
+releasen minus de auditerte tilbakekallingene. Denne spesifikasjonen er felles
+input til kompilator, digest, ny immutable boundary-FQN, binder, reconciler og
+alias desired state. Redaksjonen beholder `product_release`, men får ny
+`product_snapshot_id`; gammel FQN deauthorizeres før aliasbyttet. Et
+tilbakekallingssett kan ikke produsere en metadataidentitet som ikke allerede
+fantes som godkjent eller `UNKNOWN` i forrige fullsnapshot.
+
+## `product_manifest_v1`
+
+Manifestet har én rad per offentlig analytisk ressurs i produktets aktive
+pointer:
+
+```text
+product_id           STRING NOT NULL
+product_release      INT64 NOT NULL
+product_snapshot_id  STRING NOT NULL
+resource_name        STRING NOT NULL
+resource_kind        STRING NOT NULL    -- WIDE | LONG | FIELD_CATALOG
+schema_digest        STRING NOT NULL
+row_count            INT64 NOT NULL
+contract_version     STRING NOT NULL
+source_snapshot_at   TIMESTAMP NOT NULL
+published_at         TIMESTAMP NOT NULL
+data_cutoff_at       TIMESTAMP NULL
+snapshot_mode        STRING NOT NULL    -- FULL | PURGE_ONLY | SECURITY_REDACTION
+quality_status       STRING NOT NULL    -- PASSED | PASSED_WITH_WARNINGS
+```
+
+Separate Metabase-/Quarto-spørringer er ikke én transaksjon. Konsumenten som
+krever samme øyeblikksbilde, sammenligner derfor `product_snapshot_id` fra
+manifest, wide, long og katalog og retryer ved mismatch. For en mulig tom
+ressurs brukes én BigQuery-statement som LEFT JOINer eksakt ressursrad i
+manifestet mot viewet på `product_snapshot_id`. Da returnerer manifestdelen én
+rad med `row_count=0` selv når viewkolonnene er `NULL`; en tom→ikke-tom
+pointerendring kan ikke blandes inne i statementet. `product_release` alene er
+ikke snapshotidentitet.
+
+```sql
+SELECT manifest.product_snapshot_id, manifest.row_count, resource.*
+FROM product_manifest_v1 AS manifest
+LEFT JOIN responses_example_wide_v1 AS resource
+  ON resource.product_snapshot_id = manifest.product_snapshot_id
+WHERE manifest.resource_name = 'responses_example_wide_v1'
+```
+
+## Syntetisk semantikkeksempel
+
+En syntetisk innsending besvarer ratingfeltet `opplevelse` med `4` og
+flervalgsfeltet `prioritering` med alternativene `a` og `c`:
+
+- Wide har én response-rad med `opplevelse__rating=4`,
+  `prioritering__selection_count=2`,
+  `prioritering__a__selected=TRUE`,
+  `prioritering__b__selected=FALSE` og
+  `prioritering__c__selected=TRUE`.
+- Long har én ratingrad og to flervalgsrader. Flervalgsradene har samme
+  `answer_key` og `selection_count=2`.
+- Feltkatalogen har FIELD-rader for begge felt og OPTION-rader for `a`, `b` og
+  `c`, selv om `b` ikke er valgt i denne innsendingen.
+
+Preview kan vise slike syntetiske rader og aggregerte, lavtallsbeskyttede mål,
+men aldri en reell enkeltinnsending. Ekte mål kommer fra et fast sett
+forhåndsdefinerte celler per kilde/felt, ikke fra vilkårlige unioner,
+komplementer eller dato-/gruppekombinasjoner. Endring av draften velger blant
+de samme cellene. Celler med 1–4 distinkte innsendinger returnerer bare
+`BELOW_THRESHOLD`; 0 kan vises som 0 og minst 5 kan vises eksakt. Det brukes
+også sekundærsuppresjon: en vist total eller undergruppe skjules når en
+differanse eller et komplement kan utlede en ikke-null celle under 5.
+Eksempelvis kan ikke total `6` og delmengde `5` vises samtidig fordi det
+avslører komplementet `1`.
+
+## Dimensjoner
+
+En dimensjon kan bare publiseres hvis den finnes i et sentralt klassifisert
+register med eier, forklaring, stabil output-ID, BigQuery-type, dataklasse,
+tillatt team/app/survey-scope, maksimal kardinalitet og policy for nye verdier.
+
+Valgte dimensjoner gjentas som flate, typede skalar-kolonner i både wide og
+long. Uvalgte dimensjoner inngår ikke i produktets bidrag til det private
+snapshotet og finnes ikke i produktets offentlige ressurser. Ukjent type,
+typeendring eller overskredet policy blokkerer publisering/refresh eller krever
+ny major; råverdien blir aldri automatisk stringifisert.
+
+## Eksplisitt utelatt
+
+Følgende kan ikke velges og finnes verken i privat eller offentlig eksportlag:
+
+- tekst- og datosvar
+- rå `feedback_json` eller surveydefinisjon
+- vilkårlig context eller uklassifiserte tags
+- full URL, query-parametere og pathname
+- user-agent, viewport og skjermoppløsning
+- debug og dedupliseringsnøkkel
+- klientens eksakte tidsstempler
+- intern database-ID
+- verdier eller kolonner av typen `JSON`, `STRUCT` eller `ARRAY`
+
+## Skjemaevolusjon
+
+- Nytt felt/survey eller nullable kolonne er kompatibelt.
+- Enhver ny offentlig kolonne, view eller surveyressurs merkes også som
+  Metabase-/katalogsynk; dette gjelder både wide, long og produktregistreringen.
+- Enhver publisert metadatarevisjon eller endret kolonnebeskrivelse utløser
+  katalogoppdatering og Metabase metadata-sync/re-scan selv om fysisk schema er
+  uendret.
+- Fjerning, rename, type-/betydningsendring eller nøkkelrotasjon er breaking og
+  oppretter en ny major-view.
+- Annet team, forbudt datakategori, ukjent dimensjon eller ugyldig
+  kildekontrakt er blokkert.
+- En deprecated major beholder sitt fysiske schema frem til sin eksplisitte
+  slettedato. Kolonner som nyeste release ikke lenger tillater beholdes, men er
+  alltid `NULL`; long- og katalograder for fjernede felt forsvinner. Hvis en hel
+  survey fjernes, består dens deprecated wide-view med null rader og stabilt
+  schema frem til slettedato. Deretter fjernes viewet.
+- En deprecated major leser samme effektive retensjon og source-deletions som
+  nyeste release. `product_release` viser releasen som nå styrer allowlisten;
+  viewnavnet viser majoren.
+
+Kontrakten kan ikke publiseres før alle relevante kontroller i
+[trussel- og verifikasjonsmodellen](./trusselmodell-v1.md) er grønne.

--- a/docs/analyseprodukter/trusselmodell-v1.md
+++ b/docs/analyseprodukter/trusselmodell-v1.md
@@ -1,0 +1,295 @@
+# Trussel- og verifikasjonsmodell V1 for analyseprodukter
+
+Denne modellen beskriver sikkerhetsgrensene for teamavgrensede
+analyseprodukter og bevisene som kreves før løsningen kan gå fra lokal
+utvikling til shadow-kjøring og produksjon. Den kompletterer
+[ADR 0006](../adr/0006-teamavgrensede-analyseprodukter.md) og
+[V1-datakontrakten](./datakontrakt-v1.md).
+
+Modellen gjelder også når dataene er pseudonymiserte. Pseudonymisering er ikke
+anonymisering, og lave volum, kombinasjoner av svar og teamkontekst kan gjøre
+enkeltpersoner gjenkjennelige.
+
+## Verdier og tillitsgrenser
+
+Verdiene som skal beskyttes er respondentnære svar, source- og
+produktidentiteter, nøkkelmateriale, produktkonfigurasjon, eiermetadata og
+integriteten til aktiv release/snapshot.
+
+```text
+Lumi API / Cloud SQL
+  |  read-only, minimert eksportkontrakt
+  v
+BigQuery connection + privat staging/canonical
+  |  effective-spec-kompilert, kontrollert publisering
+  v
+Isolert produktdatasett
+  |  tilgang forvaltet av Datamarkedsplassen
+  v
+Metabase / datafortelling / notebook
+```
+
+Hver pil er en egen tillitsgrense. Ingen identitet skal ha privilegier på begge
+sider av en grense med mindre det er nødvendig og dokumentert. Menneskelige
+konsumenter skal bare kunne lese siste ledd.
+
+## Sikkerhetsinvarianter
+
+Disse invariantene er absolutte. En rød kontroll stopper publisering:
+
+1. Team A kan ikke oppdage eller lese data, preview-/driftsmetadata, counts,
+   utkast eller ikke-publiserte navn for team B gjennom Lumi eller BigQuery.
+   Eksplisitt godkjent katalogmetadata i Datamarkedsplassen er det eneste
+   discovery-unntaket.
+2. Intern Lumi-ID, rå payload og forbudte datakategorier forlater aldri Cloud
+   SQL-eksportuttrykket.
+3. Utkast eller mislykket validering kan aldri materialiseres eller endre aktiv
+   release eller snapshot.
+4. En eldre, forsinket eller replayet kjøring kan aldri aktivere eldre data
+   eller gjeninnføre slettede data.
+5. En deprecated major kan aldri bevare et felt eller en retensjon som nyeste
+   release har fjernet.
+6. Publisering gir aldri personer eller grupper lesetilgang.
+7. Pause og produktlokale feil stopper ikke retensjon, kildesletting eller
+   offboarding. Source-/plattformfeil gir retry, alarm og et målbart SLO-brudd;
+   de kan ikke skjules som vellykket slettesynk.
+8. Preview viser aldri reelle enkeltinnsendinger.
+9. Et betinget felt kan aldri releaseres når et svar-/metadatafelt i predicate
+   ikke selv er eksplisitt valgt og godkjent i produktet. Historisk flyt uten
+   en ingest-matchet revisjon rekonstrueres aldri.
+
+## Trusler, kontroller og påkrevd evidens
+
+| ID | Trussel | Forebyggende kontroll | Evidens før produksjon |
+| --- | --- | --- | --- |
+| T01 | Cross-team IDOR eller metadatalekkasje | Team avledes server-side; alle produkt-, kilde- og preview-oppslag scopes med autorisert team; uautorisert og ikke-eksisterende ressurs har lik respons; bare godkjent Marketplace-metadata kan være synlig på tvers | API-/UI-tester med team A/B, inkludert tomtilstander, feil, counts, bytte av aktivt team og allowlist for katalogmetadata |
+| T02 | Rå, forbudt eller avledet uvalgt data havner i privat/offentlig lag | Versjonert allowlist-kontrakt; typed compiler; klientleverte etiketter eksporteres aldri; et betinget felt krever offentlig valgte predicate-avhengigheter før release; tilbakekalt metadata undertrykkes i alle majors; negative kontroller før pointerbytte | Inspeksjon av eksportview, query-resultat, staging, canonical og produktviews; tester for tekst-/datosvar, UUID, JSON, URL, user-agent, debug, manipulerte/tilbakekalte etiketter, PII, HTML, kontrolltegn og allowlistet-men-uvalgt predicate-input |
+| T03 | Samme kilderad kan kobles på tvers av produkter | Produktspesifikk keyed pseudonym; separat nøkkelmateriale/derivasjonskontekst; ingen privat nøkkel eller `source_row_key` i offentlig output eller logger | Test som viser stabil nøkkel innen produkt, ulik nøkkel mellom produkt A/B og fravær av intern ID, `source_row_key` og nøkkelmateriale |
+| T04 | Replay eller rollback gjenoppretter slettede rader | Replay leser alltid dagens kilde; ingen gammel snapshot kan aktiveres; alle ikke-aktive kopier slettes/utløper | Slett kilderad, kjør nyere snapshot og forsøk replay/eldre run; raden skal være fraværende overalt |
+| T05 | Delvis/eldre kjøring blir synlig, produkt A stopper B eller konsumenten blander snapshots | Unik source-staging, atomiske monotone pointere, offentlig `product_snapshot_id`/manifest, produktlokal feilstatus og purge-only fallback | Feilinjeksjon, omvendt kjøringsrekkefølge, pointerbytte mellom separate view-spørringer og kontraktsfeil i A mens B publiserer og begge fortsatt sletter |
+| T06 | Feil metadatajoin, denominator, betinget relevans, malformed katalog eller kildeevolusjon viser feil betydning/survey | Full kildeidentitet; separat ingest-matchet `flow_hash` med normalisert flyt, avhengigheter og evaluatorversjoner; V1-rate bare for kanonisk `visibleIf`; eksplisitt felt-applicability og definition-spesifikk option-nevner; komplette kataloginvarianter og eksakt én match | Tester med samme `survey_id` i to apper, samme definition-hash med endret flow, manglende/ukjent/legacy flow, nytt felt, ny/duplisert option, sann/usann/ukjent `visibleIf`, labelendring og malformed/duplisert katalograd |
+| T07 | Pause/deprecated view bevarer data for lenge | Effektiv retensjon og source deletion anvendes ved hvert fullsnapshot og purge-only snapshot på alle majors; pause fryser bare øvre cutoff; deprecated schema er stabilt, men fjernede verdier er `NULL` | Klokke-/snapshot-tester for 30/90/180/source-max, pause, kortere release, fjernet survey/felt og deprecated major |
+| T08 | Arvet IAM, publisher/binder, alias eller post-bind viewmutasjon omgår produktgrensen | Dedikert prosjekt uten menneskelig/default arv; separate identiteter; immutable release-FQN; live SQL/digest-validering mot effective spec; alias kan bare målrette samme produkt/release/digest | IAM-inventar, binding-/aliasaudit, post-bind/TOCTOU-test, negativ A→B/revokert-alias-test og tilgangstester for alle identiteter |
+| T09 | Eksport overbelaster Cloud SQL | Én connection/query per snapshot, statement timeout, connection limit og målt 1x/10x spike; ADR 0005-stoppgrenser | Query-plan, varighet, bytes, CPU, I/O og connections under realistisk last |
+| T10 | Preview avslører en reell, liten eller differensierbar gruppe | Bare syntetiske rader; fast allowlist av aggregater; primær- og sekundærsuppresjon; ingen vilkårlig dato/gruppering eller rå eksempler | UI/API-tester for 0/1/4/5, total/delmengde `6/5/1`, kategorisummer, gjentatte draftendringer og differanseforsøk, samt logginspeksjon |
+| T11 | Navnekollisjon eller SQL-injeksjon gjennom konfigurasjon | Ingen brukerdefinerte SQL-identifikatorer; deterministisk slug+hash; quoted/static templates og allowlist | Property-/kollisjonstester med Unicode, lange ID-er, reserverte ord og SQL-metategn |
+| T12 | Drift mellom effective spec og faktisk datasett | Immutable release minus auditerte tilbakekallinger + `schema_digest`; deklarativ reconciler; status skiller ønsket og faktisk tilstand | Driftstest som endrer/sletter view utenfor Lumi og viser oppdagelse, sikker reparasjon og audit |
+| T13 | Offboarding etterlater data, grants eller markedsplassressurs | Trinnvis, idempotent offboarding med verifisert tomhet før `Slettet` | Gjentatt feilinjisert offboarding og etterkontroll av data, views, bindings, grants, credentials og katalog |
+| T14 | Høy kardinalitet eller ukjent dimensjon omgår minimering | Sentralt klassifisert dimensjonsregister med type, scope og kardinalitetspolicy; fail closed | Negative tester for uregistrert nøkkel, nytt scope, typeendring og overskredet kardinalitet |
+| T15 | Authorized-resource-kvote eller for bred dataset-authorization bryter 50-team-målet | Publiseringstopologi velges etter kvote- og privilegieanalyse; eksplisitt budsjett for produkter, surveys og majors; ingen implicit future-view-tilgang uten review | Skalatest med 50 team, opptil 500 produkter, representative surveyantall og parallelle majors, inkludert reconcile og offboarding |
+
+## Identiteter og minste privilegium
+
+Tilgangsmatrisen skal verifiseres fra faktisk IAM, ikke bare fra ønsket
+konfigurasjon:
+
+| Identitet | Skal kunne | Skal ikke kunne |
+| --- | --- | --- |
+| Cloud SQL export-bruker | `CONNECT`, `USAGE` på eksportskjema og `SELECT` på eksakte eksportviews | lese `public.*`, råtabeller, skrive eller arve default grants |
+| BigQuery connection service agent | bruke avtalt Cloud SQL-connection | lese produktdatasett eller administrere IAM |
+| Scheduled-query servicekonto | starte jobb, bruke connection, skrive privat staging/canonical | lese råtabeller direkte, gi produkt-IAM eller skrive andre prosjekter |
+| Kontraktkompilator | produsere deterministisk viewdefinisjon, FQN og `schema_digest` fra immutable release minus auditerte tilbakekallinger | Cloud-, database-, data- eller IAM-tilgang |
+| View-publisher/reconciler | opprette ny immutable release-FQN; lese privat schema/data bare i det minimum BigQuery krever; ingen jobbkjøring | mutere bundet view, databasecredential, dataset-ACL, vilkårlig query eller menneskelige grants |
+| Cross-dataset-binder/NADA-port | lese faktisk view-SQL, validere digest/policy og autorisere immutable FQN mot source | generell produktpublisering; binding når publisher fortsatt kan mutere viewet; menneskegrant uten separat Marketplace-/sikkerhetsport |
+| Alias-publisher | peke stabilt offentlig navn til aktiv, bundet boundary-FQN med samme produkt/major/release/digest | canonical-tilgang, A→B-mål, gammel/revokert FQN, boundary-mutasjon eller IAM |
+| Lumi API | forvalte teamautoriserte drafts, releaser og ønsket tilstand | direkte datapublisering, databaseeksportcredential eller IAM-grants |
+| Konsument | lese eksplisitt autorisert produktressurs | Postgres, privat BigQuery-lag, andre produkter eller IAM-administrasjon |
+
+Ingen default grants eller brede roller kan erstatte eksplisitte privilegier.
+Hvis nødvendig BigQuery-permission også kan misbrukes til menneskegrant eller
+vilkårlig source-eksponering, skal dette dokumenteres som capability og
+begrenses av separasjon, policykontroll, audit og ekstern godkjenningsport; det
+kan ikke skjules i «skal ikke kunne»-kolonnen. Credentialrotasjon,
+nøkkelversjon og eierskap skal være dokumentert før shadow.
+
+## Verifikasjonsgater
+
+### Gate A – før domenekode og prototype regnes som kontraktsriktig
+
+- [ ] Alle kolonner og invarianter i V1-kontrakten har stabile test-ID-er.
+- [ ] Compiler bruker allowlist for felttyper, dimensjoner og fysiske navn.
+- [ ] `flow_hash` beregnes fra normalisert flyt, dependencies og
+      evaluatorversjoner, registreres før ingest og inngår i release/effective
+      spec. Ukjent klienthash avvises; manglende historikk blir `UNPINNED`, og
+      eldre `logic` brukes ikke til eksakt V1-applicability.
+- [ ] Team-scope avledes gjennom eksisterende autorisasjon på hvert endepunkt.
+- [ ] Preview bruker bare syntetiske rader og en versjonert terskelpolicy:
+      1–4 distinkte innsendinger gir `BELOW_THRESHOLD`, 0 kan vises som 0, og
+      sekundærsuppresjon skjuler også viste celler når totaler, komplementer,
+      kategorisummer eller gjentatte previews ellers kan rekonstruere en
+      undertrykt celle. `6/5/1` er et obligatorisk negativt testtilfelle.
+- [ ] Draft, validering og release har revisjonsvern og auditkrav.
+
+### Gate B – før dev-spike får bruke en ekte connection
+
+- [ ] NADA har bekreftet region, connection-modell og minste servicekonto-IAM.
+- [ ] Det er avklart om prosjekt/datasett arver menneskelig eller default
+      lesetilgang.
+- [ ] Eksakt algoritme og forvaltning for produktspesifikke nøkler er
+      sikkerhetsreviewet.
+- [ ] Cloud SQL export-rollen kan ikke lese råtabeller eller `public.*`.
+- [ ] Syntetisk team A/B-datasett og negative forbudt-data-fixtures finnes.
+- [ ] Publiseringstopologien og skillet mellom compiler, publisher og
+      binder/NADA-port er valgt ut fra dokumenterte IAM-capabilities.
+- [ ] Boundary-views bruker immutable release-FQN; binder validerer live SQL
+      mot trusted `EffectivePublicationSpec` (immutable release minus auditerte
+      tilbakekallinger), og valgt mekanisme fjerner mutate-capability før
+      binding.
+
+### Gate C – før produksjons-shadow uten konsumenttilgang
+
+- [ ] Én `EXTERNAL_QUERY` gir en konsistent kandidatsnapshot ved realistisk
+      volum.
+- [ ] 1x- og 10x-måling er under stoppgrensene i ADR 0005.
+- [ ] Feilinjeksjon beviser atomisk og monoton aktivering.
+- [ ] Sletting/replay-test beviser at slettede data ikke gjenoppstår.
+- [ ] Ukjent definition/option i produkt A fryser bare A, delpubliserer ingen
+      nye A-rader og hindrer verken publisering eller slettesynk for B; purge-
+      only refresh holder A innen retensjon og slettings-SLO.
+- [ ] Purge-only er bevist som ren delmengde: samtidige forsøk på tillegg og
+      mutasjon avvises, mens sletting og utløp fjernes uten å endre
+      forretningspayload. Aktiveringsmetadata er eksplisitt utenfor
+      delmengdesammenligningen.
+- [ ] `SECURITY_REDACTION` på et fryst produkt kan bare fjerne label,
+      katalog-/viewbeskrivelse og flytte hash til `UNKNOWN`; gammel metadata
+      forsvinner fra long, katalog, alle majors og Metabase uten nye svar.
+      Releasen minus auditerte tilbakekallinger er samme effective spec for
+      kompilator, digest/FQN, binder, reconciler og alias. Ny FQN bindes,
+      gammel FQN deauthorizeres før aliasbyttet, og fallbackhashen må være
+      forhåndsmaterialisert.
+- [ ] Ratingvarianter valideres mot min/max, og NPS `0` bevares som verdi.
+- [ ] Dupliserte options blokkeres for registrert/pinnet kontrakt. Wide og long
+      bruker samme validerte option-sett og distinct N; legacy/unpinned har
+      ingen offentlige svarverdier som kan dedupliseres.
+- [ ] D1→D2 med ny option gir `NULL` for historiske D1-rader, ikke `FALSE`;
+      `selection_count` skiller utilgjengelig option fra ubesvart spørsmål.
+- [ ] D1→D2 med ny enkeltvalgsoption utvider domenet uten ny wide-kolonne;
+      option-raten bruker definition-spesifikk OPTION-katalog og utelater
+      registrerte D1-rader der optionen ikke fantes.
+- [ ] D1→D2 med nytt rating- eller enkeltvalgsfelt gir
+      `<field>__applicable=FALSE` for registrerte D1-rader og `TRUE` for
+      ubetingede D2-rader. Et ubesvart, bevist relevant D2-felt beholder `TRUE`
+      med `NULL` svarverdi, `LEGACY_DERIVED` får `NULL`, og feltraten utelater
+      både `FALSE` og `NULL`.
+- [ ] Ubetinget felt og både sann/usann `visibleIf`-gren gir henholdsvis korrekt
+      `TRUE`/`FALSE` applicability. Betingelser på svar og metadata testes;
+      tekst, ikke-godkjent eller allowlistet-men-uvalgt svar/metadata blokkerer
+      en ny release av det betingede feltet. Samme `definition_hash` med endret
+      `visibleIf` får ny `flow_hash`, og historiske rader uten entydig flow får
+      `NULL`/kvalitetsvarsel og evalueres aldri med dagens predicate.
+- [ ] `UNPINNED` felt som finnes får `applicable=NULL`, null wide-verdi og ingen
+      long-rad selv når kilden inneholder et svar. Manifestet viser bare
+      kvalitetsvarsel; eventuelt count i team-preview følger terskelpolicy.
+      Strukturelt bevist fravær i en registrert definition gir fortsatt
+      `FALSE`.
+- [ ] Enhver `applicable=FALSE` kombinert med kildeverdi fryser produktet før
+      aktivering for rating, enkeltvalg, flervalg og `EMPTY_SELECTION`, både ved
+      strukturelt fravær og usann predicate. Ingen verdi blir en tilsynelatende
+      grønn undertrykking.
+- [ ] FIELD-/OPTION-/label-source-invariantene valideres også for katalograder
+      uten answer-referanse; tilbakekalt label forsvinner fra alle majors.
+- [ ] Pause, forkortet retensjon, fjernet felt/survey og deprecated major er
+      verifisert mot samme source deletion.
+- [ ] Schema-, referanse-, isolasjons-, retensjons- og canary-kontroller stopper
+      publisering ved avvik.
+- [ ] Staging og ikke-aktive snapshots har verifisert opprydding og TTL.
+- [ ] Kvote-/privilegiemodellen er lastet med 50 team, opptil 500 produkter,
+      representative surveys og parallelle majors uten å gi fremtidige views
+      ukontrollert source-tilgang.
+- [ ] Post-bind mutasjon og TOCTOU er testet negativt. Oppdaget drift på en
+      bundet ressurs deauthorizeres før reparasjon.
+- [ ] Alias A kan ikke målrette produkt B eller en gammel/revokert release;
+      faktisk aliasmål auditeres mot trusted produkt/major/release/digest.
+
+### Gate D – før første konsument får tilgang
+
+- [ ] Datamarkedsplassen kan registrere, oppdatere og avvikle flere views som
+      ett produkt uten Lumi-operatør eller deploy per team.
+- [ ] Produktdatasettets faktiske IAM viser ingen arvet menneskelig/default
+      lesetilgang, eller en eksisterende ekstern godkjenningsport er brukt.
+- [ ] Eksakt allowlist for offentlig Marketplace-metadata er godkjent; preview,
+      driftsmetadata og ikke-publiserte navn er ikke søkbare på tvers av team.
+- [ ] Dataleveranse-, markedsplass- og Metabase-status vises som uavhengige
+      sannheter.
+- [ ] iSyfo-paritet er bevist for totalpopulasjon og, i en periode med
+      ingest-matchet flow, svarmål for samme periode og filtre. `UNPINNED`
+      historikk inngår ikke i svarpariteten eller en antatt backfill.
+- [ ] Metabase og datafortelling/notebook har lest samme kontrakt.
+- [ ] Pointerbytte mellom manifest, wide, long og katalog gir samme
+      `product_snapshot_id` eller en oppdagbar mismatch. Manifestets
+      resource-rad har schema-digest/radtall, og én-statements LEFT JOIN er
+      testet for tom→ikke-tom wide-view.
+- [ ] Team B-isolasjon er bevist i API, BigQuery og metadata/discovery.
+- [ ] Idempotent offboarding er feilinjisert og verifisert å fjerne data, views,
+      bindings, grants og markedsplassressurs før status `Slettet`.
+
+### Gate E – før bred `esyfo-analyse`-tilgang fjernes
+
+- [ ] Minst to planlagte snapshots er publisert og konsumert uten avvik.
+- [ ] Quarto/Metabase peker på ny kontrakt og ingen konsument leser `public`.
+- [ ] Dataeier har akseptert det pinnede analysevinduet før bred tilgang
+      fjernes; eldre svarhistorikk krever en separat sikkerhetsreviewet
+      backfillbeslutning.
+- [ ] Repeatable/default grants fjernes før brede tabellgrants.
+- [ ] Ubrukte Cloud SQL-roller/connections avvikles og fravær verifiseres.
+- [ ] Runbook beskriver rollback av konsumentkonfigurasjon uten rollback av
+      slettede data eller bred databasegrant.
+
+## Påkrevde driftsbevis per kjøring
+
+Følgende lagres uten respondentdata eller private nøkler:
+
+```text
+run_id
+scheduled_at
+source_snapshot_at
+product_snapshot_id
+snapshot_mode
+contract_version
+source_submission_count
+canonical_row_count
+status
+quality_status
+published_at
+cleanup_completed_at
+```
+
+Det varsles på mislykket kjøring, 36 timer uten vellykket slettesynk, stale
+source- eller produktpointer, staging eldre enn 24 timer, volumavvik,
+kontrakts-/referansebrudd, dimensjonsbrudd, drift, mislykket
+slettesynk/offboarding og tenant-/forbudt-data-canary. En daglig feil får
+automatiske retryforsøk innen seks timer. 36 timer er et målbart SLO; passering
+er et brudd med operatørvarsel og runbook. Tenant- eller forbudt-data-avvik
+stopper alltid source-publisering.
+
+## Eksterne beslutninger som fortsatt er åpne
+
+Følgende skal avklares med NADA og dokumenteres som evidens; implementasjonen
+skal ikke gjette:
+
+- om et dedikert analyseprosjekt og produktdatasett kan være servicekonto-only
+  uten arvet menneskelig tilgang
+- minste IAM, capability-separasjon, authorized-resource-kvoter og mekanisme
+  for cross-dataset binding uten implicit future-view-tilgang
+- støttet programmatisk opprettelse, oppdatering og avvikling av datasett og
+  Datamarkedsplassen-ressurser
+- fallback dersom registrering bare kan fullføres i et støttet selvbetjent UI
+- servicekonto, region, connection og credentialrotasjon for scheduled query
+- hvordan flere views og major-versjoner representeres som ett dataprodukt
+- krav til Behandlingskatalog/PVK og hvordan Metabase-grupper håndteres
+- støttet varsling for eierfornyelse og operasjonelle avvik
+
+Et ubesvart punkt kan gi en begrenset lokal/dev-spike når dataene er
+syntetiske, men kan ikke passere den relevante shadow- eller produksjonsgaten.
+
+## Residualrisiko og revurdering
+
+Selv med grønne kontroller kan små datasett og kombinasjoner av strukturerte
+svar være identifiserende for personer som kjenner konteksten. Dataeier,
+behandlingsgrunnlag, tilgangsvurdering, kortest forsvarlig retensjon og
+lavtallspraksis er derfor fortsatt nødvendige.
+
+Modellen skal revurderes ved nye datakategorier, tekst/dato, kryss-team-
+produkter, endret tilgangsmodell, annen transport enn fullsnapshot, strengere
+slettings-SLO, sikkerhetshendelse eller overskridelse av ADR 0005 sine
+kapasitetsgrenser.


### PR DESCRIPTION
## Hva

- dokumenterer arkitekturvedtaket for teamavgrensede analyseprodukter
- låser den normative V1-kontrakten for wide, long, feltkatalog og manifest
- beskriver trusselmodell, minste privilegium og verifikasjonsgater frem til
  produksjon og kontrollert cutover

## Viktige avgrensninger

- Rå/nøstet data, fritekst og datosvar er ikke del av V1.
- Betingede felt krever en registrert, ingest-matchet `flow_hash` og eksplisitt
  valgte predicate-avhengigheter.
- Historiske `UNPINNED` rader inngår i totalpopulasjonen, men feltverdiene
  publiseres ikke. V1 gjetter ikke historisk surveyflyt.
- Ingen database-, auth-, IAM-, NAIS- eller produksjonsjobbendringer inngår.

## Verifisering

- `pnpm run docs:build`
- `pnpm run lint`
- `pnpm run typecheck`
- uavhengig P0–P2-designreview uten gjenstående funn

Closes #567
Relates #482
