### PR TITLE
Bygg kildekatalog og deterministisk kontrakt-preview

### DIFF
--- a/apps/lumi-api/src/main/kotlin/no/nav/lumi/config/Routing.kt
+++ b/apps/lumi-api/src/main/kotlin/no/nav/lumi/config/Routing.kt
@@ -6,6 +6,7 @@ import io.ktor.server.plugins.ratelimit.*
 import io.ktor.server.routing.*
 import no.nav.lumi.config.auth.ClientAuthorizationPlugin
 import no.nav.lumi.config.auth.TeamAuthorizationPlugin
+import no.nav.lumi.routes.analysisProductRoutes
 import no.nav.lumi.routes.discoveryRoutes
 import no.nav.lumi.routes.feedbackRoutes
 import no.nav.lumi.routes.exportRoutes
@@ -48,6 +49,7 @@ fun Application.configureRouting() {
                     markerRoutes()
                     statsRoutes()
                     discoveryRoutes()
+                    analysisProductRoutes()
                     teamsRoutes()
                 }
             }

--- a/apps/lumi-api/src/main/kotlin/no/nav/lumi/config/StatusPages.kt
+++ b/apps/lumi-api/src/main/kotlin/no/nav/lumi/config/StatusPages.kt
@@ -6,11 +6,14 @@ import io.ktor.server.plugins.*
 import io.ktor.server.plugins.statuspages.*
 import io.ktor.server.request.*
 import io.ktor.server.response.*
+import io.ktor.util.AttributeKey
+import no.nav.lumi.config.auth.CallerIdentityKey
 import no.nav.lumi.config.exception.ApiError
 import no.nav.lumi.config.exception.ApiErrorException
 import no.nav.lumi.config.exception.ErrorType
-import no.nav.lumi.config.auth.CallerIdentityKey
 import org.slf4j.LoggerFactory
+
+val OpaqueNotFoundResponseKey = AttributeKey<Map<String, String>>("opaqueNotFoundResponse")
 
 private val statusPageLog = LoggerFactory.getLogger("StatusPages")
 private val defaultDefinitionConflictObservability = DefinitionConflictObservability()
@@ -50,8 +53,16 @@ fun Application.configureStatusPages(
         status(HttpStatusCode.NotFound) { call, status ->
             val path = call.request.path()
             statusPageLog.info("StatusPages caught 404 NotFound on $path - responding with ApiError")
-            val apiError = ApiError.notFound(status.description, path)
-            call.respond(HttpStatusCode.NotFound, apiError)
+            val opaqueResponse = call.attributes.getOrNull(OpaqueNotFoundResponseKey)
+            if (opaqueResponse != null) {
+                call.respond(
+                    HttpStatusCode.NotFound,
+                    opaqueResponse,
+                )
+            } else {
+                val apiError = ApiError.notFound(status.description, path)
+                call.respond(HttpStatusCode.NotFound, apiError)
+            }
         }
     }
 }

--- a/apps/lumi-api/src/main/kotlin/no/nav/lumi/domain/AnalysisContractCompiler.kt
+++ b/apps/lumi-api/src/main/kotlin/no/nav/lumi/domain/AnalysisContractCompiler.kt
@@ -1,0 +1,1019 @@
+package no.nav.lumi.domain
+
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonElement
+import kotlinx.serialization.json.JsonNull
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.JsonPrimitive
+import java.util.Locale
+
+const val ANALYSIS_CONTRACT_COMPILER_VERSION = "analysis-contract-compiler-v1"
+const val ANALYSIS_CONTRACT_VERSION = "v1"
+const val ANALYSIS_PREVIEW_PRIVACY_POLICY_VERSION = "synthetic-only-v1"
+private val SHA256_PATTERN = Regex("^[0-9a-f]{64}$")
+private val SYNTHETIC_FLOW_HASH = AnalysisCanonicalHash.digest("analysis-synthetic-flow-v1", emptyList())
+
+val AnalysisContractJson = Json {
+    encodeDefaults = true
+    explicitNulls = true
+}
+
+@Serializable
+enum class AnalysisColumnType {
+    STRING,
+    INT64,
+    BOOL,
+    FLOAT64,
+    DATE,
+    TIMESTAMP,
+}
+
+@Serializable
+enum class AnalysisResourceKind {
+    WIDE,
+    LONG,
+    FIELD_CATALOG,
+    MANIFEST,
+}
+
+@Serializable
+data class AnalysisColumnV1(
+    val logicalId: String,
+    val name: String,
+    val type: AnalysisColumnType,
+    val nullable: Boolean,
+    val description: String,
+)
+
+@Serializable
+data class AnalysisResourceSchemaV1(
+    val name: String,
+    val kind: AnalysisResourceKind,
+    val rowMeaning: String,
+    val sourceApp: String? = null,
+    val sourceSurveyId: String? = null,
+    val columns: List<AnalysisColumnV1>,
+    val syntheticRows: List<JsonObject> = emptyList(),
+)
+
+@Serializable
+enum class PreviewDataOrigin {
+    SYNTHETIC,
+}
+
+@Serializable
+enum class AnalysisContractPreviewStatus {
+    READY,
+    READY_WITH_WARNINGS,
+    BLOCKED,
+}
+
+@Serializable
+enum class AnalysisCompilationIssueSeverity {
+    WARNING,
+    BLOCKER,
+}
+
+@Serializable
+enum class AnalysisCompilationIssueCode {
+    TEAM_SCOPE_MISMATCH,
+    SOURCE_UNAVAILABLE,
+    SOURCE_ID_MISMATCH,
+    DEFINITION_NOT_REGISTERED,
+    DEFINITION_HASH_UNRESOLVED,
+    LEGACY_DEFINITION_OBSERVED,
+    FLOW_NOT_PINNED,
+    FIELD_UNAVAILABLE,
+    FIELD_NOT_ALLOWED,
+    FIELD_MALFORMED,
+    DIMENSION_UNAVAILABLE,
+    WIDE_COLUMN_BUDGET_WARNING,
+    WIDE_COLUMN_BUDGET_EXCEEDED,
+    PHYSICAL_NAME_COLLISION,
+}
+
+@Serializable
+data class AnalysisCompilationIssue(
+    val severity: AnalysisCompilationIssueSeverity,
+    val code: AnalysisCompilationIssueCode,
+    val sourceApp: String? = null,
+    val sourceSurveyId: String? = null,
+    val fieldId: String? = null,
+    val dimensionKey: String? = null,
+)
+
+@Serializable
+data class AnalysisSourcePinV1(
+    val app: String,
+    val surveyId: String,
+    val surveyType: SurveyType,
+    val definitionHash: String,
+    val flowHash: String,
+    val fields: List<AnalysisFieldPinV1>,
+)
+
+@Serializable
+data class AnalysisFieldPinV1(
+    val fieldId: String,
+    val fieldType: FieldType,
+    val ratingVariant: RatingVariant? = null,
+    val ratingScale: Int? = null,
+    val optionIds: List<String> = emptyList(),
+    val maxSelections: Int? = null,
+    val label: String? = null,
+    val labelSource: AnalysisLabelSource,
+)
+
+@Serializable
+data class AnalysisPublicationSpecificationV1(
+    val schemaVersion: Int = 1,
+    val compilerVersion: String = ANALYSIS_CONTRACT_COMPILER_VERSION,
+    val canonicalizationVersion: String = "length-prefixed-v1",
+    val contractVersion: String = ANALYSIS_CONTRACT_VERSION,
+    val productId: String,
+    val team: String,
+    val retention: AnalysisProductRetention,
+    val catalogRevision: String,
+    val sourcePins: List<AnalysisSourcePinV1>,
+    val dimensions: List<AnalysisDimensionDefinitionV1>,
+    val resources: List<AnalysisResourceSchemaV1>,
+    val excludedDataCategories: List<String>,
+    val baseSchemaDigest: String,
+)
+
+@Serializable
+data class AnalysisProductContractPreviewV1(
+    val schemaVersion: Int = 1,
+    val compilerVersion: String = ANALYSIS_CONTRACT_COMPILER_VERSION,
+    val contractVersion: String = ANALYSIS_CONTRACT_VERSION,
+    val privacyPolicyVersion: String = ANALYSIS_PREVIEW_PRIVACY_POLICY_VERSION,
+    val dataOrigin: PreviewDataOrigin = PreviewDataOrigin.SYNTHETIC,
+    val productId: String,
+    val draftId: String,
+    val draftRevision: Long,
+    val documentHash: String,
+    val catalogRevision: String,
+    val baseSchemaDigest: String,
+    val publicationSpecificationDigest: String? = null,
+    val status: AnalysisContractPreviewStatus,
+    val resources: List<AnalysisResourceSchemaV1>,
+    val issues: List<AnalysisCompilationIssue>,
+    val excludedDataCategories: List<String>,
+    val aggregatePreviewAvailable: Boolean = false,
+    val publicationSpecification: AnalysisPublicationSpecificationV1? = null,
+)
+
+data class AnalysisProductCompilationInput(
+    val productId: String,
+    val team: String,
+    val draftId: String,
+    val draftRevision: Long,
+    val documentHash: String,
+    val document: AnalysisProductDocumentV1,
+    val catalog: AnalysisSourceCatalogV1,
+    val dimensions: AnalysisDimensionRegistrySnapshotV1,
+)
+
+class AnalysisContractCompiler {
+    fun compilePreview(input: AnalysisProductCompilationInput): AnalysisProductContractPreviewV1 {
+        val issues = mutableListOf<AnalysisCompilationIssue>()
+        if (input.catalog.team != input.team) {
+            issues += issue(AnalysisCompilationIssueCode.TEAM_SCOPE_MISMATCH)
+        }
+
+        val catalogSources = input.catalog.sources.associateBy { it.app to it.surveyId }
+        val dimensions = input.dimensions.dimensions.associateBy { it.key }
+        val selectedDimensions = input.document.dimensionKeys.sorted().mapNotNull { key ->
+            dimensions[key] ?: run {
+                issues += issue(AnalysisCompilationIssueCode.DIMENSION_UNAVAILABLE, dimensionKey = key)
+                null
+            }
+        }
+        val selectionCatalogRevision = AnalysisCatalogRevision.computeForSelection(
+            team = input.team,
+            selections = input.document.sources,
+            sources = input.catalog.sources,
+            dimensionKeys = input.document.dimensionKeys,
+            dimensions = input.dimensions,
+        )
+
+        val resolvedSources = input.document.sources
+            .sortedWith(compareBy(AnalysisProductSourceSelection::app, AnalysisProductSourceSelection::surveyId))
+            .mapNotNull { selection ->
+                val source = catalogSources[selection.app to selection.surveyId]
+                if (source == null || input.catalog.team != input.team) {
+                    issues += issue(
+                        AnalysisCompilationIssueCode.SOURCE_UNAVAILABLE,
+                        app = selection.app,
+                        surveyId = selection.surveyId,
+                    )
+                    return@mapNotNull null
+                }
+                validateSource(source, selection, issues)
+                ResolvedAnalysisSource(
+                    source = source,
+                    selectedFields = selection.fieldIds.sorted().mapNotNull { fieldId ->
+                        val field = source.fields.singleOrNull { it.fieldId == fieldId }
+                        if (field == null) {
+                            issues += issue(
+                                AnalysisCompilationIssueCode.FIELD_UNAVAILABLE,
+                                app = source.app,
+                                surveyId = source.surveyId,
+                                fieldId = fieldId,
+                            )
+                            null
+                        } else if (field.fieldType in setOf(FieldType.TEXT, FieldType.DATE)) {
+                            issues += issue(
+                                AnalysisCompilationIssueCode.FIELD_NOT_ALLOWED,
+                                app = source.app,
+                                surveyId = source.surveyId,
+                                fieldId = fieldId,
+                            )
+                            null
+                        } else if (!field.isWellFormed()) {
+                            issues += issue(
+                                AnalysisCompilationIssueCode.FIELD_MALFORMED,
+                                app = source.app,
+                                surveyId = source.surveyId,
+                                fieldId = fieldId,
+                            )
+                            null
+                        } else {
+                            field
+                        }
+                    },
+                )
+            }
+
+        val resources = buildResources(
+            productId = input.productId,
+            team = input.team,
+            sources = resolvedSources,
+            dimensions = selectedDimensions,
+            includeSubmittedHour = input.document.includeSubmittedHour,
+            issues = issues,
+        )
+        val sortedIssues = issues.distinct().sortedWith(
+            compareBy<AnalysisCompilationIssue>(
+                { it.severity.name },
+                { it.code.name },
+                { it.sourceApp.orEmpty() },
+                { it.sourceSurveyId.orEmpty() },
+                { it.fieldId.orEmpty() },
+                { it.dimensionKey.orEmpty() },
+            ),
+        )
+        val baseSchemaDigest = digestResources(resources)
+        val exclusions = listOf(
+            "CLIENT_LABELS",
+            "CONTEXT_TAGS",
+            "DATE_ANSWERS",
+            "DEBUG",
+            "DEDUPLICATION_HASH",
+            "INTERNAL_FEEDBACK_ID",
+            "RAW_JSON",
+            "TEXT_ANSWERS",
+            "URL_AND_PATH",
+            "USER_AGENT_AND_VIEWPORT",
+        )
+        val hasBlockers = sortedIssues.any { it.severity == AnalysisCompilationIssueSeverity.BLOCKER }
+        val bareResources = resources.map { it.copy(syntheticRows = emptyList()) }
+        val specification = if (hasBlockers) {
+            null
+        } else {
+            AnalysisPublicationSpecificationV1(
+                productId = input.productId,
+                team = input.team,
+                retention = input.document.retention,
+                catalogRevision = selectionCatalogRevision,
+                sourcePins = resolvedSources.map { resolved ->
+                    AnalysisSourcePinV1(
+                        app = resolved.source.app,
+                        surveyId = resolved.source.surveyId,
+                        surveyType = requireNotNull(resolved.source.surveyType),
+                        definitionHash = requireNotNull(resolved.source.definitionHash),
+                        flowHash = requireNotNull(resolved.source.flowHash),
+                        fields = resolved.selectedFields.map { field ->
+                            AnalysisFieldPinV1(
+                                fieldId = field.fieldId,
+                                fieldType = field.fieldType,
+                                ratingVariant = field.ratingVariant,
+                                ratingScale = field.ratingScale,
+                                optionIds = field.optionIds.orEmpty(),
+                                maxSelections = field.maxSelections,
+                                label = field.label.takeIf { field.labelSource != AnalysisLabelSource.UNKNOWN },
+                                labelSource = field.labelSource,
+                            )
+                        },
+                    )
+                },
+                dimensions = selectedDimensions,
+                resources = bareResources,
+                excludedDataCategories = exclusions,
+                baseSchemaDigest = baseSchemaDigest,
+            )
+        }
+        val specificationDigest = specification?.let(::digestSpecification)
+
+        return AnalysisProductContractPreviewV1(
+            productId = input.productId,
+            draftId = input.draftId,
+            draftRevision = input.draftRevision,
+            documentHash = input.documentHash,
+            catalogRevision = selectionCatalogRevision,
+            baseSchemaDigest = baseSchemaDigest,
+            publicationSpecificationDigest = specificationDigest,
+            status = when {
+                hasBlockers -> AnalysisContractPreviewStatus.BLOCKED
+                sortedIssues.isNotEmpty() -> AnalysisContractPreviewStatus.READY_WITH_WARNINGS
+                else -> AnalysisContractPreviewStatus.READY
+            },
+            resources = resources,
+            issues = sortedIssues,
+            excludedDataCategories = exclusions,
+            publicationSpecification = specification,
+        )
+    }
+
+    private fun validateSource(
+        source: AnalysisCatalogSourceV1,
+        selection: AnalysisProductSourceSelection,
+        issues: MutableList<AnalysisCompilationIssue>,
+    ) {
+        if (source.definitionStatus != AnalysisDefinitionStatus.REGISTERED || source.surveyType == null) {
+            issues += issue(
+                AnalysisCompilationIssueCode.DEFINITION_NOT_REGISTERED,
+                app = source.app,
+                surveyId = source.surveyId,
+            )
+        }
+        if (source.definitionHash?.matches(SHA256_PATTERN) != true) {
+            issues += issue(
+                AnalysisCompilationIssueCode.DEFINITION_HASH_UNRESOLVED,
+                app = source.app,
+                surveyId = source.surveyId,
+            )
+        }
+        if (source.definitionHash != null && source.observedDefinitionHashes.any { it != null && it != source.definitionHash }) {
+            issues += issue(
+                AnalysisCompilationIssueCode.DEFINITION_HASH_UNRESOLVED,
+                app = source.app,
+                surveyId = source.surveyId,
+            )
+        }
+        if (AnalysisCatalogWarning.DEFINITION_CONTENT_MISMATCH in source.warnings) {
+            issues += issue(
+                AnalysisCompilationIssueCode.DEFINITION_HASH_UNRESOLVED,
+                app = source.app,
+                surveyId = source.surveyId,
+            )
+        }
+        if (source.observedDefinitionHashes.any { it == null }) {
+            issues += issue(
+                AnalysisCompilationIssueCode.LEGACY_DEFINITION_OBSERVED,
+                app = source.app,
+                surveyId = source.surveyId,
+            )
+        }
+        if (source.flowStatus != AnalysisFlowStatus.PINNED || source.flowHash?.matches(SHA256_PATTERN) != true) {
+            issues += issue(
+                AnalysisCompilationIssueCode.FLOW_NOT_PINNED,
+                app = source.app,
+                surveyId = source.surveyId,
+            )
+        }
+        if (AnalysisCatalogWarning.SOURCE_ID_MISMATCH in source.warnings) {
+            issues += issue(
+                AnalysisCompilationIssueCode.SOURCE_ID_MISMATCH,
+                app = source.app,
+                surveyId = source.surveyId,
+            )
+        }
+        if (selection.fieldIds.isEmpty()) {
+            // An empty source is allowed in a draft and produces a population-only
+            // wide schema. The UI may use this while fields are being selected.
+            return
+        }
+    }
+
+    private fun buildResources(
+        productId: String,
+        team: String,
+        sources: List<ResolvedAnalysisSource>,
+        dimensions: List<AnalysisDimensionDefinitionV1>,
+        includeSubmittedHour: Boolean,
+        issues: MutableList<AnalysisCompilationIssue>,
+    ): List<AnalysisResourceSchemaV1> {
+        val wide = sources.map { resolved ->
+            val dynamicColumns = buildDynamicColumns(resolved.selectedFields, dimensions)
+            val budget = dynamicColumns.size
+            if (budget >= 80) {
+                issues += issue(
+                    AnalysisCompilationIssueCode.WIDE_COLUMN_BUDGET_WARNING,
+                    severity = AnalysisCompilationIssueSeverity.WARNING,
+                    app = resolved.source.app,
+                    surveyId = resolved.source.surveyId,
+                )
+            }
+            if (budget > 120) {
+                issues += issue(
+                    AnalysisCompilationIssueCode.WIDE_COLUMN_BUDGET_EXCEEDED,
+                    app = resolved.source.app,
+                    surveyId = resolved.source.surveyId,
+                )
+            }
+            val columns = commonColumns(includeSubmittedHour) + dynamicColumns
+            ensureUniqueColumns(columns, resolved.source, issues)
+            AnalysisResourceSchemaV1(
+                name = AnalysisPhysicalNames.resourceName(resolved.source.app, resolved.source.surveyId),
+                kind = AnalysisResourceKind.WIDE,
+                rowMeaning = "One synthetic row represents one submission for this app and survey.",
+                sourceApp = resolved.source.app,
+                sourceSurveyId = resolved.source.surveyId,
+                columns = columns,
+                syntheticRows = listOf(
+                    syntheticWideRow(productId, team, resolved, dimensions, columns),
+                ),
+            )
+        }
+
+        val longColumns = longColumns(includeSubmittedHour, dimensions)
+        val catalogColumns = fieldCatalogColumns()
+        val manifestColumns = manifestColumns()
+        val longResource = AnalysisResourceSchemaV1(
+            name = "answers_long_v1",
+            kind = AnalysisResourceKind.LONG,
+            rowMeaning = "One synthetic row represents one structured answer value atom.",
+            columns = longColumns,
+            syntheticRows = sources.firstNotNullOfOrNull { resolved ->
+                resolved.selectedFields.firstOrNull()?.let { field ->
+                    syntheticLongRow(productId, team, resolved, field, dimensions, longColumns)
+                }
+            }?.let(::listOf).orEmpty(),
+        )
+        val catalogResource = AnalysisResourceSchemaV1(
+            name = "field_catalog_v1",
+            kind = AnalysisResourceKind.FIELD_CATALOG,
+            rowMeaning = "One synthetic row represents a field or option metadata entry.",
+            columns = catalogColumns,
+            syntheticRows = sources.firstNotNullOfOrNull { resolved ->
+                resolved.selectedFields.firstOrNull()?.let { field ->
+                    syntheticCatalogRows(productId, team, resolved, field, catalogColumns)
+                }
+            }.orEmpty(),
+        )
+        val publicResources = wide + longResource + catalogResource
+        val manifestResource = AnalysisResourceSchemaV1(
+            name = "product_manifest_v1",
+            kind = AnalysisResourceKind.MANIFEST,
+            rowMeaning = "One synthetic row represents one public analytic resource, excluding the manifest itself.",
+            columns = manifestColumns,
+            syntheticRows = publicResources.firstOrNull()?.let { resource ->
+                listOf(syntheticManifestRow(productId, resource.name, resource.kind, manifestColumns))
+            }.orEmpty(),
+        )
+        return publicResources + manifestResource
+    }
+
+    private fun buildDynamicColumns(
+        fields: List<AnalysisCatalogFieldV1>,
+        dimensions: List<AnalysisDimensionDefinitionV1>,
+    ): List<AnalysisColumnV1> = buildList {
+        fields.sortedBy { it.fieldId }.forEach { field ->
+            add(
+                column(
+                    logicalId = "field:${field.fieldId}:applicable",
+                    name = AnalysisPhysicalNames.fieldColumn(field.fieldId, "applicable"),
+                    type = AnalysisColumnType.BOOL,
+                    nullable = true,
+                    description = "Whether structured field '${field.fieldId}' was applicable.",
+                ),
+            )
+            when (field.fieldType) {
+                FieldType.RATING -> add(
+                    column(
+                        "field:${field.fieldId}:rating",
+                        AnalysisPhysicalNames.fieldColumn(field.fieldId, "rating"),
+                        AnalysisColumnType.INT64,
+                        true,
+                        "Rating value for structured field '${field.fieldId}'.",
+                    ),
+                )
+
+                FieldType.SINGLE_CHOICE -> add(
+                    column(
+                        "field:${field.fieldId}:option_id",
+                        AnalysisPhysicalNames.fieldColumn(field.fieldId, "option_id"),
+                        AnalysisColumnType.STRING,
+                        true,
+                        "Selected option ID for structured field '${field.fieldId}'.",
+                    ),
+                )
+
+                FieldType.MULTI_CHOICE -> {
+                    add(
+                        column(
+                            "field:${field.fieldId}:selection_count",
+                            AnalysisPhysicalNames.fieldColumn(field.fieldId, "selection_count"),
+                            AnalysisColumnType.INT64,
+                            true,
+                            "Distinct selected option count for structured field '${field.fieldId}'.",
+                        ),
+                    )
+                    field.optionIds.orEmpty().sorted().forEach { optionId ->
+                        add(
+                            column(
+                                "field:${field.fieldId}:option:$optionId:selected",
+                                AnalysisPhysicalNames.optionColumn(field.fieldId, optionId),
+                                AnalysisColumnType.BOOL,
+                                true,
+                                "Whether option '$optionId' was selected for structured field '${field.fieldId}'.",
+                            ),
+                        )
+                    }
+                }
+
+                FieldType.TEXT, FieldType.DATE -> Unit
+            }
+        }
+        dimensions.sortedBy { it.key }.forEach { dimension ->
+            add(
+                column(
+                    "dimension:${dimension.key}",
+                    AnalysisPhysicalNames.dimensionColumn(dimension),
+                    dimension.type,
+                    true,
+                    dimension.description,
+                ),
+            )
+        }
+    }
+
+    private fun ensureUniqueColumns(
+        columns: List<AnalysisColumnV1>,
+        source: AnalysisCatalogSourceV1,
+        issues: MutableList<AnalysisCompilationIssue>,
+    ) {
+        if (columns.map { it.name }.distinct().size != columns.size) {
+            issues += issue(
+                AnalysisCompilationIssueCode.PHYSICAL_NAME_COLLISION,
+                app = source.app,
+                surveyId = source.surveyId,
+            )
+        }
+    }
+
+    private fun digestResources(resources: List<AnalysisResourceSchemaV1>): String = AnalysisCanonicalHash.digest(
+        "analysis-public-schema-v1",
+        resources.sortedBy { it.name }.flatMap { resource ->
+            buildList {
+                add(resource.name)
+                add(resource.kind.name)
+                add(resource.rowMeaning)
+                add(resource.sourceApp ?: "<null>")
+                add(resource.sourceSurveyId ?: "<null>")
+                resource.columns.forEach { column ->
+                    add(column.logicalId)
+                    add(column.name)
+                    add(column.type.name)
+                    add(column.nullable.toString())
+                    add(column.description)
+                }
+            }
+        },
+    )
+
+    private fun digestSpecification(specification: AnalysisPublicationSpecificationV1): String =
+        AnalysisCanonicalHash.digest(
+            "analysis-publication-specification-v1",
+            buildList {
+                add(specification.schemaVersion.toString())
+                add(specification.compilerVersion)
+                add(specification.canonicalizationVersion)
+                add(specification.contractVersion)
+                add(specification.productId)
+                add(specification.team)
+                add(specification.retention.name)
+                add(specification.catalogRevision)
+                specification.sourcePins.forEach { pin ->
+                    add(pin.app)
+                    add(pin.surveyId)
+                    add(pin.surveyType.name)
+                    add(pin.definitionHash)
+                    add(pin.flowHash)
+                    pin.fields.forEach { field ->
+                        add(field.fieldId)
+                        add(field.fieldType.name)
+                        add(field.ratingVariant?.name ?: "<null>")
+                        add(field.ratingScale?.toString() ?: "<null>")
+                        field.optionIds.forEach(::add)
+                        add(field.maxSelections?.toString() ?: "<null>")
+                        add(field.label ?: "<null>")
+                        add(field.labelSource.name)
+                    }
+                }
+                specification.dimensions.forEach { dimension ->
+                    add(dimension.key)
+                    add(dimension.outputId)
+                    add(dimension.type.name)
+                    add(dimension.owner)
+                    add(dimension.description)
+                    add(dimension.dataClass.name)
+                    add(dimension.maxCardinality.toString())
+                    dimension.allowedValues.forEach(::add)
+                    add(dimension.newValuePolicy.name)
+                    add(dimension.defaultSelected.toString())
+                }
+                add(specification.baseSchemaDigest)
+                specification.excludedDataCategories.sorted().forEach(::add)
+            },
+        )
+
+}
+
+private data class ResolvedAnalysisSource(
+    val source: AnalysisCatalogSourceV1,
+    val selectedFields: List<AnalysisCatalogFieldV1>,
+)
+
+object AnalysisPhysicalNames {
+    fun resourceName(app: String, surveyId: String): String {
+        val identity = listOf(app, surveyId)
+        val hash = AnalysisCanonicalHash.digest("analysis-wide-resource-name-v1", identity).take(24)
+        val appSlug = slug(app, 32)
+        val surveySlug = slug(surveyId, 32)
+        return "responses_${appSlug}_${surveySlug}_${hash}_wide_v1".take(128)
+    }
+
+    fun fieldColumn(fieldId: String, suffix: String): String =
+        "field_${slug(fieldId, 32)}_${AnalysisCanonicalHash.digest("analysis-field-column-v1", listOf(fieldId)).take(24)}__$suffix"
+
+    fun optionColumn(fieldId: String, optionId: String): String =
+        "field_${slug(fieldId, 20)}_${AnalysisCanonicalHash.digest("analysis-field-option-prefix-v1", listOf(fieldId)).take(24)}" +
+            "__option_${slug(optionId, 20)}_${AnalysisCanonicalHash.digest("analysis-option-column-v1", listOf(fieldId, optionId)).take(24)}__selected"
+
+    fun dimensionColumn(dimension: AnalysisDimensionDefinitionV1): String =
+        "dim_${slug(dimension.outputId, 48)}_" +
+            AnalysisCanonicalHash.digest("analysis-dimension-column-v1", listOf(dimension.key, dimension.outputId)).take(24)
+
+    private fun slug(value: String, maxLength: Int): String {
+        val lowered = value.lowercase(Locale.ROOT)
+        val normalized = buildString {
+            lowered.forEach { char ->
+                append(if (char in 'a'..'z' || char in '0'..'9') char else '_')
+            }
+        }.replace(Regex("_+"), "_").trim('_').ifEmpty { "x" }
+        val prefixed = if (normalized.first().isDigit()) "x_$normalized" else normalized
+        return prefixed.take(maxLength).trimEnd('_').ifEmpty { "x" }
+    }
+}
+
+private fun AnalysisCatalogFieldV1.isWellFormed(): Boolean = when (fieldType) {
+    FieldType.RATING ->
+        ratingVariant != null &&
+            ratingScale == RatingVariant.getScale(ratingVariant) &&
+            optionIds == null &&
+            maxSelections == null
+
+    FieldType.SINGLE_CHOICE ->
+        ratingVariant == null &&
+            ratingScale == null &&
+            maxSelections == null &&
+            !optionIds.isNullOrEmpty() &&
+            optionIds.distinct().size == optionIds.size
+
+    FieldType.MULTI_CHOICE ->
+        ratingVariant == null &&
+            ratingScale == null &&
+            !optionIds.isNullOrEmpty() &&
+            optionIds.distinct().size == optionIds.size &&
+            (maxSelections == null || maxSelections in 1..optionIds.size)
+
+    FieldType.TEXT, FieldType.DATE -> true
+}
+
+private fun issue(
+    code: AnalysisCompilationIssueCode,
+    severity: AnalysisCompilationIssueSeverity = AnalysisCompilationIssueSeverity.BLOCKER,
+    app: String? = null,
+    surveyId: String? = null,
+    fieldId: String? = null,
+    dimensionKey: String? = null,
+) = AnalysisCompilationIssue(severity, code, app, surveyId, fieldId, dimensionKey)
+
+private fun column(
+    logicalId: String,
+    name: String,
+    type: AnalysisColumnType,
+    nullable: Boolean,
+    description: String,
+) = AnalysisColumnV1(logicalId, name, type, nullable, description)
+
+private fun commonColumns(includeSubmittedHour: Boolean): List<AnalysisColumnV1> = buildList {
+    add(column("response_key", "response_key", AnalysisColumnType.STRING, false, "Product-scoped stable response key."))
+    add(column("product_id", "product_id", AnalysisColumnType.STRING, false, "Analysis product ID."))
+    add(column("product_release", "product_release", AnalysisColumnType.INT64, false, "Immutable product release number."))
+    add(column("product_snapshot_id", "product_snapshot_id", AnalysisColumnType.STRING, false, "Atomic product snapshot ID."))
+    add(column("team_slug", "team_slug", AnalysisColumnType.STRING, false, "Owning team slug."))
+    add(column("app", "app", AnalysisColumnType.STRING, false, "Source application."))
+    add(column("survey_id", "survey_id", AnalysisColumnType.STRING, false, "Source survey ID."))
+    add(column("survey_type", "survey_type", AnalysisColumnType.STRING, false, "Survey type."))
+    add(column("submitted_date", "submitted_date", AnalysisColumnType.DATE, false, "Server storage date in Europe/Oslo."))
+    if (includeSubmittedHour) {
+        add(column("submitted_hour", "submitted_hour", AnalysisColumnType.TIMESTAMP, true, "Server storage time truncated to UTC hour."))
+    }
+    add(column("definition_hash", "definition_hash", AnalysisColumnType.STRING, true, "Ingest-matched structural definition hash."))
+    add(column("definition_status", "definition_status", AnalysisColumnType.STRING, false, "REGISTERED or LEGACY_DERIVED."))
+    add(column("flow_hash", "flow_hash", AnalysisColumnType.STRING, true, "Ingest-matched flow hash."))
+    add(column("flow_status", "flow_status", AnalysisColumnType.STRING, false, "PINNED or UNPINNED."))
+}
+
+private fun longColumns(
+    includeSubmittedHour: Boolean,
+    dimensions: List<AnalysisDimensionDefinitionV1>,
+): List<AnalysisColumnV1> = buildList {
+    addAll(commonColumns(includeSubmittedHour).let { columns ->
+        val answerKey = column("answer_key", "answer_key", AnalysisColumnType.STRING, false, "Stable logical answer key.")
+        listOf(columns.first(), answerKey) + columns.drop(1)
+    })
+    add(column("field_id", "field_id", AnalysisColumnType.STRING, false, "Stable structured field ID."))
+    add(column("field_type", "field_type", AnalysisColumnType.STRING, false, "RATING, SINGLE_CHOICE or MULTI_CHOICE."))
+    add(column("field_metadata_hash", "field_metadata_hash", AnalysisColumnType.STRING, false, "Approved or UNKNOWN field metadata hash."))
+    add(column("value_kind", "value_kind", AnalysisColumnType.STRING, false, "RATING, OPTION or EMPTY_SELECTION."))
+    add(column("rating_value", "rating_value", AnalysisColumnType.INT64, true, "Rating value."))
+    add(column("option_id", "option_id", AnalysisColumnType.STRING, true, "Selected stable option ID."))
+    add(column("option_metadata_hash", "option_metadata_hash", AnalysisColumnType.STRING, true, "Approved or UNKNOWN option metadata hash."))
+    add(column("selection_count", "selection_count", AnalysisColumnType.INT64, true, "Distinct selected option count."))
+    dimensions.sortedBy { it.key }.forEach { dimension ->
+        add(column("dimension:${dimension.key}", AnalysisPhysicalNames.dimensionColumn(dimension), dimension.type, true, dimension.description))
+    }
+}
+
+private fun fieldCatalogColumns(): List<AnalysisColumnV1> = listOf(
+    column("metadata_hash", "metadata_hash", AnalysisColumnType.STRING, false, "Metadata identity."),
+    column("entry_kind", "entry_kind", AnalysisColumnType.STRING, false, "FIELD or OPTION."),
+    column("product_id", "product_id", AnalysisColumnType.STRING, false, "Analysis product ID."),
+    column("product_release", "product_release", AnalysisColumnType.INT64, false, "Immutable product release number."),
+    column("product_snapshot_id", "product_snapshot_id", AnalysisColumnType.STRING, false, "Atomic product snapshot ID."),
+    column("team_slug", "team_slug", AnalysisColumnType.STRING, false, "Owning team slug."),
+    column("app", "app", AnalysisColumnType.STRING, false, "Source application."),
+    column("survey_id", "survey_id", AnalysisColumnType.STRING, false, "Source survey ID."),
+    column("definition_hash", "definition_hash", AnalysisColumnType.STRING, true, "Structural definition hash."),
+    column("field_id", "field_id", AnalysisColumnType.STRING, false, "Stable structured field ID."),
+    column("field_type", "field_type", AnalysisColumnType.STRING, false, "Structured field type."),
+    column("rating_variant", "rating_variant", AnalysisColumnType.STRING, true, "Rating variant."),
+    column("rating_scale", "rating_scale", AnalysisColumnType.INT64, true, "Rating scale."),
+    column("rating_min", "rating_min", AnalysisColumnType.INT64, true, "Minimum rating."),
+    column("rating_max", "rating_max", AnalysisColumnType.INT64, true, "Maximum rating."),
+    column("max_selections", "max_selections", AnalysisColumnType.INT64, true, "Maximum selections."),
+    column("option_id", "option_id", AnalysisColumnType.STRING, true, "Stable option ID."),
+    column("option_ordinal", "option_ordinal", AnalysisColumnType.INT64, true, "Option ordinal."),
+    column("display_label", "display_label", AnalysisColumnType.STRING, true, "Approved public label only."),
+    column("label_source", "label_source", AnalysisColumnType.STRING, false, "REGISTERED_METADATA, PRODUCT_ALIAS or UNKNOWN."),
+    column("metadata_revision", "metadata_revision", AnalysisColumnType.STRING, true, "Approved metadata revision."),
+    column("first_observed_date", "first_observed_date", AnalysisColumnType.DATE, true, "First structural observation date."),
+    column("last_observed_date", "last_observed_date", AnalysisColumnType.DATE, true, "Last structural observation date."),
+    column("is_current_label", "is_current_label", AnalysisColumnType.BOOL, false, "Whether this approved label is current."),
+)
+
+private fun manifestColumns(): List<AnalysisColumnV1> = listOf(
+    column("product_id", "product_id", AnalysisColumnType.STRING, false, "Analysis product ID."),
+    column("product_release", "product_release", AnalysisColumnType.INT64, false, "Immutable product release number."),
+    column("product_snapshot_id", "product_snapshot_id", AnalysisColumnType.STRING, false, "Atomic product snapshot ID."),
+    column("resource_name", "resource_name", AnalysisColumnType.STRING, false, "Public resource name."),
+    column("resource_kind", "resource_kind", AnalysisColumnType.STRING, false, "WIDE, LONG or FIELD_CATALOG."),
+    column("schema_digest", "schema_digest", AnalysisColumnType.STRING, false, "Public schema digest."),
+    column("row_count", "row_count", AnalysisColumnType.INT64, false, "Snapshot row count."),
+    column("contract_version", "contract_version", AnalysisColumnType.STRING, false, "Contract version."),
+    column("source_snapshot_at", "source_snapshot_at", AnalysisColumnType.TIMESTAMP, false, "Source snapshot timestamp."),
+    column("published_at", "published_at", AnalysisColumnType.TIMESTAMP, false, "Publication timestamp."),
+    column("data_cutoff_at", "data_cutoff_at", AnalysisColumnType.TIMESTAMP, true, "Product cutoff timestamp."),
+    column("snapshot_mode", "snapshot_mode", AnalysisColumnType.STRING, false, "FULL, PURGE_ONLY or SECURITY_REDACTION."),
+    column("quality_status", "quality_status", AnalysisColumnType.STRING, false, "PASSED or PASSED_WITH_WARNINGS."),
+)
+
+private fun syntheticWideRow(
+    productId: String,
+    team: String,
+    resolved: ResolvedAnalysisSource,
+    dimensions: List<AnalysisDimensionDefinitionV1>,
+    columns: List<AnalysisColumnV1>,
+): JsonObject = syntheticRow(columns) { column ->
+    when (column.logicalId) {
+        "response_key" -> JsonPrimitive("synthetic_response_1")
+        "product_id" -> JsonPrimitive(productId)
+        "product_release" -> JsonPrimitive(1)
+        "product_snapshot_id" -> JsonPrimitive("synthetic_snapshot_1")
+        "team_slug" -> JsonPrimitive(team)
+        "app" -> JsonPrimitive(resolved.source.app)
+        "survey_id" -> JsonPrimitive(resolved.source.surveyId)
+        "survey_type" -> JsonPrimitive(resolved.source.surveyType?.name ?: "UNKNOWN")
+        "submitted_date" -> JsonPrimitive("2000-01-01")
+        "submitted_hour" -> JsonPrimitive("2000-01-01T00:00:00Z")
+        "definition_hash" -> resolved.source.definitionHash?.let(::JsonPrimitive) ?: JsonNull
+        "definition_status" -> JsonPrimitive("REGISTERED")
+        "flow_hash" -> JsonPrimitive(SYNTHETIC_FLOW_HASH)
+        "flow_status" -> JsonPrimitive("PINNED")
+        else -> syntheticDynamicValue(column, resolved.selectedFields, dimensions)
+    }
+}
+
+private fun syntheticLongRow(
+    productId: String,
+    team: String,
+    resolved: ResolvedAnalysisSource,
+    field: AnalysisCatalogFieldV1,
+    dimensions: List<AnalysisDimensionDefinitionV1>,
+    columns: List<AnalysisColumnV1>,
+): JsonObject = syntheticRow(columns) { column ->
+    when (column.logicalId) {
+        "response_key" -> JsonPrimitive("synthetic_response_1")
+        "answer_key" -> JsonPrimitive("synthetic_answer_1")
+        "product_id" -> JsonPrimitive(productId)
+        "product_release" -> JsonPrimitive(1)
+        "product_snapshot_id" -> JsonPrimitive("synthetic_snapshot_1")
+        "team_slug" -> JsonPrimitive(team)
+        "app" -> JsonPrimitive(resolved.source.app)
+        "survey_id" -> JsonPrimitive(resolved.source.surveyId)
+        "survey_type" -> JsonPrimitive(resolved.source.surveyType?.name ?: "UNKNOWN")
+        "submitted_date" -> JsonPrimitive("2000-01-01")
+        "submitted_hour" -> JsonPrimitive("2000-01-01T00:00:00Z")
+        "definition_hash" -> resolved.source.definitionHash?.let(::JsonPrimitive) ?: JsonNull
+        "definition_status" -> JsonPrimitive("REGISTERED")
+        "flow_hash" -> JsonPrimitive(SYNTHETIC_FLOW_HASH)
+        "flow_status" -> JsonPrimitive("PINNED")
+        "field_id" -> JsonPrimitive(field.fieldId)
+        "field_type" -> JsonPrimitive(field.fieldType.name)
+        "field_metadata_hash" -> JsonPrimitive(syntheticFieldMetadataHash(resolved, field))
+        "value_kind" -> JsonPrimitive(if (field.fieldType == FieldType.RATING) "RATING" else "OPTION")
+        "rating_value" -> if (field.fieldType == FieldType.RATING) JsonPrimitive(if (field.ratingVariant == RatingVariant.NPS) 0 else 1) else JsonNull
+        "option_id" -> field.optionIds?.firstOrNull()?.let(::JsonPrimitive) ?: JsonNull
+        "option_metadata_hash" -> field.optionIds?.firstOrNull()?.let { option ->
+            JsonPrimitive(syntheticOptionMetadataHash(resolved, field, option))
+        } ?: JsonNull
+        "selection_count" -> if (field.fieldType in setOf(FieldType.SINGLE_CHOICE, FieldType.MULTI_CHOICE)) JsonPrimitive(1) else JsonNull
+        else -> syntheticDimensionValue(column, dimensions)
+    }
+}
+
+private fun syntheticFieldMetadataHash(
+    resolved: ResolvedAnalysisSource,
+    field: AnalysisCatalogFieldV1,
+): String = AnalysisCanonicalHash.digest(
+    "analysis-field-metadata-v1",
+    buildList {
+        add(resolved.source.app)
+        add(resolved.source.surveyId)
+        add(resolved.source.definitionHash ?: "<null>")
+        add(field.fieldId)
+        add(field.fieldType.name)
+        add(field.ratingVariant?.name ?: "<null>")
+        add(field.ratingScale?.toString() ?: "<null>")
+        add(field.maxSelections?.toString() ?: "<null>")
+        field.optionIds.orEmpty().forEach(::add)
+        add(field.labelSource.name)
+        if (field.labelSource != AnalysisLabelSource.UNKNOWN) add(field.label ?: "<null>")
+    },
+)
+
+private fun syntheticOptionMetadataHash(
+    resolved: ResolvedAnalysisSource,
+    field: AnalysisCatalogFieldV1,
+    optionId: String,
+): String = AnalysisCanonicalHash.digest(
+    "analysis-option-metadata-v1",
+    listOf(
+        syntheticFieldMetadataHash(resolved, field),
+        optionId,
+        field.optionIds.orEmpty().indexOf(optionId).toString(),
+    ),
+)
+
+private fun syntheticCatalogRows(
+    productId: String,
+    team: String,
+    resolved: ResolvedAnalysisSource,
+    field: AnalysisCatalogFieldV1,
+    columns: List<AnalysisColumnV1>,
+): List<JsonObject> = buildList {
+    add(syntheticCatalogRow(productId, team, resolved, field, null, null, columns))
+    field.optionIds?.firstOrNull()?.let { optionId ->
+        add(
+            syntheticCatalogRow(
+                productId,
+                team,
+                resolved,
+                field,
+                optionId,
+                field.optionIds.indexOf(optionId),
+                columns,
+            ),
+        )
+    }
+}
+
+private fun syntheticCatalogRow(
+    productId: String,
+    team: String,
+    resolved: ResolvedAnalysisSource,
+    field: AnalysisCatalogFieldV1,
+    optionId: String?,
+    optionOrdinal: Int?,
+    columns: List<AnalysisColumnV1>,
+): JsonObject = syntheticRow(columns) { column ->
+    val ratingMin = if (field.ratingVariant == RatingVariant.NPS) 0 else 1
+    val ratingMax = field.ratingScale?.let { scale -> if (field.ratingVariant == RatingVariant.NPS) scale - 1 else scale }
+    when (column.logicalId) {
+        "metadata_hash" -> JsonPrimitive(
+            optionId?.let { syntheticOptionMetadataHash(resolved, field, it) }
+                ?: syntheticFieldMetadataHash(resolved, field),
+        )
+        "entry_kind" -> JsonPrimitive(if (optionId == null) "FIELD" else "OPTION")
+        "product_id" -> JsonPrimitive(productId)
+        "product_release" -> JsonPrimitive(1)
+        "product_snapshot_id" -> JsonPrimitive("synthetic_snapshot_1")
+        "team_slug" -> JsonPrimitive(team)
+        "app" -> JsonPrimitive(resolved.source.app)
+        "survey_id" -> JsonPrimitive(resolved.source.surveyId)
+        "definition_hash" -> resolved.source.definitionHash?.let(::JsonPrimitive) ?: JsonNull
+        "field_id" -> JsonPrimitive(field.fieldId)
+        "field_type" -> JsonPrimitive(field.fieldType.name)
+        "rating_variant" -> field.ratingVariant?.name?.let(::JsonPrimitive) ?: JsonNull
+        "rating_scale" -> field.ratingScale?.let(::JsonPrimitive) ?: JsonNull
+        "rating_min" -> if (field.fieldType == FieldType.RATING) JsonPrimitive(ratingMin) else JsonNull
+        "rating_max" -> ratingMax?.let(::JsonPrimitive) ?: JsonNull
+        "max_selections" -> field.maxSelections?.let(::JsonPrimitive) ?: JsonNull
+        "option_id" -> optionId?.let(::JsonPrimitive) ?: JsonNull
+        "option_ordinal" -> optionOrdinal?.let(::JsonPrimitive) ?: JsonNull
+        "display_label", "metadata_revision", "first_observed_date", "last_observed_date" -> JsonNull
+        "label_source" -> JsonPrimitive("UNKNOWN")
+        "is_current_label" -> JsonPrimitive(true)
+        else -> JsonNull
+    }
+}
+
+private fun syntheticManifestRow(
+    productId: String,
+    resourceName: String,
+    resourceKind: AnalysisResourceKind,
+    columns: List<AnalysisColumnV1>,
+): JsonObject = syntheticRow(columns) { column ->
+    when (column.logicalId) {
+        "product_id" -> JsonPrimitive(productId)
+        "product_release" -> JsonPrimitive(1)
+        "product_snapshot_id" -> JsonPrimitive("synthetic_snapshot_1")
+        "resource_name" -> JsonPrimitive(resourceName)
+        "resource_kind" -> JsonPrimitive(resourceKind.name)
+        "schema_digest" -> JsonPrimitive("0".repeat(64))
+        "row_count" -> JsonPrimitive(1)
+        "contract_version" -> JsonPrimitive(ANALYSIS_CONTRACT_VERSION)
+        "source_snapshot_at", "published_at" -> JsonPrimitive("2000-01-01T00:00:00Z")
+        "data_cutoff_at" -> JsonNull
+        "snapshot_mode" -> JsonPrimitive("FULL")
+        "quality_status" -> JsonPrimitive("PASSED")
+        else -> JsonNull
+    }
+}
+
+private fun syntheticRow(
+    columns: List<AnalysisColumnV1>,
+    value: (AnalysisColumnV1) -> JsonElement,
+): JsonObject = JsonObject(columns.associate { column -> column.name to value(column) })
+
+private fun syntheticDynamicValue(
+    column: AnalysisColumnV1,
+    fields: List<AnalysisCatalogFieldV1>,
+    dimensions: List<AnalysisDimensionDefinitionV1>,
+): JsonElement {
+    if (column.logicalId.startsWith("dimension:")) return syntheticDimensionValue(column, dimensions)
+    val field = fields.firstOrNull { column.logicalId.startsWith("field:${it.fieldId}:") } ?: return JsonNull
+    return when {
+        column.logicalId.endsWith(":applicable") -> JsonPrimitive(true)
+        column.logicalId.endsWith(":rating") -> JsonPrimitive(if (field.ratingVariant == RatingVariant.NPS) 0 else 1)
+        column.logicalId.endsWith(":option_id") -> field.optionIds?.firstOrNull()?.let(::JsonPrimitive) ?: JsonNull
+        column.logicalId.endsWith(":selection_count") -> JsonPrimitive(1)
+        column.logicalId.endsWith(":selected") -> JsonPrimitive(
+            column.logicalId == field.optionIds?.firstOrNull()?.let { optionId ->
+                "field:${field.fieldId}:option:$optionId:selected"
+            },
+        )
+        else -> JsonNull
+    }
+}
+
+private fun syntheticDimensionValue(
+    column: AnalysisColumnV1,
+    dimensions: List<AnalysisDimensionDefinitionV1>,
+): JsonElement {
+    val key = column.logicalId.removePrefix("dimension:")
+    val dimension = dimensions.singleOrNull { it.key == key } ?: return JsonNull
+    return when (dimension.type) {
+        AnalysisColumnType.STRING -> dimension.allowedValues.firstOrNull()?.let(::JsonPrimitive) ?: JsonNull
+        AnalysisColumnType.BOOL -> JsonPrimitive(false)
+        AnalysisColumnType.FLOAT64 -> JsonPrimitive(0.0)
+        AnalysisColumnType.INT64 -> JsonPrimitive(0)
+        AnalysisColumnType.DATE -> JsonPrimitive("2000-01-01")
+        AnalysisColumnType.TIMESTAMP -> JsonPrimitive("2000-01-01T00:00:00Z")
+    }
+}

--- a/apps/lumi-api/src/main/kotlin/no/nav/lumi/domain/AnalysisProduct.kt
+++ b/apps/lumi-api/src/main/kotlin/no/nav/lumi/domain/AnalysisProduct.kt
@@ -114,12 +114,12 @@ object AnalysisProductDocumentValidator {
     }
 
     private fun normalizeSource(source: AnalysisProductSourceSelection): AnalysisProductSourceSelection {
-        val fieldIds = source.fieldIds.map { normalizeIdentifier("fieldId", it, 200) }.distinct()
+        val fieldIds = source.fieldIds.map { normalizeOpaqueIdentifier("fieldId", it, 200) }.distinct()
         require(fieldIds.size == source.fieldIds.size) { "fieldIds must be unique within a source" }
         require(fieldIds.size <= 500) { "At most 500 fields can be selected per source" }
         return source.copy(
-            app = normalizeIdentifier("app", source.app, 255),
-            surveyId = normalizeIdentifier("surveyId", source.surveyId, 200),
+            app = normalizeOpaqueIdentifier("app", source.app, 255),
+            surveyId = normalizeOpaqueIdentifier("surveyId", source.surveyId, 255),
             fieldIds = fieldIds,
         )
     }
@@ -133,6 +133,11 @@ object AnalysisProductDocumentValidator {
         require(it.isNotEmpty()) { "$name is required" }
         require(it.length <= maxLength) { "$name must be at most $maxLength characters" }
         require(identifierPattern.matches(it)) { "$name contains unsupported characters" }
+    }
+
+    private fun normalizeOpaqueIdentifier(name: String, value: String, maxLength: Int): String = value.also {
+        require(it.isNotBlank()) { "$name is required" }
+        require(it.length <= maxLength) { "$name must be at most $maxLength characters" }
     }
 }
 

--- a/apps/lumi-api/src/main/kotlin/no/nav/lumi/domain/AnalysisSourceCatalog.kt
+++ b/apps/lumi-api/src/main/kotlin/no/nav/lumi/domain/AnalysisSourceCatalog.kt
@@ -1,0 +1,272 @@
+package no.nav.lumi.domain
+
+import kotlinx.serialization.Serializable
+import java.security.MessageDigest
+
+const val ANALYSIS_SOURCE_CATALOG_SCHEMA_VERSION = 1
+
+@Serializable
+enum class AnalysisDefinitionStatus {
+    REGISTERED,
+    AUTO_DERIVED,
+    RETIRED,
+    MISSING,
+}
+
+@Serializable
+enum class AnalysisFlowStatus {
+    PINNED,
+    UNPINNED,
+}
+
+@Serializable
+enum class AnalysisLabelSource {
+    REGISTERED_METADATA,
+    PRODUCT_ALIAS,
+    UNKNOWN,
+}
+
+@Serializable
+enum class AnalysisCatalogWarning {
+    LEGACY_DEFINITION_OBSERVED,
+    HISTORICAL_DEFINITION_UNRESOLVED,
+    DEFINITION_CONTENT_MISMATCH,
+    SOURCE_ID_MISMATCH,
+}
+
+@Serializable
+data class AnalysisCatalogFieldV1(
+    val fieldId: String,
+    val fieldType: FieldType,
+    val ratingVariant: RatingVariant? = null,
+    val ratingScale: Int? = null,
+    val optionIds: List<String>? = null,
+    val maxSelections: Int? = null,
+    val label: String? = null,
+    val labelSource: AnalysisLabelSource = AnalysisLabelSource.UNKNOWN,
+)
+
+@Serializable
+data class AnalysisCatalogSourceV1(
+    val app: String,
+    val surveyId: String,
+    val surveyType: SurveyType? = null,
+    val archived: Boolean,
+    val definitionHash: String? = null,
+    val definitionStatus: AnalysisDefinitionStatus,
+    val observedDefinitionHashes: List<String?>,
+    val flowHash: String? = null,
+    val flowStatus: AnalysisFlowStatus,
+    val fields: List<AnalysisCatalogFieldV1>,
+    val warnings: List<AnalysisCatalogWarning>,
+)
+
+@Serializable
+enum class AnalysisDimensionDataClass {
+    TECHNICAL_CONTEXT,
+}
+
+@Serializable
+enum class AnalysisDimensionNewValuePolicy {
+    BLOCK,
+}
+
+@Serializable
+data class AnalysisDimensionDefinitionV1(
+    val key: String,
+    val outputId: String,
+    val type: AnalysisColumnType,
+    val owner: String,
+    val description: String,
+    val dataClass: AnalysisDimensionDataClass,
+    val maxCardinality: Int,
+    val allowedValues: List<String>,
+    val newValuePolicy: AnalysisDimensionNewValuePolicy,
+    val defaultSelected: Boolean,
+)
+
+@Serializable
+data class AnalysisDimensionRegistrySnapshotV1(
+    val schemaVersion: Int = 1,
+    val revision: String,
+    val dimensions: List<AnalysisDimensionDefinitionV1>,
+)
+
+@Serializable
+data class AnalysisSourceCatalogV1(
+    val schemaVersion: Int = ANALYSIS_SOURCE_CATALOG_SCHEMA_VERSION,
+    val team: String,
+    val catalogRevision: String,
+    val sources: List<AnalysisCatalogSourceV1>,
+    val dimensions: List<AnalysisDimensionDefinitionV1>,
+)
+
+object AnalysisDimensionRegistry {
+    private val definitions = listOf(
+        AnalysisDimensionDefinitionV1(
+            key = "deviceType",
+            outputId = "device_type",
+            type = AnalysisColumnType.STRING,
+            owner = "Lumi",
+            description = "Lukket enhetstype rapportert av Lumi-klienten.",
+            dataClass = AnalysisDimensionDataClass.TECHNICAL_CONTEXT,
+            maxCardinality = 3,
+            allowedValues = listOf("desktop", "mobile", "tablet"),
+            newValuePolicy = AnalysisDimensionNewValuePolicy.BLOCK,
+            defaultSelected = false,
+        ),
+    )
+
+    fun snapshot(): AnalysisDimensionRegistrySnapshotV1 {
+        val sorted = definitions.sortedBy { it.key }
+        return AnalysisDimensionRegistrySnapshotV1(
+            revision = AnalysisCanonicalHash.digest(
+                "analysis-dimension-registry-v1",
+                sorted.flatMap { dimension ->
+                    listOf(
+                        dimension.key,
+                        dimension.outputId,
+                        dimension.type.name,
+                        dimension.owner,
+                        dimension.description,
+                        dimension.dataClass.name,
+                        dimension.maxCardinality.toString(),
+                        dimension.allowedValues.sorted().joinToString(","),
+                        dimension.newValuePolicy.name,
+                        dimension.defaultSelected.toString(),
+                    )
+                },
+            ),
+            dimensions = sorted,
+        )
+    }
+}
+
+object AnalysisCatalogRevision {
+    fun compute(
+        team: String,
+        sources: List<AnalysisCatalogSourceV1>,
+        dimensions: AnalysisDimensionRegistrySnapshotV1,
+    ): String {
+        val facts = buildList {
+            add(team)
+            add(dimensions.revision)
+            sources.sortedWith(compareBy(AnalysisCatalogSourceV1::app, AnalysisCatalogSourceV1::surveyId))
+                .forEach { source ->
+                    addSourceFacts(source, source.fields.map { it.fieldId })
+                }
+        }
+        return "catalog-v1:${AnalysisCanonicalHash.digest("analysis-source-catalog-v1", facts)}"
+    }
+
+    fun computeForSelection(
+        team: String,
+        selections: List<AnalysisProductSourceSelection>,
+        sources: List<AnalysisCatalogSourceV1>,
+        dimensionKeys: List<String>,
+        dimensions: AnalysisDimensionRegistrySnapshotV1,
+    ): String {
+        val sourcesByKey = sources.associateBy { it.app to it.surveyId }
+        val dimensionsByKey = dimensions.dimensions.associateBy { it.key }
+        val facts = buildList {
+            add(team)
+            selections.sortedWith(compareBy(AnalysisProductSourceSelection::app, AnalysisProductSourceSelection::surveyId))
+                .forEach { selection ->
+                    val source = sourcesByKey[selection.app to selection.surveyId]
+                    if (source == null) {
+                        add(selection.app)
+                        add(selection.surveyId)
+                        add("<missing-source>")
+                        selection.fieldIds.sorted().forEach { fieldId ->
+                            add(fieldId)
+                            add("<missing-field>")
+                        }
+                    } else {
+                        addSourceFacts(source, selection.fieldIds)
+                    }
+                }
+            dimensionKeys.sorted().forEach { key ->
+                add(key)
+                val dimension = dimensionsByKey[key]
+                if (dimension == null) {
+                    add("<missing-dimension>")
+                } else {
+                    addDimensionFacts(dimension)
+                }
+            }
+        }
+        return "selection-v1:${AnalysisCanonicalHash.digest("analysis-source-selection-v1", facts)}"
+    }
+
+    private fun MutableList<String>.addSourceFacts(
+        source: AnalysisCatalogSourceV1,
+        selectedFieldIds: List<String>,
+    ) {
+        add(source.app)
+        add(source.surveyId)
+        add(source.surveyType?.name ?: "<null>")
+        add(source.definitionHash ?: "<null>")
+        add(source.definitionStatus.name)
+        add(source.flowHash ?: "<null>")
+        add(source.flowStatus.name)
+        source.observedDefinitionHashes
+            .map { it ?: "<null>" }
+            .sorted()
+            .forEach(::add)
+        source.warnings.map(Enum<*>::name).sorted().forEach(::add)
+
+        val fieldsById = source.fields.associateBy { it.fieldId }
+        selectedFieldIds.sorted().forEach { fieldId ->
+            val field = fieldsById[fieldId]
+            if (field == null) {
+                add(fieldId)
+                add("<missing-field>")
+            } else {
+                addFieldFacts(field)
+            }
+        }
+    }
+
+    private fun MutableList<String>.addFieldFacts(field: AnalysisCatalogFieldV1) {
+        add(field.fieldId)
+        add(field.fieldType.name)
+        add(field.ratingVariant?.name ?: "<null>")
+        add(field.ratingScale?.toString() ?: "<null>")
+        add(field.maxSelections?.toString() ?: "<null>")
+        field.optionIds.orEmpty().forEach(::add)
+        add(field.labelSource.name)
+        if (field.labelSource != AnalysisLabelSource.UNKNOWN) {
+            add(field.label ?: "<null>")
+        }
+    }
+
+    private fun MutableList<String>.addDimensionFacts(dimension: AnalysisDimensionDefinitionV1) {
+        add(dimension.outputId)
+        add(dimension.type.name)
+        add(dimension.owner)
+        add(dimension.description)
+        add(dimension.dataClass.name)
+        add(dimension.maxCardinality.toString())
+        dimension.allowedValues.forEach(::add)
+        add(dimension.newValuePolicy.name)
+        add(dimension.defaultSelected.toString())
+    }
+}
+
+internal object AnalysisCanonicalHash {
+    fun digest(domain: String, parts: Iterable<String>): String {
+        val canonical = buildString {
+            appendLengthPrefixed(domain)
+            parts.forEach { part -> appendLengthPrefixed(part) }
+        }
+        return MessageDigest.getInstance("SHA-256")
+            .digest(canonical.toByteArray(Charsets.UTF_8))
+            .joinToString("") { byte -> "%02x".format(byte) }
+    }
+
+    private fun StringBuilder.appendLengthPrefixed(value: String) {
+        append(value.toByteArray(Charsets.UTF_8).size)
+        append(':')
+        append(value)
+    }
+}

--- a/apps/lumi-api/src/main/kotlin/no/nav/lumi/domain/AnalysisSuppressionPolicy.kt
+++ b/apps/lumi-api/src/main/kotlin/no/nav/lumi/domain/AnalysisSuppressionPolicy.kt
@@ -1,0 +1,189 @@
+package no.nav.lumi.domain
+
+import kotlinx.serialization.Serializable
+import java.math.BigInteger
+
+@Serializable
+data class AnalysisCountCell(val id: String, val count: Long)
+
+@Serializable
+data class AnalysisCountEquation(val totalId: String, val componentIds: Set<String>)
+
+@Serializable
+enum class AnalysisCountStatus {
+    EXACT,
+    BELOW_THRESHOLD,
+}
+
+@Serializable
+data class AnalysisPublishedCountCell(
+    val id: String,
+    val value: Long?,
+    val status: AnalysisCountStatus,
+)
+
+/**
+ * Pure policy for a future fixed aggregate preview. It deliberately has no
+ * repository or route integration: live aggregate publication needs a
+ * separately reviewed, snapshot-sticky cell model first.
+ */
+class AnalysisSuppressionPolicyV1 {
+    fun apply(
+        cells: List<AnalysisCountCell>,
+        equations: List<AnalysisCountEquation> = emptyList(),
+    ): List<AnalysisPublishedCountCell> {
+        require(cells.map { it.id }.distinct().size == cells.size) { "Count cell IDs must be unique" }
+        require(cells.all { it.count >= 0 }) { "Counts cannot be negative" }
+
+        val counts = cells.associate { it.id to it.count }
+        equations.forEach { equation ->
+            require(equation.totalId in counts) { "Unknown total cell" }
+            require(equation.componentIds.isNotEmpty()) { "An equation needs components" }
+            require(equation.componentIds.all { it in counts }) { "Unknown component cell" }
+            require(equation.totalId !in equation.componentIds) { "A total cannot be its own component" }
+            require(equation.componentIds.sumOf { counts.getValue(it) } == counts.getValue(equation.totalId)) {
+                "Count equation is not additive"
+            }
+        }
+
+        val protected = cells
+            .filter { it.count in 1..4 }
+            .mapTo(linkedSetOf(), AnalysisCountCell::id)
+        val suppressed = protected.toMutableSet()
+
+        while (true) {
+            val identifiable = identifiableCells(protected, suppressed, equations)
+            if (identifiable.isEmpty()) break
+
+            val connected = connectedCells(identifiable, equations)
+            val componentIds = equations.flatMapTo(mutableSetOf()) { it.componentIds }
+            val secondary = cells
+                .asSequence()
+                .filter { it.id !in suppressed && it.id in connected }
+                .sortedWith(
+                    compareByDescending<AnalysisCountCell> { it.id in componentIds }
+                        .thenByDescending { it.count }
+                        .thenBy { it.id },
+                )
+                .firstOrNull()
+                ?: error("Identifiable suppressed cell has no publishable secondary cell")
+            suppressed += secondary.id
+        }
+
+        return cells.sortedBy { it.id }.map { cell ->
+            if (cell.id in suppressed) {
+                AnalysisPublishedCountCell(cell.id, null, AnalysisCountStatus.BELOW_THRESHOLD)
+            } else {
+                AnalysisPublishedCountCell(cell.id, cell.count, AnalysisCountStatus.EXACT)
+            }
+        }
+    }
+
+    private fun identifiableCells(
+        protected: Set<String>,
+        suppressed: Set<String>,
+        equations: List<AnalysisCountEquation>,
+    ): Set<String> {
+        val columns = suppressed.sorted()
+        val fullRank = coefficientRank(columns, equations)
+        return protected.sorted().filterTo(linkedSetOf()) { candidate ->
+            fullRank > coefficientRank(columns.filterNot { it == candidate }, equations)
+        }
+    }
+
+    private fun coefficientRank(
+        columns: List<String>,
+        equations: List<AnalysisCountEquation>,
+    ): Int {
+        if (columns.isEmpty()) return 0
+        val coefficients = equations.map { equation ->
+            columns.map { cellId ->
+                when {
+                    cellId == equation.totalId -> 1
+                    cellId in equation.componentIds -> -1
+                    else -> 0
+                }
+            }
+        }
+        return exactRank(coefficients)
+    }
+
+    private fun connectedCells(
+        seeds: Set<String>,
+        equations: List<AnalysisCountEquation>,
+    ): Set<String> {
+        val connected = seeds.toMutableSet()
+        var changed: Boolean
+        do {
+            changed = false
+            equations.forEach { equation ->
+                val participants = setOf(equation.totalId) + equation.componentIds
+                if (participants.any { it in connected } && connected.addAll(participants)) changed = true
+            }
+        } while (changed)
+        return connected
+    }
+}
+
+private fun exactRank(coefficients: List<List<Int>>): Int {
+    if (coefficients.isEmpty() || coefficients.first().isEmpty()) return 0
+    val matrix = coefficients.map { row -> row.map(ExactFraction::of).toMutableList() }.toMutableList()
+    val columnCount = matrix.first().size
+    var pivotRow = 0
+
+    for (column in 0 until columnCount) {
+        val candidate = (pivotRow until matrix.size).firstOrNull { !matrix[it][column].isZero } ?: continue
+        if (candidate != pivotRow) {
+            val swapped = matrix[pivotRow]
+            matrix[pivotRow] = matrix[candidate]
+            matrix[candidate] = swapped
+        }
+
+        val pivot = matrix[pivotRow][column]
+        for (row in pivotRow + 1 until matrix.size) {
+            if (matrix[row][column].isZero) continue
+            val factor = matrix[row][column] / pivot
+            for (nextColumn in column until columnCount) {
+                matrix[row][nextColumn] = matrix[row][nextColumn] - factor * matrix[pivotRow][nextColumn]
+            }
+        }
+        pivotRow += 1
+        if (pivotRow == matrix.size) break
+    }
+    return pivotRow
+}
+
+private class ExactFraction private constructor(
+    val numerator: BigInteger,
+    val denominator: BigInteger,
+) {
+    val isZero: Boolean get() = numerator == BigInteger.ZERO
+
+    operator fun minus(other: ExactFraction): ExactFraction = of(
+        numerator * other.denominator - other.numerator * denominator,
+        denominator * other.denominator,
+    )
+
+    operator fun times(other: ExactFraction): ExactFraction = of(
+        numerator * other.numerator,
+        denominator * other.denominator,
+    )
+
+    operator fun div(other: ExactFraction): ExactFraction {
+        require(!other.isZero) { "Cannot divide by zero" }
+        return of(numerator * other.denominator, denominator * other.numerator)
+    }
+
+    companion object {
+        fun of(value: Int): ExactFraction = ExactFraction(BigInteger.valueOf(value.toLong()), BigInteger.ONE)
+
+        private fun of(numerator: BigInteger, denominator: BigInteger): ExactFraction {
+            if (numerator == BigInteger.ZERO) return ExactFraction(BigInteger.ZERO, BigInteger.ONE)
+            val sign = if (denominator.signum() < 0) BigInteger.valueOf(-1) else BigInteger.ONE
+            val signedNumerator = numerator * sign
+            val positiveDenominator = denominator * sign
+            val divisor = signedNumerator.abs().gcd(positiveDenominator)
+            return ExactFraction(signedNumerator / divisor, positiveDenominator / divisor)
+        }
+    }
+}

--- a/apps/lumi-api/src/main/kotlin/no/nav/lumi/repository/AnalysisSourceCatalogRepository.kt
+++ b/apps/lumi-api/src/main/kotlin/no/nav/lumi/repository/AnalysisSourceCatalogRepository.kt
@@ -1,0 +1,148 @@
+package no.nav.lumi.repository
+
+import kotlinx.serialization.json.Json
+import no.nav.lumi.domain.AnalysisCatalogFieldV1
+import no.nav.lumi.domain.AnalysisCatalogRevision
+import no.nav.lumi.domain.AnalysisCatalogSourceV1
+import no.nav.lumi.domain.AnalysisCatalogWarning
+import no.nav.lumi.domain.AnalysisDefinitionStatus
+import no.nav.lumi.domain.AnalysisDimensionRegistry
+import no.nav.lumi.domain.AnalysisFlowStatus
+import no.nav.lumi.domain.AnalysisLabelSource
+import no.nav.lumi.domain.AnalysisSourceCatalogV1
+import no.nav.lumi.domain.SurveyDefinition
+import no.nav.lumi.domain.computeHash
+import org.jetbrains.exposed.v1.jdbc.transactions.TransactionManager
+
+class AnalysisSourceCatalogRepository {
+    private val json = Json { ignoreUnknownKeys = true }
+
+    suspend fun findCatalog(team: String): AnalysisSourceCatalogV1 = dbQuery {
+        val connection = TransactionManager.current().connection.connection as java.sql.Connection
+        val sources = connection.prepareStatement(
+            """
+            WITH observations AS (
+                SELECT
+                    app,
+                    COALESCE(survey_id, feedback_json ->> 'surveyId') AS catalog_survey_id,
+                    jsonb_agg(DISTINCT definition_hash ORDER BY definition_hash) AS definition_hashes,
+                    BOOL_OR(
+                        survey_id IS NOT NULL AND
+                        feedback_json ->> 'surveyId' IS NOT NULL AND
+                        survey_id <> feedback_json ->> 'surveyId'
+                    ) AS has_source_id_mismatch
+                FROM feedback
+                WHERE team = ?
+                  AND length(btrim(COALESCE(survey_id, feedback_json ->> 'surveyId', ''))) > 0
+                GROUP BY app, COALESCE(survey_id, feedback_json ->> 'surveyId')
+            )
+            SELECT
+                source.app,
+                source.survey_id,
+                definition.definition_hash,
+                definition.definition::text,
+                definition.source AS definition_source,
+                definition.retired_at,
+                metadata.archived_at,
+                COALESCE(observation.definition_hashes, '[]'::jsonb)::text AS observed_definition_hashes,
+                COALESCE(observation.has_source_id_mismatch, FALSE) AS has_source_id_mismatch
+            FROM analysis_control.analysis_sources AS source
+            LEFT JOIN survey_definitions AS definition
+              ON definition.team = source.team
+             AND definition.survey_id = source.survey_id
+            LEFT JOIN survey_metadata AS metadata
+              ON metadata.team = source.team
+             AND metadata.survey_id = source.survey_id
+            LEFT JOIN observations AS observation
+              ON observation.app = source.app
+             AND observation.catalog_survey_id = source.survey_id
+            WHERE source.team = ?
+            ORDER BY source.app, source.survey_id
+            """.trimIndent(),
+        ).use { statement ->
+            statement.setString(1, team)
+            statement.setString(2, team)
+            statement.executeQuery().use { result ->
+                buildList {
+                    while (result.next()) {
+                        val app = result.getString("app")
+                        val surveyId = result.getString("survey_id")
+                        val observedDefinitionHashes = json.decodeFromString<List<String?>>(
+                            result.getString("observed_definition_hashes"),
+                        ).distinct().sortedWith(nullsFirst(naturalOrder()))
+                        val hasSourceIdMismatch = result.getBoolean("has_source_id_mismatch")
+                        val definitionJson = result.getString("definition")
+                        val definition = definitionJson?.let { json.decodeFromString<SurveyDefinition>(it) }
+                        val definitionHash = result.getString("definition_hash")
+                        val definitionStatus = when {
+                            definition == null && definitionHash == null -> AnalysisDefinitionStatus.MISSING
+                            result.getObject("retired_at") != null || definition == null -> AnalysisDefinitionStatus.RETIRED
+                            result.getString("definition_source") == SurveyDefinitionSource.API ->
+                                AnalysisDefinitionStatus.REGISTERED
+                            else -> AnalysisDefinitionStatus.AUTO_DERIVED
+                        }
+                        val warnings = buildSet {
+                            if (observedDefinitionHashes.any { it == null }) {
+                                add(AnalysisCatalogWarning.LEGACY_DEFINITION_OBSERVED)
+                            }
+                            if (
+                                observedDefinitionHashes.any { observed ->
+                                    observed != null && observed != definitionHash
+                                }
+                            ) {
+                                add(AnalysisCatalogWarning.HISTORICAL_DEFINITION_UNRESOLVED)
+                            }
+                            if (hasSourceIdMismatch) {
+                                add(AnalysisCatalogWarning.SOURCE_ID_MISMATCH)
+                            }
+                            if (definition != null && definition.surveyId != surveyId) {
+                                add(AnalysisCatalogWarning.SOURCE_ID_MISMATCH)
+                            }
+                            if (definition != null && definitionHash != definition.computeHash()) {
+                                add(AnalysisCatalogWarning.DEFINITION_CONTENT_MISMATCH)
+                            }
+                        }
+                        add(
+                            AnalysisCatalogSourceV1(
+                                app = app,
+                                surveyId = surveyId,
+                                surveyType = definition?.surveyType,
+                                archived = result.getObject("archived_at") != null,
+                                definitionHash = definitionHash,
+                                definitionStatus = definitionStatus,
+                                observedDefinitionHashes = observedDefinitionHashes,
+                                flowHash = null,
+                                flowStatus = AnalysisFlowStatus.UNPINNED,
+                                fields = definition?.fields.orEmpty()
+                                    .sortedBy { it.fieldId }
+                                    .map { field ->
+                                        AnalysisCatalogFieldV1(
+                                            fieldId = field.fieldId,
+                                            fieldType = field.fieldType,
+                                            ratingVariant = field.ratingVariant,
+                                            ratingScale = field.ratingScale,
+                                            optionIds = field.optionIds,
+                                            maxSelections = field.maxSelections,
+                                            // Submission labels and authoring labels are not approved
+                                            // public metadata and are intentionally unavailable here.
+                                            label = null,
+                                            labelSource = AnalysisLabelSource.UNKNOWN,
+                                        )
+                                    },
+                                warnings = warnings.sortedBy { it.name },
+                            ),
+                        )
+                    }
+                }
+            }
+        }
+        val dimensions = AnalysisDimensionRegistry.snapshot()
+        AnalysisSourceCatalogV1(
+            team = team,
+            catalogRevision = AnalysisCatalogRevision.compute(team, sources, dimensions),
+            sources = sources,
+            dimensions = dimensions.dimensions,
+        )
+    }
+
+}

--- a/apps/lumi-api/src/main/kotlin/no/nav/lumi/routes/AnalysisProductRoutes.kt
+++ b/apps/lumi-api/src/main/kotlin/no/nav/lumi/routes/AnalysisProductRoutes.kt
@@ -1,0 +1,35 @@
+package no.nav.lumi.routes
+
+import io.ktor.http.HttpStatusCode
+import io.ktor.server.resources.get
+import io.ktor.server.response.respond
+import io.ktor.server.routing.Route
+import no.nav.lumi.config.OpaqueNotFoundResponseKey
+import no.nav.lumi.config.auth.authorizedTeam
+import no.nav.lumi.service.AnalysisProductPreviewService
+import java.util.UUID
+
+private val defaultAnalysisProductPreviewService = AnalysisProductPreviewService()
+
+fun Route.analysisProductRoutes(
+    previewService: AnalysisProductPreviewService = defaultAnalysisProductPreviewService,
+) {
+    get<ApiV1Intern.AnalysisProducts.Catalog> {
+        call.respond(previewService.catalog(call.authorizedTeam))
+    }
+
+    get<ApiV1Intern.AnalysisProducts.Id.Preview> { params ->
+        val productId = runCatching { UUID.fromString(params.parent.productId) }.getOrNull()
+        val preview = productId?.let { previewService.preview(call.authorizedTeam, it) }
+        if (preview == null) {
+            val unavailable = mapOf("error" to "ANALYSIS_PRODUCT_UNAVAILABLE")
+            call.attributes.put(OpaqueNotFoundResponseKey, unavailable)
+            call.respond(
+                HttpStatusCode.NotFound,
+                unavailable,
+            )
+        } else {
+            call.respond(preview)
+        }
+    }
+}

--- a/apps/lumi-api/src/main/kotlin/no/nav/lumi/routes/Resources.kt
+++ b/apps/lumi-api/src/main/kotlin/no/nav/lumi/routes/Resources.kt
@@ -5,7 +5,29 @@ import kotlinx.serialization.Serializable
 
 @Resource("/api/v1/intern")
 class ApiV1Intern {
-    
+    @Resource("analysis-products")
+    @Serializable
+    class AnalysisProducts(
+        val parent: ApiV1Intern = ApiV1Intern(),
+        /** Optional team scope. The authorization plugin validates this value. */
+        val team: String? = null,
+    ) {
+        @Resource("catalog")
+        @Serializable
+        class Catalog(val parent: AnalysisProducts = AnalysisProducts())
+
+        @Resource("{productId}")
+        @Serializable
+        class Id(
+            val parent: AnalysisProducts = AnalysisProducts(),
+            val productId: String,
+        ) {
+            @Resource("preview")
+            @Serializable
+            class Preview(val parent: Id)
+        }
+    }
+
     @Resource("feedback")
     @Serializable
     class Feedback(

--- a/apps/lumi-api/src/main/kotlin/no/nav/lumi/service/AnalysisProductPreviewService.kt
+++ b/apps/lumi-api/src/main/kotlin/no/nav/lumi/service/AnalysisProductPreviewService.kt
@@ -1,0 +1,35 @@
+package no.nav.lumi.service
+
+import no.nav.lumi.domain.AnalysisContractCompiler
+import no.nav.lumi.domain.AnalysisDimensionRegistry
+import no.nav.lumi.domain.AnalysisProductCompilationInput
+import no.nav.lumi.domain.AnalysisProductContractPreviewV1
+import no.nav.lumi.repository.AnalysisProductRepository
+import no.nav.lumi.repository.AnalysisSourceCatalogRepository
+import java.util.UUID
+
+class AnalysisProductPreviewService(
+    private val productRepository: AnalysisProductRepository = AnalysisProductRepository(),
+    private val catalogRepository: AnalysisSourceCatalogRepository = AnalysisSourceCatalogRepository(),
+    private val compiler: AnalysisContractCompiler = AnalysisContractCompiler(),
+) {
+    suspend fun catalog(team: String) = catalogRepository.findCatalog(team)
+
+    suspend fun preview(team: String, productId: UUID): AnalysisProductContractPreviewV1? {
+        val product = productRepository.findById(team, productId) ?: return null
+        val draft = product.draft ?: return null
+        val catalog = catalogRepository.findCatalog(team)
+        return compiler.compilePreview(
+            AnalysisProductCompilationInput(
+                productId = product.id,
+                team = team,
+                draftId = draft.id,
+                draftRevision = draft.revision,
+                documentHash = draft.documentHash,
+                document = draft.document,
+                catalog = catalog,
+                dimensions = AnalysisDimensionRegistry.snapshot(),
+            ),
+        )
+    }
+}

--- a/apps/lumi-api/src/main/resources/db/migration/V20__analysis_source_catalog.sql
+++ b/apps/lumi-api/src/main/resources/db/migration/V20__analysis_source_catalog.sql
@@ -1,0 +1,74 @@
+-- Stable app-scoped source identities for the analysis-product catalog.
+--
+-- Install writer capture in this short migration before V21 backfills existing
+-- rows. This also covers old application pods during a rolling deployment.
+
+CREATE TABLE analysis_control.analysis_sources (
+    team                VARCHAR(255) NOT NULL,
+    app                 VARCHAR(255) NOT NULL,
+    survey_id           VARCHAR(255) NOT NULL,
+    first_submission_at TIMESTAMPTZ NOT NULL,
+    last_submission_at  TIMESTAMPTZ NOT NULL,
+    created_at          TIMESTAMPTZ NOT NULL DEFAULT clock_timestamp(),
+    updated_at          TIMESTAMPTZ NOT NULL DEFAULT clock_timestamp(),
+    PRIMARY KEY (team, app, survey_id),
+    CONSTRAINT chk_analysis_source_team_nonblank CHECK (length(btrim(team)) > 0),
+    CONSTRAINT chk_analysis_source_app_nonblank CHECK (length(btrim(app)) > 0),
+    CONSTRAINT chk_analysis_source_survey_nonblank CHECK (length(btrim(survey_id)) > 0),
+    CONSTRAINT chk_analysis_source_activity_order CHECK (first_submission_at <= last_submission_at)
+);
+
+CREATE INDEX idx_analysis_sources_team_survey
+    ON analysis_control.analysis_sources(team, survey_id, app);
+
+CREATE FUNCTION analysis_control.capture_analysis_source()
+RETURNS TRIGGER
+LANGUAGE plpgsql
+AS $$
+DECLARE
+    catalog_survey_id TEXT := COALESCE(NEW.survey_id, NEW.feedback_json ->> 'surveyId');
+BEGIN
+    IF catalog_survey_id IS NOT NULL
+       AND length(btrim(catalog_survey_id)) > 0
+       AND length(catalog_survey_id) <= 255
+       AND length(btrim(NEW.team)) > 0
+       AND length(btrim(NEW.app)) > 0 THEN
+        INSERT INTO analysis_control.analysis_sources (
+            team,
+            app,
+            survey_id,
+            first_submission_at,
+            last_submission_at
+        )
+        VALUES (
+            NEW.team,
+            NEW.app,
+            catalog_survey_id,
+            NEW.opprettet,
+            NEW.opprettet
+        )
+        ON CONFLICT (team, app, survey_id) DO UPDATE
+        SET first_submission_at = LEAST(
+                analysis_control.analysis_sources.first_submission_at,
+                EXCLUDED.first_submission_at
+            ),
+            last_submission_at = GREATEST(
+                analysis_control.analysis_sources.last_submission_at,
+                EXCLUDED.last_submission_at
+            ),
+            updated_at = statement_timestamp();
+    END IF;
+
+    RETURN NEW;
+END;
+$$;
+
+CREATE TRIGGER feedback_analysis_source_capture
+    AFTER INSERT ON feedback
+    FOR EACH ROW
+    EXECUTE FUNCTION analysis_control.capture_analysis_source();
+
+REVOKE ALL ON analysis_control.analysis_sources FROM PUBLIC;
+REVOKE ALL ON analysis_control.analysis_sources FROM "esyfo-analyse";
+REVOKE ALL ON FUNCTION analysis_control.capture_analysis_source() FROM PUBLIC;
+REVOKE ALL ON FUNCTION analysis_control.capture_analysis_source() FROM "esyfo-analyse";

--- a/apps/lumi-api/src/main/resources/db/migration/V21__backfill_analysis_source_catalog.sql
+++ b/apps/lumi-api/src/main/resources/db/migration/V21__backfill_analysis_source_catalog.sql
@@ -1,0 +1,32 @@
+-- Backfill only after V20 writer capture has committed. Inserts racing with
+-- this scan are handled by the trigger and reconciled by ON CONFLICT.
+
+INSERT INTO analysis_control.analysis_sources (
+    team,
+    app,
+    survey_id,
+    first_submission_at,
+    last_submission_at
+)
+SELECT
+    team,
+    app,
+    COALESCE(survey_id, feedback_json ->> 'surveyId') AS catalog_survey_id,
+    MIN(opprettet),
+    MAX(opprettet)
+FROM feedback
+WHERE length(btrim(team)) > 0
+  AND length(btrim(app)) > 0
+  AND length(btrim(COALESCE(survey_id, feedback_json ->> 'surveyId', ''))) > 0
+  AND length(COALESCE(survey_id, feedback_json ->> 'surveyId', '')) <= 255
+GROUP BY team, app, COALESCE(survey_id, feedback_json ->> 'surveyId')
+ON CONFLICT (team, app, survey_id) DO UPDATE
+SET first_submission_at = LEAST(
+        analysis_control.analysis_sources.first_submission_at,
+        EXCLUDED.first_submission_at
+    ),
+    last_submission_at = GREATEST(
+        analysis_control.analysis_sources.last_submission_at,
+        EXCLUDED.last_submission_at
+    ),
+    updated_at = statement_timestamp();

--- a/apps/lumi-api/src/test/kotlin/no/nav/lumi/TestDatabase.kt
+++ b/apps/lumi-api/src/test/kotlin/no/nav/lumi/TestDatabase.kt
@@ -98,6 +98,7 @@ object TestDatabase {
                         "analysis_control.analysis_product_releases, " +
                         "analysis_control.analysis_product_drafts, " +
                         "analysis_control.analysis_products, " +
+                        "analysis_control.analysis_sources, " +
                         "rating_marker, feedback, survey_definitions, survey_metadata, " +
                         "survey_authoring_revisions, survey_authoring_projects, " +
                         "feedback_retention_job_state CASCADE"

--- a/apps/lumi-api/src/test/kotlin/no/nav/lumi/TestUtils.kt
+++ b/apps/lumi-api/src/test/kotlin/no/nav/lumi/TestUtils.kt
@@ -31,6 +31,7 @@ import no.nav.lumi.routes.surveyArchiveRoutes
 import no.nav.lumi.routes.surveyAuthoringRoutes
 import no.nav.lumi.routes.surveyFacetRoutes
 import no.nav.lumi.routes.submissionRoutes
+import no.nav.lumi.routes.analysisProductRoutes
 import no.nav.lumi.routes.discoveryRoutes
 import no.nav.lumi.repository.FeedbackStatsRepository
 import java.time.LocalDate
@@ -317,6 +318,7 @@ fun Application.testModule(
             statsRoutes(statsService)
             exportRoutes(exportService)
             discoveryRoutes()
+            analysisProductRoutes()
         }
     }
 }

--- a/apps/lumi-api/src/test/kotlin/no/nav/lumi/domain/AnalysisContractCompilerTest.kt
+++ b/apps/lumi-api/src/test/kotlin/no/nav/lumi/domain/AnalysisContractCompilerTest.kt
@@ -1,0 +1,423 @@
+package no.nav.lumi.domain
+
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.collections.shouldContain
+import io.kotest.matchers.collections.shouldHaveSize
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+import kotlinx.serialization.json.jsonPrimitive
+
+class AnalysisContractCompilerTest : FunSpec({
+    val compiler = AnalysisContractCompiler()
+
+    test("produces deterministic schemas and synthetic preview without trusting client labels") {
+        val source = catalogSource(
+            fields = listOf(
+                catalogField("score", FieldType.RATING, RatingVariant.NPS, 11),
+                catalogField("reason", FieldType.SINGLE_CHOICE, optionIds = listOf("a", "b")),
+                catalogField(
+                    "priorities",
+                    FieldType.MULTI_CHOICE,
+                    optionIds = listOf("first", "second"),
+                    maxSelections = 2,
+                ),
+            ),
+        )
+        val catalog = catalogSnapshot(listOf(source))
+        val document = productDocument(
+            sources = listOf(
+                AnalysisProductSourceSelection(
+                    app = "my-app",
+                    surveyId = "survey-one",
+                    fieldIds = listOf("score", "reason", "priorities"),
+                ),
+            ),
+            dimensionKeys = listOf("deviceType"),
+            includeSubmittedHour = true,
+        )
+
+        val first = compiler.compilePreview(compilationInput(document, catalog))
+        val second = compiler.compilePreview(
+            compilationInput(
+                document.copy(
+                    sources = document.sources.reversed().map { it.copy(fieldIds = it.fieldIds.reversed()) },
+                    dimensionKeys = document.dimensionKeys.reversed(),
+                ),
+                catalog.copy(sources = catalog.sources.reversed()),
+            ),
+        )
+
+        first.baseSchemaDigest shouldBe second.baseSchemaDigest
+        first.resources shouldBe second.resources
+        first.dataOrigin shouldBe PreviewDataOrigin.SYNTHETIC
+        first.status shouldBe AnalysisContractPreviewStatus.BLOCKED
+        first.issues.map { it.code } shouldContain AnalysisCompilationIssueCode.FLOW_NOT_PINNED
+        first.resources shouldHaveSize 4
+
+        val wide = first.resources.single { it.kind == AnalysisResourceKind.WIDE }
+        wide.name.startsWith("responses_my_app_survey_one_") shouldBe true
+        wide.columns.single { it.name == "submitted_hour" }.type shouldBe AnalysisColumnType.TIMESTAMP
+        wide.columns.any { it.logicalId == "field:score:rating" && it.type == AnalysisColumnType.INT64 } shouldBe true
+        wide.columns.any { it.logicalId == "field:reason:option_id" && it.type == AnalysisColumnType.STRING } shouldBe true
+        wide.columns.count { it.logicalId.startsWith("field:priorities:option:") } shouldBe 2
+        wide.columns.any { it.logicalId == "dimension:deviceType" } shouldBe true
+        wide.syntheticRows shouldHaveSize 1
+        wide.syntheticRows.single().getValue("flow_hash").jsonPrimitive.content.matches(
+            Regex("^[0-9a-f]{64}$"),
+        ) shouldBe true
+
+        val serialized = AnalysisContractJson.encodeToString(AnalysisProductContractPreviewV1.serializer(), first)
+        serialized.contains("untrusted question label") shouldBe false
+        serialized.contains("untrusted option label") shouldBe false
+        serialized.contains("feedback_json") shouldBe false
+        serialized.contains("internal-feedback-id") shouldBe false
+        serialized.contains("2000-01-01") shouldBe true
+    }
+
+    test("keeps equal survey IDs in different apps separate") {
+        val catalog = catalogSnapshot(
+            listOf(
+                catalogSource(app = "app-a"),
+                catalogSource(app = "app-b"),
+            ),
+        )
+        val document = productDocument(
+            sources = listOf(
+                AnalysisProductSourceSelection("app-a", "survey-one", listOf("score")),
+                AnalysisProductSourceSelection("app-b", "survey-one", listOf("score")),
+            ),
+        )
+
+        val preview = compiler.compilePreview(compilationInput(document, catalog))
+
+        preview.resources.count { it.kind == AnalysisResourceKind.WIDE } shouldBe 2
+        preview.resources.filter { it.kind == AnalysisResourceKind.WIDE }.map { it.name }.distinct().size shouldBe 2
+    }
+
+    test("pins complete field and dimension contracts when provenance is available") {
+        val firstSource = catalogSource(
+            fields = listOf(catalogField("reason", FieldType.SINGLE_CHOICE, optionIds = listOf("a", "b"))),
+        ).copy(
+            flowHash = "f".repeat(64),
+            flowStatus = AnalysisFlowStatus.PINNED,
+        )
+        val secondSource = firstSource.copy(
+            fields = listOf(catalogField("reason", FieldType.SINGLE_CHOICE, optionIds = listOf("a", "b", "c"))),
+        )
+        val document = productDocument(
+            sources = listOf(AnalysisProductSourceSelection("my-app", "survey-one", listOf("reason"))),
+            dimensionKeys = listOf("deviceType"),
+        )
+
+        val first = compiler.compilePreview(compilationInput(document, catalogSnapshot(listOf(firstSource))))
+        val second = compiler.compilePreview(compilationInput(document, catalogSnapshot(listOf(secondSource))))
+
+        first.status shouldBe AnalysisContractPreviewStatus.READY
+        first.publicationSpecification shouldNotBe null
+        val specification = requireNotNull(first.publicationSpecification)
+        specification.sourcePins.single().fields.single().optionIds shouldBe listOf("a", "b")
+        specification.dimensions.single().allowedValues shouldBe listOf("desktop", "mobile", "tablet")
+        first.baseSchemaDigest shouldBe second.baseSchemaDigest
+        first.publicationSpecificationDigest shouldNotBe second.publicationSpecificationDigest
+        first.catalogRevision shouldNotBe second.catalogRevision
+    }
+
+    test("publication specification binds retention") {
+        val source = catalogSource().copy(
+            flowHash = "f".repeat(64),
+            flowStatus = AnalysisFlowStatus.PINNED,
+        )
+        val sourceSelection = listOf(AnalysisProductSourceSelection("my-app", "survey-one", listOf("score")))
+        val shortRetention = compiler.compilePreview(
+            compilationInput(
+                productDocument(sourceSelection).copy(retention = AnalysisProductRetention.DAYS_30),
+                catalogSnapshot(listOf(source)),
+            ),
+        )
+        val sourceMaximum = compiler.compilePreview(
+            compilationInput(
+                productDocument(sourceSelection).copy(retention = AnalysisProductRetention.SOURCE_MAXIMUM),
+                catalogSnapshot(listOf(source)),
+            ),
+        )
+
+        shortRetention.baseSchemaDigest shouldBe sourceMaximum.baseSchemaDigest
+        shortRetention.publicationSpecification?.retention shouldBe AnalysisProductRetention.DAYS_30
+        shortRetention.publicationSpecificationDigest shouldNotBe sourceMaximum.publicationSpecificationDigest
+    }
+
+    test("selection revision ignores unrelated catalog sources and unselected fields") {
+        val selected = catalogSource().copy(
+            flowHash = "f".repeat(64),
+            flowStatus = AnalysisFlowStatus.PINNED,
+        )
+        val selectedWithExtraField = selected.copy(
+            fields = selected.fields + catalogField("not-selected", FieldType.RATING, RatingVariant.EMOJI, 5),
+        )
+        val unrelated = catalogSource(app = "another-app").copy(
+            flowHash = "e".repeat(64),
+            flowStatus = AnalysisFlowStatus.PINNED,
+        )
+        val document = productDocument(
+            sources = listOf(AnalysisProductSourceSelection("my-app", "survey-one", listOf("score"))),
+        )
+
+        val baseline = compiler.compilePreview(compilationInput(document, catalogSnapshot(listOf(selected))))
+        val expandedCatalog = compiler.compilePreview(
+            compilationInput(document, catalogSnapshot(listOf(selectedWithExtraField, unrelated))),
+        )
+
+        baseline.catalogRevision shouldBe expandedCatalog.catalogRevision
+        baseline.publicationSpecificationDigest shouldBe expandedCatalog.publicationSpecificationDigest
+    }
+
+    test("uses the exact documented resource shapes and never manifests the manifest itself") {
+        val preview = compiler.compilePreview(
+            compilationInput(
+                productDocument(
+                    sources = listOf(AnalysisProductSourceSelection("my-app", "survey-one", listOf("score"))),
+                ),
+                catalogSnapshot(listOf(catalogSource())),
+            ),
+        )
+
+        preview.resources.map { it.kind } shouldBe listOf(
+            AnalysisResourceKind.WIDE,
+            AnalysisResourceKind.LONG,
+            AnalysisResourceKind.FIELD_CATALOG,
+            AnalysisResourceKind.MANIFEST,
+        )
+        preview.resources.single { it.kind == AnalysisResourceKind.LONG }.columns.map { it.name } shouldBe listOf(
+            "response_key", "answer_key", "product_id", "product_release", "product_snapshot_id",
+            "team_slug", "app", "survey_id", "survey_type", "submitted_date", "definition_hash",
+            "definition_status", "flow_hash", "flow_status", "field_id", "field_type",
+            "field_metadata_hash", "value_kind", "rating_value", "option_id",
+            "option_metadata_hash", "selection_count",
+        )
+        preview.resources.single { it.kind == AnalysisResourceKind.MANIFEST }.columns.map { it.name } shouldBe listOf(
+            "product_id", "product_release", "product_snapshot_id", "resource_name", "resource_kind",
+            "schema_digest", "row_count", "contract_version", "source_snapshot_at", "published_at",
+            "data_cutoff_at", "snapshot_mode", "quality_status",
+        )
+        preview.resources.single { it.kind == AnalysisResourceKind.MANIFEST }
+            .syntheticRows.single().getValue("resource_name").jsonPrimitive.content shouldNotBe "product_manifest_v1"
+    }
+
+    test("fails closed for foreign, unknown, forbidden and malformed selections") {
+        val malformed = catalogField(
+            fieldId = "bad-choice",
+            fieldType = FieldType.SINGLE_CHOICE,
+            optionIds = listOf("same", "same"),
+        )
+        val catalog = catalogSnapshot(
+            listOf(
+                catalogSource(
+                    definitionStatus = AnalysisDefinitionStatus.AUTO_DERIVED,
+                    fields = listOf(
+                        catalogField("comment", FieldType.TEXT),
+                        malformed,
+                    ),
+                ),
+            ),
+        )
+        val document = productDocument(
+            sources = listOf(
+                AnalysisProductSourceSelection(
+                    "my-app",
+                    "survey-one",
+                    listOf("comment", "bad-choice", "missing"),
+                ),
+            ),
+            dimensionKeys = listOf("context.tags.secret"),
+        )
+
+        val preview = compiler.compilePreview(compilationInput(document, catalog))
+
+        preview.status shouldBe AnalysisContractPreviewStatus.BLOCKED
+        preview.issues.map { it.code }.toSet() shouldBe setOf(
+            AnalysisCompilationIssueCode.DEFINITION_NOT_REGISTERED,
+            AnalysisCompilationIssueCode.FLOW_NOT_PINNED,
+            AnalysisCompilationIssueCode.FIELD_NOT_ALLOWED,
+            AnalysisCompilationIssueCode.FIELD_MALFORMED,
+            AnalysisCompilationIssueCode.FIELD_UNAVAILABLE,
+            AnalysisCompilationIssueCode.DIMENSION_UNAVAILABLE,
+        )
+        preview.publicationSpecification shouldBe null
+    }
+
+    test("fails closed for missing and malformed provenance hashes") {
+        val source = catalogSource().copy(
+            definitionHash = null,
+            observedDefinitionHashes = emptyList(),
+            flowHash = "not-a-hash",
+            flowStatus = AnalysisFlowStatus.PINNED,
+        )
+        val document = productDocument(
+            sources = listOf(AnalysisProductSourceSelection("my-app", "survey-one", listOf("score"))),
+        )
+
+        val preview = compiler.compilePreview(compilationInput(document, catalogSnapshot(listOf(source))))
+
+        preview.status shouldBe AnalysisContractPreviewStatus.BLOCKED
+        preview.issues.map { it.code }.toSet() shouldBe setOf(
+            AnalysisCompilationIssueCode.DEFINITION_HASH_UNRESOLVED,
+            AnalysisCompilationIssueCode.FLOW_NOT_PINNED,
+        )
+        preview.publicationSpecification shouldBe null
+    }
+
+    test("synthetic option rows preserve exact metadata references and selections") {
+        val field = catalogField(
+            "choice",
+            FieldType.MULTI_CHOICE,
+            optionIds = listOf("a", "x:a:y"),
+            maxSelections = 2,
+        )
+        val preview = compiler.compilePreview(
+            compilationInput(
+                productDocument(
+                    sources = listOf(AnalysisProductSourceSelection("my-app", "survey-one", listOf("choice"))),
+                ),
+                catalogSnapshot(listOf(catalogSource(fields = listOf(field)))),
+            ),
+        )
+
+        val wide = preview.resources.single { it.kind == AnalysisResourceKind.WIDE }
+        val wideRow = wide.syntheticRows.single()
+        val optionColumns = wide.columns.filter { it.logicalId.endsWith(":selected") }
+        wideRow.getValue(optionColumns[0].name).jsonPrimitive.content shouldBe "true"
+        wideRow.getValue(optionColumns[1].name).jsonPrimitive.content shouldBe "false"
+
+        val longRow = preview.resources.single { it.kind == AnalysisResourceKind.LONG }.syntheticRows.single()
+        val catalogRows = preview.resources.single { it.kind == AnalysisResourceKind.FIELD_CATALOG }.syntheticRows
+        catalogRows.map { it.getValue("entry_kind").jsonPrimitive.content } shouldBe listOf("FIELD", "OPTION")
+        longRow.getValue("field_metadata_hash") shouldBe catalogRows[0].getValue("metadata_hash")
+        longRow.getValue("option_metadata_hash") shouldBe catalogRows[1].getValue("metadata_hash")
+        longRow.getValue("option_id") shouldBe catalogRows[1].getValue("option_id")
+    }
+
+    test("manifest synthetic row uses the actual first resource kind") {
+        val preview = compiler.compilePreview(
+            compilationInput(productDocument(sources = emptyList()), catalogSnapshot(emptyList())),
+        )
+
+        val manifestRow = preview.resources.single { it.kind == AnalysisResourceKind.MANIFEST }.syntheticRows.single()
+        manifestRow.getValue("resource_name").jsonPrimitive.content shouldBe "answers_long_v1"
+        manifestRow.getValue("resource_kind").jsonPrimitive.content shouldBe "LONG"
+    }
+
+    test("warns at 80 dynamic columns and blocks only above 120") {
+        fun previewFor(ratingFields: Int, dimensions: List<String> = emptyList()): AnalysisProductContractPreviewV1 {
+            val fields = (1..ratingFields).map { catalogField("rating-$it", FieldType.RATING, RatingVariant.EMOJI, 5) }
+            val source = catalogSource(fields = fields)
+            return compiler.compilePreview(
+                compilationInput(
+                    productDocument(
+                        sources = listOf(
+                            AnalysisProductSourceSelection(
+                                "my-app",
+                                "survey-one",
+                                fields.map { it.fieldId },
+                            ),
+                        ),
+                        dimensionKeys = dimensions,
+                    ),
+                    catalogSnapshot(listOf(source)),
+                ),
+            )
+        }
+
+        previewFor(39).issues.any { it.code == AnalysisCompilationIssueCode.WIDE_COLUMN_BUDGET_WARNING } shouldBe false
+        previewFor(40).issues.any { it.code == AnalysisCompilationIssueCode.WIDE_COLUMN_BUDGET_WARNING } shouldBe true
+        previewFor(60).issues.any { it.code == AnalysisCompilationIssueCode.WIDE_COLUMN_BUDGET_EXCEEDED } shouldBe false
+        previewFor(61).issues.any { it.code == AnalysisCompilationIssueCode.WIDE_COLUMN_BUDGET_EXCEEDED } shouldBe true
+    }
+
+    test("physical names are bounded and contain no SQL metacharacters") {
+        val unsafe = AnalysisPhysicalNames.resourceName(
+            app = "Å SELECT * FROM x; -- " + "a".repeat(200),
+            surveyId = "1/../../survey" + "b".repeat(200),
+        )
+
+        (unsafe.length <= 128) shouldBe true
+        unsafe.matches(Regex("^[a-z][a-z0-9_]*$")) shouldBe true
+        unsafe.contains("select", ignoreCase = true) shouldBe true
+        unsafe.contains(";") shouldBe false
+        unsafe.contains("-") shouldBe false
+    }
+})
+
+private fun compilationInput(
+    document: AnalysisProductDocumentV1,
+    catalog: AnalysisSourceCatalogV1,
+) = AnalysisProductCompilationInput(
+    productId = "00000000-0000-0000-0000-000000000001",
+    team = "team-a",
+    draftId = "00000000-0000-0000-0000-000000000002",
+    draftRevision = 1,
+    documentHash = "a".repeat(64),
+    document = document,
+    catalog = catalog,
+    dimensions = AnalysisDimensionRegistry.snapshot(),
+)
+
+private fun productDocument(
+    sources: List<AnalysisProductSourceSelection>,
+    dimensionKeys: List<String> = emptyList(),
+    includeSubmittedHour: Boolean = false,
+) = AnalysisProductDocumentV1(
+    name = "Analysis",
+    purpose = "Safe analysis",
+    dataOwner = "owner",
+    technicalOwner = "technical-owner",
+    useCases = listOf(AnalysisProductUseCase.METABASE),
+    retention = AnalysisProductRetention.SOURCE_MAXIMUM,
+    reviewDate = "2027-08-29",
+    sources = sources,
+    dimensionKeys = dimensionKeys,
+    includeSubmittedHour = includeSubmittedHour,
+)
+
+private fun catalogSnapshot(sources: List<AnalysisCatalogSourceV1>) = AnalysisSourceCatalogV1(
+    team = "team-a",
+    catalogRevision = AnalysisCatalogRevision.compute("team-a", sources, AnalysisDimensionRegistry.snapshot()),
+    sources = sources,
+    dimensions = AnalysisDimensionRegistry.snapshot().dimensions,
+)
+
+private fun catalogSource(
+    app: String = "my-app",
+    definitionStatus: AnalysisDefinitionStatus = AnalysisDefinitionStatus.REGISTERED,
+    fields: List<AnalysisCatalogFieldV1> = listOf(
+        catalogField("score", FieldType.RATING, RatingVariant.NPS, 11),
+    ),
+) = AnalysisCatalogSourceV1(
+    app = app,
+    surveyId = "survey-one",
+    surveyType = SurveyType.CUSTOM,
+    archived = false,
+    definitionHash = "d".repeat(64),
+    definitionStatus = definitionStatus,
+    observedDefinitionHashes = listOf("d".repeat(64)),
+    flowStatus = AnalysisFlowStatus.UNPINNED,
+    fields = fields,
+    warnings = emptyList(),
+)
+
+private fun catalogField(
+    fieldId: String,
+    fieldType: FieldType,
+    ratingVariant: RatingVariant? = null,
+    ratingScale: Int? = null,
+    optionIds: List<String>? = null,
+    maxSelections: Int? = null,
+) = AnalysisCatalogFieldV1(
+    fieldId = fieldId,
+    fieldType = fieldType,
+    ratingVariant = ratingVariant,
+    ratingScale = ratingScale,
+    optionIds = optionIds,
+    maxSelections = maxSelections,
+    label = null,
+    labelSource = AnalysisLabelSource.UNKNOWN,
+)

--- a/apps/lumi-api/src/test/kotlin/no/nav/lumi/domain/AnalysisProductTest.kt
+++ b/apps/lumi-api/src/test/kotlin/no/nav/lumi/domain/AnalysisProductTest.kt
@@ -20,9 +20,9 @@ class AnalysisProductTest : FunSpec({
                 reviewDate = "2027-08-29",
                 sources = listOf(
                     AnalysisProductSourceSelection(
-                        app = " bro-frontend ",
-                        surveyId = " kartlegging ",
-                        fieldIds = listOf(" opplevelse "),
+                        app = "bro-frontend",
+                        surveyId = "kartlegging",
+                        fieldIds = listOf("opplevelse"),
                     ),
                 ),
                 dimensionKeys = listOf(" deviceType "),
@@ -46,12 +46,12 @@ class AnalysisProductTest : FunSpec({
         }
     }
 
-    test("rejects duplicate normalized source and field identities") {
+    test("rejects duplicate source and field identities") {
         shouldThrow<IllegalArgumentException> {
             AnalysisProductDocumentValidator.validate(
                 validDocument(
                     sources = listOf(
-                        AnalysisProductSourceSelection("app-a", "survey-a", listOf("field-a", " field-a ")),
+                        AnalysisProductSourceSelection("app-a", "survey-a", listOf("field-a", "field-a")),
                     ),
                 ),
                 today,
@@ -63,12 +63,30 @@ class AnalysisProductTest : FunSpec({
                 validDocument(
                     sources = listOf(
                         AnalysisProductSourceSelection("app-a", "survey-a"),
-                        AnalysisProductSourceSelection(" app-a ", "survey-a"),
+                        AnalysisProductSourceSelection("app-a", "survey-a"),
                     ),
                 ),
                 today,
             )
         }
+    }
+
+    test("accepts bounded opaque source identifiers") {
+        val validated = AnalysisProductDocumentValidator.validate(
+            validDocument(
+                sources = listOf(
+                    AnalysisProductSourceSelection(
+                        app = " app/flate ",
+                        surveyId = "survey:2026",
+                        fieldIds = listOf("mål-1"),
+                    ),
+                ),
+            ),
+            today,
+        )
+
+        validated.document.sources.single() shouldBe
+            AnalysisProductSourceSelection(" app/flate ", "survey:2026", listOf("mål-1"))
     }
 })
 

--- a/apps/lumi-api/src/test/kotlin/no/nav/lumi/domain/AnalysisSuppressionPolicyTest.kt
+++ b/apps/lumi-api/src/test/kotlin/no/nav/lumi/domain/AnalysisSuppressionPolicyTest.kt
@@ -1,0 +1,95 @@
+package no.nav.lumi.domain
+
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+class AnalysisSuppressionPolicyTest : FunSpec({
+    val policy = AnalysisSuppressionPolicyV1()
+
+    test("shows zero and counts from five while hiding one through four") {
+        val result = policy.apply(
+            cells = listOf(
+                AnalysisCountCell("zero", 0),
+                AnalysisCountCell("one", 1),
+                AnalysisCountCell("four", 4),
+                AnalysisCountCell("five", 5),
+            ),
+        ).associateBy { it.id }
+
+        result.getValue("zero") shouldBe AnalysisPublishedCountCell("zero", 0, AnalysisCountStatus.EXACT)
+        result.getValue("one") shouldBe AnalysisPublishedCountCell("one", null, AnalysisCountStatus.BELOW_THRESHOLD)
+        result.getValue("four") shouldBe AnalysisPublishedCountCell("four", null, AnalysisCountStatus.BELOW_THRESHOLD)
+        result.getValue("five") shouldBe AnalysisPublishedCountCell("five", 5, AnalysisCountStatus.EXACT)
+    }
+
+    test("secondary suppression prevents reconstructing a 6 5 1 complement") {
+        val result = policy.apply(
+            cells = listOf(
+                AnalysisCountCell("total", 6),
+                AnalysisCountCell("selected", 5),
+                AnalysisCountCell("complement", 1),
+            ),
+            equations = listOf(AnalysisCountEquation("total", setOf("selected", "complement"))),
+        ).associateBy { it.id }
+
+        result.getValue("total").value shouldBe 6
+        result.getValue("selected").status shouldBe AnalysisCountStatus.BELOW_THRESHOLD
+        result.getValue("complement").status shouldBe AnalysisCountStatus.BELOW_THRESHOLD
+    }
+
+    test("is order invariant idempotent and uses one external suppression status") {
+        val cells = listOf(
+            AnalysisCountCell("total", 10),
+            AnalysisCountCell("large", 7),
+            AnalysisCountCell("small", 3),
+            AnalysisCountCell("other", 0),
+        )
+        val equations = listOf(AnalysisCountEquation("total", setOf("large", "small")))
+
+        val first = policy.apply(cells, equations)
+        val permuted = policy.apply(cells.reversed(), equations.reversed())
+
+        first shouldBe permuted
+        first.single { it.id == "large" }.status shouldBe AnalysisCountStatus.BELOW_THRESHOLD
+        first.single { it.id == "small" }.status shouldBe AnalysisCountStatus.BELOW_THRESHOLD
+        first.map { it.status }.toSet() shouldBe setOf(AnalysisCountStatus.EXACT, AnalysisCountStatus.BELOW_THRESHOLD)
+    }
+
+    test("two already hidden components do not require hiding the total") {
+        val result = policy.apply(
+            cells = listOf(
+                AnalysisCountCell("total", 5),
+                AnalysisCountCell("a", 3),
+                AnalysisCountCell("b", 2),
+            ),
+            equations = listOf(AnalysisCountEquation("total", setOf("a", "b"))),
+        ).associateBy { it.id }
+
+        result.getValue("total").status shouldBe AnalysisCountStatus.EXACT
+        result.getValue("a").status shouldBe AnalysisCountStatus.BELOW_THRESHOLD
+        result.getValue("b").status shouldBe AnalysisCountStatus.BELOW_THRESHOLD
+    }
+
+    test("secondary suppression protects overlapping equations as one system") {
+        val result = policy.apply(
+            cells = listOf(
+                AnalysisCountCell("a", 3),
+                AnalysisCountCell("b", 3),
+                AnalysisCountCell("c", 3),
+                AnalysisCountCell("ab", 6),
+                AnalysisCountCell("ac", 6),
+                AnalysisCountCell("bc", 6),
+            ),
+            equations = listOf(
+                AnalysisCountEquation("ab", setOf("a", "b")),
+                AnalysisCountEquation("ac", setOf("a", "c")),
+                AnalysisCountEquation("bc", setOf("b", "c")),
+            ),
+        ).associateBy { it.id }
+
+        result.getValue("a").status shouldBe AnalysisCountStatus.BELOW_THRESHOLD
+        result.getValue("b").status shouldBe AnalysisCountStatus.BELOW_THRESHOLD
+        result.getValue("c").status shouldBe AnalysisCountStatus.BELOW_THRESHOLD
+        result.values.count { it.id in setOf("ab", "ac", "bc") && it.value == null } shouldBe 1
+    }
+})

--- a/apps/lumi-api/src/test/kotlin/no/nav/lumi/repository/AnalysisProductMigrationTest.kt
+++ b/apps/lumi-api/src/test/kotlin/no/nav/lumi/repository/AnalysisProductMigrationTest.kt
@@ -36,7 +36,8 @@ class AnalysisProductMigrationTest : FunSpec({
                         'analysis_control.analysis_products',
                         'analysis_control.analysis_product_drafts',
                         'analysis_control.analysis_product_releases',
-                        'analysis_control.analysis_product_audit_events'
+                        'analysis_control.analysis_product_audit_events',
+                        'analysis_control.analysis_sources'
                     ]) AS table_name
                 """.trimIndent(),
             ).use { statement ->

--- a/apps/lumi-api/src/test/kotlin/no/nav/lumi/repository/AnalysisSourceCatalogMigrationTest.kt
+++ b/apps/lumi-api/src/test/kotlin/no/nav/lumi/repository/AnalysisSourceCatalogMigrationTest.kt
@@ -1,0 +1,153 @@
+package no.nav.lumi.repository
+
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import no.nav.lumi.PsqlContainer
+import org.flywaydb.core.Flyway
+import org.flywaydb.core.api.MigrationVersion
+import java.sql.DriverManager
+import java.sql.Types
+import java.time.OffsetDateTime
+
+class AnalysisSourceCatalogMigrationTest : FunSpec({
+    val container = PsqlContainer()
+
+    beforeSpec {
+        container.start()
+        waitForDatabase(container)
+    }
+    afterSpec { container.stop() }
+
+    test("captures rolling writers before backfill and keeps the table closed") {
+        val beforeCatalog = Flyway.configure()
+            .dataSource(container.jdbcUrl, container.username, container.password)
+            .locations("classpath:db/migration")
+            .target(MigrationVersion.fromVersion("19"))
+            .load()
+        beforeCatalog.migrate()
+
+        DriverManager.getConnection(container.jdbcUrl, container.username, container.password).use { connection ->
+            insertFeedback(connection, "feedback-backfill", "2026-08-01T10:00:00Z", "app-a", "survey-a", "survey-a")
+            insertFeedback(connection, "feedback-json-fallback", "2026-08-01T11:00:00Z", "app-json", null, "survey-json")
+            insertFeedback(
+                connection,
+                "feedback-padded-invalid",
+                "2026-08-01T11:30:00Z",
+                "app-padded",
+                null,
+                "survey-padding" + " ".repeat(250),
+            )
+        }
+
+        Flyway.configure()
+            .dataSource(container.jdbcUrl, container.username, container.password)
+            .locations("classpath:db/migration")
+            .target(MigrationVersion.fromVersion("20"))
+            .load()
+            .migrate()
+
+        DriverManager.getConnection(container.jdbcUrl, container.username, container.password).use { connection ->
+            insertFeedback(connection, "feedback-rolling", "2026-08-01T12:00:00Z", "app-b", "survey-a", "survey-a")
+
+            connection.prepareStatement(
+                """
+                SELECT COUNT(*)
+                FROM analysis_control.analysis_sources
+                WHERE team = 'team-a' AND app = 'app-b' AND survey_id = 'survey-a'
+                """.trimIndent(),
+            ).use { statement ->
+                statement.executeQuery().use { result ->
+                    result.next() shouldBe true
+                    result.getInt(1) shouldBe 1
+                }
+            }
+
+            connection.autoCommit = false
+            insertFeedback(connection, "feedback-rollback", "2026-08-01T13:00:00Z", "app-rollback", "survey-a", "survey-a")
+            connection.rollback()
+        }
+
+        Flyway.configure()
+            .dataSource(container.jdbcUrl, container.username, container.password)
+            .locations("classpath:db/migration")
+            .load()
+            .migrate()
+
+        DriverManager.getConnection(container.jdbcUrl, container.username, container.password).use { connection ->
+            connection.prepareStatement(
+                """
+                SELECT team, app, survey_id, first_submission_at, last_submission_at
+                FROM analysis_control.analysis_sources
+                ORDER BY app
+                """.trimIndent(),
+            ).use { statement ->
+                statement.executeQuery().use { result ->
+                    result.next() shouldBe true
+                    result.getString("team") shouldBe "team-a"
+                    result.getString("app") shouldBe "app-a"
+                    result.getString("survey_id") shouldBe "survey-a"
+                    result.getObject("first_submission_at") shouldBe result.getObject("last_submission_at")
+
+                    result.next() shouldBe true
+                    result.getString("app") shouldBe "app-b"
+                    result.getString("survey_id") shouldBe "survey-a"
+
+                    result.next() shouldBe true
+                    result.getString("app") shouldBe "app-json"
+                    result.getString("survey_id") shouldBe "survey-json"
+                    result.next() shouldBe false
+                }
+            }
+
+            connection.prepareStatement(
+                "SELECT has_table_privilege('esyfo-analyse', 'analysis_control.analysis_sources', 'SELECT')",
+            ).use { statement ->
+                statement.executeQuery().use { result ->
+                    result.next() shouldBe true
+                    result.getBoolean(1) shouldBe false
+                }
+            }
+        }
+    }
+})
+
+private fun insertFeedback(
+    connection: java.sql.Connection,
+    id: String,
+    submittedAt: String,
+    app: String,
+    surveyIdColumn: String?,
+    surveyIdJson: String,
+) {
+    connection.prepareStatement(
+        """
+        INSERT INTO feedback (
+            id, opprettet, feedback_json, team, app, survey_id, definition_hash
+        )
+        VALUES (?, ?, ?::jsonb, ?, ?, ?, ?)
+        """.trimIndent(),
+    ).use { statement ->
+        statement.setString(1, id)
+        statement.setObject(2, OffsetDateTime.parse(submittedAt))
+        statement.setString(3, """{"surveyId":"$surveyIdJson","surveyType":"custom","answers":[]}""")
+        statement.setString(4, "team-a")
+        statement.setString(5, app)
+        if (surveyIdColumn == null) statement.setNull(6, Types.VARCHAR) else statement.setString(6, surveyIdColumn)
+        statement.setString(7, "a".repeat(64))
+        statement.executeUpdate()
+    }
+}
+
+private fun waitForDatabase(container: PsqlContainer) {
+    var lastFailure: Exception? = null
+    repeat(30) {
+        try {
+            DriverManager.getConnection(container.jdbcUrl, container.username, container.password).use { }
+            return
+        } catch (failure: Exception) {
+            lastFailure = failure
+            Thread.sleep(100)
+        }
+    }
+    throw checkNotNull(lastFailure)
+}

--- a/apps/lumi-api/src/test/kotlin/no/nav/lumi/repository/AnalysisSourceCatalogRepositoryTest.kt
+++ b/apps/lumi-api/src/test/kotlin/no/nav/lumi/repository/AnalysisSourceCatalogRepositoryTest.kt
@@ -1,0 +1,167 @@
+package no.nav.lumi.repository
+
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.collections.shouldContain
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+import no.nav.lumi.TestDatabase
+import no.nav.lumi.domain.AnalysisCatalogWarning
+import no.nav.lumi.domain.AnalysisDefinitionStatus
+import no.nav.lumi.domain.AnalysisFlowStatus
+
+class AnalysisSourceCatalogRepositoryTest : FunSpec({
+    val repository = AnalysisSourceCatalogRepository()
+    val feedbackRepository = FeedbackRepository()
+
+    beforeSpec { TestDatabase.initialize() }
+    beforeTest { TestDatabase.clearAllData() }
+
+    test("keeps catalog SQL scoped by team even when source identities are equal") {
+        insertDefinition("team-a", "survey", "a".repeat(64), "field-a")
+        insertDefinition("team-b", "survey", "b".repeat(64), "field-b")
+        feedbackRepository.save(feedbackJson("survey", "secret label A"), "team-a", "same-app", "survey", "a".repeat(64))
+        feedbackRepository.save(feedbackJson("survey", "secret label B"), "team-b", "same-app", "survey", "b".repeat(64))
+
+        val teamA = repository.findCatalog("team-a")
+        val serialized = no.nav.lumi.domain.AnalysisContractJson.encodeToString(
+            no.nav.lumi.domain.AnalysisSourceCatalogV1.serializer(),
+            teamA,
+        )
+
+        teamA.sources.single().fields.single().fieldId shouldBe "field-a"
+        serialized.contains("field-b") shouldBe false
+        serialized.contains("secret label A") shouldBe false
+        serialized.contains("secret label B") shouldBe false
+        serialized.contains("b".repeat(64)) shouldBe false
+    }
+
+    test("keeps the same survey ID in two apps as separate stable sources") {
+        insertDefinition("team-a", "survey", "a".repeat(64), "field")
+        feedbackRepository.save(feedbackJson("survey"), "team-a", "app-a", "survey", "a".repeat(64))
+        feedbackRepository.save(feedbackJson("survey"), "team-a", "app-b", "survey", "a".repeat(64))
+
+        val catalog = repository.findCatalog("team-a")
+
+        catalog.sources.map { it.app to it.surveyId } shouldBe listOf(
+            "app-a" to "survey",
+            "app-b" to "survey",
+        )
+    }
+
+    test("source identity survives deletion of the last feedback row") {
+        insertDefinition("team-a", "survey", "a".repeat(64), "field")
+        val created = feedbackRepository.save(
+            feedbackJson("survey"),
+            "team-a",
+            "app-a",
+            "survey",
+            "a".repeat(64),
+        )
+        val id = (created as no.nav.lumi.domain.SaveResult.Created).id
+
+        feedbackRepository.delete(id, "team-a") shouldBe true
+
+        val source = repository.findCatalog("team-a").sources.single()
+        source.app shouldBe "app-a"
+        source.surveyId shouldBe "survey"
+        source.observedDefinitionHashes shouldBe emptyList()
+    }
+
+    test("catalog revision ignores new rows with the same contract but changes for a new observed hash") {
+        insertDefinition("team-a", "survey", "a".repeat(64), "field")
+        feedbackRepository.save(feedbackJson("survey"), "team-a", "app-a", "survey", "a".repeat(64))
+        val first = repository.findCatalog("team-a")
+
+        feedbackRepository.save(feedbackJson("survey"), "team-a", "app-a", "survey", "a".repeat(64))
+        val second = repository.findCatalog("team-a")
+
+        feedbackRepository.save(feedbackJson("survey"), "team-a", "app-a", "survey", "c".repeat(64))
+        val third = repository.findCatalog("team-a")
+
+        second.catalogRevision shouldBe first.catalogRevision
+        third.catalogRevision shouldNotBe first.catalogRevision
+        third.sources.single().warnings shouldContain AnalysisCatalogWarning.HISTORICAL_DEFINITION_UNRESOLVED
+    }
+
+    test("reports untrusted structural and source mismatches without reconstructing flow") {
+        insertDefinition("team-a", "survey-column", "a".repeat(64), "field", source = "auto")
+        feedbackRepository.save(
+            feedbackJson("survey-json"),
+            "team-a",
+            "app-a",
+            "survey-column",
+            null,
+        )
+
+        val source = repository.findCatalog("team-a").sources.single()
+
+        source.definitionStatus shouldBe AnalysisDefinitionStatus.AUTO_DERIVED
+        source.flowStatus shouldBe AnalysisFlowStatus.UNPINNED
+        source.observedDefinitionHashes shouldBe listOf(null)
+        source.warnings shouldContain AnalysisCatalogWarning.LEGACY_DEFINITION_OBSERVED
+        source.warnings shouldContain AnalysisCatalogWarning.SOURCE_ID_MISMATCH
+    }
+})
+
+private fun insertDefinition(
+    team: String,
+    surveyId: String,
+    hash: String,
+    fieldId: String,
+    source: String = "api",
+) {
+    TestDatabase.dataSource.connection.use { connection ->
+        connection.prepareStatement(
+            """
+            INSERT INTO survey_definitions (
+                id, team, survey_id, definition_hash, definition, source,
+                last_submission_at, definition_retention_at
+            )
+            VALUES (
+                gen_random_uuid(), ?, ?, ?, ?::jsonb, ?,
+                clock_timestamp(), clock_timestamp() + interval '18 months'
+            )
+            """.trimIndent(),
+        ).use { statement ->
+            statement.setString(1, team)
+            statement.setString(2, surveyId)
+            statement.setString(3, hash)
+            statement.setString(
+                4,
+                """
+                {
+                  "surveyId": "$surveyId",
+                  "surveyType": "custom",
+                  "fields": [{
+                    "fieldId": "$fieldId",
+                    "fieldType": "RATING",
+                    "ratingVariant": "nps",
+                    "ratingScale": 11,
+                    "optionIds": null,
+                    "maxSelections": null
+                  }]
+                }
+                """.trimIndent(),
+            )
+            statement.setString(5, source)
+            statement.executeUpdate()
+        }
+        connection.commit()
+    }
+}
+
+private fun feedbackJson(surveyId: String, label: String = "untrusted question label") =
+    """
+    {
+      "schemaVersion": 2,
+      "surveyId": "$surveyId",
+      "surveyType": "custom",
+      "submittedAt": "2026-08-29T12:00:00Z",
+      "answers": [{
+        "fieldId": "field",
+        "fieldType": "RATING",
+        "question": {"label": "$label"},
+        "value": {"type": "rating", "rating": 0, "ratingVariant": "nps", "ratingScale": 11}
+      }]
+    }
+    """.trimIndent()

--- a/apps/lumi-api/src/test/kotlin/no/nav/lumi/repository/SurveyDefinitionRepositoryTest.kt
+++ b/apps/lumi-api/src/test/kotlin/no/nav/lumi/repository/SurveyDefinitionRepositoryTest.kt
@@ -90,16 +90,14 @@ class SurveyDefinitionRepositoryTest : FunSpec({
             }
             connection.commit()
         }
-        val beforeUpdate = Instant.now().minusSeconds(1)
-
         dbQuery {
             repository.recordStoredSubmissionInCurrentTransaction("team-a", "survey-activity")
         }
 
         val stored = repository.findByTeamAndSurveyId("team-a", "survey-activity").shouldNotBeNull()
-        (stored.lastSubmissionAt >= beforeUpdate) shouldBe true
+        (stored.lastSubmissionAt > oldActivity) shouldBe true
         (
-            stored.definitionRetentionAt >= beforeUpdate.atZone(ZoneOffset.UTC)
+            stored.definitionRetentionAt >= stored.lastSubmissionAt.atZone(ZoneOffset.UTC)
                 .plusMonths(18)
                 .toInstant()
         ) shouldBe true

--- a/apps/lumi-api/src/test/kotlin/no/nav/lumi/routes/AnalysisProductRoutesTest.kt
+++ b/apps/lumi-api/src/test/kotlin/no/nav/lumi/routes/AnalysisProductRoutesTest.kt
@@ -1,0 +1,153 @@
+package no.nav.lumi.routes
+
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import io.ktor.client.call.body
+import io.ktor.client.request.get
+import io.ktor.client.request.header
+import io.ktor.http.HttpHeaders
+import io.ktor.http.HttpStatusCode
+import io.ktor.server.testing.testApplication
+import no.nav.lumi.TestDatabase
+import no.nav.lumi.createTestClient
+import no.nav.lumi.domain.AnalysisContractPreviewStatus
+import no.nav.lumi.domain.AnalysisCompilationIssueCode
+import no.nav.lumi.domain.FieldDefinition
+import no.nav.lumi.domain.FieldType
+import no.nav.lumi.domain.AnalysisProductContractPreviewV1
+import no.nav.lumi.domain.AnalysisProductDocumentV1
+import no.nav.lumi.domain.AnalysisProductRetention
+import no.nav.lumi.domain.AnalysisProductSourceSelection
+import no.nav.lumi.domain.AnalysisProductUseCase
+import no.nav.lumi.domain.AnalysisSourceCatalogV1
+import no.nav.lumi.domain.RatingVariant
+import no.nav.lumi.domain.SurveyDefinition
+import no.nav.lumi.domain.SurveyType
+import no.nav.lumi.domain.computeHash
+import no.nav.lumi.repository.AnalysisProductRepository
+import no.nav.lumi.repository.FeedbackRepository
+import no.nav.lumi.repository.SurveyDefinitionRepository
+import no.nav.lumi.testModule
+import java.time.Clock
+import java.time.Instant
+import java.time.ZoneOffset
+
+class AnalysisProductRoutesTest : FunSpec({
+    beforeSpec { TestDatabase.initialize() }
+    beforeTest { TestDatabase.clearAllData() }
+
+    test("catalog requires authentication and derives team only from authorization") {
+        testApplication {
+            application { testModule() }
+            val client = createTestClient()
+
+            client.get("/api/v1/intern/analysis-products/catalog?team=team-test").status shouldBe
+                HttpStatusCode.Unauthorized
+
+            client.get("/api/v1/intern/analysis-products/catalog?team=not-authorized") {
+                header(HttpHeaders.Authorization, "Bearer token")
+            }.status shouldBe HttpStatusCode.Forbidden
+
+            val response = client.get("/api/v1/intern/analysis-products/catalog?team=team-test") {
+                header(HttpHeaders.Authorization, "Bearer token")
+            }
+            response.status shouldBe HttpStatusCode.OK
+            response.body<AnalysisSourceCatalogV1>().team shouldBe "team-test"
+        }
+    }
+
+    test("preview returns the same not found response for a foreign and random product") {
+        val foreign = createProduct("flex")
+
+        testApplication {
+            application { testModule() }
+            val client = createTestClient()
+
+            val foreignResponse = client.get(
+                "/api/v1/intern/analysis-products/${foreign.id}/preview?team=team-test",
+            ) {
+                header(HttpHeaders.Authorization, "Bearer token")
+            }
+            val randomResponse = client.get(
+                "/api/v1/intern/analysis-products/00000000-0000-0000-0000-000000000099/preview?team=team-test",
+            ) {
+                header(HttpHeaders.Authorization, "Bearer token")
+            }
+
+            foreignResponse.status shouldBe HttpStatusCode.NotFound
+            randomResponse.status shouldBe HttpStatusCode.NotFound
+            foreignResponse.body<String>() shouldBe randomResponse.body<String>()
+        }
+    }
+
+    test("preview is synthetic and blocked while flow provenance is missing") {
+        registerSource("team-test")
+        val product = createProduct("team-test")
+
+        testApplication {
+            application { testModule() }
+            val response = createTestClient().get(
+                "/api/v1/intern/analysis-products/${product.id}/preview?team=team-test",
+            ) {
+                header(HttpHeaders.Authorization, "Bearer token")
+            }
+
+            response.status shouldBe HttpStatusCode.OK
+            val preview = response.body<AnalysisProductContractPreviewV1>()
+            preview.status shouldBe AnalysisContractPreviewStatus.BLOCKED
+            preview.issues.map { it.code } shouldBe listOf(AnalysisCompilationIssueCode.FLOW_NOT_PINNED)
+            preview.aggregatePreviewAvailable shouldBe false
+            preview.publicationSpecification shouldBe null
+        }
+    }
+})
+
+private suspend fun createProduct(team: String) =
+    (AnalysisProductRepository(
+        Clock.fixed(Instant.parse("2026-08-29T12:00:00Z"), ZoneOffset.UTC),
+    ).create(
+        team = team,
+        document = AnalysisProductDocumentV1(
+            name = "Analysis",
+            purpose = "Safe analysis",
+            dataOwner = "A123456",
+            technicalOwner = "A123456",
+            useCases = listOf(AnalysisProductUseCase.METABASE),
+            retention = AnalysisProductRetention.SOURCE_MAXIMUM,
+            reviewDate = "2027-08-29",
+            sources = listOf(AnalysisProductSourceSelection("app", "survey", listOf("field"))),
+        ),
+        principalIdentity = "A123456",
+    ) as no.nav.lumi.repository.CreateAnalysisProductResult.Created).product
+
+private suspend fun registerSource(team: String) {
+    val definition = SurveyDefinition(
+        surveyId = "survey",
+        surveyType = SurveyType.CUSTOM,
+        fields = listOf(
+            FieldDefinition(
+                fieldId = "field",
+                fieldType = FieldType.RATING,
+                ratingVariant = RatingVariant.NPS,
+                ratingScale = 11,
+                optionIds = null,
+            ),
+        ),
+    )
+    val hash = definition.computeHash()
+    SurveyDefinitionRepository().insertApiDefinitionIfUnderLimit(team, definition, hash, 500)
+    FeedbackRepository().save(
+        feedbackJson = """
+            {
+              "schemaVersion": 2,
+              "surveyId": "survey",
+              "surveyType": "custom",
+              "answers": []
+            }
+        """.trimIndent(),
+        team = team,
+        app = "app",
+        surveyId = "survey",
+        definitionHash = hash,
+    )
+}


### PR DESCRIPTION
## Sammendrag

- oppretter en varig, team- og appavgrenset kildekatalog med rolling-deploy-sikker writer-capture og separat backfill
- kompilerer valgte strukturerte felt og kodeeide dimensjoner til en deterministisk flat kontrakt og syntetisk preview
- binder preview og publiseringsspesifikasjon til utkast, valgt katalogscope, provenance, retensjon og skjemadigester
- blokkerer manglende eller tvetydig definisjons-/flowprovenance og utelater fritekst, rå JSON, klientlabels og øvrige ikke-godkjente datakategorier

## Avgrensning

Denne endringen publiserer ingen data, oppretter ikke BigQuery-/IAM-ressurser og kobler ikke på live aggregater eller aktivering. Flow er med vilje UNPINNED til ingest-matchet flowregistrering er på plass. Previewrader er kun syntetiske.

## Verifisering

- pnpm run lint
- pnpm run typecheck
- pnpm run api:test
- migreringstest for V19 → V20 → gammel writer → V21, JSON-fallback og rollback
- regresjonstester for teamisolasjon, opaque 404, determinisme, provenance, metadatareferanser og sekundærsuppresjon

Closes #571
Part of #482