### PR TITLE
Etabler domenemodell og lagring for analyseprodukter

### DIFF
--- a/apps/lumi-api/src/main/kotlin/no/nav/lumi/domain/AnalysisProduct.kt
+++ b/apps/lumi-api/src/main/kotlin/no/nav/lumi/domain/AnalysisProduct.kt
@@ -1,0 +1,222 @@
+package no.nav.lumi.domain
+
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.JsonObject
+import java.time.LocalDate
+
+const val ANALYSIS_PRODUCT_DOCUMENT_SCHEMA_VERSION = 1
+const val MAX_ANALYSIS_PRODUCT_DOCUMENT_BYTES = 256 * 1024
+
+/** Desired product lifecycle, deliberately separate from later delivery/platform status. */
+@Serializable
+enum class AnalysisProductLifecycleState {
+    DRAFT,
+    ENABLED,
+    PAUSED,
+    OFFBOARDING,
+    DELETED,
+}
+
+@Serializable
+enum class AnalysisProductUseCase {
+    METABASE,
+    DATA_STORY_NOTEBOOK,
+}
+
+@Serializable
+enum class AnalysisProductRetention {
+    SOURCE_MAXIMUM,
+    DAYS_30,
+    DAYS_90,
+    DAYS_180,
+}
+
+@Serializable
+data class AnalysisProductSourceSelection(
+    val app: String,
+    val surveyId: String,
+    val fieldIds: List<String> = emptyList(),
+)
+
+/**
+ * Mutable control-plane input. The type deliberately has no team property:
+ * ownership is supplied by the already-authorized server context.
+ *
+ * Source ownership, field classifications and dimensions are validated by the
+ * catalog/compiler slice. This foundation only validates bounded, structural
+ * input before it can be persisted as a draft.
+ */
+@Serializable
+data class AnalysisProductDocumentV1(
+    val schemaVersion: Int = ANALYSIS_PRODUCT_DOCUMENT_SCHEMA_VERSION,
+    val name: String,
+    val purpose: String,
+    val dataOwner: String,
+    val technicalOwner: String,
+    val processingReference: String? = null,
+    val useCases: List<AnalysisProductUseCase>,
+    val retention: AnalysisProductRetention,
+    val reviewDate: String,
+    val sources: List<AnalysisProductSourceSelection> = emptyList(),
+    val dimensionKeys: List<String> = emptyList(),
+    val includeSubmittedHour: Boolean = false,
+)
+
+data class ValidatedAnalysisProductDocument(
+    val document: AnalysisProductDocumentV1,
+    val reviewDate: LocalDate,
+)
+
+object AnalysisProductDocumentValidator {
+    private val identifierPattern = Regex("^[A-Za-z0-9._-]+$")
+
+    fun validate(
+        raw: AnalysisProductDocumentV1,
+        today: LocalDate,
+    ): ValidatedAnalysisProductDocument {
+        require(raw.schemaVersion == ANALYSIS_PRODUCT_DOCUMENT_SCHEMA_VERSION) {
+            "Only analysis product document schema version 1 is supported"
+        }
+
+        val normalized = raw.copy(
+            name = requiredText("name", raw.name, 120),
+            purpose = requiredText("purpose", raw.purpose, 2_000),
+            dataOwner = requiredText("dataOwner", raw.dataOwner, 255),
+            technicalOwner = requiredText("technicalOwner", raw.technicalOwner, 255),
+            processingReference = raw.processingReference?.trim()?.takeIf(String::isNotEmpty)?.also {
+                require(it.length <= 500) { "processingReference must be at most 500 characters" }
+            },
+            useCases = raw.useCases.distinct(),
+            sources = raw.sources.map(::normalizeSource),
+            dimensionKeys = raw.dimensionKeys.map { normalizeIdentifier("dimension key", it, 100) }.distinct(),
+        )
+
+        require(normalized.useCases.isNotEmpty()) { "At least one analysis use case is required" }
+        require(normalized.useCases.size == raw.useCases.size) { "Analysis use cases must be unique" }
+        require(normalized.sources.size <= 100) { "At most 100 sources can be selected" }
+        require(normalized.sources.map { it.app to it.surveyId }.distinct().size == normalized.sources.size) {
+            "Each app and surveyId source must be unique"
+        }
+        require(normalized.dimensionKeys.size == raw.dimensionKeys.size) { "Dimension keys must be unique" }
+        require(normalized.dimensionKeys.size <= 50) { "At most 50 dimensions can be selected" }
+
+        val reviewDate = try {
+            LocalDate.parse(normalized.reviewDate)
+        } catch (_: Exception) {
+            throw IllegalArgumentException("reviewDate must use ISO-8601 date format")
+        }
+        require(!reviewDate.isBefore(today)) { "reviewDate cannot be in the past" }
+        require(!reviewDate.isAfter(today.plusMonths(12))) {
+            "reviewDate must be at most 12 months in the future"
+        }
+
+        return ValidatedAnalysisProductDocument(normalized, reviewDate)
+    }
+
+    private fun normalizeSource(source: AnalysisProductSourceSelection): AnalysisProductSourceSelection {
+        val fieldIds = source.fieldIds.map { normalizeIdentifier("fieldId", it, 200) }.distinct()
+        require(fieldIds.size == source.fieldIds.size) { "fieldIds must be unique within a source" }
+        require(fieldIds.size <= 500) { "At most 500 fields can be selected per source" }
+        return source.copy(
+            app = normalizeIdentifier("app", source.app, 255),
+            surveyId = normalizeIdentifier("surveyId", source.surveyId, 200),
+            fieldIds = fieldIds,
+        )
+    }
+
+    private fun requiredText(name: String, value: String, maxLength: Int): String = value.trim().also {
+        require(it.isNotEmpty()) { "$name is required" }
+        require(it.length <= maxLength) { "$name must be at most $maxLength characters" }
+    }
+
+    private fun normalizeIdentifier(name: String, value: String, maxLength: Int): String = value.trim().also {
+        require(it.isNotEmpty()) { "$name is required" }
+        require(it.length <= maxLength) { "$name must be at most $maxLength characters" }
+        require(identifierPattern.matches(it)) { "$name contains unsupported characters" }
+    }
+}
+
+@Serializable
+data class AnalysisProductDraft(
+    val id: String,
+    val revision: Long,
+    val baseReleaseNumber: Long?,
+    val document: AnalysisProductDocumentV1,
+    val documentHash: String,
+    val validation: AnalysisProductDraftValidation?,
+    val createdBy: String,
+    val updatedBy: String,
+    val createdAt: String,
+    val updatedAt: String,
+)
+
+@Serializable
+data class AnalysisProductDraftValidation(
+    val revision: Long,
+    val catalogRevision: String,
+    val baseSchemaDigest: String,
+    val validatedBy: String,
+    val validatedAt: String,
+)
+
+@Serializable
+data class AnalysisProduct(
+    val id: String,
+    val team: String,
+    val lifecycleState: AnalysisProductLifecycleState,
+    val rowVersion: Long,
+    val lastReleaseNumber: Long,
+    val desiredReleaseNumber: Long?,
+    val activeReleaseNumber: Long?,
+    val dataCutoffAt: String?,
+    val draft: AnalysisProductDraft?,
+    val createdBy: String,
+    val updatedBy: String,
+    val createdAt: String,
+    val updatedAt: String,
+)
+
+@Serializable
+data class AnalysisProductRelease(
+    val id: String,
+    val productId: String,
+    val releaseNumber: Long,
+    val sourceDraftId: String,
+    val sourceDraftRevision: Long,
+    val sourceDocument: AnalysisProductDocumentV1,
+    val sourceDocumentHash: String,
+    val publicationSpecification: JsonObject,
+    val publicationSpecificationDigest: String,
+    val catalogRevision: String,
+    val baseSchemaDigest: String,
+    val publishedBy: String,
+    val publishedAt: String,
+)
+
+@Serializable
+enum class AnalysisProductAuditEventType {
+    PRODUCT_CREATED,
+    DRAFT_UPDATED,
+    DRAFT_VALIDATED,
+    RELEASE_PUBLISHED,
+    RELEASE_DESIRED,
+    RELEASE_ACTIVATED,
+    LIFECYCLE_CHANGED,
+}
+
+@Serializable
+data class AnalysisProductAuditEvent(
+    val id: String,
+    val productId: String,
+    val eventNumber: Long,
+    val eventType: AnalysisProductAuditEventType,
+    val actorId: String,
+    val productVersion: Long,
+    val draftId: String?,
+    val draftRevision: Long?,
+    val releaseNumber: Long?,
+    val subjectDigest: String?,
+    val previousState: AnalysisProductLifecycleState?,
+    val nextState: AnalysisProductLifecycleState?,
+    val occurredAt: String,
+)

--- a/apps/lumi-api/src/main/kotlin/no/nav/lumi/repository/AnalysisProductRepository.kt
+++ b/apps/lumi-api/src/main/kotlin/no/nav/lumi/repository/AnalysisProductRepository.kt
@@ -1,0 +1,549 @@
+package no.nav.lumi.repository
+
+import kotlinx.serialization.decodeFromString
+import kotlinx.serialization.encodeToString
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.jsonObject
+import no.nav.lumi.domain.AnalysisProduct
+import no.nav.lumi.domain.AnalysisProductAuditEvent
+import no.nav.lumi.domain.AnalysisProductAuditEventType
+import no.nav.lumi.domain.AnalysisProductDocumentV1
+import no.nav.lumi.domain.AnalysisProductDocumentValidator
+import no.nav.lumi.domain.AnalysisProductDraft
+import no.nav.lumi.domain.AnalysisProductDraftValidation
+import no.nav.lumi.domain.AnalysisProductLifecycleState
+import no.nav.lumi.domain.AnalysisProductRelease
+import no.nav.lumi.domain.MAX_ANALYSIS_PRODUCT_DOCUMENT_BYTES
+import org.jetbrains.exposed.v1.jdbc.transactions.TransactionManager
+import java.security.MessageDigest
+import java.sql.Connection
+import java.sql.PreparedStatement
+import java.sql.ResultSet
+import java.sql.Types
+import java.time.Clock
+import java.time.LocalDate
+import java.time.OffsetDateTime
+import java.util.UUID
+
+sealed interface CreateAnalysisProductResult {
+    data class Created(val product: AnalysisProduct) : CreateAnalysisProductResult
+    data object LimitReached : CreateAnalysisProductResult
+}
+
+sealed interface UpdateAnalysisProductDraftResult {
+    data class Updated(val product: AnalysisProduct) : UpdateAnalysisProductDraftResult
+    data object NotFound : UpdateAnalysisProductDraftResult
+    data object VersionConflict : UpdateAnalysisProductDraftResult
+}
+
+/**
+ * Team-scoped persistence for the analysis-product control plane.
+ *
+ * There is intentionally no release write method in this slice. A release may
+ * only be created after the catalog/compiler slice can produce a
+ * server-validated draft revision, catalog revision and schema digest in one
+ * transaction.
+ */
+class AnalysisProductRepository(
+    private val clock: Clock = Clock.systemUTC(),
+) {
+    private val json = Json {
+        encodeDefaults = true
+        ignoreUnknownKeys = true
+    }
+
+    suspend fun create(
+        team: String,
+        document: AnalysisProductDocumentV1,
+        principalIdentity: String,
+    ): CreateAnalysisProductResult {
+        val normalizedTeam = requiredValue("team", team, 255)
+        val actor = requiredValue("principalIdentity", principalIdentity, 320)
+        val storedDocument = prepareDocument(document)
+
+        return dbQuery {
+            val connection = currentJdbcConnection()
+            lockTeamProductLimit(connection, normalizedTeam)
+            if (countNonDeletedProducts(connection, normalizedTeam) >= MAX_PRODUCTS_PER_TEAM) {
+                return@dbQuery CreateAnalysisProductResult.LimitReached
+            }
+
+            val productId = UUID.randomUUID()
+            val draftId = UUID.randomUUID()
+            connection.prepareStatement(
+                """
+                    INSERT INTO analysis_control.analysis_products (
+                        id, team, created_by, updated_by
+                    )
+                    VALUES (?, ?, ?, ?)
+                """.trimIndent(),
+            ).use { statement ->
+                statement.setObject(1, productId)
+                statement.setString(2, normalizedTeam)
+                statement.setString(3, actor)
+                statement.setString(4, actor)
+                statement.executeUpdate()
+            }
+
+            connection.prepareStatement(
+                """
+                    INSERT INTO analysis_control.analysis_product_drafts (
+                        id, team, product_id, document, document_hash, created_by, updated_by
+                    )
+                    VALUES (?, ?, ?, ?::jsonb, ?, ?, ?)
+                """.trimIndent(),
+            ).use { statement ->
+                statement.setObject(1, draftId)
+                statement.setString(2, normalizedTeam)
+                statement.setObject(3, productId)
+                statement.setString(4, storedDocument.json)
+                statement.setString(5, storedDocument.hash)
+                statement.setString(6, actor)
+                statement.setString(7, actor)
+                statement.executeUpdate()
+            }
+
+            insertAuditEvent(
+                connection = connection,
+                team = normalizedTeam,
+                productId = productId,
+                eventNumber = 1,
+                eventType = AnalysisProductAuditEventType.PRODUCT_CREATED,
+                actor = actor,
+                productVersion = 1,
+                draftId = draftId,
+                draftRevision = 1,
+                subjectDigest = storedDocument.hash,
+                nextState = AnalysisProductLifecycleState.DRAFT,
+            )
+
+            CreateAnalysisProductResult.Created(
+                checkNotNull(findByIdInCurrentTransaction(connection, normalizedTeam, productId)),
+            )
+        }
+    }
+
+    suspend fun findByTeam(team: String): List<AnalysisProduct> {
+        val normalizedTeam = requiredValue("team", team, 255)
+        return dbQuery {
+            val connection = currentJdbcConnection()
+            connection.prepareStatement("$PRODUCT_WITH_DRAFT_SELECT WHERE p.team = ? ORDER BY p.updated_at DESC").use {
+                statement ->
+                statement.setString(1, normalizedTeam)
+                statement.executeQuery().use { result ->
+                    buildList {
+                        while (result.next()) add(result.toProduct())
+                    }
+                }
+            }
+        }
+    }
+
+    suspend fun findById(team: String, productId: UUID): AnalysisProduct? {
+        val normalizedTeam = requiredValue("team", team, 255)
+        return dbQuery {
+            findByIdInCurrentTransaction(currentJdbcConnection(), normalizedTeam, productId)
+        }
+    }
+
+    suspend fun updateDraft(
+        team: String,
+        productId: UUID,
+        draftId: UUID,
+        expectedRevision: Long,
+        document: AnalysisProductDocumentV1,
+        principalIdentity: String,
+    ): UpdateAnalysisProductDraftResult {
+        require(expectedRevision > 0) { "expectedRevision must be positive" }
+        val normalizedTeam = requiredValue("team", team, 255)
+        val actor = requiredValue("principalIdentity", principalIdentity, 320)
+        val storedDocument = prepareDocument(document)
+
+        return dbQuery {
+            val connection = currentJdbcConnection()
+            val nextRevision = connection.prepareStatement(
+                """
+                    UPDATE analysis_control.analysis_product_drafts AS d
+                    SET revision = d.revision + 1,
+                        document = ?::jsonb,
+                        document_hash = ?,
+                        validated_revision = NULL,
+                        validated_catalog_revision = NULL,
+                        validated_base_schema_digest = NULL,
+                        validated_by = NULL,
+                        validated_at = NULL,
+                        updated_by = ?,
+                        updated_at = clock_timestamp()
+                    FROM analysis_control.analysis_products AS p
+                    WHERE d.product_id = p.id
+                      AND d.team = p.team
+                      AND p.team = ?
+                      AND p.id = ?
+                      AND d.id = ?
+                      AND d.revision = ?
+                    RETURNING d.revision
+                """.trimIndent(),
+            ).use { statement ->
+                statement.setString(1, storedDocument.json)
+                statement.setString(2, storedDocument.hash)
+                statement.setString(3, actor)
+                statement.setString(4, normalizedTeam)
+                statement.setObject(5, productId)
+                statement.setObject(6, draftId)
+                statement.setLong(7, expectedRevision)
+                statement.executeQuery().use { result -> if (result.next()) result.getLong("revision") else null }
+            }
+
+            if (nextRevision == null) {
+                return@dbQuery classifyDraftMiss(
+                    connection = connection,
+                    team = normalizedTeam,
+                    productId = productId,
+                    draftId = draftId,
+                )
+            }
+
+            val productVersion = connection.prepareStatement(
+                """
+                    UPDATE analysis_control.analysis_products
+                    SET row_version = row_version + 1,
+                        updated_by = ?,
+                        updated_at = clock_timestamp()
+                    WHERE team = ? AND id = ?
+                    RETURNING row_version
+                """.trimIndent(),
+            ).use { statement ->
+                statement.setString(1, actor)
+                statement.setString(2, normalizedTeam)
+                statement.setObject(3, productId)
+                statement.executeQuery().use { result ->
+                    check(result.next()) { "Analysis product disappeared while updating its draft" }
+                    result.getLong("row_version")
+                }
+            }
+
+            insertAuditEvent(
+                connection = connection,
+                team = normalizedTeam,
+                productId = productId,
+                eventNumber = productVersion,
+                eventType = AnalysisProductAuditEventType.DRAFT_UPDATED,
+                actor = actor,
+                productVersion = productVersion,
+                draftId = draftId,
+                draftRevision = nextRevision,
+                subjectDigest = storedDocument.hash,
+            )
+
+            UpdateAnalysisProductDraftResult.Updated(
+                checkNotNull(findByIdInCurrentTransaction(connection, normalizedTeam, productId)),
+            )
+        }
+    }
+
+    suspend fun findReleases(team: String, productId: UUID): List<AnalysisProductRelease>? {
+        val normalizedTeam = requiredValue("team", team, 255)
+        return dbQuery {
+            val connection = currentJdbcConnection()
+            if (!productExists(connection, normalizedTeam, productId)) return@dbQuery null
+
+            connection.prepareStatement(
+                """
+                    SELECT r.*
+                    FROM analysis_control.analysis_product_releases AS r
+                    WHERE r.team = ? AND r.product_id = ?
+                    ORDER BY r.release_number DESC
+                """.trimIndent(),
+            ).use { statement ->
+                statement.setString(1, normalizedTeam)
+                statement.setObject(2, productId)
+                statement.executeQuery().use { result ->
+                    buildList {
+                        while (result.next()) add(result.toRelease())
+                    }
+                }
+            }
+        }
+    }
+
+    suspend fun findAuditEvents(team: String, productId: UUID): List<AnalysisProductAuditEvent>? {
+        val normalizedTeam = requiredValue("team", team, 255)
+        return dbQuery {
+            val connection = currentJdbcConnection()
+            if (!productExists(connection, normalizedTeam, productId)) return@dbQuery null
+
+            connection.prepareStatement(
+                """
+                    SELECT a.*
+                    FROM analysis_control.analysis_product_audit_events AS a
+                    WHERE a.team = ? AND a.product_id = ?
+                    ORDER BY a.event_number ASC
+                """.trimIndent(),
+            ).use { statement ->
+                statement.setString(1, normalizedTeam)
+                statement.setObject(2, productId)
+                statement.executeQuery().use { result ->
+                    buildList {
+                        while (result.next()) add(result.toAuditEvent())
+                    }
+                }
+            }
+        }
+    }
+
+    private fun prepareDocument(document: AnalysisProductDocumentV1): StoredDocument {
+        val validated = AnalysisProductDocumentValidator.validate(document, LocalDate.now(clock))
+        val encoded = json.encodeToString(validated.document)
+        require(encoded.toByteArray(Charsets.UTF_8).size <= MAX_ANALYSIS_PRODUCT_DOCUMENT_BYTES) {
+            "Analysis product document must be at most $MAX_ANALYSIS_PRODUCT_DOCUMENT_BYTES bytes"
+        }
+        return StoredDocument(encoded, sha256(encoded))
+    }
+
+    private fun classifyDraftMiss(
+        connection: Connection,
+        team: String,
+        productId: UUID,
+        draftId: UUID,
+    ): UpdateAnalysisProductDraftResult {
+        connection.prepareStatement(
+            """
+                SELECT d.revision
+                FROM analysis_control.analysis_products AS p
+                JOIN analysis_control.analysis_product_drafts AS d
+                  ON d.team = p.team AND d.product_id = p.id
+                WHERE p.team = ? AND p.id = ? AND d.id = ?
+            """.trimIndent(),
+        ).use { statement ->
+            statement.setString(1, team)
+            statement.setObject(2, productId)
+            statement.setObject(3, draftId)
+            statement.executeQuery().use { result ->
+                return if (result.next()) {
+                    UpdateAnalysisProductDraftResult.VersionConflict
+                } else {
+                    UpdateAnalysisProductDraftResult.NotFound
+                }
+            }
+        }
+    }
+
+    private fun findByIdInCurrentTransaction(
+        connection: Connection,
+        team: String,
+        productId: UUID,
+    ): AnalysisProduct? = connection.prepareStatement(
+        "$PRODUCT_WITH_DRAFT_SELECT WHERE p.team = ? AND p.id = ?",
+    ).use { statement ->
+        statement.setString(1, team)
+        statement.setObject(2, productId)
+        statement.executeQuery().use { result -> if (result.next()) result.toProduct() else null }
+    }
+
+    private fun productExists(connection: Connection, team: String, productId: UUID): Boolean =
+        connection.prepareStatement(
+            "SELECT 1 FROM analysis_control.analysis_products WHERE team = ? AND id = ?",
+        ).use { statement ->
+            statement.setString(1, team)
+            statement.setObject(2, productId)
+            statement.executeQuery().use { it.next() }
+        }
+
+    private fun insertAuditEvent(
+        connection: Connection,
+        team: String,
+        productId: UUID,
+        eventNumber: Long,
+        eventType: AnalysisProductAuditEventType,
+        actor: String,
+        productVersion: Long,
+        draftId: UUID? = null,
+        draftRevision: Long? = null,
+        releaseNumber: Long? = null,
+        subjectDigest: String? = null,
+        previousState: AnalysisProductLifecycleState? = null,
+        nextState: AnalysisProductLifecycleState? = null,
+    ) {
+        connection.prepareStatement(
+            """
+                INSERT INTO analysis_control.analysis_product_audit_events (
+                    id, team, product_id, event_number, event_type, actor_id,
+                    product_version, draft_id, draft_revision, release_number,
+                    subject_digest, previous_state, next_state
+                )
+                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            """.trimIndent(),
+        ).use { statement ->
+            statement.setObject(1, UUID.randomUUID())
+            statement.setString(2, team)
+            statement.setObject(3, productId)
+            statement.setLong(4, eventNumber)
+            statement.setString(5, eventType.name)
+            statement.setString(6, actor)
+            statement.setLong(7, productVersion)
+            statement.setObject(8, draftId)
+            statement.setNullableLong(9, draftRevision)
+            statement.setNullableLong(10, releaseNumber)
+            statement.setString(11, subjectDigest)
+            statement.setString(12, previousState?.name)
+            statement.setString(13, nextState?.name)
+            statement.executeUpdate()
+        }
+    }
+
+    private fun ResultSet.toProduct(): AnalysisProduct {
+        val draftId = getObject("draft_id", UUID::class.java)
+        return AnalysisProduct(
+            id = getObject("product_id", UUID::class.java).toString(),
+            team = getString("product_team"),
+            lifecycleState = AnalysisProductLifecycleState.valueOf(getString("lifecycle_state")),
+            rowVersion = getLong("row_version"),
+            lastReleaseNumber = getLong("last_release_number"),
+            desiredReleaseNumber = nullableLong("desired_release_number"),
+            activeReleaseNumber = nullableLong("active_release_number"),
+            dataCutoffAt = getObject("data_cutoff_at", OffsetDateTime::class.java)?.toString(),
+            draft = draftId?.let {
+                val validatedRevision = nullableLong("validated_revision")
+                AnalysisProductDraft(
+                    id = it.toString(),
+                    revision = getLong("draft_revision"),
+                    baseReleaseNumber = nullableLong("base_release_number"),
+                    document = json.decodeFromString(getString("draft_document")),
+                    documentHash = getString("draft_document_hash"),
+                    validation = validatedRevision?.let { revision ->
+                        AnalysisProductDraftValidation(
+                            revision = revision,
+                            catalogRevision = getString("validated_catalog_revision"),
+                            baseSchemaDigest = getString("validated_base_schema_digest"),
+                            validatedBy = getString("validated_by"),
+                            validatedAt = getObject("validated_at", OffsetDateTime::class.java).toString(),
+                        )
+                    },
+                    createdBy = getString("draft_created_by"),
+                    updatedBy = getString("draft_updated_by"),
+                    createdAt = getObject("draft_created_at", OffsetDateTime::class.java).toString(),
+                    updatedAt = getObject("draft_updated_at", OffsetDateTime::class.java).toString(),
+                )
+            },
+            createdBy = getString("product_created_by"),
+            updatedBy = getString("product_updated_by"),
+            createdAt = getObject("product_created_at", OffsetDateTime::class.java).toString(),
+            updatedAt = getObject("product_updated_at", OffsetDateTime::class.java).toString(),
+        )
+    }
+
+    private fun ResultSet.toRelease() = AnalysisProductRelease(
+        id = getObject("id", UUID::class.java).toString(),
+        productId = getObject("product_id", UUID::class.java).toString(),
+        releaseNumber = getLong("release_number"),
+        sourceDraftId = getObject("source_draft_id", UUID::class.java).toString(),
+        sourceDraftRevision = getLong("source_draft_revision"),
+        sourceDocument = json.decodeFromString(getString("source_document")),
+        sourceDocumentHash = getString("source_document_hash"),
+        publicationSpecification = json.parseToJsonElement(getString("publication_specification")).jsonObject,
+        publicationSpecificationDigest = getString("publication_specification_digest"),
+        catalogRevision = getString("catalog_revision"),
+        baseSchemaDigest = getString("base_schema_digest"),
+        publishedBy = getString("published_by"),
+        publishedAt = getObject("published_at", OffsetDateTime::class.java).toString(),
+    )
+
+    private fun ResultSet.toAuditEvent() = AnalysisProductAuditEvent(
+        id = getObject("id", UUID::class.java).toString(),
+        productId = getObject("product_id", UUID::class.java).toString(),
+        eventNumber = getLong("event_number"),
+        eventType = AnalysisProductAuditEventType.valueOf(getString("event_type")),
+        actorId = getString("actor_id"),
+        productVersion = getLong("product_version"),
+        draftId = getObject("draft_id", UUID::class.java)?.toString(),
+        draftRevision = nullableLong("draft_revision"),
+        releaseNumber = nullableLong("release_number"),
+        subjectDigest = getString("subject_digest"),
+        previousState = getString("previous_state")?.let(AnalysisProductLifecycleState::valueOf),
+        nextState = getString("next_state")?.let(AnalysisProductLifecycleState::valueOf),
+        occurredAt = getObject("occurred_at", OffsetDateTime::class.java).toString(),
+    )
+
+    private fun currentJdbcConnection(): Connection =
+        TransactionManager.current().connection.connection as Connection
+
+    private fun lockTeamProductLimit(connection: Connection, team: String) {
+        connection.prepareStatement(
+            "SELECT pg_advisory_xact_lock(hashtextextended(?, 0))",
+        ).use { statement ->
+            statement.setString(1, "analysis-product-limit:$team")
+            statement.execute()
+        }
+    }
+
+    private fun countNonDeletedProducts(connection: Connection, team: String): Int =
+        connection.prepareStatement(
+            """
+                SELECT count(*)
+                FROM analysis_control.analysis_products
+                WHERE team = ? AND lifecycle_state <> 'DELETED'
+            """.trimIndent(),
+        ).use { statement ->
+            statement.setString(1, team)
+            statement.executeQuery().use { result ->
+                check(result.next())
+                result.getInt(1)
+            }
+        }
+
+    private fun ResultSet.nullableLong(column: String): Long? = getLong(column).let {
+        if (wasNull()) null else it
+    }
+
+    private fun PreparedStatement.setNullableLong(index: Int, value: Long?) {
+        if (value == null) setNull(index, Types.BIGINT) else setLong(index, value)
+    }
+
+    private data class StoredDocument(val json: String, val hash: String)
+
+    private companion object {
+        const val MAX_PRODUCTS_PER_TEAM = 10
+
+        val PRODUCT_WITH_DRAFT_SELECT = """
+            SELECT
+                p.id AS product_id,
+                p.team AS product_team,
+                p.lifecycle_state,
+                p.row_version,
+                p.last_release_number,
+                p.desired_release_number,
+                p.active_release_number,
+                p.data_cutoff_at,
+                p.created_by AS product_created_by,
+                p.updated_by AS product_updated_by,
+                p.created_at AS product_created_at,
+                p.updated_at AS product_updated_at,
+                d.id AS draft_id,
+                d.revision AS draft_revision,
+                d.base_release_number,
+                d.document AS draft_document,
+                d.document_hash AS draft_document_hash,
+                d.validated_revision,
+                d.validated_catalog_revision,
+                d.validated_base_schema_digest,
+                d.validated_by,
+                d.validated_at,
+                d.created_by AS draft_created_by,
+                d.updated_by AS draft_updated_by,
+                d.created_at AS draft_created_at,
+                d.updated_at AS draft_updated_at
+            FROM analysis_control.analysis_products AS p
+            LEFT JOIN analysis_control.analysis_product_drafts AS d
+              ON d.team = p.team AND d.product_id = p.id
+        """.trimIndent()
+
+        fun requiredValue(name: String, raw: String, maxLength: Int): String = raw.trim().also {
+            require(it.isNotEmpty()) { "$name is required" }
+            require(it.length <= maxLength) { "$name must be at most $maxLength characters" }
+        }
+
+        fun sha256(value: String): String = MessageDigest.getInstance("SHA-256")
+            .digest(value.toByteArray(Charsets.UTF_8))
+            .joinToString("") { "%02x".format(it) }
+    }
+}

--- a/apps/lumi-api/src/main/resources/db/migration/V19__analysis_product_control_plane.sql
+++ b/apps/lumi-api/src/main/resources/db/migration/V19__analysis_product_control_plane.sql
@@ -1,0 +1,462 @@
+-- Team-scoped control-plane state for managed analysis products.
+--
+-- This deliberately lives outside public. The legacy esyfo-analyse role has
+-- broad SELECT/default privileges in public and must never see drafts, owner
+-- metadata, release specifications or audit actors.
+
+CREATE SCHEMA analysis_control;
+
+REVOKE ALL ON SCHEMA analysis_control FROM PUBLIC;
+REVOKE ALL ON SCHEMA analysis_control FROM "esyfo-analyse";
+
+CREATE TABLE analysis_control.analysis_products (
+    id                     UUID PRIMARY KEY,
+    team                   VARCHAR(255) NOT NULL,
+    lifecycle_state        VARCHAR(32) NOT NULL DEFAULT 'DRAFT',
+    row_version            BIGINT NOT NULL DEFAULT 1 CHECK (row_version > 0),
+    last_release_number    BIGINT NOT NULL DEFAULT 0 CHECK (last_release_number >= 0),
+    desired_release_number BIGINT,
+    active_release_number  BIGINT,
+    data_cutoff_at         TIMESTAMPTZ,
+    created_by             TEXT NOT NULL,
+    updated_by             TEXT NOT NULL,
+    created_at             TIMESTAMPTZ NOT NULL DEFAULT clock_timestamp(),
+    updated_at             TIMESTAMPTZ NOT NULL DEFAULT clock_timestamp(),
+    CONSTRAINT uq_analysis_products_team_id UNIQUE (team, id),
+    CONSTRAINT chk_analysis_product_lifecycle
+        CHECK (lifecycle_state IN ('DRAFT', 'ENABLED', 'PAUSED', 'OFFBOARDING', 'DELETED')),
+    CONSTRAINT chk_analysis_product_desired_release
+        CHECK (
+            desired_release_number IS NULL OR
+            (desired_release_number > 0 AND desired_release_number <= last_release_number)
+        ),
+    CONSTRAINT chk_analysis_product_active_release
+        CHECK (
+            active_release_number IS NULL OR
+            (active_release_number > 0 AND active_release_number <= last_release_number)
+        )
+);
+
+CREATE TABLE analysis_control.analysis_product_drafts (
+    id                               UUID PRIMARY KEY,
+    team                             VARCHAR(255) NOT NULL,
+    product_id                       UUID NOT NULL,
+    revision                         BIGINT NOT NULL DEFAULT 1 CHECK (revision > 0),
+    base_release_number              BIGINT,
+    document                         JSONB NOT NULL,
+    document_hash                    VARCHAR(64) NOT NULL,
+    validated_revision               BIGINT,
+    validated_catalog_revision       VARCHAR(128),
+    validated_base_schema_digest     VARCHAR(64),
+    validated_by                     TEXT,
+    validated_at                     TIMESTAMPTZ,
+    created_by                       TEXT NOT NULL,
+    updated_by                       TEXT NOT NULL,
+    created_at                       TIMESTAMPTZ NOT NULL DEFAULT clock_timestamp(),
+    updated_at                       TIMESTAMPTZ NOT NULL DEFAULT clock_timestamp(),
+    CONSTRAINT uq_analysis_product_draft_product UNIQUE (product_id),
+    CONSTRAINT uq_analysis_product_draft_team_product UNIQUE (team, product_id),
+    CONSTRAINT fk_analysis_product_draft_product
+        FOREIGN KEY (team, product_id)
+        REFERENCES analysis_control.analysis_products(team, id),
+    CONSTRAINT chk_analysis_product_draft_base_release
+        CHECK (base_release_number IS NULL OR base_release_number > 0),
+    CONSTRAINT chk_analysis_product_draft_document_object
+        CHECK (jsonb_typeof(document) = 'object'),
+    CONSTRAINT chk_analysis_product_draft_schema_v1
+        CHECK (
+            document ->> 'schemaVersion' IS NOT NULL AND
+            document ->> 'schemaVersion' = '1'
+        ),
+    CONSTRAINT chk_analysis_product_draft_hash
+        CHECK (document_hash ~ '^[0-9a-f]{64}$'),
+    CONSTRAINT chk_analysis_product_draft_validation_complete
+        CHECK (
+            (
+                validated_revision IS NULL AND
+                validated_catalog_revision IS NULL AND
+                validated_base_schema_digest IS NULL AND
+                validated_by IS NULL AND
+                validated_at IS NULL
+            ) OR (
+                validated_revision IS NOT NULL AND
+                validated_revision = revision AND
+                validated_catalog_revision IS NOT NULL AND
+                length(btrim(validated_catalog_revision)) > 0 AND
+                validated_base_schema_digest IS NOT NULL AND
+                validated_base_schema_digest ~ '^[0-9a-f]{64}$' AND
+                validated_by IS NOT NULL AND
+                validated_at IS NOT NULL
+            )
+        )
+);
+
+CREATE TABLE analysis_control.analysis_product_releases (
+    id                   UUID PRIMARY KEY,
+    team                 VARCHAR(255) NOT NULL,
+    product_id           UUID NOT NULL,
+    release_number       BIGINT NOT NULL CHECK (release_number > 0),
+    source_draft_id      UUID NOT NULL,
+    source_draft_revision BIGINT NOT NULL CHECK (source_draft_revision > 0),
+    source_document      JSONB NOT NULL,
+    source_document_hash VARCHAR(64) NOT NULL,
+    publication_specification JSONB NOT NULL,
+    publication_specification_digest VARCHAR(64) NOT NULL,
+    catalog_revision     VARCHAR(128) NOT NULL,
+    base_schema_digest   VARCHAR(64) NOT NULL,
+    published_by         TEXT NOT NULL,
+    published_at         TIMESTAMPTZ NOT NULL DEFAULT clock_timestamp(),
+    CONSTRAINT uq_analysis_product_release_number
+        UNIQUE (team, product_id, release_number),
+    CONSTRAINT fk_analysis_product_release_product
+        FOREIGN KEY (team, product_id)
+        REFERENCES analysis_control.analysis_products(team, id),
+    CONSTRAINT chk_analysis_product_release_source_document_object
+        CHECK (jsonb_typeof(source_document) = 'object'),
+    CONSTRAINT chk_analysis_product_release_source_schema_v1
+        CHECK (
+            source_document ->> 'schemaVersion' IS NOT NULL AND
+            source_document ->> 'schemaVersion' = '1'
+        ),
+    CONSTRAINT chk_analysis_product_release_source_document_hash
+        CHECK (source_document_hash ~ '^[0-9a-f]{64}$'),
+    CONSTRAINT chk_analysis_product_release_specification_object
+        CHECK (jsonb_typeof(publication_specification) = 'object'),
+    CONSTRAINT chk_analysis_product_release_specification_schema_v1
+        CHECK (
+            publication_specification ->> 'schemaVersion' IS NOT NULL AND
+            publication_specification ->> 'schemaVersion' = '1'
+        ),
+    CONSTRAINT chk_analysis_product_release_specification_digest
+        CHECK (publication_specification_digest ~ '^[0-9a-f]{64}$'),
+    CONSTRAINT chk_analysis_product_release_catalog_revision
+        CHECK (length(btrim(catalog_revision)) > 0),
+    CONSTRAINT chk_analysis_product_release_schema_digest
+        CHECK (base_schema_digest ~ '^[0-9a-f]{64}$')
+);
+
+ALTER TABLE analysis_control.analysis_products
+    ADD CONSTRAINT fk_analysis_product_desired_release
+        FOREIGN KEY (team, id, desired_release_number)
+        REFERENCES analysis_control.analysis_product_releases(team, product_id, release_number),
+    ADD CONSTRAINT fk_analysis_product_active_release
+        FOREIGN KEY (team, id, active_release_number)
+        REFERENCES analysis_control.analysis_product_releases(team, product_id, release_number);
+
+ALTER TABLE analysis_control.analysis_product_drafts
+    ADD CONSTRAINT fk_analysis_product_draft_base_release
+        FOREIGN KEY (team, product_id, base_release_number)
+        REFERENCES analysis_control.analysis_product_releases(team, product_id, release_number);
+
+CREATE TABLE analysis_control.analysis_product_audit_events (
+    id                 UUID PRIMARY KEY,
+    team               VARCHAR(255) NOT NULL,
+    product_id         UUID NOT NULL,
+    event_number       BIGINT NOT NULL CHECK (event_number > 0),
+    event_type         VARCHAR(40) NOT NULL,
+    actor_id           TEXT NOT NULL,
+    product_version    BIGINT NOT NULL CHECK (product_version > 0),
+    draft_id           UUID,
+    draft_revision     BIGINT,
+    release_number     BIGINT,
+    subject_digest     VARCHAR(64),
+    previous_state     VARCHAR(32),
+    next_state         VARCHAR(32),
+    occurred_at        TIMESTAMPTZ NOT NULL DEFAULT clock_timestamp(),
+    CONSTRAINT uq_analysis_product_audit_event_number
+        UNIQUE (team, product_id, event_number),
+    CONSTRAINT fk_analysis_product_audit_product
+        FOREIGN KEY (team, product_id)
+        REFERENCES analysis_control.analysis_products(team, id),
+    CONSTRAINT chk_analysis_product_audit_event_type
+        CHECK (event_type IN (
+            'PRODUCT_CREATED',
+            'DRAFT_UPDATED',
+            'DRAFT_VALIDATED',
+            'RELEASE_PUBLISHED',
+            'RELEASE_DESIRED',
+            'RELEASE_ACTIVATED',
+            'LIFECYCLE_CHANGED'
+        )),
+    CONSTRAINT chk_analysis_product_audit_version
+        CHECK (event_number = product_version),
+    CONSTRAINT chk_analysis_product_audit_draft_revision
+        CHECK (
+            (draft_id IS NULL AND draft_revision IS NULL) OR
+            (draft_id IS NOT NULL AND draft_revision IS NOT NULL AND draft_revision > 0)
+        ),
+    CONSTRAINT chk_analysis_product_audit_release_number
+        CHECK (release_number IS NULL OR release_number > 0),
+    CONSTRAINT chk_analysis_product_audit_digest
+        CHECK (subject_digest IS NULL OR subject_digest ~ '^[0-9a-f]{64}$'),
+    CONSTRAINT chk_analysis_product_audit_previous_state
+        CHECK (
+            previous_state IS NULL OR
+            previous_state IN ('DRAFT', 'ENABLED', 'PAUSED', 'OFFBOARDING', 'DELETED')
+        ),
+    CONSTRAINT chk_analysis_product_audit_next_state
+        CHECK (
+            next_state IS NULL OR
+            next_state IN ('DRAFT', 'ENABLED', 'PAUSED', 'OFFBOARDING', 'DELETED')
+        ),
+    CONSTRAINT chk_analysis_product_audit_payload
+        CHECK (
+            (
+                event_type = 'PRODUCT_CREATED' AND
+                draft_id IS NOT NULL AND subject_digest IS NOT NULL AND
+                release_number IS NULL AND previous_state IS NULL AND next_state = 'DRAFT'
+            ) OR (
+                event_type IN ('DRAFT_UPDATED', 'DRAFT_VALIDATED') AND
+                draft_id IS NOT NULL AND subject_digest IS NOT NULL AND
+                release_number IS NULL AND previous_state IS NULL AND next_state IS NULL
+            ) OR (
+                event_type IN ('RELEASE_PUBLISHED', 'RELEASE_DESIRED', 'RELEASE_ACTIVATED') AND
+                draft_id IS NULL AND release_number IS NOT NULL AND subject_digest IS NOT NULL AND
+                previous_state IS NULL AND next_state IS NULL
+            ) OR (
+                event_type = 'LIFECYCLE_CHANGED' AND
+                draft_id IS NULL AND release_number IS NULL AND subject_digest IS NULL AND
+                previous_state IS NOT NULL AND next_state IS NOT NULL AND
+                previous_state <> next_state
+            )
+        )
+);
+
+CREATE INDEX idx_analysis_products_team_state_updated
+    ON analysis_control.analysis_products(team, lifecycle_state, updated_at DESC);
+
+CREATE FUNCTION analysis_control.enforce_product_limit()
+RETURNS TRIGGER
+LANGUAGE plpgsql
+AS $$
+DECLARE
+    product_count INTEGER;
+BEGIN
+    IF NEW.lifecycle_state = 'DELETED' THEN
+        RETURN NEW;
+    END IF;
+
+    IF TG_OP = 'UPDATE' THEN
+        IF OLD.team = NEW.team AND OLD.lifecycle_state <> 'DELETED' THEN
+            RETURN NEW;
+        END IF;
+    END IF;
+
+    PERFORM pg_advisory_xact_lock(
+        hashtextextended('analysis-product-limit:' || NEW.team, 0)
+    );
+
+    SELECT count(*)
+    INTO product_count
+    FROM analysis_control.analysis_products
+    WHERE team = NEW.team
+      AND lifecycle_state <> 'DELETED'
+      AND id <> NEW.id;
+
+    IF product_count >= 10 THEN
+        RAISE EXCEPTION 'team has reached the analysis product limit'
+            USING ERRCODE = '23514';
+    END IF;
+
+    RETURN NEW;
+END;
+$$;
+
+CREATE TRIGGER trg_analysis_product_limit
+BEFORE INSERT OR UPDATE OF team, lifecycle_state
+ON analysis_control.analysis_products
+FOR EACH ROW
+EXECUTE FUNCTION analysis_control.enforce_product_limit();
+
+-- A release keeps the source draft UUID as immutable provenance after the
+-- mutable draft row is removed. A permanent FK would prevent that lifecycle,
+-- so insertion proves the composite identity and exact validation under row
+-- locks instead.
+CREATE FUNCTION analysis_control.validate_release_insert()
+RETURNS TRIGGER
+LANGUAGE plpgsql
+AS $$
+DECLARE
+    product_last_release BIGINT;
+    draft_revision BIGINT;
+    draft_document JSONB;
+    draft_document_hash VARCHAR(64);
+    draft_validated_revision BIGINT;
+    draft_catalog_revision VARCHAR(128);
+    draft_schema_digest VARCHAR(64);
+BEGIN
+    SELECT
+        p.last_release_number,
+        d.revision,
+        d.document,
+        d.document_hash,
+        d.validated_revision,
+        d.validated_catalog_revision,
+        d.validated_base_schema_digest
+    INTO
+        product_last_release,
+        draft_revision,
+        draft_document,
+        draft_document_hash,
+        draft_validated_revision,
+        draft_catalog_revision,
+        draft_schema_digest
+    FROM analysis_control.analysis_products AS p
+    JOIN analysis_control.analysis_product_drafts AS d
+      ON d.team = p.team AND d.product_id = p.id
+    WHERE p.team = NEW.team
+      AND p.id = NEW.product_id
+      AND d.id = NEW.source_draft_id
+    FOR UPDATE OF p, d;
+
+    IF NOT FOUND THEN
+        RAISE EXCEPTION 'release source draft does not belong to product'
+            USING ERRCODE = '23503';
+    END IF;
+
+    IF NEW.release_number <> product_last_release + 1 THEN
+        RAISE EXCEPTION 'release number is not the next product release'
+            USING ERRCODE = '23514';
+    END IF;
+
+    IF NEW.source_draft_revision <> draft_revision OR
+       NEW.source_document <> draft_document OR
+       NEW.source_document_hash <> draft_document_hash THEN
+        RAISE EXCEPTION 'release source does not match the current draft revision'
+            USING ERRCODE = '23514';
+    END IF;
+
+    IF draft_validated_revision IS NULL OR
+       draft_validated_revision <> draft_revision OR
+       draft_catalog_revision <> NEW.catalog_revision OR
+       draft_schema_digest <> NEW.base_schema_digest THEN
+        RAISE EXCEPTION 'release source draft is not validated for this catalog and schema'
+            USING ERRCODE = '23514';
+    END IF;
+
+    RETURN NEW;
+END;
+$$;
+
+CREATE TRIGGER trg_analysis_product_release_validate_insert
+BEFORE INSERT
+ON analysis_control.analysis_product_releases
+FOR EACH ROW
+EXECUTE FUNCTION analysis_control.validate_release_insert();
+
+-- Audit rows retain semantic UUID/number references after drafts are replaced.
+-- Validate the references at append time instead of using cascading FKs that
+-- would either block the lifecycle or erase the audit trail.
+CREATE FUNCTION analysis_control.validate_audit_insert()
+RETURNS TRIGGER
+LANGUAGE plpgsql
+AS $$
+DECLARE
+    current_product_version BIGINT;
+    referenced_digest VARCHAR(64);
+BEGIN
+    SELECT p.row_version
+    INTO current_product_version
+    FROM analysis_control.analysis_products AS p
+    WHERE p.team = NEW.team
+      AND p.id = NEW.product_id;
+
+    IF NOT FOUND THEN
+        RAISE EXCEPTION 'audit product does not exist'
+            USING ERRCODE = '23503';
+    END IF;
+
+    IF NEW.product_version <> current_product_version THEN
+        RAISE EXCEPTION 'audit version does not match current product version'
+            USING ERRCODE = '23514';
+    END IF;
+
+    IF NEW.draft_id IS NOT NULL THEN
+        SELECT d.document_hash
+        INTO referenced_digest
+        FROM analysis_control.analysis_product_drafts AS d
+        WHERE d.team = NEW.team
+          AND d.product_id = NEW.product_id
+          AND d.id = NEW.draft_id
+          AND d.revision = NEW.draft_revision;
+
+        IF NOT FOUND THEN
+            RAISE EXCEPTION 'audit draft reference does not belong to product revision'
+                USING ERRCODE = '23503';
+        END IF;
+
+        IF NEW.event_type IN ('PRODUCT_CREATED', 'DRAFT_UPDATED', 'DRAFT_VALIDATED') AND
+           NEW.subject_digest IS DISTINCT FROM referenced_digest THEN
+            RAISE EXCEPTION 'audit digest does not match referenced draft'
+                USING ERRCODE = '23514';
+        END IF;
+    END IF;
+
+    IF NEW.release_number IS NOT NULL THEN
+        SELECT r.publication_specification_digest
+        INTO referenced_digest
+        FROM analysis_control.analysis_product_releases AS r
+        WHERE r.team = NEW.team
+          AND r.product_id = NEW.product_id
+          AND r.release_number = NEW.release_number;
+
+        IF NOT FOUND THEN
+            RAISE EXCEPTION 'audit release reference does not belong to product'
+                USING ERRCODE = '23503';
+        END IF;
+
+        IF NEW.event_type IN ('RELEASE_PUBLISHED', 'RELEASE_DESIRED', 'RELEASE_ACTIVATED') AND
+           NEW.subject_digest IS DISTINCT FROM referenced_digest THEN
+            RAISE EXCEPTION 'audit digest does not match referenced release'
+                USING ERRCODE = '23514';
+        END IF;
+    END IF;
+
+    RETURN NEW;
+END;
+$$;
+
+CREATE TRIGGER trg_analysis_product_audit_validate_insert
+BEFORE INSERT
+ON analysis_control.analysis_product_audit_events
+FOR EACH ROW
+EXECUTE FUNCTION analysis_control.validate_audit_insert();
+
+CREATE FUNCTION analysis_control.reject_history_mutation()
+RETURNS TRIGGER
+LANGUAGE plpgsql
+AS $$
+BEGIN
+    RAISE EXCEPTION '% is append-only', TG_TABLE_NAME
+        USING ERRCODE = '55000';
+END;
+$$;
+
+CREATE TRIGGER trg_analysis_product_release_immutable
+BEFORE UPDATE OR DELETE
+ON analysis_control.analysis_product_releases
+FOR EACH ROW
+EXECUTE FUNCTION analysis_control.reject_history_mutation();
+
+CREATE TRIGGER trg_analysis_product_release_truncate_immutable
+BEFORE TRUNCATE
+ON analysis_control.analysis_product_releases
+FOR EACH STATEMENT
+EXECUTE FUNCTION analysis_control.reject_history_mutation();
+
+CREATE TRIGGER trg_analysis_product_audit_immutable
+BEFORE UPDATE OR DELETE
+ON analysis_control.analysis_product_audit_events
+FOR EACH ROW
+EXECUTE FUNCTION analysis_control.reject_history_mutation();
+
+CREATE TRIGGER trg_analysis_product_audit_truncate_immutable
+BEFORE TRUNCATE
+ON analysis_control.analysis_product_audit_events
+FOR EACH STATEMENT
+EXECUTE FUNCTION analysis_control.reject_history_mutation();
+
+REVOKE ALL ON ALL TABLES IN SCHEMA analysis_control FROM PUBLIC;
+REVOKE ALL ON ALL TABLES IN SCHEMA analysis_control FROM "esyfo-analyse";
+REVOKE ALL ON ALL FUNCTIONS IN SCHEMA analysis_control FROM PUBLIC;
+REVOKE ALL ON ALL FUNCTIONS IN SCHEMA analysis_control FROM "esyfo-analyse";

--- a/apps/lumi-api/src/test/kotlin/no/nav/lumi/TestDatabase.kt
+++ b/apps/lumi-api/src/test/kotlin/no/nav/lumi/TestDatabase.kt
@@ -82,10 +82,33 @@ object TestDatabase {
     fun clearAllData() {
         dataSource.connection.use { conn ->
             conn.createStatement().use { stmt ->
+                // Production history is protected from TRUNCATE. Disable only
+                // those two named triggers inside this rolled-back-on-failure
+                // test cleanup transaction.
                 stmt.execute(
-                    "TRUNCATE TABLE rating_marker, feedback, survey_definitions, survey_metadata, " +
+                    "ALTER TABLE analysis_control.analysis_product_audit_events " +
+                        "DISABLE TRIGGER trg_analysis_product_audit_truncate_immutable",
+                )
+                stmt.execute(
+                    "ALTER TABLE analysis_control.analysis_product_releases " +
+                        "DISABLE TRIGGER trg_analysis_product_release_truncate_immutable",
+                )
+                stmt.execute(
+                    "TRUNCATE TABLE analysis_control.analysis_product_audit_events, " +
+                        "analysis_control.analysis_product_releases, " +
+                        "analysis_control.analysis_product_drafts, " +
+                        "analysis_control.analysis_products, " +
+                        "rating_marker, feedback, survey_definitions, survey_metadata, " +
                         "survey_authoring_revisions, survey_authoring_projects, " +
                         "feedback_retention_job_state CASCADE"
+                )
+                stmt.execute(
+                    "ALTER TABLE analysis_control.analysis_product_audit_events " +
+                        "ENABLE TRIGGER trg_analysis_product_audit_truncate_immutable",
+                )
+                stmt.execute(
+                    "ALTER TABLE analysis_control.analysis_product_releases " +
+                        "ENABLE TRIGGER trg_analysis_product_release_truncate_immutable",
                 )
             }
             conn.commit()

--- a/apps/lumi-api/src/test/kotlin/no/nav/lumi/domain/AnalysisProductTest.kt
+++ b/apps/lumi-api/src/test/kotlin/no/nav/lumi/domain/AnalysisProductTest.kt
@@ -1,0 +1,87 @@
+package no.nav.lumi.domain
+
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import java.time.LocalDate
+
+class AnalysisProductTest : FunSpec({
+    val today = LocalDate.parse("2026-08-29")
+
+    test("normalizes bounded draft metadata without accepting a team field") {
+        val validated = AnalysisProductDocumentValidator.validate(
+            AnalysisProductDocumentV1(
+                name = "  Ukentlig kartlegging  ",
+                purpose = "  Analyse av strukturerte svar  ",
+                dataOwner = "  data-owner@nav.no  ",
+                technicalOwner = "  tech-owner@nav.no  ",
+                useCases = listOf(AnalysisProductUseCase.METABASE),
+                retention = AnalysisProductRetention.DAYS_90,
+                reviewDate = "2027-08-29",
+                sources = listOf(
+                    AnalysisProductSourceSelection(
+                        app = " bro-frontend ",
+                        surveyId = " kartlegging ",
+                        fieldIds = listOf(" opplevelse "),
+                    ),
+                ),
+                dimensionKeys = listOf(" deviceType "),
+            ),
+            today,
+        )
+
+        validated.document.name shouldBe "Ukentlig kartlegging"
+        validated.document.sources.single().app shouldBe "bro-frontend"
+        validated.document.sources.single().fieldIds shouldBe listOf("opplevelse")
+        validated.document.dimensionKeys shouldBe listOf("deviceType")
+        validated.reviewDate shouldBe LocalDate.parse("2027-08-29")
+    }
+
+    test("requires review within the next twelve months") {
+        shouldThrow<IllegalArgumentException> {
+            AnalysisProductDocumentValidator.validate(validDocument(reviewDate = "2027-08-30"), today)
+        }
+        shouldThrow<IllegalArgumentException> {
+            AnalysisProductDocumentValidator.validate(validDocument(reviewDate = "2026-08-28"), today)
+        }
+    }
+
+    test("rejects duplicate normalized source and field identities") {
+        shouldThrow<IllegalArgumentException> {
+            AnalysisProductDocumentValidator.validate(
+                validDocument(
+                    sources = listOf(
+                        AnalysisProductSourceSelection("app-a", "survey-a", listOf("field-a", " field-a ")),
+                    ),
+                ),
+                today,
+            )
+        }
+
+        shouldThrow<IllegalArgumentException> {
+            AnalysisProductDocumentValidator.validate(
+                validDocument(
+                    sources = listOf(
+                        AnalysisProductSourceSelection("app-a", "survey-a"),
+                        AnalysisProductSourceSelection(" app-a ", "survey-a"),
+                    ),
+                ),
+                today,
+            )
+        }
+    }
+})
+
+private fun validDocument(
+    reviewDate: String = "2027-08-29",
+    sources: List<AnalysisProductSourceSelection> = emptyList(),
+) = AnalysisProductDocumentV1(
+    name = "Kartlegging",
+    purpose = "Analyse av strukturerte svar",
+    dataOwner = "data-owner@nav.no",
+    technicalOwner = "tech-owner@nav.no",
+    useCases = listOf(AnalysisProductUseCase.METABASE),
+    retention = AnalysisProductRetention.SOURCE_MAXIMUM,
+    reviewDate = reviewDate,
+    sources = sources,
+)

--- a/apps/lumi-api/src/test/kotlin/no/nav/lumi/repository/AnalysisProductMigrationTest.kt
+++ b/apps/lumi-api/src/test/kotlin/no/nav/lumi/repository/AnalysisProductMigrationTest.kt
@@ -1,0 +1,553 @@
+package no.nav.lumi.repository
+
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.async
+import kotlinx.coroutines.awaitAll
+import kotlinx.coroutines.coroutineScope
+import no.nav.lumi.TestDatabase
+import java.sql.SQLException
+import java.util.UUID
+import java.util.concurrent.CountDownLatch
+
+class AnalysisProductMigrationTest : FunSpec({
+    beforeSpec { TestDatabase.initialize() }
+    beforeTest { TestDatabase.clearAllData() }
+
+    test("control plane is inaccessible to public and the legacy analysis role") {
+        TestDatabase.dataSource.connection.use { connection ->
+            connection.prepareStatement(
+                "SELECT has_schema_privilege('esyfo-analyse', 'analysis_control', 'USAGE')",
+            ).use { statement ->
+                statement.executeQuery().use { result ->
+                    result.next() shouldBe true
+                    result.getBoolean(1) shouldBe false
+                }
+            }
+
+            connection.prepareStatement(
+                """
+                    SELECT bool_and(
+                        NOT has_table_privilege('esyfo-analyse', table_name, 'SELECT')
+                    )
+                    FROM unnest(ARRAY[
+                        'analysis_control.analysis_products',
+                        'analysis_control.analysis_product_drafts',
+                        'analysis_control.analysis_product_releases',
+                        'analysis_control.analysis_product_audit_events'
+                    ]) AS table_name
+                """.trimIndent(),
+            ).use { statement ->
+                statement.executeQuery().use { result ->
+                    result.next() shouldBe true
+                    result.getBoolean(1) shouldBe true
+                }
+            }
+
+            connection.prepareStatement(
+                """
+                    SELECT NOT EXISTS (
+                        SELECT 1
+                        FROM pg_namespace AS n
+                        CROSS JOIN LATERAL aclexplode(
+                            COALESCE(n.nspacl, acldefault('n', n.nspowner))
+                        ) AS acl
+                        WHERE n.nspname = 'analysis_control'
+                          AND acl.grantee = 0
+                    )
+                """.trimIndent(),
+            ).use { statement ->
+                statement.executeQuery().use { result ->
+                    result.next() shouldBe true
+                    result.getBoolean(1) shouldBe true
+                }
+            }
+
+            connection.prepareStatement(
+                """
+                    SELECT NOT EXISTS (
+                        SELECT 1
+                        FROM pg_class AS c
+                        JOIN pg_namespace AS n ON n.oid = c.relnamespace
+                        CROSS JOIN LATERAL aclexplode(
+                            COALESCE(c.relacl, acldefault('r', c.relowner))
+                        ) AS acl
+                        WHERE n.nspname = 'analysis_control'
+                          AND c.relkind IN ('r', 'p')
+                          AND acl.grantee = 0
+                    )
+                """.trimIndent(),
+            ).use { statement ->
+                statement.executeQuery().use { result ->
+                    result.next() shouldBe true
+                    result.getBoolean(1) shouldBe true
+                }
+            }
+        }
+    }
+
+    test("database trigger enforces the ten product ceiling without repository help") {
+        repeat(10) { insertProductOnly("team-a") }
+
+        shouldThrow<SQLException> {
+            insertProductOnly("team-a")
+        }
+        insertProductOnly("team-b")
+    }
+
+    test("database trigger serializes concurrent direct inserts at the product ceiling") {
+        repeat(9) { insertProductOnly("team-a") }
+        val ready = CountDownLatch(2)
+        val start = CountDownLatch(1)
+
+        val results = coroutineScope {
+            List(2) {
+                async(Dispatchers.IO) {
+                    insertProductAtLimit("team-a", ready, start)
+                }
+            }.also {
+                ready.await()
+                start.countDown()
+            }.awaitAll()
+        }
+
+        results.count(DirectInsertOutcome::succeeded) shouldBe 1
+        results.single { !it.succeeded }.sqlState shouldBe "23514"
+        countProducts("team-a") shouldBe 10
+    }
+
+    test("draft storage rejects missing schema version and partial validation evidence") {
+        val emptyDocumentProduct = insertProductOnly("team-a")
+        shouldThrow<SQLException> {
+            insertDraft(
+                productId = emptyDocumentProduct,
+                document = "{}",
+            )
+        }
+
+        val partialValidationProduct = insertProductOnly("team-a")
+        shouldThrow<SQLException> {
+            insertDraft(
+                productId = partialValidationProduct,
+                validatedRevision = 1,
+                validatedCatalogRevision = "catalog-1",
+                validatedBy = "A123456",
+                hasValidatedAt = true,
+            )
+        }
+    }
+
+    test("release storage accepts only the exact validated draft provenance and next sequence") {
+        val draft = insertValidatedDraft()
+        val foreignDraft = insertValidatedDraft(team = draft.team)
+
+        shouldThrow<SQLException> { insertRelease(draft, sourceDraftId = UUID.randomUUID()) }
+        shouldThrow<SQLException> { insertRelease(draft, sourceDraftId = foreignDraft.draftId) }
+        shouldThrow<SQLException> { insertRelease(draft, sourceDraftRevision = 2) }
+        shouldThrow<SQLException> { insertRelease(draft, releaseNumber = 2) }
+        shouldThrow<SQLException> {
+            insertRelease(draft, sourceDocument = draft.document.replace("Kartlegging", "Changed"))
+        }
+        shouldThrow<SQLException> { insertRelease(draft, sourceDocumentHash = "d".repeat(64)) }
+        shouldThrow<SQLException> { insertRelease(draft, catalogRevision = "catalog-2") }
+        shouldThrow<SQLException> { insertRelease(draft, baseSchemaDigest = "d".repeat(64)) }
+        shouldThrow<SQLException> { insertRelease(draft, publicationSpecification = "{}") }
+
+        insertRelease(draft)
+        executeUpdate(
+            "DELETE FROM analysis_control.analysis_product_drafts WHERE id = ?",
+            draft.draftId,
+        ) shouldBe 1
+    }
+
+    test("audit storage rejects foreign references, mismatched digests and stale versions") {
+        val draft = insertValidatedDraft()
+        insertRelease(draft)
+        val foreignDraft = insertValidatedDraft(team = draft.team)
+
+        shouldThrow<SQLException> {
+            insertAudit(
+                draft = draft,
+                eventType = "DRAFT_UPDATED",
+                draftId = foreignDraft.draftId,
+                draftRevision = 1,
+                subjectDigest = foreignDraft.documentHash,
+            )
+        }
+        shouldThrow<SQLException> {
+            insertAudit(
+                draft = draft,
+                eventType = "RELEASE_DESIRED",
+                releaseNumber = 2,
+                subjectDigest = draft.publicationSpecificationDigest,
+            )
+        }
+        shouldThrow<SQLException> {
+            insertAudit(
+                draft = draft,
+                eventType = "RELEASE_DESIRED",
+                releaseNumber = 1,
+                subjectDigest = "d".repeat(64),
+            )
+        }
+        shouldThrow<SQLException> {
+            insertAudit(
+                draft = draft,
+                eventType = "DRAFT_UPDATED",
+                productVersion = 2,
+                draftId = draft.draftId,
+                draftRevision = 1,
+                subjectDigest = draft.documentHash,
+            )
+        }
+    }
+
+    test("release and audit history reject update delete and truncate") {
+        val fixture = insertHistoryFixture()
+
+        shouldThrow<SQLException> {
+            executeUpdate(
+                "UPDATE analysis_control.analysis_product_releases SET published_by = 'changed' WHERE id = ?",
+                fixture.releaseId,
+            )
+        }
+        shouldThrow<SQLException> {
+            executeUpdate(
+                "DELETE FROM analysis_control.analysis_product_releases WHERE id = ?",
+                fixture.releaseId,
+            )
+        }
+        shouldThrow<SQLException> {
+            executeUpdate(
+                "UPDATE analysis_control.analysis_product_audit_events SET actor_id = 'changed' WHERE id = ?",
+                fixture.auditId,
+            )
+        }
+        shouldThrow<SQLException> {
+            executeUpdate(
+                "DELETE FROM analysis_control.analysis_product_audit_events WHERE id = ?",
+                fixture.auditId,
+            )
+        }
+        shouldThrow<SQLException> {
+            executeStatement("TRUNCATE TABLE analysis_control.analysis_product_releases")
+        }
+        shouldThrow<SQLException> {
+            executeStatement("TRUNCATE TABLE analysis_control.analysis_product_audit_events")
+        }
+    }
+
+    test("desired and active pointers cannot reference another product release") {
+        val firstProductId = insertProductOnly(team = "team-a")
+        val second = insertHistoryFixture(team = "team-a")
+
+        shouldThrow<SQLException> {
+            TestDatabase.dataSource.connection.use { connection ->
+                connection.prepareStatement(
+                    """
+                        UPDATE analysis_control.analysis_products
+                        SET last_release_number = 1, desired_release_number = 1
+                        WHERE id = ?
+                    """.trimIndent(),
+                ).use { statement ->
+                    statement.setObject(1, firstProductId)
+                    statement.executeUpdate()
+                }
+                connection.commit()
+            }
+        }
+
+        executeUpdate(
+            """
+                UPDATE analysis_control.analysis_products
+                SET last_release_number = 1, desired_release_number = 1
+                WHERE id = ?
+            """.trimIndent(),
+            second.productId,
+        ) shouldBe 1
+    }
+})
+
+private data class HistoryFixture(
+    val productId: UUID,
+    val releaseId: UUID,
+    val auditId: UUID,
+)
+
+private data class DirectInsertOutcome(
+    val succeeded: Boolean,
+    val sqlState: String? = null,
+)
+
+private data class DraftFixture(
+    val team: String,
+    val productId: UUID,
+    val draftId: UUID,
+    val document: String,
+    val documentHash: String = "a".repeat(64),
+    val catalogRevision: String = "catalog-1",
+    val baseSchemaDigest: String = "b".repeat(64),
+    val publicationSpecification: String =
+        """{"schemaVersion": 1, "pinnedDefinitionVersion": 7}""",
+    val publicationSpecificationDigest: String = "c".repeat(64),
+)
+
+private fun insertProductOnly(team: String): UUID {
+    val productId = UUID.randomUUID()
+    TestDatabase.dataSource.connection.use { connection ->
+        connection.prepareStatement(
+            """
+                INSERT INTO analysis_control.analysis_products (
+                    id, team, created_by, updated_by
+                ) VALUES (?, ?, 'A123456', 'A123456')
+            """.trimIndent(),
+        ).use { statement ->
+            statement.setObject(1, productId)
+            statement.setString(2, team)
+            statement.executeUpdate()
+        }
+        connection.commit()
+    }
+    return productId
+}
+
+private fun insertProductAtLimit(
+    team: String,
+    ready: CountDownLatch,
+    start: CountDownLatch,
+): DirectInsertOutcome = TestDatabase.dataSource.connection.use { connection ->
+    ready.countDown()
+    start.await()
+    try {
+        connection.prepareStatement(
+            """
+                INSERT INTO analysis_control.analysis_products (
+                    id, team, created_by, updated_by
+                ) VALUES (?, ?, 'A123456', 'A123456')
+            """.trimIndent(),
+        ).use { statement ->
+            statement.setObject(1, UUID.randomUUID())
+            statement.setString(2, team)
+            statement.executeUpdate()
+        }
+        connection.commit()
+        DirectInsertOutcome(succeeded = true)
+    } catch (error: SQLException) {
+        connection.rollback()
+        DirectInsertOutcome(succeeded = false, sqlState = error.sqlState)
+    }
+}
+
+private fun countProducts(team: String): Int = TestDatabase.dataSource.connection.use { connection ->
+    connection.prepareStatement(
+        "SELECT count(*) FROM analysis_control.analysis_products WHERE team = ?",
+    ).use { statement ->
+        statement.setString(1, team)
+        statement.executeQuery().use { result ->
+            result.next()
+            result.getInt(1)
+        }
+    }
+}
+
+@Suppress("LongParameterList")
+private fun insertDraft(
+    productId: UUID,
+    team: String = "team-a",
+    draftId: UUID = UUID.randomUUID(),
+    document: String = validDocumentJson(),
+    documentHash: String = "a".repeat(64),
+    validatedRevision: Long? = null,
+    validatedCatalogRevision: String? = null,
+    validatedBaseSchemaDigest: String? = null,
+    validatedBy: String? = null,
+    hasValidatedAt: Boolean = false,
+) {
+    TestDatabase.dataSource.connection.use { connection ->
+        connection.prepareStatement(
+            """
+                INSERT INTO analysis_control.analysis_product_drafts (
+                    id, team, product_id, document, document_hash,
+                    validated_revision, validated_catalog_revision,
+                    validated_base_schema_digest, validated_by, validated_at,
+                    created_by, updated_by
+                ) VALUES (?, ?, ?, ?::jsonb, ?, ?, ?, ?, ?,
+                          CASE WHEN ? THEN clock_timestamp() END, 'A123456', 'A123456')
+            """.trimIndent(),
+        ).use { statement ->
+            statement.setObject(1, draftId)
+            statement.setString(2, team)
+            statement.setObject(3, productId)
+            statement.setString(4, document)
+            statement.setString(5, documentHash)
+            statement.setObject(6, validatedRevision)
+            statement.setString(7, validatedCatalogRevision)
+            statement.setString(8, validatedBaseSchemaDigest)
+            statement.setString(9, validatedBy)
+            statement.setBoolean(10, hasValidatedAt)
+            statement.executeUpdate()
+        }
+        connection.commit()
+    }
+}
+
+private fun insertValidatedDraft(
+    team: String = "team-a",
+    productId: UUID = insertProductOnly(team),
+): DraftFixture {
+    val fixture = DraftFixture(
+        team = team,
+        productId = productId,
+        draftId = UUID.randomUUID(),
+        document = validDocumentJson(),
+    )
+    insertDraft(
+        productId = fixture.productId,
+        team = fixture.team,
+        draftId = fixture.draftId,
+        document = fixture.document,
+        documentHash = fixture.documentHash,
+        validatedRevision = 1,
+        validatedCatalogRevision = fixture.catalogRevision,
+        validatedBaseSchemaDigest = fixture.baseSchemaDigest,
+        validatedBy = "A123456",
+        hasValidatedAt = true,
+    )
+    return fixture
+}
+
+@Suppress("LongParameterList")
+private fun insertRelease(
+    draft: DraftFixture,
+    releaseNumber: Long = 1,
+    sourceDraftId: UUID = draft.draftId,
+    sourceDraftRevision: Long = 1,
+    sourceDocument: String = draft.document,
+    sourceDocumentHash: String = draft.documentHash,
+    publicationSpecification: String = draft.publicationSpecification,
+    publicationSpecificationDigest: String = draft.publicationSpecificationDigest,
+    catalogRevision: String = draft.catalogRevision,
+    baseSchemaDigest: String = draft.baseSchemaDigest,
+): UUID {
+    val releaseId = UUID.randomUUID()
+    TestDatabase.dataSource.connection.use { connection ->
+        connection.prepareStatement(
+            """
+                INSERT INTO analysis_control.analysis_product_releases (
+                    id, team, product_id, release_number, source_draft_id,
+                    source_draft_revision, source_document, source_document_hash,
+                    publication_specification, publication_specification_digest,
+                    catalog_revision, base_schema_digest, published_by
+                ) VALUES (?, ?, ?, ?, ?, ?, ?::jsonb, ?, ?::jsonb, ?, ?, ?, 'A123456')
+            """.trimIndent(),
+        ).use { statement ->
+            statement.setObject(1, releaseId)
+            statement.setString(2, draft.team)
+            statement.setObject(3, draft.productId)
+            statement.setLong(4, releaseNumber)
+            statement.setObject(5, sourceDraftId)
+            statement.setLong(6, sourceDraftRevision)
+            statement.setString(7, sourceDocument)
+            statement.setString(8, sourceDocumentHash)
+            statement.setString(9, publicationSpecification)
+            statement.setString(10, publicationSpecificationDigest)
+            statement.setString(11, catalogRevision)
+            statement.setString(12, baseSchemaDigest)
+            statement.executeUpdate()
+        }
+        connection.prepareStatement(
+            """
+                UPDATE analysis_control.analysis_products
+                SET last_release_number = ?
+                WHERE team = ? AND id = ?
+            """.trimIndent(),
+        ).use { statement ->
+            statement.setLong(1, releaseNumber)
+            statement.setString(2, draft.team)
+            statement.setObject(3, draft.productId)
+            statement.executeUpdate()
+        }
+        connection.commit()
+    }
+    return releaseId
+}
+
+@Suppress("LongParameterList")
+private fun insertAudit(
+    draft: DraftFixture,
+    eventType: String,
+    productVersion: Long = 1,
+    draftId: UUID? = null,
+    draftRevision: Long? = null,
+    releaseNumber: Long? = null,
+    subjectDigest: String? = null,
+): UUID {
+    val auditId = UUID.randomUUID()
+    TestDatabase.dataSource.connection.use { connection ->
+        connection.prepareStatement(
+            """
+                INSERT INTO analysis_control.analysis_product_audit_events (
+                    id, team, product_id, event_number, event_type, actor_id,
+                    product_version, draft_id, draft_revision, release_number, subject_digest
+                ) VALUES (?, ?, ?, ?, ?, 'A123456', ?, ?, ?, ?, ?)
+            """.trimIndent(),
+        ).use { statement ->
+            statement.setObject(1, auditId)
+            statement.setString(2, draft.team)
+            statement.setObject(3, draft.productId)
+            statement.setLong(4, productVersion)
+            statement.setString(5, eventType)
+            statement.setLong(6, productVersion)
+            statement.setObject(7, draftId)
+            statement.setObject(8, draftRevision)
+            statement.setObject(9, releaseNumber)
+            statement.setString(10, subjectDigest)
+            statement.executeUpdate()
+        }
+        connection.commit()
+    }
+    return auditId
+}
+
+private fun insertHistoryFixture(team: String = "team-a"): HistoryFixture {
+    val draft = insertValidatedDraft(team)
+    val releaseId = insertRelease(draft)
+    val auditId = insertAudit(
+        draft = draft,
+        eventType = "RELEASE_PUBLISHED",
+        releaseNumber = 1,
+        subjectDigest = draft.publicationSpecificationDigest,
+    )
+    return HistoryFixture(draft.productId, releaseId, auditId)
+}
+
+private fun executeUpdate(sql: String, id: UUID): Int = TestDatabase.dataSource.connection.use { connection ->
+    connection.prepareStatement(sql).use { statement ->
+        statement.setObject(1, id)
+        val updated = statement.executeUpdate()
+        connection.commit()
+        updated
+    }
+}
+
+private fun executeStatement(sql: String) {
+    TestDatabase.dataSource.connection.use { connection ->
+        connection.createStatement().use { statement -> statement.execute(sql) }
+        connection.commit()
+    }
+}
+
+private fun validDocumentJson() = """
+    {
+      "schemaVersion": 1,
+      "name": "Kartlegging",
+      "purpose": "Analyse av strukturerte svar",
+      "dataOwner": "data-owner@nav.no",
+      "technicalOwner": "tech-owner@nav.no",
+      "useCases": ["METABASE"],
+      "retention": "SOURCE_MAXIMUM",
+      "reviewDate": "2027-08-29"
+    }
+""".trimIndent()

--- a/apps/lumi-api/src/test/kotlin/no/nav/lumi/repository/AnalysisProductRepositoryTest.kt
+++ b/apps/lumi-api/src/test/kotlin/no/nav/lumi/repository/AnalysisProductRepositoryTest.kt
@@ -1,0 +1,335 @@
+package no.nav.lumi.repository
+
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.collections.shouldHaveSize
+import io.kotest.matchers.shouldBe
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.async
+import kotlinx.coroutines.awaitAll
+import kotlinx.coroutines.coroutineScope
+import no.nav.lumi.TestDatabase
+import no.nav.lumi.domain.AnalysisProductAuditEventType
+import no.nav.lumi.domain.AnalysisProductDocumentV1
+import no.nav.lumi.domain.AnalysisProductRetention
+import no.nav.lumi.domain.AnalysisProductSourceSelection
+import no.nav.lumi.domain.AnalysisProductUseCase
+import java.time.Clock
+import java.time.Instant
+import java.time.ZoneOffset
+import java.util.UUID
+
+class AnalysisProductRepositoryTest : FunSpec({
+    val repository = AnalysisProductRepository(
+        Clock.fixed(Instant.parse("2026-08-29T12:00:00Z"), ZoneOffset.UTC),
+    )
+
+    beforeSpec { TestDatabase.initialize() }
+    beforeTest { TestDatabase.clearAllData() }
+
+    test("creates product draft and audit atomically and scopes every read to team") {
+        val product = repository.createProduct(team = "team-a")
+        repository.createProduct(team = "team-b")
+
+        product.team shouldBe "team-a"
+        product.rowVersion shouldBe 1
+        product.draft?.revision shouldBe 1
+        product.draft?.createdBy shouldBe "A123456"
+
+        repository.findByTeam("team-a").map { it.id } shouldBe listOf(product.id)
+        repository.findById("team-b", UUID.fromString(product.id)) shouldBe null
+        repository.findAuditEvents("team-b", UUID.fromString(product.id)) shouldBe null
+        repository.findReleases("team-b", UUID.fromString(product.id)) shouldBe null
+
+        val audit = repository.findAuditEvents("team-a", UUID.fromString(product.id))!!.single()
+        audit.eventType shouldBe AnalysisProductAuditEventType.PRODUCT_CREATED
+        audit.draftId shouldBe product.draft?.id
+        audit.subjectDigest shouldBe product.draft?.documentHash
+    }
+
+    test("draft update uses draft identity and optimistic revision") {
+        val product = repository.createProduct()
+        val productId = UUID.fromString(product.id)
+        val draftId = UUID.fromString(product.draft!!.id)
+        markDraftValidatedForTest(productId)
+
+        val updated = repository.updateDraft(
+            team = "team-a",
+            productId = productId,
+            draftId = draftId,
+            expectedRevision = 1,
+            document = validDocument(name = "Updated"),
+            principalIdentity = "A654321",
+        ) as UpdateAnalysisProductDraftResult.Updated
+
+        updated.product.rowVersion shouldBe 2
+        updated.product.draft?.revision shouldBe 2
+        updated.product.draft?.document?.name shouldBe "Updated"
+        updated.product.draft?.updatedBy shouldBe "A654321"
+        updated.product.draft?.validation shouldBe null
+
+        repository.updateDraft(
+            team = "team-a",
+            productId = productId,
+            draftId = draftId,
+            expectedRevision = 1,
+            document = validDocument(name = "Stale"),
+            principalIdentity = "A111111",
+        ) shouldBe UpdateAnalysisProductDraftResult.VersionConflict
+
+        repository.updateDraft(
+            team = "team-b",
+            productId = productId,
+            draftId = draftId,
+            expectedRevision = 2,
+            document = validDocument(name = "Foreign"),
+            principalIdentity = "B111111",
+        ) shouldBe UpdateAnalysisProductDraftResult.NotFound
+
+        repository.findAuditEvents("team-a", productId)!!.map { it.eventType } shouldBe listOf(
+            AnalysisProductAuditEventType.PRODUCT_CREATED,
+            AnalysisProductAuditEventType.DRAFT_UPDATED,
+        )
+    }
+
+    test("reads immutable releases only inside the owning team") {
+        val product = repository.createProduct()
+        val productId = UUID.fromString(product.id)
+        val releaseId = insertReleaseForTest(productId)
+
+        val release = repository.findReleases("team-a", productId)!!.single()
+        release.id shouldBe releaseId.toString()
+        release.productId shouldBe product.id
+        release.releaseNumber shouldBe 1
+        release.sourceDraftId shouldBe product.draft?.id
+        release.sourceDocument.name shouldBe "Kartlegging"
+        release.publicationSpecification["schemaVersion"]?.toString() shouldBe "1"
+        release.publicationSpecification["pinnedDefinitionVersion"]?.toString() shouldBe "7"
+        release.publicationSpecificationDigest shouldBe "c".repeat(64)
+
+        repository.findReleases("team-b", productId) shouldBe null
+        repository.findReleases("team-a", UUID.randomUUID()) shouldBe null
+    }
+
+    test("exactly one concurrent draft update wins") {
+        val product = repository.createProduct()
+        val productId = UUID.fromString(product.id)
+        val draftId = UUID.fromString(product.draft!!.id)
+
+        val results = coroutineScope {
+            listOf("First", "Second").map { name ->
+                async(Dispatchers.IO) {
+                    repository.updateDraft(
+                        team = "team-a",
+                        productId = productId,
+                        draftId = draftId,
+                        expectedRevision = 1,
+                        document = validDocument(name = name),
+                        principalIdentity = "A123456",
+                    )
+                }
+            }.awaitAll()
+        }
+
+        results.filterIsInstance<UpdateAnalysisProductDraftResult.Updated>() shouldHaveSize 1
+        results.filterIsInstance<UpdateAnalysisProductDraftResult.VersionConflict>() shouldHaveSize 1
+        repository.findById("team-a", productId)?.rowVersion shouldBe 2
+        repository.findAuditEvents("team-a", productId)!! shouldHaveSize 2
+    }
+
+    test("concurrent creation cannot exceed ten non-deleted products per team") {
+        repeat(9) { index -> repository.createProduct(name = "Product $index") }
+
+        val results = coroutineScope {
+            listOf("Tenth A", "Tenth B").map { name ->
+                async(Dispatchers.IO) {
+                    repository.create(
+                        team = "team-a",
+                        document = validDocument(name = name),
+                        principalIdentity = "A123456",
+                    )
+                }
+            }.awaitAll()
+        }
+
+        results.filterIsInstance<CreateAnalysisProductResult.Created>() shouldHaveSize 1
+        results.filterIsInstance<CreateAnalysisProductResult.LimitReached>() shouldHaveSize 1
+        repository.findByTeam("team-a") shouldHaveSize 10
+
+        val otherTeamResult = repository.create(
+            team = "team-b",
+            document = validDocument(name = "Other team"),
+            principalIdentity = "B123456",
+        )
+        (otherTeamResult is CreateAnalysisProductResult.Created) shouldBe true
+    }
+
+    test("audit failure rolls draft and aggregate version back") {
+        val product = repository.createProduct()
+        val productId = UUID.fromString(product.id)
+        val draftId = UUID.fromString(product.draft!!.id)
+        installRejectingAuditTrigger("DRAFT_UPDATED")
+
+        try {
+            shouldThrow<Exception> {
+                repository.updateDraft(
+                    team = "team-a",
+                    productId = productId,
+                    draftId = draftId,
+                    expectedRevision = 1,
+                    document = validDocument(name = "Must roll back"),
+                    principalIdentity = "A123456",
+                )
+            }
+        } finally {
+            removeRejectingAuditTrigger()
+        }
+
+        val unchanged = repository.findById("team-a", productId)!!
+        unchanged.rowVersion shouldBe 1
+        unchanged.draft?.revision shouldBe 1
+        unchanged.draft?.document?.name shouldBe "Kartlegging"
+        repository.findAuditEvents("team-a", productId)!! shouldHaveSize 1
+    }
+
+    test("audit failure rolls product creation and its draft back") {
+        installRejectingAuditTrigger("PRODUCT_CREATED")
+
+        try {
+            shouldThrow<Exception> {
+                repository.create(
+                    team = "team-a",
+                    document = validDocument(),
+                    principalIdentity = "A123456",
+                )
+            }
+        } finally {
+            removeRejectingAuditTrigger()
+        }
+
+        repository.findByTeam("team-a") shouldHaveSize 0
+    }
+})
+
+private suspend fun AnalysisProductRepository.createProduct(
+    team: String = "team-a",
+    name: String = "Kartlegging",
+) = (create(team, validDocument(name), "A123456") as CreateAnalysisProductResult.Created).product
+
+private fun validDocument(name: String = "Kartlegging") = AnalysisProductDocumentV1(
+    name = name,
+    purpose = "Analyse av strukturerte svar",
+    dataOwner = "data-owner@nav.no",
+    technicalOwner = "tech-owner@nav.no",
+    useCases = listOf(AnalysisProductUseCase.METABASE),
+    retention = AnalysisProductRetention.SOURCE_MAXIMUM,
+    reviewDate = "2027-08-29",
+    sources = listOf(
+        AnalysisProductSourceSelection("app-a", "survey-a", listOf("field-a")),
+    ),
+)
+
+private fun markDraftValidatedForTest(productId: UUID) {
+    TestDatabase.dataSource.connection.use { connection ->
+        connection.prepareStatement(
+            """
+                UPDATE analysis_control.analysis_product_drafts
+                SET validated_revision = revision,
+                    validated_catalog_revision = 'catalog-1',
+                    validated_base_schema_digest = ?,
+                    validated_by = 'A123456',
+                    validated_at = clock_timestamp()
+                WHERE product_id = ?
+            """.trimIndent(),
+        ).use { statement ->
+            statement.setString(1, "b".repeat(64))
+            statement.setObject(2, productId)
+            statement.executeUpdate() shouldBe 1
+        }
+        connection.commit()
+    }
+}
+
+private fun insertReleaseForTest(productId: UUID): UUID {
+    val releaseId = UUID.randomUUID()
+    markDraftValidatedForTest(productId)
+    TestDatabase.dataSource.connection.use { connection ->
+        connection.prepareStatement(
+            """
+                INSERT INTO analysis_control.analysis_product_releases (
+                    id, team, product_id, release_number, source_draft_id,
+                    source_draft_revision, source_document, source_document_hash,
+                    publication_specification, publication_specification_digest,
+                    catalog_revision, base_schema_digest, published_by
+                )
+                SELECT ?, team, product_id, 1, id, revision, document, document_hash,
+                       '{"schemaVersion": 1, "pinnedDefinitionVersion": 7}'::jsonb,
+                       ?, 'catalog-1', ?, 'A123456'
+                FROM analysis_control.analysis_product_drafts
+                WHERE product_id = ?
+            """.trimIndent(),
+        ).use { statement ->
+            statement.setObject(1, releaseId)
+            statement.setString(2, "c".repeat(64))
+            statement.setString(3, "b".repeat(64))
+            statement.setObject(4, productId)
+            statement.executeUpdate() shouldBe 1
+        }
+        connection.prepareStatement(
+            """
+                UPDATE analysis_control.analysis_products
+                SET last_release_number = 1
+                WHERE id = ?
+            """.trimIndent(),
+        ).use { statement ->
+            statement.setObject(1, productId)
+            statement.executeUpdate() shouldBe 1
+        }
+        connection.commit()
+    }
+    return releaseId
+}
+
+private fun installRejectingAuditTrigger(eventType: String) {
+    TestDatabase.dataSource.connection.use { connection ->
+        connection.createStatement().use { statement ->
+            statement.execute(
+                """
+                    CREATE FUNCTION analysis_control.reject_audit_for_test()
+                    RETURNS TRIGGER
+                    LANGUAGE plpgsql
+                    AS ${'$'}${'$'}
+                    BEGIN
+                        IF NEW.event_type = TG_ARGV[0] THEN
+                            RAISE EXCEPTION 'reject audit for test';
+                        END IF;
+                        RETURN NEW;
+                    END;
+                    ${'$'}${'$'}
+                """.trimIndent(),
+            )
+            statement.execute(
+                """
+                    CREATE TRIGGER trg_reject_audit_for_test
+                    BEFORE INSERT ON analysis_control.analysis_product_audit_events
+                    FOR EACH ROW
+                    EXECUTE FUNCTION analysis_control.reject_audit_for_test('$eventType')
+                """.trimIndent(),
+            )
+        }
+        connection.commit()
+    }
+}
+
+private fun removeRejectingAuditTrigger() {
+    TestDatabase.dataSource.connection.use { connection ->
+        connection.createStatement().use { statement ->
+            statement.execute(
+                "DROP TRIGGER IF EXISTS trg_reject_audit_for_test " +
+                    "ON analysis_control.analysis_product_audit_events",
+            )
+            statement.execute("DROP FUNCTION IF EXISTS analysis_control.reject_audit_for_test()")
+        }
+        connection.commit()
+    }
+}


### PR DESCRIPTION
## Hva

- etablerer en versjonert domenemodell for teamavgrensede analyseprodukter
- lagrer produkt, muterbart utkast, immutable releaser og append-only audit i et eget lukket schema
- skiller ønsket release fra aktiv release, og skiller draft-kilden fra den kompilerte publiseringsspesifikasjonen
- håndhever ti aktive produkter per team, også ved samtidige direkte databaseinnsettinger
- gir repository-støtte for atomisk opprettelse, team-scopede lesinger og optimistisk draftoppdatering

## Sikkerhet og integritet

- PUBLIC og legacy-rollen esyfo-analyse har ingen tilgang til schema, tabeller eller funksjoner
- release-provenance bindes ved innsetting til nøyaktig produkt, draft-ID, revisjon, dokument, hash, katalog og baseskjema
- release- og audit-historikk avviser update, delete og truncate
- audit validerer hendelsesform, team/product-referanser, digest og gjeldende aggregate-versjon
- ingen HTTP-ruter, eksport, IAM, publisering eller aktivering introduseres i denne delen

## Verifisering

- 18 målrettede domene- og PostgreSQL/Testcontainers-tester
- samtidighetstester for produktgrense og optimistisk draftrevisjon
- negative migrasjonstester for privilege isolation, falsk provenance, release-rekkefølge, ufullstendig validering og destruktive historikkoperasjoner
- pnpm run lint
- pnpm run typecheck

Denne følger ADR- og sikkerhetsgrunnlaget i #568. Anbefalt merge-rekkefølge er #568 først.

Closes #569
Related to #482
