### PR TITLE
Bind visibleIf-flow til analysekontrakten ved ingest

### DIFF
--- a/apps/lumi-api/src/main/kotlin/no/nav/lumi/domain/AnalysisContractCompiler.kt
+++ b/apps/lumi-api/src/main/kotlin/no/nav/lumi/domain/AnalysisContractCompiler.kt
@@ -84,6 +84,8 @@ enum class AnalysisCompilationIssueCode {
     DEFINITION_HASH_UNRESOLVED,
     LEGACY_DEFINITION_OBSERVED,
     FLOW_NOT_PINNED,
+    UNPINNED_FLOW_HISTORY_EXCLUDED,
+    FLOW_DEPENDENCY_NOT_SELECTED,
     FIELD_UNAVAILABLE,
     FIELD_NOT_ALLOWED,
     FIELD_MALFORMED,
@@ -110,6 +112,7 @@ data class AnalysisSourcePinV1(
     val surveyType: SurveyType,
     val definitionHash: String,
     val flowHash: String,
+    val allowedFlowHashes: List<String> = listOf(flowHash),
     val fields: List<AnalysisFieldPinV1>,
 )
 
@@ -123,6 +126,7 @@ data class AnalysisFieldPinV1(
     val maxSelections: Int? = null,
     val label: String? = null,
     val labelSource: AnalysisLabelSource,
+    val flowDependencies: List<AnalysisFlowDependencyV1> = emptyList(),
 )
 
 @Serializable
@@ -210,7 +214,7 @@ class AnalysisContractCompiler {
                     )
                     return@mapNotNull null
                 }
-                validateSource(source, selection, issues)
+                validateSource(source, selection, input.document.dimensionKeys, issues)
                 ResolvedAnalysisSource(
                     source = source,
                     selectedFields = selection.fieldIds.sorted().mapNotNull { fieldId ->
@@ -294,6 +298,9 @@ class AnalysisContractCompiler {
                         surveyType = requireNotNull(resolved.source.surveyType),
                         definitionHash = requireNotNull(resolved.source.definitionHash),
                         flowHash = requireNotNull(resolved.source.flowHash),
+                        allowedFlowHashes = resolved.source.flowHashes.sorted().ifEmpty {
+                            listOf(requireNotNull(resolved.source.flowHash))
+                        },
                         fields = resolved.selectedFields.map { field ->
                             AnalysisFieldPinV1(
                                 fieldId = field.fieldId,
@@ -304,6 +311,7 @@ class AnalysisContractCompiler {
                                 maxSelections = field.maxSelections,
                                 label = field.label.takeIf { field.labelSource != AnalysisLabelSource.UNKNOWN },
                                 labelSource = field.labelSource,
+                                flowDependencies = field.flowDependencies,
                             )
                         },
                     )
@@ -339,6 +347,7 @@ class AnalysisContractCompiler {
     private fun validateSource(
         source: AnalysisCatalogSourceV1,
         selection: AnalysisProductSourceSelection,
+        selectedDimensionKeys: List<String>,
         issues: MutableList<AnalysisCompilationIssue>,
     ) {
         if (source.definitionStatus != AnalysisDefinitionStatus.REGISTERED || source.surveyType == null) {
@@ -383,6 +392,27 @@ class AnalysisContractCompiler {
                 surveyId = source.surveyId,
             )
         }
+        if (
+            source.flowHashes.any { !it.matches(SHA256_PATTERN) } ||
+            (source.flowHashes.isNotEmpty() && source.flowHash !in source.flowHashes)
+        ) {
+            issues += issue(
+                AnalysisCompilationIssueCode.FLOW_NOT_PINNED,
+                app = source.app,
+                surveyId = source.surveyId,
+            )
+        }
+        if (
+            source.flowStatus == AnalysisFlowStatus.PINNED &&
+            AnalysisCatalogWarning.LEGACY_FLOW_OBSERVED in source.warnings
+        ) {
+            issues += issue(
+                AnalysisCompilationIssueCode.UNPINNED_FLOW_HISTORY_EXCLUDED,
+                severity = AnalysisCompilationIssueSeverity.WARNING,
+                app = source.app,
+                surveyId = source.surveyId,
+            )
+        }
         if (AnalysisCatalogWarning.SOURCE_ID_MISMATCH in source.warnings) {
             issues += issue(
                 AnalysisCompilationIssueCode.SOURCE_ID_MISMATCH,
@@ -390,6 +420,26 @@ class AnalysisContractCompiler {
                 surveyId = source.surveyId,
             )
         }
+        source.fields
+            .filter { it.fieldId in selection.fieldIds }
+            .flatMap { field -> field.flowDependencies.map { dependency -> field.fieldId to dependency } }
+            .forEach { (fieldId, dependency) ->
+                val selected = when (dependency.source) {
+                    AnalysisFlowDependencySource.ANSWER -> dependency.key in selection.fieldIds
+                    AnalysisFlowDependencySource.METADATA -> dependency.key in selectedDimensionKeys
+                }
+                if (!selected) {
+                    issues += issue(
+                        AnalysisCompilationIssueCode.FLOW_DEPENDENCY_NOT_SELECTED,
+                        app = source.app,
+                        surveyId = source.surveyId,
+                        fieldId = fieldId,
+                        dimensionKey = dependency.key.takeIf {
+                            dependency.source == AnalysisFlowDependencySource.METADATA
+                        },
+                    )
+                }
+            }
         if (selection.fieldIds.isEmpty()) {
             // An empty source is allowed in a draft and produces a population-only
             // wide schema. The UI may use this while fields are being selected.
@@ -602,6 +652,7 @@ class AnalysisContractCompiler {
                     add(pin.surveyType.name)
                     add(pin.definitionHash)
                     add(pin.flowHash)
+                    pin.allowedFlowHashes.sorted().forEach(::add)
                     pin.fields.forEach { field ->
                         add(field.fieldId)
                         add(field.fieldType.name)
@@ -611,6 +662,12 @@ class AnalysisContractCompiler {
                         add(field.maxSelections?.toString() ?: "<null>")
                         add(field.label ?: "<null>")
                         add(field.labelSource.name)
+                        field.flowDependencies
+                            .sortedWith(compareBy(AnalysisFlowDependencyV1::source, AnalysisFlowDependencyV1::key))
+                            .forEach { dependency ->
+                                add(dependency.source.name)
+                                add(dependency.key)
+                            }
                     }
                 }
                 specification.dimensions.forEach { dimension ->

--- a/apps/lumi-api/src/main/kotlin/no/nav/lumi/domain/AnalysisSourceCatalog.kt
+++ b/apps/lumi-api/src/main/kotlin/no/nav/lumi/domain/AnalysisSourceCatalog.kt
@@ -27,9 +27,23 @@ enum class AnalysisLabelSource {
 }
 
 @Serializable
+enum class AnalysisFlowDependencySource {
+    ANSWER,
+    METADATA,
+}
+
+@Serializable
+data class AnalysisFlowDependencyV1(
+    val source: AnalysisFlowDependencySource,
+    val key: String,
+)
+
+@Serializable
 enum class AnalysisCatalogWarning {
     LEGACY_DEFINITION_OBSERVED,
     HISTORICAL_DEFINITION_UNRESOLVED,
+    LEGACY_FLOW_OBSERVED,
+    UNKNOWN_FLOW_OBSERVED,
     DEFINITION_CONTENT_MISMATCH,
     SOURCE_ID_MISMATCH,
 }
@@ -44,6 +58,7 @@ data class AnalysisCatalogFieldV1(
     val maxSelections: Int? = null,
     val label: String? = null,
     val labelSource: AnalysisLabelSource = AnalysisLabelSource.UNKNOWN,
+    val flowDependencies: List<AnalysisFlowDependencyV1> = emptyList(),
 )
 
 @Serializable
@@ -56,6 +71,8 @@ data class AnalysisCatalogSourceV1(
     val definitionStatus: AnalysisDefinitionStatus,
     val observedDefinitionHashes: List<String?>,
     val flowHash: String? = null,
+    val flowHashes: List<String> = emptyList(),
+    val observedFlowHashes: List<String?> = emptyList(),
     val flowStatus: AnalysisFlowStatus,
     val fields: List<AnalysisCatalogFieldV1>,
     val warnings: List<AnalysisCatalogWarning>,
@@ -208,6 +225,11 @@ object AnalysisCatalogRevision {
         add(source.definitionHash ?: "<null>")
         add(source.definitionStatus.name)
         add(source.flowHash ?: "<null>")
+        source.flowHashes.sorted().forEach(::add)
+        source.observedFlowHashes
+            .map { it ?: "<null>" }
+            .sorted()
+            .forEach(::add)
         add(source.flowStatus.name)
         source.observedDefinitionHashes
             .map { it ?: "<null>" }
@@ -238,6 +260,12 @@ object AnalysisCatalogRevision {
         if (field.labelSource != AnalysisLabelSource.UNKNOWN) {
             add(field.label ?: "<null>")
         }
+        field.flowDependencies
+            .sortedWith(compareBy(AnalysisFlowDependencyV1::source, AnalysisFlowDependencyV1::key))
+            .forEach { dependency ->
+                add(dependency.source.name)
+                add(dependency.key)
+            }
     }
 
     private fun MutableList<String>.addDimensionFacts(dimension: AnalysisDimensionDefinitionV1) {

--- a/apps/lumi-api/src/main/kotlin/no/nav/lumi/domain/SurveyDefinitionPayload.kt
+++ b/apps/lumi-api/src/main/kotlin/no/nav/lumi/domain/SurveyDefinitionPayload.kt
@@ -45,6 +45,7 @@ data class FeedbackSubmissionV2(
     val timeToCompleteMs: Long? = null,
     val deduplicationKey: String,
     val definition: SurveyDefinitionPayload,
+    val flow: SurveyFlowDefinitionV1? = null,
     val context: SubmissionContextV1? = null,
     val answers: List<Answer>
 )

--- a/apps/lumi-api/src/main/kotlin/no/nav/lumi/domain/SurveyFlowDefinition.kt
+++ b/apps/lumi-api/src/main/kotlin/no/nav/lumi/domain/SurveyFlowDefinition.kt
@@ -1,0 +1,128 @@
+package no.nav.lumi.domain
+
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.JsonElement
+import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.booleanOrNull
+import java.math.BigDecimal
+
+const val SURVEY_FLOW_SCHEMA_VERSION = 1
+const val SURVEY_FLOW_EVALUATOR_VERSION = "visible-if-v1"
+
+@Serializable
+enum class SurveyFlowCombinator {
+    ALL,
+    ANY,
+}
+
+@Serializable
+enum class SurveyFlowConditionSource {
+    ANSWER,
+    METADATA,
+}
+
+@Serializable
+enum class SurveyFlowOperator {
+    EQ,
+    NEQ,
+    GT,
+    LT,
+    CONTAINS,
+    EXISTS,
+}
+
+@Serializable
+data class SurveyFlowCondition(
+    val source: SurveyFlowConditionSource,
+    val key: String,
+    val operator: SurveyFlowOperator,
+    val value: JsonElement? = null,
+)
+
+@Serializable
+data class SurveyVisibleIfDefinition(
+    val combinator: SurveyFlowCombinator,
+    val conditions: List<SurveyFlowCondition>,
+)
+
+@Serializable
+data class SurveyFlowFieldDefinition(
+    val fieldId: String,
+    val visibleIf: SurveyVisibleIfDefinition? = null,
+)
+
+@Serializable
+data class SurveyFlowDefinitionV1(
+    val schemaVersion: Int,
+    val evaluatorVersion: String,
+    val fields: List<SurveyFlowFieldDefinition>,
+) {
+    fun normalized(): SurveyFlowDefinitionV1 = copy(
+        fields = fields.map { field ->
+            field.copy(
+                visibleIf = field.visibleIf?.copy(
+                    conditions = field.visibleIf.conditions.sortedWith(SURVEY_FLOW_CONDITION_COMPARATOR),
+                ),
+            )
+        },
+    )
+
+    fun computeHash(): String {
+        val normalized = normalized()
+        return AnalysisCanonicalHash.digest(
+            domain = "survey-visible-if-flow-v1",
+            parts = buildList {
+                add(normalized.schemaVersion.toString())
+                add(normalized.evaluatorVersion)
+                normalized.fields.forEach { field ->
+                    add(field.fieldId)
+                    val visibleIf = field.visibleIf
+                    if (visibleIf == null) {
+                        add("UNCONDITIONAL")
+                    } else {
+                        add("CONDITIONAL")
+                        add(visibleIf.combinator.name)
+                        visibleIf.conditions.forEach { condition ->
+                            add(condition.source.name)
+                            add(condition.key)
+                            add(condition.operator.name)
+                            add(condition.valueCanonicalType())
+                            add(condition.valueCanonicalContent())
+                        }
+                    }
+                }
+            },
+        )
+    }
+}
+
+private val SURVEY_FLOW_CONDITION_COMPARATOR = compareBy<SurveyFlowCondition>(
+    { it.source.name },
+    SurveyFlowCondition::key,
+    { it.operator.name },
+    SurveyFlowCondition::valueCanonicalType,
+    SurveyFlowCondition::valueCanonicalContent,
+)
+
+private fun SurveyFlowCondition.valueCanonicalType(): String = when (val primitive = value as? JsonPrimitive) {
+    null -> "NONE"
+    else -> when {
+        primitive.isString -> "STRING"
+        primitive.booleanOrNull != null -> "BOOLEAN"
+        else -> "NUMBER"
+    }
+}
+
+private fun SurveyFlowCondition.valueCanonicalContent(): String = when (val primitive = value as? JsonPrimitive) {
+    null -> ""
+    else -> when {
+        primitive.isString -> primitive.content
+        primitive.booleanOrNull != null -> primitive.booleanOrNull.toString()
+        else -> canonicalNumber(primitive.content)
+    }
+}
+
+private fun canonicalNumber(value: String): String {
+    val number = BigDecimal(value).stripTrailingZeros()
+    return if (number.compareTo(BigDecimal.ZERO) == 0) "0" else number.toPlainString()
+}

--- a/apps/lumi-api/src/main/kotlin/no/nav/lumi/repository/AnalysisSourceCatalogRepository.kt
+++ b/apps/lumi-api/src/main/kotlin/no/nav/lumi/repository/AnalysisSourceCatalogRepository.kt
@@ -1,5 +1,6 @@
 package no.nav.lumi.repository
 
+import kotlinx.serialization.Serializable
 import kotlinx.serialization.json.Json
 import no.nav.lumi.domain.AnalysisCatalogFieldV1
 import no.nav.lumi.domain.AnalysisCatalogRevision
@@ -8,10 +9,15 @@ import no.nav.lumi.domain.AnalysisCatalogWarning
 import no.nav.lumi.domain.AnalysisDefinitionStatus
 import no.nav.lumi.domain.AnalysisDimensionRegistry
 import no.nav.lumi.domain.AnalysisFlowStatus
+import no.nav.lumi.domain.AnalysisFlowDependencySource
+import no.nav.lumi.domain.AnalysisFlowDependencyV1
 import no.nav.lumi.domain.AnalysisLabelSource
 import no.nav.lumi.domain.AnalysisSourceCatalogV1
 import no.nav.lumi.domain.SurveyDefinition
+import no.nav.lumi.domain.SurveyFlowConditionSource
+import no.nav.lumi.domain.SurveyFlowDefinitionV1
 import no.nav.lumi.domain.computeHash
+import no.nav.lumi.validation.SurveyFlowValidator
 import org.jetbrains.exposed.v1.jdbc.transactions.TransactionManager
 
 class AnalysisSourceCatalogRepository {
@@ -23,18 +29,49 @@ class AnalysisSourceCatalogRepository {
             """
             WITH observations AS (
                 SELECT
-                    app,
-                    COALESCE(survey_id, feedback_json ->> 'surveyId') AS catalog_survey_id,
-                    jsonb_agg(DISTINCT definition_hash ORDER BY definition_hash) AS definition_hashes,
+                    observation.app,
+                    observation.survey_id,
+                    jsonb_agg(
+                        DISTINCT observation.definition_hash
+                        ORDER BY observation.definition_hash
+                    ) AS definition_hashes,
+                    jsonb_agg(
+                        DISTINCT observation.flow_hash
+                        ORDER BY observation.flow_hash
+                    ) AS observed_flow_hashes,
+                    (
+                        array_agg(
+                            observation.flow_hash
+                            ORDER BY observation.last_submission_at DESC,
+                                     observation.flow_hash ASC NULLS FIRST
+                        )
+                    )[1] AS latest_flow_hash,
+                    COALESCE(
+                        jsonb_agg(
+                            jsonb_build_object(
+                                'definitionHash', contract.definition_hash,
+                                'flowHash', contract.flow_hash,
+                                'definition', contract.definition,
+                                'flow', contract.flow_definition
+                            )
+                            ORDER BY observation.last_submission_at DESC, observation.flow_hash DESC
+                        ) FILTER (WHERE contract.flow_hash IS NOT NULL),
+                        '[]'::jsonb
+                    ) AS registered_flow_contracts,
+                    BOOL_OR(observation.flow_hash IS NULL) AS has_unpinned_flow,
                     BOOL_OR(
-                        survey_id IS NOT NULL AND
-                        feedback_json ->> 'surveyId' IS NOT NULL AND
-                        survey_id <> feedback_json ->> 'surveyId'
-                    ) AS has_source_id_mismatch
-                FROM feedback
-                WHERE team = ?
-                  AND length(btrim(COALESCE(survey_id, feedback_json ->> 'surveyId', ''))) > 0
-                GROUP BY app, COALESCE(survey_id, feedback_json ->> 'surveyId')
+                        observation.flow_hash IS NOT NULL AND contract.flow_hash IS NULL
+                    ) AS has_unknown_flow,
+                    BOOL_OR(observation.has_source_id_mismatch) AS has_source_id_mismatch
+                FROM analysis_control.analysis_source_contract_observations AS observation
+                LEFT JOIN analysis_control.analysis_source_contracts AS contract
+                  ON contract.team = observation.team
+                 AND contract.app = observation.app
+                 AND contract.survey_id = observation.survey_id
+                 AND contract.definition_hash = observation.definition_hash
+                 AND contract.flow_hash = observation.flow_hash
+                WHERE observation.team = ?
+                GROUP BY observation.app, observation.survey_id
             )
             SELECT
                 source.app,
@@ -45,6 +82,11 @@ class AnalysisSourceCatalogRepository {
                 definition.retired_at,
                 metadata.archived_at,
                 COALESCE(observation.definition_hashes, '[]'::jsonb)::text AS observed_definition_hashes,
+                COALESCE(observation.observed_flow_hashes, '[]'::jsonb)::text AS observed_flow_hashes,
+                observation.latest_flow_hash,
+                COALESCE(observation.registered_flow_contracts, '[]'::jsonb)::text AS registered_flow_contracts,
+                COALESCE(observation.has_unpinned_flow, FALSE) AS has_unpinned_flow,
+                COALESCE(observation.has_unknown_flow, FALSE) AS has_unknown_flow,
                 COALESCE(observation.has_source_id_mismatch, FALSE) AS has_source_id_mismatch
             FROM analysis_control.analysis_sources AS source
             LEFT JOIN survey_definitions AS definition
@@ -55,7 +97,7 @@ class AnalysisSourceCatalogRepository {
              AND metadata.survey_id = source.survey_id
             LEFT JOIN observations AS observation
               ON observation.app = source.app
-             AND observation.catalog_survey_id = source.survey_id
+             AND observation.survey_id = source.survey_id
             WHERE source.team = ?
             ORDER BY source.app, source.survey_id
             """.trimIndent(),
@@ -70,10 +112,48 @@ class AnalysisSourceCatalogRepository {
                         val observedDefinitionHashes = json.decodeFromString<List<String?>>(
                             result.getString("observed_definition_hashes"),
                         ).distinct().sortedWith(nullsFirst(naturalOrder()))
+                        val observedFlowHashes = json.decodeFromString<List<String?>>(
+                            result.getString("observed_flow_hashes"),
+                        ).distinct().sortedWith(nullsFirst(naturalOrder()))
+                        val decodedContracts = runCatching {
+                            json.decodeFromString<List<CatalogRegisteredFlowContract>>(
+                                result.getString("registered_flow_contracts"),
+                            )
+                        }
+                        val registeredContracts = decodedContracts.getOrDefault(emptyList())
+                        val validContracts = registeredContracts.filter { contract ->
+                            contract.isValidFor(surveyId)
+                        }
+                        val knownFlowHashes = validContracts.map { it.flowHash }.distinct().sorted()
+                        val latestObservedFlowHash = result.getString("latest_flow_hash")
+                        val currentFlowHash = validContracts
+                            .singleOrNull { it.flowHash == latestObservedFlowHash }
+                            ?.flowHash
+                        val hasUnpinnedFlow = result.getBoolean("has_unpinned_flow")
+                        val hasUnknownFlow = result.getBoolean("has_unknown_flow") ||
+                            decodedContracts.isFailure || validContracts.size != registeredContracts.size
                         val hasSourceIdMismatch = result.getBoolean("has_source_id_mismatch")
                         val definitionJson = result.getString("definition")
                         val definition = definitionJson?.let { json.decodeFromString<SurveyDefinition>(it) }
                         val definitionHash = result.getString("definition_hash")
+                        val dependenciesByField = validContracts
+                            .flatMap { contract -> contract.flow.fields }
+                            .groupBy { it.fieldId }
+                            .mapValues { (_, flowFields) ->
+                                flowFields.flatMap { flowField ->
+                                    flowField.visibleIf?.conditions.orEmpty().map { condition ->
+                                        AnalysisFlowDependencyV1(
+                                            source = when (condition.source) {
+                                                SurveyFlowConditionSource.ANSWER -> AnalysisFlowDependencySource.ANSWER
+                                                SurveyFlowConditionSource.METADATA -> AnalysisFlowDependencySource.METADATA
+                                            },
+                                            key = condition.key,
+                                        )
+                                    }
+                                }.distinct().sortedWith(
+                                    compareBy(AnalysisFlowDependencyV1::source, AnalysisFlowDependencyV1::key),
+                                )
+                            }
                         val definitionStatus = when {
                             definition == null && definitionHash == null -> AnalysisDefinitionStatus.MISSING
                             result.getObject("retired_at") != null || definition == null -> AnalysisDefinitionStatus.RETIRED
@@ -95,6 +175,12 @@ class AnalysisSourceCatalogRepository {
                             if (hasSourceIdMismatch) {
                                 add(AnalysisCatalogWarning.SOURCE_ID_MISMATCH)
                             }
+                            if (hasUnpinnedFlow) {
+                                add(AnalysisCatalogWarning.LEGACY_FLOW_OBSERVED)
+                            }
+                            if (hasUnknownFlow) {
+                                add(AnalysisCatalogWarning.UNKNOWN_FLOW_OBSERVED)
+                            }
                             if (definition != null && definition.surveyId != surveyId) {
                                 add(AnalysisCatalogWarning.SOURCE_ID_MISMATCH)
                             }
@@ -111,8 +197,14 @@ class AnalysisSourceCatalogRepository {
                                 definitionHash = definitionHash,
                                 definitionStatus = definitionStatus,
                                 observedDefinitionHashes = observedDefinitionHashes,
-                                flowHash = null,
-                                flowStatus = AnalysisFlowStatus.UNPINNED,
+                                flowHash = currentFlowHash,
+                                flowHashes = knownFlowHashes,
+                                observedFlowHashes = observedFlowHashes,
+                                flowStatus = if (currentFlowHash != null && !hasUnknownFlow) {
+                                    AnalysisFlowStatus.PINNED
+                                } else {
+                                    AnalysisFlowStatus.UNPINNED
+                                },
                                 fields = definition?.fields.orEmpty()
                                     .sortedBy { it.fieldId }
                                     .map { field ->
@@ -127,6 +219,7 @@ class AnalysisSourceCatalogRepository {
                                             // public metadata and are intentionally unavailable here.
                                             label = null,
                                             labelSource = AnalysisLabelSource.UNKNOWN,
+                                            flowDependencies = dependenciesByField[field.fieldId].orEmpty(),
                                         )
                                     },
                                 warnings = warnings.sortedBy { it.name },
@@ -145,4 +238,19 @@ class AnalysisSourceCatalogRepository {
         )
     }
 
+}
+
+@Serializable
+private data class CatalogRegisteredFlowContract(
+    val definitionHash: String,
+    val flowHash: String,
+    val definition: SurveyDefinition,
+    val flow: SurveyFlowDefinitionV1,
+) {
+    fun isValidFor(surveyId: String): Boolean = runCatching {
+        check(definition.surveyId == surveyId)
+        check(definition.computeHash() == definitionHash)
+        check(flow.computeHash() == flowHash)
+        SurveyFlowValidator.validate(flow, definition)
+    }.isSuccess
 }

--- a/apps/lumi-api/src/main/kotlin/no/nav/lumi/repository/AnalysisSourceContractRepository.kt
+++ b/apps/lumi-api/src/main/kotlin/no/nav/lumi/repository/AnalysisSourceContractRepository.kt
@@ -1,0 +1,189 @@
+package no.nav.lumi.repository
+
+import kotlinx.serialization.encodeToString
+import kotlinx.serialization.json.Json
+import no.nav.lumi.domain.SurveyDefinition
+import no.nav.lumi.domain.SurveyFlowDefinitionV1
+import no.nav.lumi.domain.computeHash
+import org.jetbrains.exposed.v1.jdbc.transactions.TransactionManager
+
+class AnalysisSourceContractRepository {
+    private val json = Json {
+        encodeDefaults = true
+        explicitNulls = true
+    }
+
+    internal fun registerInCurrentTransaction(
+        team: String,
+        app: String,
+        definitionHash: String,
+        definition: SurveyDefinition,
+        flow: SurveyFlowDefinitionV1,
+    ): String? {
+        check(definition.computeHash() == definitionHash) {
+            "Cannot register a source contract with a mismatched definition hash"
+        }
+
+        val normalizedFlow = flow.normalized()
+        val flowHash = normalizedFlow.computeHash()
+        val definitionJson = json.encodeToString(definition)
+        val flowJson = json.encodeToString(normalizedFlow)
+        val connection = TransactionManager.current().connection.connection as java.sql.Connection
+
+        connection.prepareStatement(
+            "SELECT pg_advisory_xact_lock(" +
+                "analysis_control.source_contract_lock_key(?, ?, ?, ?))",
+        ).use { statement ->
+            statement.setString(1, team)
+            statement.setString(2, app)
+            statement.setString(3, definition.surveyId)
+            statement.setString(4, definitionHash)
+            statement.execute()
+        }
+
+        if (
+            readAndVerifyContract(
+                connection,
+                team,
+                app,
+                definition.surveyId,
+                definitionHash,
+                flowHash,
+                definitionJson,
+                flowJson,
+            )
+        ) {
+            return flowHash
+        }
+
+        if (flowJson.toByteArray(Charsets.UTF_8).size > MAX_FLOW_CONTRACT_BYTES) return null
+
+        // The common path above only takes the source lock. A team-wide lock
+        // is needed for new revisions so the aggregate byte budget remains
+        // race-free without serializing every submission for a team.
+        connection.prepareStatement(
+            "SELECT pg_advisory_xact_lock(" +
+                "analysis_control.source_contract_team_lock_key(?))",
+        ).use { statement ->
+            statement.setString(1, team)
+            statement.execute()
+        }
+
+        connection.prepareStatement(
+            """
+            WITH candidate AS (
+                SELECT
+                    ?::text AS team,
+                    ?::text AS app,
+                    ?::text AS survey_id,
+                    ?::text AS definition_hash,
+                    ?::text AS flow_hash,
+                    ?::jsonb AS definition,
+                    ?::jsonb AS flow_definition
+            )
+            INSERT INTO analysis_control.analysis_source_contracts (
+                team, app, survey_id, definition_hash, flow_hash, definition, flow_definition
+            )
+            SELECT
+                candidate.team,
+                candidate.app,
+                candidate.survey_id,
+                candidate.definition_hash,
+                candidate.flow_hash,
+                candidate.definition,
+                candidate.flow_definition
+            FROM candidate
+            WHERE (
+                SELECT count(*)
+                FROM analysis_control.analysis_source_contracts
+                WHERE team = candidate.team
+                  AND app = candidate.app
+                  AND survey_id = candidate.survey_id
+                  AND definition_hash = candidate.definition_hash
+            ) < ?
+              AND octet_length(candidate.flow_definition::text) <= ?
+              AND (
+                  SELECT COALESCE(
+                      sum(octet_length(definition::text) + octet_length(flow_definition::text)),
+                      0
+                  )
+                  FROM analysis_control.analysis_source_contracts
+                  WHERE team = candidate.team
+              ) + octet_length(candidate.definition::text) +
+                  octet_length(candidate.flow_definition::text) <= ?
+            ON CONFLICT (team, app, survey_id, definition_hash, flow_hash) DO NOTHING
+            """.trimIndent(),
+        ).use { statement ->
+            statement.setString(1, team)
+            statement.setString(2, app)
+            statement.setString(3, definition.surveyId)
+            statement.setString(4, definitionHash)
+            statement.setString(5, flowHash)
+            statement.setString(6, definitionJson)
+            statement.setString(7, flowJson)
+            statement.setInt(8, MAX_FLOW_REVISIONS_PER_SOURCE_DEFINITION)
+            statement.setInt(9, MAX_FLOW_CONTRACT_BYTES)
+            statement.setInt(10, MAX_TEAM_CONTRACT_BYTES)
+            statement.executeUpdate()
+        }
+
+        if (
+            !readAndVerifyContract(
+                connection,
+                team,
+                app,
+                definition.surveyId,
+                definitionHash,
+                flowHash,
+                definitionJson,
+                flowJson,
+            )
+        ) {
+            return null
+        }
+
+        return flowHash
+    }
+
+    private fun readAndVerifyContract(
+        connection: java.sql.Connection,
+        team: String,
+        app: String,
+        surveyId: String,
+        definitionHash: String,
+        flowHash: String,
+        definitionJson: String,
+        flowJson: String,
+    ): Boolean {
+        connection.prepareStatement(
+            """
+            SELECT definition::text, flow_definition::text
+            FROM analysis_control.analysis_source_contracts
+            WHERE team = ? AND app = ? AND survey_id = ?
+              AND definition_hash = ? AND flow_hash = ?
+            """.trimIndent(),
+        ).use { statement ->
+            statement.setString(1, team)
+            statement.setString(2, app)
+            statement.setString(3, surveyId)
+            statement.setString(4, definitionHash)
+            statement.setString(5, flowHash)
+            statement.executeQuery().use { result ->
+                if (!result.next()) return false
+                check(json.parseToJsonElement(result.getString(1)) == json.parseToJsonElement(definitionJson)) {
+                    "Stored source contract definition does not match its hash"
+                }
+                check(json.parseToJsonElement(result.getString(2)) == json.parseToJsonElement(flowJson)) {
+                    "Stored source flow does not match its hash"
+                }
+            }
+        }
+        return true
+    }
+
+    internal companion object {
+        const val MAX_FLOW_REVISIONS_PER_SOURCE_DEFINITION = 50
+        const val MAX_FLOW_CONTRACT_BYTES = 64 * 1024
+        const val MAX_TEAM_CONTRACT_BYTES = 16 * 1024 * 1024
+    }
+}

--- a/apps/lumi-api/src/main/kotlin/no/nav/lumi/repository/FeedbackRepository.kt
+++ b/apps/lumi-api/src/main/kotlin/no/nav/lumi/repository/FeedbackRepository.kt
@@ -78,10 +78,11 @@ class FeedbackRepository(
         app: String,
         surveyId: String? = null,
         definitionHash: String? = null,
+        flowHash: String? = null,
         deduplicationKeyHash: String? = null
     ): SaveResult {
         return dbQuery {
-            saveInCurrentTransaction(feedbackJson, team, app, surveyId, definitionHash, deduplicationKeyHash)
+            saveInCurrentTransaction(feedbackJson, team, app, surveyId, definitionHash, flowHash, deduplicationKeyHash)
         }
     }
 
@@ -106,6 +107,7 @@ class FeedbackRepository(
         app: String,
         surveyId: String? = null,
         definitionHash: String? = null,
+        flowHash: String? = null,
         deduplicationKeyHash: String? = null
     ): SaveResult {
         val id = UUID.randomUUID().toString()
@@ -119,6 +121,7 @@ class FeedbackRepository(
                 it[FeedbackTable.app] = app
                 it[FeedbackTable.surveyId] = surveyId
                 it[FeedbackTable.definitionHash] = definitionHash
+                it[FeedbackTable.flowHash] = flowHash
                 it[FeedbackTable.deduplicationKeyHash] = deduplicationKeyHash
             }.insertedCount > 0
 
@@ -141,6 +144,7 @@ class FeedbackRepository(
                 it[FeedbackTable.app] = app
                 it[FeedbackTable.surveyId] = surveyId
                 it[FeedbackTable.definitionHash] = definitionHash
+                it[FeedbackTable.flowHash] = flowHash
                 it[FeedbackTable.deduplicationKeyHash] = deduplicationKeyHash
             }
 

--- a/apps/lumi-api/src/main/kotlin/no/nav/lumi/repository/FeedbackTable.kt
+++ b/apps/lumi-api/src/main/kotlin/no/nav/lumi/repository/FeedbackTable.kt
@@ -23,6 +23,7 @@ object FeedbackTable : Table("feedback") {
     val app = varchar("app", 255)
     val surveyId = varchar("survey_id", 255).nullable()
     val definitionHash = varchar("definition_hash", 64).nullable()
+    val flowHash = varchar("flow_hash", 64).nullable()
     val deduplicationKeyHash = varchar("deduplication_key_hash", 64).nullable()
 
     override val primaryKey = PrimaryKey(id)

--- a/apps/lumi-api/src/main/kotlin/no/nav/lumi/routes/InternalSubmissionRoutes.kt
+++ b/apps/lumi-api/src/main/kotlin/no/nav/lumi/routes/InternalSubmissionRoutes.kt
@@ -87,13 +87,14 @@ fun Route.internalSubmissionRoutes(
                         team = identity.team,
                         app = identity.app,
                         submission = submission,
-                        definition = parsedSubmission.definition
+                        definition = parsedSubmission.definition,
+                        flow = parsedSubmission.flow,
                     )
 
                     val metricOutcome = when (val saveResult = submissionOutcome.saveResult) {
                         is SaveResult.Created -> {
                             log.info(
-                                "Internal submission: saved feedback id=${saveResult.id} team=${identity.team} app=${identity.app} surveyId=${submission.surveyId} definitionHash=${submissionOutcome.definitionHash}"
+                                "Internal submission: saved feedback id=${saveResult.id} team=${identity.team} app=${identity.app} surveyId=${submission.surveyId} definitionHash=${submissionOutcome.definitionHash} flowPinned=${submissionOutcome.flowHash != null}"
                             )
                             call.respond(HttpStatusCode.Created, mapOf("id" to saveResult.id))
                             SubmissionMetricOutcome.CREATED

--- a/apps/lumi-api/src/main/kotlin/no/nav/lumi/routes/SubmissionRouteParsing.kt
+++ b/apps/lumi-api/src/main/kotlin/no/nav/lumi/routes/SubmissionRouteParsing.kt
@@ -16,6 +16,7 @@ import no.nav.lumi.config.exception.ApiErrorException
 import no.nav.lumi.domain.FeedbackSubmissionV1
 import no.nav.lumi.domain.FeedbackSubmissionV2
 import no.nav.lumi.domain.SurveyDefinition
+import no.nav.lumi.domain.SurveyFlowDefinitionV1
 import no.nav.lumi.validation.SubmissionV2Validator
 import no.nav.lumi.validation.SubmissionValidator
 
@@ -29,7 +30,8 @@ internal val strictSubmissionJson = Json {
 
 internal data class ParsedSubmission(
     val submission: FeedbackSubmissionV1,
-    val definition: SurveyDefinition? = null
+    val definition: SurveyDefinition? = null,
+    val flow: SurveyFlowDefinitionV1? = null,
 )
 
 internal fun decodeValidatedSubmission(jsonElement: JsonElement): ParsedSubmission {
@@ -47,7 +49,8 @@ internal fun decodeValidatedSubmission(jsonElement: JsonElement): ParsedSubmissi
             SubmissionV2Validator.validateSubmissionV2(submission)
             ParsedSubmission(
                 submission = submission.toV1CompatibleSubmission(),
-                definition = submission.definition.toSurveyDefinition(submission.surveyId)
+                definition = submission.definition.toSurveyDefinition(submission.surveyId),
+                flow = submission.flow,
             )
         }
 

--- a/apps/lumi-api/src/main/kotlin/no/nav/lumi/routes/SubmissionRoutes.kt
+++ b/apps/lumi-api/src/main/kotlin/no/nav/lumi/routes/SubmissionRoutes.kt
@@ -114,7 +114,8 @@ private suspend fun handleSubmission(
             team = identity.team,
             app = identity.app,
             submission = parsedSubmission.submission,
-            definition = parsedSubmission.definition
+            definition = parsedSubmission.definition,
+            flow = parsedSubmission.flow,
         )
     )
     submissionObservability.record(submissionChannel, outcome)
@@ -129,7 +130,7 @@ private suspend fun respondWithSubmissionResult(
     when (val saveResult = submissionOutcome.saveResult) {
         is SaveResult.Created -> {
             log.info(
-                "Saved feedback id=${saveResult.id} team=${identity.team} app=${identity.app} surveyId=${submission.surveyId} definitionHash=${submissionOutcome.definitionHash}"
+                "Saved feedback id=${saveResult.id} team=${identity.team} app=${identity.app} surveyId=${submission.surveyId} definitionHash=${submissionOutcome.definitionHash} flowPinned=${submissionOutcome.flowHash != null}"
             )
             call.respond(HttpStatusCode.Created, mapOf("id" to saveResult.id))
             return SubmissionMetricOutcome.CREATED

--- a/apps/lumi-api/src/main/kotlin/no/nav/lumi/service/FeedbackService.kt
+++ b/apps/lumi-api/src/main/kotlin/no/nav/lumi/service/FeedbackService.kt
@@ -60,6 +60,7 @@ class FeedbackService(
             app = app,
             surveyId = surveyId,
             definitionHash = definitionHash,
+            flowHash = null,
             deduplicationKeyHash = prepared.deduplicationKeyHash
         )
     }
@@ -109,8 +110,9 @@ class FeedbackService(
      * 4. Context debug — recursive PII redaction of all string values and keys
      * 5. Root deduplicationKey — removed before persistence; only the scoped hash is retained
      *    in the dedicated database column when deduplication is requested.
-     * 6. Text answers — PII redacted, but HTML preserved (React escapes at render)
-     * 7. Metadata fields (question.label, options[].label etc.) — NOT sanitized
+     * 6. Definition and flow — removed from raw feedback JSON; validated private contracts are stored separately.
+     * 7. Text answers — PII redacted, but HTML preserved (React escapes at render)
+     * 8. Metadata fields (question.label, options[].label etc.) — NOT sanitized
      *    These are survey-defined by the team admin, not user-authored free text.
      *    SubmissionValidator enforces length limits on all metadata fields.
      *    React escapes all output, so stored HTML is inert in the dashboard.
@@ -123,6 +125,7 @@ class FeedbackService(
             val deduplicationKey = extractDeduplicationKey(jsonObj)
             jsonObj.remove("deduplicationKey")
             jsonObj.remove("definition")
+            jsonObj.remove("flow")
 
             val context = jsonObj["context"] as? JsonObject
             if (context != null) {

--- a/apps/lumi-api/src/main/kotlin/no/nav/lumi/service/SubmissionService.kt
+++ b/apps/lumi-api/src/main/kotlin/no/nav/lumi/service/SubmissionService.kt
@@ -3,17 +3,22 @@ package no.nav.lumi.service
 import no.nav.lumi.domain.FeedbackSubmissionV1
 import no.nav.lumi.domain.SaveResult
 import no.nav.lumi.domain.SurveyDefinition
+import no.nav.lumi.domain.SurveyFlowDefinitionV1
+import no.nav.lumi.repository.AnalysisSourceContractRepository
 import no.nav.lumi.repository.FeedbackRepository
+import no.nav.lumi.validation.SurveyFlowValidator
 
 data class SubmissionOutcome(
     val saveResult: SaveResult,
-    val definitionHash: String? = null
+    val definitionHash: String? = null,
+    val flowHash: String? = null,
 )
 
 class SubmissionService(
     private val feedbackService: FeedbackService = FeedbackService(),
     private val surveyDefinitionService: SurveyDefinitionService = SurveyDefinitionService(),
     private val feedbackRepository: FeedbackRepository = FeedbackRepository(),
+    private val sourceContractRepository: AnalysisSourceContractRepository = AnalysisSourceContractRepository(),
     internal val afterScopedDeduplicationLockAcquired: suspend () -> Unit = {}
 ) {
     suspend fun submit(
@@ -21,7 +26,8 @@ class SubmissionService(
         team: String,
         app: String,
         submission: FeedbackSubmissionV1,
-        definition: SurveyDefinition? = null
+        definition: SurveyDefinition? = null,
+        flow: SurveyFlowDefinitionV1? = null,
     ): SubmissionOutcome {
         if (submission.deduplicationKey == null) {
             val prepared = feedbackService.prepareForSave(feedbackJson, team, submission.surveyId)
@@ -32,18 +38,20 @@ class SubmissionService(
                     definition = definition,
                     inCurrentTransaction = true
                 )
+                val flowHash = registerFlowContract(team, app, definitionResult, definition, flow)
                 val saveResult = feedbackRepository.saveInCurrentTransaction(
                     feedbackJson = prepared.feedbackJson,
                     team = team,
                     app = app,
                     surveyId = definitionResult.surveyId,
                     definitionHash = definitionResult.definitionHash,
+                    flowHash = flowHash,
                 )
                 surveyDefinitionService.recordStoredSubmissionInCurrentTransaction(
                     team,
                     definitionResult.surveyId,
                 )
-                SubmissionOutcome(saveResult, definitionResult.definitionHash)
+                SubmissionOutcome(saveResult, definitionResult.definitionHash, flowHash)
             }
         }
 
@@ -79,12 +87,14 @@ class SubmissionService(
                 definition = definition,
                 inCurrentTransaction = true
             )
+            val flowHash = registerFlowContract(team, app, definitionResult, definition, flow)
             val saveResult = feedbackRepository.saveInCurrentTransaction(
                 feedbackJson = prepared.feedbackJson,
                 team = team,
                 app = app,
                 surveyId = definitionResult.surveyId,
                 definitionHash = definitionResult.definitionHash,
+                flowHash = flowHash,
                 deduplicationKeyHash = deduplicationKeyHash
             )
 
@@ -97,9 +107,28 @@ class SubmissionService(
 
             SubmissionOutcome(
                 saveResult = saveResult,
-                definitionHash = definitionResult.definitionHash.takeIf { saveResult is SaveResult.Created }
+                definitionHash = definitionResult.definitionHash.takeIf { saveResult is SaveResult.Created },
+                flowHash = flowHash.takeIf { saveResult is SaveResult.Created },
             )
         }
+    }
+
+    private fun registerFlowContract(
+        team: String,
+        app: String,
+        definitionResult: RegistrationResult,
+        definition: SurveyDefinition?,
+        flow: SurveyFlowDefinitionV1?,
+    ): String? {
+        if (definition == null || flow == null) return null
+        SurveyFlowValidator.validate(flow, definition)
+        return sourceContractRepository.registerInCurrentTransaction(
+            team = team,
+            app = app,
+            definitionHash = definitionResult.definitionHash,
+            definition = definition,
+            flow = flow,
+        )
     }
 
     private suspend fun registerDefinition(

--- a/apps/lumi-api/src/main/kotlin/no/nav/lumi/validation/SubmissionV2Validator.kt
+++ b/apps/lumi-api/src/main/kotlin/no/nav/lumi/validation/SubmissionV2Validator.kt
@@ -24,6 +24,7 @@ object SubmissionV2Validator {
 
         val definition = submission.definition.toSurveyDefinition(submission.surveyId)
         SurveyDefinitionValidator.validateDefinition(definition)
+        submission.flow?.let { SurveyFlowValidator.validate(it, definition) }
         SpecializedSurveyContractValidator.validateDefinition(
             surveyType = submission.surveyType,
             fields = submission.definition.fields

--- a/apps/lumi-api/src/main/kotlin/no/nav/lumi/validation/SurveyFlowValidator.kt
+++ b/apps/lumi-api/src/main/kotlin/no/nav/lumi/validation/SurveyFlowValidator.kt
@@ -1,0 +1,179 @@
+package no.nav.lumi.validation
+
+import kotlinx.serialization.json.JsonNull
+import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.booleanOrNull
+import kotlinx.serialization.json.doubleOrNull
+import no.nav.lumi.config.exception.ApiErrorException
+import no.nav.lumi.domain.AnalysisColumnType
+import no.nav.lumi.domain.AnalysisDimensionRegistry
+import no.nav.lumi.domain.FieldDefinition
+import no.nav.lumi.domain.FieldType
+import no.nav.lumi.domain.SURVEY_FLOW_EVALUATOR_VERSION
+import no.nav.lumi.domain.SURVEY_FLOW_SCHEMA_VERSION
+import no.nav.lumi.domain.SurveyDefinition
+import no.nav.lumi.domain.SurveyFlowCondition
+import no.nav.lumi.domain.SurveyFlowConditionSource
+import no.nav.lumi.domain.SurveyFlowDefinitionV1
+import no.nav.lumi.domain.SurveyFlowOperator
+
+object SurveyFlowValidator {
+    fun validate(flow: SurveyFlowDefinitionV1, definition: SurveyDefinition) {
+        if (flow.schemaVersion != SURVEY_FLOW_SCHEMA_VERSION) {
+            invalid("flow.schemaVersion must be $SURVEY_FLOW_SCHEMA_VERSION")
+        }
+        if (flow.evaluatorVersion != SURVEY_FLOW_EVALUATOR_VERSION) {
+            invalid("flow.evaluatorVersion must be $SURVEY_FLOW_EVALUATOR_VERSION")
+        }
+
+        val definitionFieldIds = definition.fields.map(FieldDefinition::fieldId)
+        val flowFieldIds = flow.fields.map { it.fieldId }
+        if (flowFieldIds != definitionFieldIds) {
+            invalid("flow.fields must match definition.fields in order")
+        }
+        if (flowFieldIds.distinct().size != flowFieldIds.size) {
+            invalid("flow.fields.fieldId must be unique")
+        }
+
+        val definitionById = definition.fields.associateBy(FieldDefinition::fieldId)
+        val priorFieldIds = mutableSetOf<String>()
+        flow.fields.forEach { field ->
+            val visibleIf = field.visibleIf
+            if (visibleIf != null) {
+                if (visibleIf.conditions.isEmpty() || visibleIf.conditions.size > MAX_CONDITIONS_PER_FIELD) {
+                    invalid("flow visibleIf.conditions must contain between 1 and $MAX_CONDITIONS_PER_FIELD entries")
+                }
+                visibleIf.conditions.forEach { condition ->
+                    validateCondition(condition, priorFieldIds, definitionById)
+                }
+            }
+            priorFieldIds += field.fieldId
+        }
+    }
+
+    private fun validateCondition(
+        condition: SurveyFlowCondition,
+        priorFieldIds: Set<String>,
+        definitionById: Map<String, FieldDefinition>,
+    ) {
+        if (condition.key.isBlank() || condition.key.length > MAX_KEY_LENGTH) {
+            invalid("flow condition key must be non-blank and at most $MAX_KEY_LENGTH characters")
+        }
+
+        if (condition.operator == SurveyFlowOperator.EXISTS) {
+            if (condition.value != null) invalid("EXISTS flow conditions must not include value")
+        } else {
+            val value = condition.value
+            if (value == null || value is JsonNull || value !is JsonPrimitive) {
+                invalid("${condition.operator} flow conditions require a scalar value")
+            }
+            if (!value.isString && value.booleanOrNull == null && value.doubleOrNull?.isFinite() != true) {
+                invalid("flow condition value must be a finite string, number or boolean")
+            }
+            if (value.isString && value.content.length > MAX_STRING_VALUE_LENGTH) {
+                invalid("flow string condition value must be at most $MAX_STRING_VALUE_LENGTH characters")
+            }
+        }
+
+        if (condition.source == SurveyFlowConditionSource.ANSWER) {
+            if (condition.key !in priorFieldIds) {
+                invalid("ANSWER flow conditions must reference an earlier field")
+            }
+            val referenced = definitionById.getValue(condition.key)
+            if (condition.operator !in allowedOperators(referenced.fieldType)) {
+                invalid("flow operator ${condition.operator} is not supported for ${referenced.fieldType}")
+            }
+            validateAnswerValue(condition, referenced)
+        } else {
+            validateMetadataCondition(condition)
+        }
+    }
+
+    private fun validateAnswerValue(condition: SurveyFlowCondition, referenced: FieldDefinition) {
+        if (condition.operator == SurveyFlowOperator.EXISTS) return
+        val value = condition.value as JsonPrimitive
+        val valid = when (referenced.fieldType) {
+            FieldType.RATING -> {
+                val numeric = value.doubleOrNull
+                val rating = numeric
+                    ?.takeIf { it.isFinite() && it % 1.0 == 0.0 && it in Int.MIN_VALUE.toDouble()..Int.MAX_VALUE.toDouble() }
+                    ?.toInt()
+                val minimum = if (referenced.ratingVariant == no.nav.lumi.domain.RatingVariant.NPS) 0 else 1
+                val maximum = requireNotNull(referenced.ratingScale) -
+                    if (referenced.ratingVariant == no.nav.lumi.domain.RatingVariant.NPS) 1 else 0
+                !value.isString && rating != null && rating in minimum..maximum
+            }
+            FieldType.SINGLE_CHOICE, FieldType.MULTI_CHOICE ->
+                value.isString && value.content in referenced.optionIds.orEmpty()
+            FieldType.TEXT, FieldType.DATE -> value.isString && value.content.isNotBlank()
+        }
+        if (!valid) invalid("flow condition value is outside the domain for ${referenced.fieldType}")
+    }
+
+    private fun validateMetadataCondition(condition: SurveyFlowCondition) {
+        val dimension = AnalysisDimensionRegistry.snapshot().dimensions.singleOrNull { it.key == condition.key }
+            ?: return
+        val allowed = when (dimension.type) {
+            AnalysisColumnType.STRING -> setOf(
+                SurveyFlowOperator.EXISTS,
+                SurveyFlowOperator.EQ,
+                SurveyFlowOperator.NEQ,
+                SurveyFlowOperator.CONTAINS,
+            )
+            AnalysisColumnType.INT64, AnalysisColumnType.FLOAT64 -> setOf(
+                SurveyFlowOperator.EXISTS,
+                SurveyFlowOperator.EQ,
+                SurveyFlowOperator.NEQ,
+                SurveyFlowOperator.GT,
+                SurveyFlowOperator.LT,
+            )
+            AnalysisColumnType.BOOL, AnalysisColumnType.DATE, AnalysisColumnType.TIMESTAMP -> setOf(
+                SurveyFlowOperator.EXISTS,
+                SurveyFlowOperator.EQ,
+                SurveyFlowOperator.NEQ,
+            )
+        }
+        if (condition.operator !in allowed) {
+            invalid("flow operator ${condition.operator} is not supported for metadata ${condition.key}")
+        }
+        if (condition.operator == SurveyFlowOperator.EXISTS) return
+        val value = condition.value as JsonPrimitive
+        if (dimension.type == AnalysisColumnType.STRING && !value.isString) {
+            invalid("flow condition value must be a string for metadata ${condition.key}")
+        }
+        if (
+            condition.operator in setOf(SurveyFlowOperator.EQ, SurveyFlowOperator.NEQ) &&
+            dimension.allowedValues.isNotEmpty() &&
+            value.content !in dimension.allowedValues
+        ) {
+            invalid("flow condition value is outside the domain for metadata ${condition.key}")
+        }
+    }
+
+    private fun allowedOperators(fieldType: FieldType): Set<SurveyFlowOperator> = when (fieldType) {
+        FieldType.RATING -> setOf(
+            SurveyFlowOperator.EXISTS,
+            SurveyFlowOperator.EQ,
+            SurveyFlowOperator.NEQ,
+            SurveyFlowOperator.GT,
+            SurveyFlowOperator.LT,
+        )
+        FieldType.SINGLE_CHOICE, FieldType.TEXT, FieldType.DATE -> setOf(
+            SurveyFlowOperator.EXISTS,
+            SurveyFlowOperator.EQ,
+            SurveyFlowOperator.NEQ,
+            SurveyFlowOperator.CONTAINS,
+        )
+        FieldType.MULTI_CHOICE -> setOf(
+            SurveyFlowOperator.EXISTS,
+            SurveyFlowOperator.CONTAINS,
+        )
+    }
+
+    private fun invalid(message: String): Nothing =
+        throw ApiErrorException.BadRequestException("Invalid payload: $message")
+
+    private const val MAX_CONDITIONS_PER_FIELD = 50
+    private const val MAX_KEY_LENGTH = 200
+    private const val MAX_STRING_VALUE_LENGTH = 2_048
+}

--- a/apps/lumi-api/src/main/resources/db/migration/V22__analysis_source_contracts.sql
+++ b/apps/lumi-api/src/main/resources/db/migration/V22__analysis_source_contracts.sql
@@ -1,0 +1,385 @@
+-- Materialize future source-contract observations at ingest. Full flow
+-- contracts are registered by the API before the corresponding feedback row
+-- is inserted; old pods and direct writers remain valid with flow_hash NULL.
+
+ALTER TABLE feedback
+    ADD COLUMN flow_hash VARCHAR(64),
+    ADD CONSTRAINT chk_feedback_flow_hash
+        CHECK (flow_hash IS NULL OR flow_hash ~ '^[0-9a-f]{64}$'),
+    ADD CONSTRAINT chk_feedback_flow_requires_definition
+        CHECK (flow_hash IS NULL OR definition_hash IS NOT NULL),
+    ADD CONSTRAINT chk_feedback_flow_requires_survey
+        CHECK (flow_hash IS NULL OR survey_id IS NOT NULL);
+
+CREATE INDEX idx_feedback_analysis_source_contract
+    ON feedback (
+        team,
+        app,
+        (COALESCE(survey_id, feedback_json ->> 'surveyId')),
+        definition_hash,
+        flow_hash
+    );
+
+CREATE TABLE analysis_control.analysis_source_contracts (
+    team              VARCHAR(255) NOT NULL,
+    app               VARCHAR(255) NOT NULL,
+    survey_id         VARCHAR(255) NOT NULL,
+    definition_hash   VARCHAR(64) NOT NULL,
+    flow_hash         VARCHAR(64) NOT NULL,
+    definition        JSONB NOT NULL,
+    flow_definition   JSONB NOT NULL,
+    created_at        TIMESTAMPTZ NOT NULL DEFAULT clock_timestamp(),
+    PRIMARY KEY (team, app, survey_id, definition_hash, flow_hash),
+    CONSTRAINT chk_analysis_source_contract_definition_hash
+        CHECK (definition_hash ~ '^[0-9a-f]{64}$'),
+    CONSTRAINT chk_analysis_source_contract_flow_hash
+        CHECK (flow_hash ~ '^[0-9a-f]{64}$'),
+    CONSTRAINT chk_analysis_source_contract_definition_object
+        CHECK (jsonb_typeof(definition) = 'object'),
+    CONSTRAINT chk_analysis_source_contract_flow_object
+        CHECK (jsonb_typeof(flow_definition) = 'object'),
+    CONSTRAINT chk_analysis_source_contract_flow_schema
+        CHECK (flow_definition ->> 'schemaVersion' = '1'),
+    CONSTRAINT chk_analysis_source_contract_evaluator
+        CHECK (flow_definition ->> 'evaluatorVersion' = 'visible-if-v1'),
+    CONSTRAINT chk_analysis_source_contract_flow_size
+        CHECK (octet_length(flow_definition::text) <= 65536)
+);
+
+ALTER TABLE feedback
+    ADD CONSTRAINT fk_feedback_analysis_source_contract
+    FOREIGN KEY (team, app, survey_id, definition_hash, flow_hash)
+    REFERENCES analysis_control.analysis_source_contracts (
+        team,
+        app,
+        survey_id,
+        definition_hash,
+        flow_hash
+    )
+    MATCH SIMPLE
+    ON DELETE RESTRICT;
+
+CREATE TABLE analysis_control.analysis_source_contract_observations (
+    id                  UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    team                VARCHAR(255) NOT NULL,
+    app                 VARCHAR(255) NOT NULL,
+    survey_id           VARCHAR(255) NOT NULL,
+    definition_hash     VARCHAR(64),
+    flow_hash           VARCHAR(64),
+    has_source_id_mismatch BOOLEAN NOT NULL DEFAULT FALSE,
+    first_submission_at TIMESTAMPTZ NOT NULL,
+    last_submission_at  TIMESTAMPTZ NOT NULL,
+    created_at          TIMESTAMPTZ NOT NULL DEFAULT clock_timestamp(),
+    updated_at          TIMESTAMPTZ NOT NULL DEFAULT clock_timestamp(),
+    CONSTRAINT uq_analysis_source_contract_observation
+        UNIQUE NULLS NOT DISTINCT (team, app, survey_id, definition_hash, flow_hash),
+    CONSTRAINT chk_analysis_source_observation_definition_hash
+        CHECK (definition_hash IS NULL OR definition_hash ~ '^[0-9a-f]{64}$'),
+    CONSTRAINT chk_analysis_source_observation_flow_hash
+        CHECK (flow_hash IS NULL OR flow_hash ~ '^[0-9a-f]{64}$'),
+    CONSTRAINT chk_analysis_source_observation_flow_requires_definition
+        CHECK (flow_hash IS NULL OR definition_hash IS NOT NULL),
+    CONSTRAINT chk_analysis_source_observation_activity_order
+        CHECK (first_submission_at <= last_submission_at)
+);
+
+CREATE FUNCTION analysis_control.reject_source_contract_update()
+RETURNS TRIGGER
+LANGUAGE plpgsql
+AS $$
+BEGIN
+    RAISE EXCEPTION '% is immutable; delete only through retention cleanup', TG_TABLE_NAME
+        USING ERRCODE = '55000';
+END;
+$$;
+
+CREATE TRIGGER trg_analysis_source_contract_immutable
+BEFORE UPDATE
+ON analysis_control.analysis_source_contracts
+FOR EACH ROW
+EXECUTE FUNCTION analysis_control.reject_source_contract_update();
+
+CREATE TRIGGER trg_analysis_source_contract_reject_truncate
+BEFORE TRUNCATE
+ON analysis_control.analysis_source_contracts
+FOR EACH STATEMENT
+EXECUTE FUNCTION analysis_control.reject_source_contract_update();
+
+CREATE FUNCTION analysis_control.source_contract_lock_key(
+    lock_team TEXT,
+    lock_app TEXT,
+    lock_survey_id TEXT,
+    lock_definition_hash TEXT
+)
+RETURNS BIGINT
+LANGUAGE SQL
+IMMUTABLE
+STRICT
+PARALLEL SAFE
+AS $$
+    SELECT hashtextextended(
+        length(lock_team)::TEXT || ':' || lock_team ||
+        length(lock_app)::TEXT || ':' || lock_app ||
+        length(lock_survey_id)::TEXT || ':' || lock_survey_id ||
+        length(lock_definition_hash)::TEXT || ':' || lock_definition_hash,
+        0
+    );
+$$;
+
+CREATE FUNCTION analysis_control.source_contract_team_lock_key(lock_team TEXT)
+RETURNS BIGINT
+LANGUAGE SQL
+IMMUTABLE
+STRICT
+PARALLEL SAFE
+AS $$
+    SELECT hashtextextended(length(lock_team)::TEXT || ':' || lock_team, 1);
+$$;
+
+CREATE FUNCTION analysis_control.refresh_deleted_source_contract_observations()
+RETURNS TRIGGER
+LANGUAGE plpgsql
+AS $$
+DECLARE
+    affected_source RECORD;
+BEGIN
+    -- Serialize cleanup with registration. Without this lock, deletion of the
+    -- final referenced row could remove a contract while a concurrent
+    -- submission is between contract registration and feedback insertion.
+    FOR affected_source IN
+        SELECT DISTINCT
+            team,
+            app,
+            COALESCE(survey_id, feedback_json ->> 'surveyId') AS survey_id,
+            definition_hash
+        FROM deleted_feedback
+        WHERE definition_hash IS NOT NULL
+          AND length(btrim(COALESCE(survey_id, feedback_json ->> 'surveyId', ''))) > 0
+          AND length(COALESCE(survey_id, feedback_json ->> 'surveyId', '')) <= 255
+        ORDER BY team, app, survey_id, definition_hash
+    LOOP
+        PERFORM pg_advisory_xact_lock(
+            analysis_control.source_contract_lock_key(
+                affected_source.team,
+                affected_source.app,
+                affected_source.survey_id,
+                affected_source.definition_hash
+            )
+        );
+    END LOOP;
+
+    -- Recompute only the exact contract pairs touched by this DELETE. This
+    -- preserves exact first/last/mismatch facts without rescanning every
+    -- historical revision for the source.
+    DELETE FROM analysis_control.analysis_source_contract_observations AS observation
+    USING (
+        SELECT DISTINCT
+            team,
+            app,
+            COALESCE(survey_id, feedback_json ->> 'surveyId') AS survey_id,
+            definition_hash,
+            flow_hash
+        FROM deleted_feedback
+        WHERE length(btrim(COALESCE(survey_id, feedback_json ->> 'surveyId', ''))) > 0
+          AND length(COALESCE(survey_id, feedback_json ->> 'surveyId', '')) <= 255
+    ) AS affected
+    WHERE observation.team = affected.team
+      AND observation.app = affected.app
+      AND observation.survey_id = affected.survey_id
+      AND observation.definition_hash IS NOT DISTINCT FROM affected.definition_hash
+      AND observation.flow_hash IS NOT DISTINCT FROM affected.flow_hash;
+
+    INSERT INTO analysis_control.analysis_source_contract_observations (
+        team,
+        app,
+        survey_id,
+        definition_hash,
+        flow_hash,
+        has_source_id_mismatch,
+        first_submission_at,
+        last_submission_at
+    )
+    SELECT
+        feedback.team,
+        feedback.app,
+        COALESCE(feedback.survey_id, feedback.feedback_json ->> 'surveyId') AS survey_id,
+        feedback.definition_hash,
+        feedback.flow_hash,
+        BOOL_OR(
+            feedback.survey_id IS NOT NULL AND
+            feedback.feedback_json ->> 'surveyId' IS NOT NULL AND
+            feedback.survey_id <> feedback.feedback_json ->> 'surveyId'
+        ),
+        MIN(feedback.opprettet),
+        MAX(feedback.opprettet)
+    FROM feedback
+    JOIN (
+        SELECT DISTINCT
+            team,
+            app,
+            COALESCE(survey_id, feedback_json ->> 'surveyId') AS survey_id,
+            definition_hash,
+            flow_hash
+        FROM deleted_feedback
+        WHERE length(btrim(COALESCE(survey_id, feedback_json ->> 'surveyId', ''))) > 0
+          AND length(COALESCE(survey_id, feedback_json ->> 'surveyId', '')) <= 255
+    ) AS affected
+      ON affected.team = feedback.team
+     AND affected.app = feedback.app
+     AND affected.survey_id = COALESCE(feedback.survey_id, feedback.feedback_json ->> 'surveyId')
+     AND affected.definition_hash IS NOT DISTINCT FROM feedback.definition_hash
+     AND affected.flow_hash IS NOT DISTINCT FROM feedback.flow_hash
+    GROUP BY
+        feedback.team,
+        feedback.app,
+        COALESCE(feedback.survey_id, feedback.feedback_json ->> 'surveyId'),
+        feedback.definition_hash,
+        feedback.flow_hash
+    ON CONFLICT (team, app, survey_id, definition_hash, flow_hash) DO UPDATE
+    SET first_submission_at = LEAST(
+            analysis_control.analysis_source_contract_observations.first_submission_at,
+            EXCLUDED.first_submission_at
+        ),
+        last_submission_at = GREATEST(
+            analysis_control.analysis_source_contract_observations.last_submission_at,
+            EXCLUDED.last_submission_at
+        ),
+        has_source_id_mismatch =
+            analysis_control.analysis_source_contract_observations.has_source_id_mismatch OR
+            EXCLUDED.has_source_id_mismatch,
+        updated_at = statement_timestamp();
+
+    -- The immutable contract contains private predicate constants. Retain it
+    -- only while at least one pinned feedback row references it. The FK plus
+    -- the source lock makes this safe against concurrent submissions.
+    DELETE FROM analysis_control.analysis_source_contracts AS contract
+    USING (
+        SELECT DISTINCT
+            team,
+            app,
+            COALESCE(survey_id, feedback_json ->> 'surveyId') AS survey_id,
+            definition_hash,
+            flow_hash
+        FROM deleted_feedback
+        WHERE definition_hash IS NOT NULL
+          AND flow_hash IS NOT NULL
+          AND length(btrim(COALESCE(survey_id, feedback_json ->> 'surveyId', ''))) > 0
+          AND length(COALESCE(survey_id, feedback_json ->> 'surveyId', '')) <= 255
+    ) AS affected
+    WHERE contract.team = affected.team
+      AND contract.app = affected.app
+      AND contract.survey_id = affected.survey_id
+      AND contract.definition_hash = affected.definition_hash
+      AND contract.flow_hash = affected.flow_hash
+      AND NOT EXISTS (
+          SELECT 1
+          FROM feedback
+          WHERE feedback.team = contract.team
+            AND feedback.app = contract.app
+            AND feedback.survey_id = contract.survey_id
+            AND feedback.definition_hash = contract.definition_hash
+            AND feedback.flow_hash = contract.flow_hash
+      );
+
+    RETURN NULL;
+END;
+$$;
+
+CREATE TRIGGER feedback_analysis_source_contract_delete_refresh
+AFTER DELETE ON feedback
+REFERENCING OLD TABLE AS deleted_feedback
+FOR EACH STATEMENT
+EXECUTE FUNCTION analysis_control.refresh_deleted_source_contract_observations();
+
+CREATE OR REPLACE FUNCTION analysis_control.capture_analysis_source()
+RETURNS TRIGGER
+LANGUAGE plpgsql
+AS $$
+DECLARE
+    catalog_survey_id TEXT := COALESCE(NEW.survey_id, NEW.feedback_json ->> 'surveyId');
+BEGIN
+    IF catalog_survey_id IS NOT NULL
+       AND length(btrim(catalog_survey_id)) > 0
+       AND length(catalog_survey_id) <= 255
+       AND length(btrim(NEW.team)) > 0
+       AND length(btrim(NEW.app)) > 0 THEN
+        INSERT INTO analysis_control.analysis_sources (
+            team,
+            app,
+            survey_id,
+            first_submission_at,
+            last_submission_at
+        )
+        VALUES (
+            NEW.team,
+            NEW.app,
+            catalog_survey_id,
+            NEW.opprettet,
+            NEW.opprettet
+        )
+        ON CONFLICT (team, app, survey_id) DO UPDATE
+        SET first_submission_at = LEAST(
+                analysis_control.analysis_sources.first_submission_at,
+                EXCLUDED.first_submission_at
+            ),
+            last_submission_at = GREATEST(
+                analysis_control.analysis_sources.last_submission_at,
+                EXCLUDED.last_submission_at
+            ),
+            updated_at = statement_timestamp();
+
+        INSERT INTO analysis_control.analysis_source_contract_observations (
+            team,
+            app,
+            survey_id,
+            definition_hash,
+            flow_hash,
+            has_source_id_mismatch,
+            first_submission_at,
+            last_submission_at
+        )
+        VALUES (
+            NEW.team,
+            NEW.app,
+            catalog_survey_id,
+            NEW.definition_hash,
+            NEW.flow_hash,
+            NEW.survey_id IS NOT NULL AND
+                NEW.feedback_json ->> 'surveyId' IS NOT NULL AND
+                NEW.survey_id <> NEW.feedback_json ->> 'surveyId',
+            NEW.opprettet,
+            NEW.opprettet
+        )
+        ON CONFLICT (team, app, survey_id, definition_hash, flow_hash) DO UPDATE
+        SET first_submission_at = LEAST(
+                analysis_control.analysis_source_contract_observations.first_submission_at,
+                EXCLUDED.first_submission_at
+            ),
+            last_submission_at = GREATEST(
+                analysis_control.analysis_source_contract_observations.last_submission_at,
+                EXCLUDED.last_submission_at
+            ),
+            has_source_id_mismatch =
+                analysis_control.analysis_source_contract_observations.has_source_id_mismatch OR
+                EXCLUDED.has_source_id_mismatch,
+            updated_at = statement_timestamp();
+    END IF;
+
+    RETURN NEW;
+END;
+$$;
+
+REVOKE ALL ON analysis_control.analysis_source_contracts FROM PUBLIC;
+REVOKE ALL ON analysis_control.analysis_source_contracts FROM "esyfo-analyse";
+REVOKE ALL ON analysis_control.analysis_source_contract_observations FROM PUBLIC;
+REVOKE ALL ON analysis_control.analysis_source_contract_observations FROM "esyfo-analyse";
+REVOKE ALL ON FUNCTION analysis_control.reject_source_contract_update() FROM PUBLIC;
+REVOKE ALL ON FUNCTION analysis_control.reject_source_contract_update() FROM "esyfo-analyse";
+REVOKE ALL ON FUNCTION analysis_control.source_contract_lock_key(TEXT, TEXT, TEXT, TEXT) FROM PUBLIC;
+REVOKE ALL ON FUNCTION analysis_control.source_contract_lock_key(TEXT, TEXT, TEXT, TEXT) FROM "esyfo-analyse";
+REVOKE ALL ON FUNCTION analysis_control.source_contract_team_lock_key(TEXT) FROM PUBLIC;
+REVOKE ALL ON FUNCTION analysis_control.source_contract_team_lock_key(TEXT) FROM "esyfo-analyse";
+REVOKE ALL ON FUNCTION analysis_control.refresh_deleted_source_contract_observations() FROM PUBLIC;
+REVOKE ALL ON FUNCTION analysis_control.refresh_deleted_source_contract_observations() FROM "esyfo-analyse";
+REVOKE ALL ON FUNCTION analysis_control.capture_analysis_source() FROM PUBLIC;
+REVOKE ALL ON FUNCTION analysis_control.capture_analysis_source() FROM "esyfo-analyse";

--- a/apps/lumi-api/src/main/resources/db/migration/V23__backfill_analysis_source_contract_observations.sql
+++ b/apps/lumi-api/src/main/resources/db/migration/V23__backfill_analysis_source_contract_observations.sql
@@ -1,0 +1,45 @@
+-- Backfill after V22 installed writer capture so rolling application pods and
+-- concurrent inserts cannot fall through the materialized observation table.
+
+INSERT INTO analysis_control.analysis_source_contract_observations (
+    team,
+    app,
+    survey_id,
+    definition_hash,
+    flow_hash,
+    has_source_id_mismatch,
+    first_submission_at,
+    last_submission_at
+)
+SELECT
+    team,
+    app,
+    COALESCE(survey_id, feedback_json ->> 'surveyId') AS catalog_survey_id,
+    definition_hash,
+    flow_hash,
+    BOOL_OR(
+        survey_id IS NOT NULL AND
+        feedback_json ->> 'surveyId' IS NOT NULL AND
+        survey_id <> feedback_json ->> 'surveyId'
+    ),
+    MIN(opprettet),
+    MAX(opprettet)
+FROM feedback
+WHERE length(btrim(COALESCE(survey_id, feedback_json ->> 'surveyId', ''))) > 0
+  AND length(COALESCE(survey_id, feedback_json ->> 'surveyId', '')) <= 255
+  AND length(btrim(team)) > 0
+  AND length(btrim(app)) > 0
+GROUP BY team, app, COALESCE(survey_id, feedback_json ->> 'surveyId'), definition_hash, flow_hash
+ON CONFLICT (team, app, survey_id, definition_hash, flow_hash) DO UPDATE
+SET first_submission_at = LEAST(
+        analysis_control.analysis_source_contract_observations.first_submission_at,
+        EXCLUDED.first_submission_at
+    ),
+    last_submission_at = GREATEST(
+        analysis_control.analysis_source_contract_observations.last_submission_at,
+        EXCLUDED.last_submission_at
+    ),
+    has_source_id_mismatch =
+        analysis_control.analysis_source_contract_observations.has_source_id_mismatch OR
+        EXCLUDED.has_source_id_mismatch,
+    updated_at = statement_timestamp();

--- a/apps/lumi-api/src/test/kotlin/no/nav/lumi/TestDatabase.kt
+++ b/apps/lumi-api/src/test/kotlin/no/nav/lumi/TestDatabase.kt
@@ -83,7 +83,7 @@ object TestDatabase {
         dataSource.connection.use { conn ->
             conn.createStatement().use { stmt ->
                 // Production history is protected from TRUNCATE. Disable only
-                // those two named triggers inside this rolled-back-on-failure
+                // the named triggers inside this rolled-back-on-failure
                 // test cleanup transaction.
                 stmt.execute(
                     "ALTER TABLE analysis_control.analysis_product_audit_events " +
@@ -94,10 +94,16 @@ object TestDatabase {
                         "DISABLE TRIGGER trg_analysis_product_release_truncate_immutable",
                 )
                 stmt.execute(
+                    "ALTER TABLE analysis_control.analysis_source_contracts " +
+                        "DISABLE TRIGGER trg_analysis_source_contract_reject_truncate",
+                )
+                stmt.execute(
                     "TRUNCATE TABLE analysis_control.analysis_product_audit_events, " +
                         "analysis_control.analysis_product_releases, " +
                         "analysis_control.analysis_product_drafts, " +
                         "analysis_control.analysis_products, " +
+                        "analysis_control.analysis_source_contract_observations, " +
+                        "analysis_control.analysis_source_contracts, " +
                         "analysis_control.analysis_sources, " +
                         "rating_marker, feedback, survey_definitions, survey_metadata, " +
                         "survey_authoring_revisions, survey_authoring_projects, " +
@@ -110,6 +116,10 @@ object TestDatabase {
                 stmt.execute(
                     "ALTER TABLE analysis_control.analysis_product_releases " +
                         "ENABLE TRIGGER trg_analysis_product_release_truncate_immutable",
+                )
+                stmt.execute(
+                    "ALTER TABLE analysis_control.analysis_source_contracts " +
+                        "ENABLE TRIGGER trg_analysis_source_contract_reject_truncate",
                 )
             }
             conn.commit()

--- a/apps/lumi-api/src/test/kotlin/no/nav/lumi/domain/AnalysisContractCompilerTest.kt
+++ b/apps/lumi-api/src/test/kotlin/no/nav/lumi/domain/AnalysisContractCompilerTest.kt
@@ -122,6 +122,69 @@ class AnalysisContractCompilerTest : FunSpec({
         first.catalogRevision shouldNotBe second.catalogRevision
     }
 
+    test("pins all known flow revisions and warns without inventing legacy flow") {
+        val currentFlow = "f".repeat(64)
+        val earlierFlow = "e".repeat(64)
+        val source = catalogSource(
+            fields = listOf(
+                catalogField("score", FieldType.RATING, RatingVariant.NPS, 11).copy(
+                    flowDependencies = listOf(
+                        AnalysisFlowDependencyV1(AnalysisFlowDependencySource.METADATA, "deviceType"),
+                    ),
+                ),
+            ),
+        ).copy(
+            flowHash = currentFlow,
+            flowHashes = listOf(earlierFlow, currentFlow),
+            observedFlowHashes = listOf(null, earlierFlow, currentFlow),
+            flowStatus = AnalysisFlowStatus.PINNED,
+            warnings = listOf(AnalysisCatalogWarning.LEGACY_FLOW_OBSERVED),
+        )
+        val document = productDocument(
+            listOf(AnalysisProductSourceSelection("my-app", "survey-one", listOf("score"))),
+            dimensionKeys = listOf("deviceType"),
+        )
+
+        val preview = compiler.compilePreview(compilationInput(document, catalogSnapshot(listOf(source))))
+
+        preview.status shouldBe AnalysisContractPreviewStatus.READY_WITH_WARNINGS
+        preview.issues.map { it.code } shouldContain AnalysisCompilationIssueCode.UNPINNED_FLOW_HISTORY_EXCLUDED
+        preview.publicationSpecification?.sourcePins?.single()?.flowHash shouldBe currentFlow
+        preview.publicationSpecification?.sourcePins?.single()?.allowedFlowHashes shouldBe
+            listOf(earlierFlow, currentFlow)
+    }
+
+    test("blocks a conditional field until its flow dependency is selected") {
+        val source = catalogSource(
+            fields = listOf(
+                catalogField("score", FieldType.RATING, RatingVariant.NPS, 11).copy(
+                    flowDependencies = listOf(
+                        AnalysisFlowDependencyV1(AnalysisFlowDependencySource.METADATA, "deviceType"),
+                    ),
+                ),
+            ),
+        ).copy(
+            flowHash = "f".repeat(64),
+            flowHashes = listOf("f".repeat(64)),
+            flowStatus = AnalysisFlowStatus.PINNED,
+        )
+        val selection = listOf(AnalysisProductSourceSelection("my-app", "survey-one", listOf("score")))
+
+        val blocked = compiler.compilePreview(
+            compilationInput(productDocument(selection), catalogSnapshot(listOf(source))),
+        )
+        val ready = compiler.compilePreview(
+            compilationInput(
+                productDocument(selection, dimensionKeys = listOf("deviceType")),
+                catalogSnapshot(listOf(source)),
+            ),
+        )
+
+        blocked.status shouldBe AnalysisContractPreviewStatus.BLOCKED
+        blocked.issues.map { it.code } shouldContain AnalysisCompilationIssueCode.FLOW_DEPENDENCY_NOT_SELECTED
+        ready.status shouldBe AnalysisContractPreviewStatus.READY
+    }
+
     test("publication specification binds retention") {
         val source = catalogSource().copy(
             flowHash = "f".repeat(64),

--- a/apps/lumi-api/src/test/kotlin/no/nav/lumi/domain/SurveyFlowDefinitionTest.kt
+++ b/apps/lumi-api/src/test/kotlin/no/nav/lumi/domain/SurveyFlowDefinitionTest.kt
@@ -1,0 +1,246 @@
+package no.nav.lumi.domain
+
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import kotlinx.serialization.json.JsonPrimitive
+import no.nav.lumi.config.exception.ApiErrorException
+import no.nav.lumi.validation.SurveyFlowValidator
+
+class SurveyFlowDefinitionTest : FunSpec({
+    val definition = SurveyDefinition(
+        surveyId = "survey",
+        surveyType = SurveyType.CUSTOM,
+        fields = listOf(
+            FieldDefinition("rating", FieldType.RATING, RatingVariant.NPS, 11, null),
+            FieldDefinition("details", FieldType.TEXT, null, null, null),
+        ),
+    )
+
+    test("hash is stable across condition order and equivalent number syntax") {
+        val first = flow(
+            listOf(
+                SurveyFlowCondition(
+                    SurveyFlowConditionSource.METADATA,
+                    "deviceType",
+                    SurveyFlowOperator.EQ,
+                    JsonPrimitive("mobile"),
+                ),
+                SurveyFlowCondition(
+                    SurveyFlowConditionSource.ANSWER,
+                    "rating",
+                    SurveyFlowOperator.LT,
+                    JsonPrimitive(7),
+                ),
+            ),
+        )
+        val reordered = flow(
+            listOf(
+                SurveyFlowCondition(
+                    SurveyFlowConditionSource.ANSWER,
+                    "rating",
+                    SurveyFlowOperator.LT,
+                    JsonPrimitive(7.0),
+                ),
+                SurveyFlowCondition(
+                    SurveyFlowConditionSource.METADATA,
+                    "deviceType",
+                    SurveyFlowOperator.EQ,
+                    JsonPrimitive("mobile"),
+                ),
+            ),
+        )
+
+        SurveyFlowValidator.validate(first, definition)
+        SurveyFlowValidator.validate(reordered, definition)
+        first.computeHash() shouldBe reordered.computeHash()
+    }
+
+    test("hash changes when a predicate changes") {
+        val first = flow(
+            listOf(
+                SurveyFlowCondition(
+                    SurveyFlowConditionSource.ANSWER,
+                    "rating",
+                    SurveyFlowOperator.LT,
+                    JsonPrimitive(7),
+                ),
+            ),
+        )
+        val changed = flow(
+            listOf(
+                SurveyFlowCondition(
+                    SurveyFlowConditionSource.ANSWER,
+                    "rating",
+                    SurveyFlowOperator.LT,
+                    JsonPrimitive(8),
+                ),
+            ),
+        )
+
+        (first.computeHash() == changed.computeHash()) shouldBe false
+    }
+
+    test("hash is order-independent when condition components contain NUL") {
+        val firstCondition = SurveyFlowCondition(
+            SurveyFlowConditionSource.METADATA,
+            "x",
+            SurveyFlowOperator.EQ,
+            JsonPrimitive("a\u0000NEQ\u0000STRING\u0000b"),
+        )
+        val secondCondition = SurveyFlowCondition(
+            SurveyFlowConditionSource.METADATA,
+            "x\u0000EQ\u0000STRING\u0000a",
+            SurveyFlowOperator.NEQ,
+            JsonPrimitive("b"),
+        )
+
+        flow(listOf(firstCondition, secondCondition)).computeHash() shouldBe
+            flow(listOf(secondCondition, firstCondition)).computeHash()
+    }
+
+    test("hash has a stable golden value for the persisted v1 identity") {
+        val golden = SurveyFlowDefinitionV1(
+            schemaVersion = 1,
+            evaluatorVersion = SURVEY_FLOW_EVALUATOR_VERSION,
+            fields = listOf(
+                SurveyFlowFieldDefinition("q_rating"),
+                SurveyFlowFieldDefinition(
+                    "q_choice",
+                    SurveyVisibleIfDefinition(
+                        SurveyFlowCombinator.ANY,
+                        listOf(
+                            SurveyFlowCondition(
+                                SurveyFlowConditionSource.METADATA,
+                                "segment",
+                                SurveyFlowOperator.EQ,
+                                JsonPrimitive("blå"),
+                            ),
+                            SurveyFlowCondition(
+                                SurveyFlowConditionSource.METADATA,
+                                "other",
+                                SurveyFlowOperator.EXISTS,
+                            ),
+                            SurveyFlowCondition(
+                                SurveyFlowConditionSource.ANSWER,
+                                "q_rating",
+                                SurveyFlowOperator.LT,
+                                JsonPrimitive(7.0),
+                            ),
+                            SurveyFlowCondition(
+                                SurveyFlowConditionSource.METADATA,
+                                "flag",
+                                SurveyFlowOperator.EQ,
+                                JsonPrimitive(true),
+                            ),
+                        ),
+                    ),
+                ),
+            ),
+        )
+
+        golden.computeHash() shouldBe "dacdee83ce50bc6533433f055c2311d3fd38e8e0f5edd5171e639db72ff56541"
+    }
+
+    test("validator rejects forward answer dependencies") {
+        val invalid = SurveyFlowDefinitionV1(
+            schemaVersion = 1,
+            evaluatorVersion = SURVEY_FLOW_EVALUATOR_VERSION,
+            fields = listOf(
+                SurveyFlowFieldDefinition(
+                    fieldId = "rating",
+                    visibleIf = SurveyVisibleIfDefinition(
+                        combinator = SurveyFlowCombinator.ALL,
+                        conditions = listOf(
+                            SurveyFlowCondition(
+                                SurveyFlowConditionSource.ANSWER,
+                                "details",
+                                SurveyFlowOperator.EXISTS,
+                            ),
+                        ),
+                    ),
+                ),
+                SurveyFlowFieldDefinition("details"),
+            ),
+        )
+
+        shouldThrow<ApiErrorException.BadRequestException> {
+            SurveyFlowValidator.validate(invalid, definition)
+        }
+    }
+
+    test("validator rejects operators that cannot match the referenced field") {
+        val invalid = flow(
+            listOf(
+                SurveyFlowCondition(
+                    SurveyFlowConditionSource.ANSWER,
+                    "rating",
+                    SurveyFlowOperator.CONTAINS,
+                    JsonPrimitive("7"),
+                ),
+            ),
+        )
+
+        shouldThrow<ApiErrorException.BadRequestException> {
+            SurveyFlowValidator.validate(invalid, definition)
+        }
+    }
+
+    test("validator rejects values outside the referenced field and metadata domains") {
+        val invalidRating = flow(
+            listOf(
+                SurveyFlowCondition(
+                    SurveyFlowConditionSource.ANSWER,
+                    "rating",
+                    SurveyFlowOperator.LT,
+                    JsonPrimitive("7"),
+                ),
+            ),
+        )
+        val invalidMetadata = flow(
+            listOf(
+                SurveyFlowCondition(
+                    SurveyFlowConditionSource.METADATA,
+                    "deviceType",
+                    SurveyFlowOperator.GT,
+                    JsonPrimitive(7),
+                ),
+            ),
+        )
+        val oversizedPredicate = flow(
+            listOf(
+                SurveyFlowCondition(
+                    SurveyFlowConditionSource.METADATA,
+                    "customSegment",
+                    SurveyFlowOperator.EQ,
+                    JsonPrimitive("x".repeat(2_049)),
+                ),
+            ),
+        )
+
+        shouldThrow<ApiErrorException.BadRequestException> {
+            SurveyFlowValidator.validate(invalidRating, definition)
+        }
+        shouldThrow<ApiErrorException.BadRequestException> {
+            SurveyFlowValidator.validate(invalidMetadata, definition)
+        }
+        shouldThrow<ApiErrorException.BadRequestException> {
+            SurveyFlowValidator.validate(oversizedPredicate, definition)
+        }
+    }
+})
+
+private fun flow(conditions: List<SurveyFlowCondition>) = SurveyFlowDefinitionV1(
+    schemaVersion = 1,
+    evaluatorVersion = SURVEY_FLOW_EVALUATOR_VERSION,
+    fields = listOf(
+        SurveyFlowFieldDefinition("rating"),
+        SurveyFlowFieldDefinition(
+            fieldId = "details",
+            visibleIf = SurveyVisibleIfDefinition(
+                combinator = SurveyFlowCombinator.ANY,
+                conditions = conditions,
+            ),
+        ),
+    ),
+)

--- a/apps/lumi-api/src/test/kotlin/no/nav/lumi/repository/AnalysisSourceCatalogMigrationTest.kt
+++ b/apps/lumi-api/src/test/kotlin/no/nav/lumi/repository/AnalysisSourceCatalogMigrationTest.kt
@@ -1,11 +1,13 @@
 package no.nav.lumi.repository
 
+import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.shouldBe
 import no.nav.lumi.PsqlContainer
 import org.flywaydb.core.Flyway
 import org.flywaydb.core.api.MigrationVersion
 import java.sql.DriverManager
+import java.sql.SQLException
 import java.sql.Types
 import java.time.OffsetDateTime
 
@@ -70,6 +72,30 @@ class AnalysisSourceCatalogMigrationTest : FunSpec({
         Flyway.configure()
             .dataSource(container.jdbcUrl, container.username, container.password)
             .locations("classpath:db/migration")
+            .target(MigrationVersion.fromVersion("22"))
+            .load()
+            .migrate()
+
+        DriverManager.getConnection(container.jdbcUrl, container.username, container.password).use { connection ->
+            insertFeedback(connection, "feedback-contract-rolling", "2026-08-01T14:00:00Z", "app-c", "survey-a", "survey-a")
+            connection.prepareStatement(
+                """
+                SELECT COUNT(*)
+                FROM analysis_control.analysis_source_contract_observations
+                WHERE team = 'team-a' AND app = 'app-c' AND survey_id = 'survey-a'
+                  AND flow_hash IS NULL
+                """.trimIndent(),
+            ).use { statement ->
+                statement.executeQuery().use { result ->
+                    result.next() shouldBe true
+                    result.getInt(1) shouldBe 1
+                }
+            }
+        }
+
+        Flyway.configure()
+            .dataSource(container.jdbcUrl, container.username, container.password)
+            .locations("classpath:db/migration")
             .load()
             .migrate()
 
@@ -93,6 +119,10 @@ class AnalysisSourceCatalogMigrationTest : FunSpec({
                     result.getString("survey_id") shouldBe "survey-a"
 
                     result.next() shouldBe true
+                    result.getString("app") shouldBe "app-c"
+                    result.getString("survey_id") shouldBe "survey-a"
+
+                    result.next() shouldBe true
                     result.getString("app") shouldBe "app-json"
                     result.getString("survey_id") shouldBe "survey-json"
                     result.next() shouldBe false
@@ -107,6 +137,132 @@ class AnalysisSourceCatalogMigrationTest : FunSpec({
                     result.getBoolean(1) shouldBe false
                 }
             }
+
+            connection.prepareStatement(
+                """
+                SELECT
+                    has_table_privilege(
+                        'esyfo-analyse',
+                        'analysis_control.analysis_source_contracts',
+                        'SELECT'
+                    ),
+                    has_table_privilege(
+                        'esyfo-analyse',
+                        'analysis_control.analysis_source_contract_observations',
+                        'SELECT'
+                    )
+                """.trimIndent(),
+            ).use { statement ->
+                statement.executeQuery().use { result ->
+                    result.next() shouldBe true
+                    result.getBoolean(1) shouldBe false
+                    result.getBoolean(2) shouldBe false
+                }
+            }
+        }
+
+        DriverManager.getConnection(container.jdbcUrl, container.username, container.password).use { connection ->
+            connection.autoCommit = false
+            shouldThrow<SQLException> {
+                connection.prepareStatement(
+                    """
+                    INSERT INTO feedback (
+                        id, feedback_json, team, app, survey_id, definition_hash, flow_hash
+                    ) VALUES (
+                        'unknown-flow', '{"surveyId":"survey-a","answers":[]}'::jsonb,
+                        'team-a', 'app-unknown', 'survey-a', ?, ?
+                    )
+                    """.trimIndent(),
+                ).use { statement ->
+                    statement.setString(1, "a".repeat(64))
+                    statement.setString(2, "e".repeat(64))
+                    statement.executeUpdate()
+                }
+            }
+            connection.rollback()
+        }
+
+        DriverManager.getConnection(container.jdbcUrl, container.username, container.password).use { connection ->
+            connection.autoCommit = false
+            shouldThrow<SQLException> {
+                connection.prepareStatement(
+                    """
+                    INSERT INTO analysis_control.analysis_source_contracts (
+                        team, app, survey_id, definition_hash, flow_hash, definition, flow_definition
+                    ) VALUES (
+                        'team-a', 'app-large', 'survey-a', ?, ?, '{}'::jsonb,
+                        jsonb_build_object(
+                            'schemaVersion', 1,
+                            'evaluatorVersion', 'visible-if-v1',
+                            'padding', repeat('x', 65536)
+                        )
+                    )
+                    """.trimIndent(),
+                ).use { statement ->
+                    statement.setString(1, "a".repeat(64))
+                    statement.setString(2, "f".repeat(64))
+                    statement.executeUpdate()
+                }
+            }
+            connection.rollback()
+        }
+
+        DriverManager.getConnection(container.jdbcUrl, container.username, container.password).use { connection ->
+            connection.autoCommit = false
+            shouldThrow<SQLException> {
+                connection.prepareStatement(
+                    """
+                    INSERT INTO feedback (
+                        id, feedback_json, team, app, survey_id, definition_hash, flow_hash
+                    ) VALUES (
+                        'flow-without-survey', '{"surveyId":"survey-a","answers":[]}'::jsonb,
+                        'team-a', 'app-unknown', NULL, ?, ?
+                    )
+                    """.trimIndent(),
+                ).use { statement ->
+                    statement.setString(1, "a".repeat(64))
+                    statement.setString(2, "e".repeat(64))
+                    statement.executeUpdate()
+                }
+            }
+            connection.rollback()
+        }
+
+        DriverManager.getConnection(container.jdbcUrl, container.username, container.password).use { connection ->
+            connection.autoCommit = false
+            connection.createStatement().use { statement ->
+                statement.executeUpdate(
+                    """
+                    INSERT INTO analysis_control.analysis_source_contracts (
+                        team, app, survey_id, definition_hash, flow_hash, definition, flow_definition
+                    ) VALUES (
+                        'team-a', 'app-a', 'survey-a', '${"a".repeat(64)}', '${"f".repeat(64)}',
+                        '{}'::jsonb,
+                        '{"schemaVersion":1,"evaluatorVersion":"visible-if-v1"}'::jsonb
+                    )
+                    """.trimIndent(),
+                )
+                shouldThrow<SQLException> {
+                    statement.executeUpdate(
+                        """
+                        UPDATE analysis_control.analysis_source_contracts
+                        SET flow_definition = flow_definition
+                        WHERE team = 'team-a' AND app = 'app-a' AND survey_id = 'survey-a'
+                        """.trimIndent(),
+                    )
+                }
+            }
+            connection.rollback()
+        }
+
+        DriverManager.getConnection(container.jdbcUrl, container.username, container.password).use { connection ->
+            connection.autoCommit = false
+            shouldThrow<SQLException> {
+                connection.createStatement().use { statement ->
+                    statement.execute("TRUNCATE analysis_control.analysis_source_contracts")
+                }
+            }
+            connection.rollback()
         }
     }
 })

--- a/apps/lumi-api/src/test/kotlin/no/nav/lumi/repository/AnalysisSourceCatalogRepositoryTest.kt
+++ b/apps/lumi-api/src/test/kotlin/no/nav/lumi/repository/AnalysisSourceCatalogRepositoryTest.kt
@@ -101,6 +101,41 @@ class AnalysisSourceCatalogRepositoryTest : FunSpec({
         source.warnings shouldContain AnalysisCatalogWarning.LEGACY_DEFINITION_OBSERVED
         source.warnings shouldContain AnalysisCatalogWarning.SOURCE_ID_MISMATCH
     }
+
+    test("fails closed when a materialized observation has no registered contract") {
+        insertDefinition("team-a", "survey", "a".repeat(64), "field")
+        feedbackRepository.save(
+            feedbackJson("survey"),
+            "team-a",
+            "app-a",
+            "survey",
+            "a".repeat(64),
+        )
+        TestDatabase.dataSource.connection.use { connection ->
+            connection.prepareStatement(
+                """
+                INSERT INTO analysis_control.analysis_source_contract_observations (
+                    team, app, survey_id, definition_hash, flow_hash,
+                    first_submission_at, last_submission_at
+                )
+                VALUES ('team-a', 'app-a', 'survey', ?, ?, now() + interval '1 second', now() + interval '1 second')
+                """.trimIndent(),
+            ).use { statement ->
+                statement.setString(1, "a".repeat(64))
+                statement.setString(2, "f".repeat(64))
+                statement.executeUpdate() shouldBe 1
+            }
+            connection.commit()
+        }
+
+        val source = repository.findCatalog("team-a").sources.single()
+
+        source.flowStatus shouldBe AnalysisFlowStatus.UNPINNED
+        source.flowHash shouldBe null
+        source.flowHashes shouldBe emptyList()
+        source.observedFlowHashes shouldBe listOf(null, "f".repeat(64))
+        source.warnings shouldContain AnalysisCatalogWarning.UNKNOWN_FLOW_OBSERVED
+    }
 })
 
 private fun insertDefinition(

--- a/apps/lumi-api/src/test/kotlin/no/nav/lumi/repository/AnalysisSourceContractIngestTest.kt
+++ b/apps/lumi-api/src/test/kotlin/no/nav/lumi/repository/AnalysisSourceContractIngestTest.kt
@@ -1,0 +1,460 @@
+package no.nav.lumi.repository
+
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.collections.shouldContain
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.string.shouldNotContain
+import kotlinx.serialization.json.JsonPrimitive
+import no.nav.lumi.TestDatabase
+import no.nav.lumi.createdId
+import no.nav.lumi.domain.AnalysisCatalogWarning
+import no.nav.lumi.domain.AnalysisFlowStatus
+import no.nav.lumi.domain.AnalysisFlowDependencySource
+import no.nav.lumi.domain.Answer
+import no.nav.lumi.domain.AnswerValue
+import no.nav.lumi.domain.FeedbackSubmissionV1
+import no.nav.lumi.domain.FieldDefinition
+import no.nav.lumi.domain.FieldType
+import no.nav.lumi.domain.Question
+import no.nav.lumi.domain.RatingVariant
+import no.nav.lumi.domain.SURVEY_FLOW_EVALUATOR_VERSION
+import no.nav.lumi.domain.SurveyDefinition
+import no.nav.lumi.domain.SurveyFlowCombinator
+import no.nav.lumi.domain.SurveyFlowCondition
+import no.nav.lumi.domain.SurveyFlowConditionSource
+import no.nav.lumi.domain.SurveyFlowDefinitionV1
+import no.nav.lumi.domain.SurveyFlowFieldDefinition
+import no.nav.lumi.domain.SurveyFlowOperator
+import no.nav.lumi.domain.SurveyType
+import no.nav.lumi.domain.SurveyVisibleIfDefinition
+import no.nav.lumi.service.SubmissionService
+
+class AnalysisSourceContractIngestTest : FunSpec({
+    val submissionService = SubmissionService()
+    val feedbackRepository = FeedbackRepository()
+    val catalogRepository = AnalysisSourceCatalogRepository()
+
+    beforeSpec { TestDatabase.initialize() }
+    beforeTest { TestDatabase.clearAllData() }
+
+    test("persists an app-scoped immutable flow contract and pins the catalog source") {
+        val result = submissionService.submit(
+            feedbackJson = payload("key-1234567890123456", includeFlow = true, threshold = 7),
+            team = "team-a",
+            app = "app-a",
+            submission = submission("key-1234567890123456"),
+            definition = definition(),
+            flow = flow(7),
+        )
+
+        val flowHash = result.flowHash!!
+        val raw = feedbackRepository.findRawById(result.saveResult.createdId(), "team-a")!!
+        raw.feedbackJson shouldNotContain "\"definition\""
+        raw.feedbackJson shouldNotContain "\"flow\""
+
+        TestDatabase.dataSource.connection.use { connection ->
+            connection.prepareStatement(
+                "SELECT flow_hash FROM feedback WHERE id = ?",
+            ).use { statement ->
+                statement.setString(1, result.saveResult.createdId())
+                statement.executeQuery().use { rows ->
+                    rows.next() shouldBe true
+                    rows.getString(1) shouldBe flowHash
+                }
+            }
+            connection.prepareStatement(
+                """
+                SELECT count(*)
+                FROM analysis_control.analysis_source_contracts
+                WHERE team = 'team-a' AND app = 'app-a' AND survey_id = 'survey'
+                """.trimIndent(),
+            ).use { statement ->
+                statement.executeQuery().use { rows ->
+                    rows.next() shouldBe true
+                    rows.getInt(1) shouldBe 1
+                }
+            }
+            connection.commit()
+        }
+
+        val source = catalogRepository.findCatalog("team-a").sources.single()
+        source.flowStatus shouldBe AnalysisFlowStatus.PINNED
+        source.flowHash shouldBe flowHash
+        source.flowHashes shouldBe listOf(flowHash)
+        source.observedFlowHashes shouldBe listOf(flowHash)
+        source.fields.single { it.fieldId == "details" }.flowDependencies.single().let { dependency ->
+            dependency.source shouldBe AnalysisFlowDependencySource.ANSWER
+            dependency.key shouldBe "rating"
+        }
+    }
+
+    test("keeps unpinned history visible as a warning after future rows become pinned") {
+        submissionService.submit(
+            feedbackJson = payload("legacy-12345678901234", includeFlow = false),
+            team = "team-a",
+            app = "app-a",
+            submission = submission("legacy-12345678901234"),
+            definition = definition(),
+        )
+        val pinned = submissionService.submit(
+            feedbackJson = payload("pinned-12345678901234", includeFlow = true, threshold = 7),
+            team = "team-a",
+            app = "app-a",
+            submission = submission("pinned-12345678901234"),
+            definition = definition(),
+            flow = flow(7),
+        )
+
+        val source = catalogRepository.findCatalog("team-a").sources.single()
+        source.flowStatus shouldBe AnalysisFlowStatus.PINNED
+        source.flowHashes shouldBe listOf(pinned.flowHash!!)
+        source.observedFlowHashes shouldBe listOf(null, pinned.flowHash)
+        source.warnings shouldContain AnalysisCatalogWarning.LEGACY_FLOW_OBSERVED
+    }
+
+    test("regresses the source to unpinned when the latest submission has no flow") {
+        val pinned = submissionService.submit(
+            feedbackJson = payload("pinned-12345678901234", includeFlow = true, threshold = 7),
+            team = "team-a",
+            app = "app-a",
+            submission = submission("pinned-12345678901234"),
+            definition = definition(),
+            flow = flow(7),
+        )
+        val pinnedCatalog = catalogRepository.findCatalog("team-a")
+
+        submissionService.submit(
+            feedbackJson = payload("legacy-12345678901234", includeFlow = false),
+            team = "team-a",
+            app = "app-a",
+            submission = submission("legacy-12345678901234"),
+            definition = definition(),
+        )
+
+        val regressedCatalog = catalogRepository.findCatalog("team-a")
+        val source = regressedCatalog.sources.single()
+        source.flowStatus shouldBe AnalysisFlowStatus.UNPINNED
+        source.flowHash shouldBe null
+        source.flowHashes shouldBe listOf(pinned.flowHash!!)
+        source.observedFlowHashes shouldBe listOf(null, pinned.flowHash)
+        (pinnedCatalog.catalogRevision == regressedCatalog.catalogRevision) shouldBe false
+    }
+
+    test("pins every observed known flow revision without overwriting history") {
+        val first = submissionService.submit(
+            payload("first-123456789012345", includeFlow = true, threshold = 7),
+            "team-a",
+            "app-a",
+            submission("first-123456789012345"),
+            definition(),
+            flow(7),
+        )
+        val second = submissionService.submit(
+            payload("second-12345678901234", includeFlow = true, threshold = 8),
+            "team-a",
+            "app-a",
+            submission("second-12345678901234"),
+            definition(),
+            flow(8),
+        )
+
+        val source = catalogRepository.findCatalog("team-a").sources.single()
+        source.flowStatus shouldBe AnalysisFlowStatus.PINNED
+        source.flowHashes shouldBe listOf(first.flowHash!!, second.flowHash!!).sorted()
+        source.observedFlowHashes shouldBe source.flowHashes
+    }
+
+    test("bounds immutable revisions and keeps overflow feedback unpinned") {
+        var overflowFlowHash: String? = "not-run"
+        repeat(AnalysisSourceContractRepository.MAX_FLOW_REVISIONS_PER_SOURCE_DEFINITION + 1) { index ->
+            val deduplicationKey = "quota-${index.toString().padStart(20, '0')}"
+            val value = "segment-$index"
+            overflowFlowHash = submissionService.submit(
+                feedbackJson = metadataPayload(deduplicationKey, value),
+                team = "team-a",
+                app = "app-a",
+                submission = submission(deduplicationKey),
+                definition = definition(),
+                flow = metadataFlow(value),
+            ).flowHash
+        }
+
+        overflowFlowHash shouldBe null
+        val source = catalogRepository.findCatalog("team-a").sources.single()
+        source.flowStatus shouldBe AnalysisFlowStatus.UNPINNED
+        source.flowHashes.size shouldBe
+            AnalysisSourceContractRepository.MAX_FLOW_REVISIONS_PER_SOURCE_DEFINITION
+
+        TestDatabase.dataSource.connection.use { connection ->
+            connection.prepareStatement(
+                "SELECT count(*) FROM analysis_control.analysis_source_contracts",
+            ).use { statement ->
+                statement.executeQuery().use { rows ->
+                    rows.next() shouldBe true
+                    rows.getInt(1) shouldBe
+                        AnalysisSourceContractRepository.MAX_FLOW_REVISIONS_PER_SOURCE_DEFINITION
+                }
+            }
+            connection.commit()
+        }
+    }
+
+    test("keeps an oversized normalized flow contract unpinned") {
+        val deduplicationKey = "oversized-1234567890123"
+        val result = submissionService.submit(
+            feedbackJson = payload(deduplicationKey, includeFlow = true),
+            team = "team-a",
+            app = "app-a",
+            submission = submission(deduplicationKey),
+            definition = definition(),
+            flow = oversizedFlow(),
+        )
+
+        result.flowHash shouldBe null
+        catalogRepository.findCatalog("team-a").sources.single().flowStatus shouldBe
+            AnalysisFlowStatus.UNPINNED
+
+        TestDatabase.dataSource.connection.use { connection ->
+            connection.prepareStatement(
+                "SELECT count(*) FROM analysis_control.analysis_source_contracts",
+            ).use { statement ->
+                statement.executeQuery().use { rows ->
+                    rows.next() shouldBe true
+                    rows.getInt(1) shouldBe 0
+                }
+            }
+            connection.commit()
+        }
+    }
+
+    test("removes materialized observations when retained feedback is deleted") {
+        val created = submissionService.submit(
+            payload("delete-12345678901234", includeFlow = true, threshold = 7),
+            "team-a",
+            "app-a",
+            submission("delete-12345678901234"),
+            definition(),
+            flow(7),
+        )
+
+        feedbackRepository.delete(created.saveResult.createdId(), "team-a") shouldBe true
+
+        val source = catalogRepository.findCatalog("team-a").sources.single()
+        source.flowStatus shouldBe AnalysisFlowStatus.UNPINNED
+        source.flowHash shouldBe null
+        source.flowHashes shouldBe emptyList()
+        source.observedFlowHashes shouldBe emptyList()
+
+        TestDatabase.dataSource.connection.use { connection ->
+            connection.prepareStatement(
+                "SELECT count(*) FROM analysis_control.analysis_source_contracts",
+            ).use { statement ->
+                statement.executeQuery().use { rows ->
+                    rows.next() shouldBe true
+                    rows.getInt(1) shouldBe 0
+                }
+            }
+            connection.commit()
+        }
+    }
+
+    test("retains a contract until its final referenced feedback row is deleted") {
+        val first = submissionService.submit(
+            payload("first-123456789012345", includeFlow = true, threshold = 7),
+            "team-a",
+            "app-a",
+            submission("first-123456789012345"),
+            definition(),
+            flow(7),
+        )
+        val second = submissionService.submit(
+            payload("second-12345678901234", includeFlow = true, threshold = 7),
+            "team-a",
+            "app-a",
+            submission("second-12345678901234"),
+            definition(),
+            flow(7),
+        )
+
+        feedbackRepository.delete(second.saveResult.createdId(), "team-a") shouldBe true
+        catalogRepository.findCatalog("team-a").sources.single().flowHash shouldBe first.flowHash
+
+        feedbackRepository.delete(first.saveResult.createdId(), "team-a") shouldBe true
+        catalogRepository.findCatalog("team-a").sources.single().flowHash shouldBe null
+    }
+})
+
+private fun definition() = SurveyDefinition(
+    surveyId = "survey",
+    surveyType = SurveyType.CUSTOM,
+    fields = listOf(
+        FieldDefinition("rating", FieldType.RATING, RatingVariant.NPS, 11, null),
+        FieldDefinition("details", FieldType.TEXT, null, null, null),
+    ),
+)
+
+private fun flow(threshold: Int) = SurveyFlowDefinitionV1(
+    schemaVersion = 1,
+    evaluatorVersion = SURVEY_FLOW_EVALUATOR_VERSION,
+    fields = listOf(
+        SurveyFlowFieldDefinition("rating"),
+        SurveyFlowFieldDefinition(
+            "details",
+            SurveyVisibleIfDefinition(
+                SurveyFlowCombinator.ALL,
+                listOf(
+                    SurveyFlowCondition(
+                        SurveyFlowConditionSource.ANSWER,
+                        "rating",
+                        SurveyFlowOperator.LT,
+                        JsonPrimitive(threshold),
+                    ),
+                ),
+            ),
+        ),
+    ),
+)
+
+private fun metadataFlow(value: String) = SurveyFlowDefinitionV1(
+    schemaVersion = 1,
+    evaluatorVersion = SURVEY_FLOW_EVALUATOR_VERSION,
+    fields = listOf(
+        SurveyFlowFieldDefinition("rating"),
+        SurveyFlowFieldDefinition(
+            "details",
+            SurveyVisibleIfDefinition(
+                SurveyFlowCombinator.ALL,
+                listOf(
+                    SurveyFlowCondition(
+                        SurveyFlowConditionSource.METADATA,
+                        "customSegment",
+                        SurveyFlowOperator.EQ,
+                        JsonPrimitive(value),
+                    ),
+                ),
+            ),
+        ),
+    ),
+)
+
+private fun oversizedFlow() = SurveyFlowDefinitionV1(
+    schemaVersion = 1,
+    evaluatorVersion = SURVEY_FLOW_EVALUATOR_VERSION,
+    fields = listOf(
+        SurveyFlowFieldDefinition("rating"),
+        SurveyFlowFieldDefinition(
+            "details",
+            SurveyVisibleIfDefinition(
+                SurveyFlowCombinator.ALL,
+                List(50) { index ->
+                    SurveyFlowCondition(
+                        SurveyFlowConditionSource.METADATA,
+                        "customSegment$index",
+                        SurveyFlowOperator.EQ,
+                        JsonPrimitive(index.toString().padStart(2, '0') + "x".repeat(2_046)),
+                    )
+                },
+            ),
+        ),
+    ),
+)
+
+private fun submission(deduplicationKey: String) = FeedbackSubmissionV1(
+    schemaVersion = 2,
+    surveyId = "survey",
+    surveyType = SurveyType.CUSTOM,
+    submittedAt = "2026-08-29T12:00:00Z",
+    deduplicationKey = deduplicationKey,
+    answers = listOf(
+        Answer(
+            fieldId = "rating",
+            fieldType = FieldType.RATING,
+            question = Question("Rating"),
+            value = AnswerValue.Rating(5, RatingVariant.NPS, 11),
+        ),
+    ),
+)
+
+private fun payload(deduplicationKey: String, includeFlow: Boolean, threshold: Int = 7): String = """
+    {
+      "schemaVersion": 2,
+      "surveyId": "survey",
+      "surveyType": "custom",
+      "submittedAt": "2026-08-29T12:00:00Z",
+      "deduplicationKey": "$deduplicationKey",
+      "definition": {
+        "surveyType": "custom",
+        "fields": [
+          {"fieldId": "rating", "fieldType": "RATING", "ratingVariant": "nps", "ratingScale": 11},
+          {"fieldId": "details", "fieldType": "TEXT"}
+        ]
+      },
+      ${if (includeFlow) """
+      "flow": {
+        "schemaVersion": 1,
+        "evaluatorVersion": "visible-if-v1",
+        "fields": [
+          {"fieldId": "rating"},
+          {
+            "fieldId": "details",
+            "visibleIf": {
+              "combinator": "ALL",
+              "conditions": [
+                {"source": "ANSWER", "key": "rating", "operator": "LT", "value": $threshold}
+              ]
+            }
+          }
+        ]
+      },
+      """ else ""}
+      "answers": [
+        {
+          "fieldId": "rating",
+          "fieldType": "RATING",
+          "question": {"label": "Rating"},
+          "value": {"type": "rating", "rating": 5, "ratingVariant": "nps", "ratingScale": 11}
+        }
+      ]
+    }
+""".trimIndent()
+
+private fun metadataPayload(deduplicationKey: String, value: String): String = """
+    {
+      "schemaVersion": 2,
+      "surveyId": "survey",
+      "surveyType": "custom",
+      "submittedAt": "2026-08-29T12:00:00Z",
+      "deduplicationKey": "$deduplicationKey",
+      "definition": {
+        "surveyType": "custom",
+        "fields": [
+          {"fieldId": "rating", "fieldType": "RATING", "ratingVariant": "nps", "ratingScale": 11},
+          {"fieldId": "details", "fieldType": "TEXT"}
+        ]
+      },
+      "flow": {
+        "schemaVersion": 1,
+        "evaluatorVersion": "visible-if-v1",
+        "fields": [
+          {"fieldId": "rating"},
+          {
+            "fieldId": "details",
+            "visibleIf": {
+              "combinator": "ALL",
+              "conditions": [
+                {"source": "METADATA", "key": "customSegment", "operator": "EQ", "value": "$value"}
+              ]
+            }
+          }
+        ]
+      },
+      "answers": [
+        {
+          "fieldId": "rating",
+          "fieldType": "RATING",
+          "question": {"label": "Rating"},
+          "value": {"type": "rating", "rating": 5, "ratingVariant": "nps", "ratingScale": 11}
+        }
+      ]
+    }
+""".trimIndent()

--- a/apps/lumi-api/src/test/kotlin/no/nav/lumi/routes/InternalSubmissionRoutesTest.kt
+++ b/apps/lumi-api/src/test/kotlin/no/nav/lumi/routes/InternalSubmissionRoutesTest.kt
@@ -148,7 +148,7 @@ class InternalSubmissionRoutesTest : FunSpec({
     test("should accept valid schemaVersion 2 payload on internal route") {
         val submissionService = mockk<SubmissionService>()
         coEvery {
-            submissionService.submit(any(), any(), any(), any(), any())
+            submissionService.submit(any(), any(), any(), any(), any(), any())
         } returns SubmissionOutcome(SaveResult.Created("created-v2"), "hash-v2")
 
         testApplication {
@@ -186,7 +186,8 @@ class InternalSubmissionRoutesTest : FunSpec({
                         it.surveyId == "modia-feedback-v2" &&
                             it.surveyType.name == "RATING" &&
                             it.fields.map { field -> field.fieldId } == listOf("feedback")
-                    }
+                    },
+                    null,
                 )
             }
         }
@@ -197,7 +198,7 @@ class InternalSubmissionRoutesTest : FunSpec({
         val submissionObservability = SubmissionObservability(meterRegistry)
         val submissionService = mockk<SubmissionService>()
         coEvery {
-            submissionService.submit(any(), any(), any(), any(), any())
+            submissionService.submit(any(), any(), any(), any(), any(), any())
         } returns SubmissionOutcome(SaveResult.Created("created-proxy"), "hash-proxy")
 
         testApplication {
@@ -234,7 +235,7 @@ class InternalSubmissionRoutesTest : FunSpec({
         val submissionObservability = SubmissionObservability(meterRegistry)
         val submissionService = mockk<SubmissionService>()
         coEvery {
-            submissionService.submit(any(), any(), any(), any(), any())
+            submissionService.submit(any(), any(), any(), any(), any(), any())
         } returns SubmissionOutcome(SaveResult.Created("created-proxy"), "hash-proxy")
 
         testApplication {

--- a/apps/lumi-api/src/test/kotlin/no/nav/lumi/routes/SubmissionV2RoutesTest.kt
+++ b/apps/lumi-api/src/test/kotlin/no/nav/lumi/routes/SubmissionV2RoutesTest.kt
@@ -104,6 +104,33 @@ private fun submissionPayloadV2Raw(
     }
 """.trimIndent()
 
+private fun submissionPayloadV2WithFlow() = """
+    {
+      "schemaVersion": 2,
+      "surveyId": "dp-feedback-v2",
+      "surveyType": "rating",
+      "submittedAt": "2026-01-10T12:00:12Z",
+      "deduplicationKey": "client-key-123456",
+      "definition": {
+        "surveyType": "rating",
+        "fields": [{"fieldId": "feedback", "fieldType": "TEXT"}]
+      },
+      "flow": {
+        "schemaVersion": 1,
+        "evaluatorVersion": "visible-if-v1",
+        "fields": [{"fieldId": "feedback"}]
+      },
+      "answers": [
+        {
+          "fieldId": "feedback",
+          "fieldType": "TEXT",
+          "question": {"label": "Hvorfor?"},
+          "value": {"type": "text", "text": "Bra"}
+        }
+      ]
+    }
+""".trimIndent()
+
 private fun topTasksPayloadV2(successFieldId: String = "success") = """
     {
       "schemaVersion": 2,
@@ -172,7 +199,7 @@ class SubmissionV2RoutesTest : FunSpec({
         val submissionObservability = SubmissionObservability(meterRegistry)
         val submissionService = mockk<SubmissionService>()
         coEvery {
-            submissionService.submit(any(), any(), any(), any(), any())
+            submissionService.submit(any(), any(), any(), any(), any(), any())
         } returns SubmissionOutcome(SaveResult.Created("created-v2"), "hash-v2")
 
         testApplication {
@@ -216,7 +243,7 @@ class SubmissionV2RoutesTest : FunSpec({
                 .counter()
                 .count() shouldBe 1.0
             coVerify(exactly = 0) {
-                submissionService.submit(any(), any(), any(), any(), any())
+                submissionService.submit(any(), any(), any(), any(), any(), any())
             }
         }
     }
@@ -230,7 +257,7 @@ class SubmissionV2RoutesTest : FunSpec({
             val submissionObservability = SubmissionObservability(meterRegistry)
             val submissionService = mockk<SubmissionService>()
             coEvery {
-                submissionService.submit(any(), any(), any(), any(), any())
+                submissionService.submit(any(), any(), any(), any(), any(), any())
             } returns SubmissionOutcome(SaveResult.Created("created-v2"), "hash-v2")
 
             testApplication {
@@ -267,7 +294,7 @@ class SubmissionV2RoutesTest : FunSpec({
         val submissionObservability = SubmissionObservability(meterRegistry)
         val submissionService = mockk<SubmissionService>()
         coEvery {
-            submissionService.submit(any(), any(), any(), any(), any())
+            submissionService.submit(any(), any(), any(), any(), any(), any())
         } returns SubmissionOutcome(SaveResult.Created("created-azure"), "hash-azure")
 
         testApplication {
@@ -292,7 +319,7 @@ class SubmissionV2RoutesTest : FunSpec({
     test("v1 still works on existing submission endpoint") {
         val submissionService = mockk<SubmissionService>()
         coEvery {
-            submissionService.submit(any(), any(), any(), any(), any())
+            submissionService.submit(any(), any(), any(), any(), any(), any())
         } returns SubmissionOutcome(SaveResult.Created("created-v1"), "hash-v1")
 
         testApplication {
@@ -323,7 +350,7 @@ class SubmissionV2RoutesTest : FunSpec({
 
             response.status shouldBe HttpStatusCode.Created
             coVerify(exactly = 1) {
-                submissionService.submit(any(), "local-dev", "local-app", any(), null)
+                submissionService.submit(any(), "local-dev", "local-app", any(), null, null)
             }
         }
     }
@@ -331,7 +358,7 @@ class SubmissionV2RoutesTest : FunSpec({
     test("v2 accepts complete definition on existing submission endpoint") {
         val submissionService = mockk<SubmissionService>()
         coEvery {
-            submissionService.submit(any(), any(), any(), any(), any())
+            submissionService.submit(any(), any(), any(), any(), any(), any())
         } returns SubmissionOutcome(SaveResult.Created("created-v2"), "hash-v2")
 
         testApplication {
@@ -354,8 +381,62 @@ class SubmissionV2RoutesTest : FunSpec({
                         it.surveyId == "dp-feedback-v2" &&
                             it.surveyType.name == "RATING" &&
                             it.fields.map { field -> field.fieldId } == listOf("feedback")
-                    }
+                    },
+                    null,
                 )
+            }
+        }
+    }
+
+    test("v2 passes a validated visibleIf flow contract to ingest") {
+        val submissionService = mockk<SubmissionService>()
+        coEvery {
+            submissionService.submit(any(), any(), any(), any(), any(), any())
+        } returns SubmissionOutcome(SaveResult.Created("created-flow"), "definition-hash", "flow-hash")
+
+        testApplication {
+            application { submissionRoutesTestModule(submissionService) }
+            val response = createTestClient().post("/api/tokenx/v1/feedback") {
+                contentType(ContentType.Application.Json)
+                setBody(submissionPayloadV2WithFlow())
+            }
+
+            response.status shouldBe HttpStatusCode.Created
+            coVerify(exactly = 1) {
+                submissionService.submit(
+                    any(),
+                    "local-dev",
+                    "local-app",
+                    any(),
+                    any(),
+                    match {
+                        it.schemaVersion == 1 &&
+                            it.evaluatorVersion == "visible-if-v1" &&
+                            it.fields.map { field -> field.fieldId } == listOf("feedback")
+                    },
+                )
+            }
+        }
+    }
+
+    test("v2 rejects an unknown flow evaluator before ingest") {
+        val submissionService = mockk<SubmissionService>()
+
+        testApplication {
+            application { submissionRoutesTestModule(submissionService) }
+            val response = createTestClient().post("/api/tokenx/v1/feedback") {
+                contentType(ContentType.Application.Json)
+                setBody(
+                    submissionPayloadV2WithFlow().replace(
+                        "visible-if-v1",
+                        "visible-if-v2",
+                    ),
+                )
+            }
+
+            response.status shouldBe HttpStatusCode.BadRequest
+            coVerify(exactly = 0) {
+                submissionService.submit(any(), any(), any(), any(), any(), any())
             }
         }
     }
@@ -363,7 +444,7 @@ class SubmissionV2RoutesTest : FunSpec({
     test("v2 accepts the canonical specialized survey contract") {
         val submissionService = mockk<SubmissionService>()
         coEvery {
-            submissionService.submit(any(), any(), any(), any(), any())
+            submissionService.submit(any(), any(), any(), any(), any(), any())
         } returns SubmissionOutcome(SaveResult.Created("created-specialized"), "hash-specialized")
 
         testApplication {
@@ -375,7 +456,7 @@ class SubmissionV2RoutesTest : FunSpec({
 
             response.status shouldBe HttpStatusCode.Created
             coVerify(exactly = 1) {
-                submissionService.submit(any(), any(), any(), any(), any())
+                submissionService.submit(any(), any(), any(), any(), any(), any())
             }
         }
     }
@@ -383,7 +464,7 @@ class SubmissionV2RoutesTest : FunSpec({
     test("v2 accepts the success field emitted by deprecated Top Tasks builders") {
         val submissionService = mockk<SubmissionService>()
         coEvery {
-            submissionService.submit(any(), any(), any(), any(), any())
+            submissionService.submit(any(), any(), any(), any(), any(), any())
         } returns SubmissionOutcome(SaveResult.Created("created-legacy"), "hash-legacy")
 
         testApplication {
@@ -395,7 +476,7 @@ class SubmissionV2RoutesTest : FunSpec({
 
             response.status shouldBe HttpStatusCode.Created
             coVerify(exactly = 1) {
-                submissionService.submit(any(), any(), any(), any(), any())
+                submissionService.submit(any(), any(), any(), any(), any(), any())
             }
         }
     }
@@ -433,7 +514,7 @@ class SubmissionV2RoutesTest : FunSpec({
             response.status shouldBe HttpStatusCode.BadRequest
             Json.parseToJsonElement(response.bodyAsText()).jsonObject["message"]?.jsonPrimitive?.content shouldBe
                 "Invalid payload: definition is required for schemaVersion=2"
-            coVerify(exactly = 0) { submissionService.submit(any(), any(), any(), any(), any()) }
+            coVerify(exactly = 0) { submissionService.submit(any(), any(), any(), any(), any(), any()) }
         }
     }
 
@@ -478,7 +559,7 @@ class SubmissionV2RoutesTest : FunSpec({
             response.status shouldBe HttpStatusCode.BadRequest
             Json.parseToJsonElement(response.bodyAsText()).jsonObject["message"]?.jsonPrimitive?.content shouldBe
                 "Invalid payload: deduplicationKey is required for schemaVersion=2"
-            coVerify(exactly = 0) { submissionService.submit(any(), any(), any(), any(), any()) }
+            coVerify(exactly = 0) { submissionService.submit(any(), any(), any(), any(), any(), any()) }
         }
     }
 
@@ -516,7 +597,7 @@ class SubmissionV2RoutesTest : FunSpec({
             response.status shouldBe HttpStatusCode.BadRequest
             Json.parseToJsonElement(response.bodyAsText()).jsonObject["message"]?.jsonPrimitive?.content shouldBe
                 "Invalid payload"
-            coVerify(exactly = 0) { submissionService.submit(any(), any(), any(), any(), any()) }
+            coVerify(exactly = 0) { submissionService.submit(any(), any(), any(), any(), any(), any()) }
         }
     }
 
@@ -561,7 +642,7 @@ class SubmissionV2RoutesTest : FunSpec({
 
             response.status shouldBe HttpStatusCode.BadRequest
             response.bodyAsText() shouldContain "schemaVersion must be an integer"
-            coVerify(exactly = 0) { submissionService.submit(any(), any(), any(), any(), any()) }
+            coVerify(exactly = 0) { submissionService.submit(any(), any(), any(), any(), any(), any()) }
         }
     }
 
@@ -606,7 +687,7 @@ class SubmissionV2RoutesTest : FunSpec({
 
             response.status shouldBe HttpStatusCode.BadRequest
             response.bodyAsText() shouldContain "schemaVersion must be an integer"
-            coVerify(exactly = 0) { submissionService.submit(any(), any(), any(), any(), any()) }
+            coVerify(exactly = 0) { submissionService.submit(any(), any(), any(), any(), any(), any()) }
         }
     }
 
@@ -624,7 +705,7 @@ class SubmissionV2RoutesTest : FunSpec({
 
             response.status shouldBe HttpStatusCode.BadRequest
             response.bodyAsText() shouldContain "surveyType must match definition.surveyType"
-            coVerify(exactly = 0) { submissionService.submit(any(), any(), any(), any(), any()) }
+            coVerify(exactly = 0) { submissionService.submit(any(), any(), any(), any(), any(), any()) }
         }
     }
 
@@ -642,7 +723,7 @@ class SubmissionV2RoutesTest : FunSpec({
 
             response.status shouldBe HttpStatusCode.BadRequest
             response.bodyAsText() shouldContain "answers.fieldId"
-            coVerify(exactly = 0) { submissionService.submit(any(), any(), any(), any(), any()) }
+            coVerify(exactly = 0) { submissionService.submit(any(), any(), any(), any(), any(), any()) }
         }
     }
 
@@ -690,7 +771,7 @@ class SubmissionV2RoutesTest : FunSpec({
 
             response.status shouldBe HttpStatusCode.BadRequest
             response.bodyAsText() shouldContain "must not include optionIds"
-            coVerify(exactly = 0) { submissionService.submit(any(), any(), any(), any(), any()) }
+            coVerify(exactly = 0) { submissionService.submit(any(), any(), any(), any(), any(), any()) }
         }
     }
 
@@ -735,7 +816,7 @@ class SubmissionV2RoutesTest : FunSpec({
 
             response.status shouldBe HttpStatusCode.BadRequest
             response.bodyAsText() shouldContain "fieldType=SINGLE_CHOICE, expected TEXT"
-            coVerify(exactly = 0) { submissionService.submit(any(), any(), any(), any(), any()) }
+            coVerify(exactly = 0) { submissionService.submit(any(), any(), any(), any(), any(), any()) }
         }
     }
 
@@ -767,7 +848,7 @@ class SubmissionV2RoutesTest : FunSpec({
 
             response.status shouldBe HttpStatusCode.BadRequest
             response.bodyAsText() shouldContain "definition.fields max count"
-            coVerify(exactly = 0) { submissionService.submit(any(), any(), any(), any(), any()) }
+            coVerify(exactly = 0) { submissionService.submit(any(), any(), any(), any(), any(), any()) }
         }
     }
 
@@ -807,7 +888,7 @@ class SubmissionV2RoutesTest : FunSpec({
 
             response.status shouldBe HttpStatusCode.BadRequest
             response.bodyAsText() shouldContain "question.options"
-            coVerify(exactly = 0) { submissionService.submit(any(), any(), any(), any(), any()) }
+            coVerify(exactly = 0) { submissionService.submit(any(), any(), any(), any(), any(), any()) }
         }
     }
 
@@ -854,14 +935,14 @@ class SubmissionV2RoutesTest : FunSpec({
 
             response.status shouldBe HttpStatusCode.BadRequest
             response.bodyAsText() shouldContain "definition.optionIds"
-            coVerify(exactly = 0) { submissionService.submit(any(), any(), any(), any(), any()) }
+            coVerify(exactly = 0) { submissionService.submit(any(), any(), any(), any(), any(), any()) }
         }
     }
 
     test("v2 accepts choice answer when question options match definition") {
         val submissionService = mockk<SubmissionService>()
         coEvery {
-            submissionService.submit(any(), any(), any(), any(), any())
+            submissionService.submit(any(), any(), any(), any(), any(), any())
         } returns SubmissionOutcome(SaveResult.Created("created-choice"), "hash-choice")
 
         testApplication {
@@ -903,7 +984,7 @@ class SubmissionV2RoutesTest : FunSpec({
 
             response.status shouldBe HttpStatusCode.Created
             coVerify(exactly = 1) {
-                submissionService.submit(any(), any(), any(), any(), any())
+                submissionService.submit(any(), any(), any(), any(), any(), any())
             }
         }
     }
@@ -951,14 +1032,14 @@ class SubmissionV2RoutesTest : FunSpec({
 
             response.status shouldBe HttpStatusCode.BadRequest
             response.bodyAsText() shouldContain "exceeds maxSelections=1"
-            coVerify(exactly = 0) { submissionService.submit(any(), any(), any(), any(), any()) }
+            coVerify(exactly = 0) { submissionService.submit(any(), any(), any(), any(), any(), any()) }
         }
     }
 
     test("v2 returns 409 when full definition structure changes for same surveyId") {
         val submissionService = mockk<SubmissionService>()
         coEvery {
-            submissionService.submit(any(), any(), any(), any(), any())
+            submissionService.submit(any(), any(), any(), any(), any(), any())
         } answers {
             if (firstArg<String>().contains("followup")) {
                 throw ApiErrorException.ConflictException(
@@ -1025,7 +1106,7 @@ class SubmissionV2RoutesTest : FunSpec({
         val submissionObservability = SubmissionObservability(meterRegistry)
         val submissionService = mockk<SubmissionService>()
         coEvery {
-            submissionService.submit(any(), any(), any(), any(), any())
+            submissionService.submit(any(), any(), any(), any(), any(), any())
         } returnsMany listOf(
             SubmissionOutcome(SaveResult.Created("created-v2"), "hash-v2"),
             SubmissionOutcome(SaveResult.Duplicate("created-v2"))

--- a/apps/lumi-api/src/test/kotlin/no/nav/lumi/service/FeedbackServicePrepareForSaveTest.kt
+++ b/apps/lumi-api/src/test/kotlin/no/nav/lumi/service/FeedbackServicePrepareForSaveTest.kt
@@ -24,6 +24,11 @@ class FeedbackServicePrepareForSaveTest : FunSpec({
                         }
                     ]
                 },
+                "flow": {
+                    "schemaVersion": 1,
+                    "evaluatorVersion": "visible-if-v1",
+                    "fields": [{"fieldId": "feedback"}]
+                },
                 "answers": [
                     {
                         "fieldId": "feedback",
@@ -42,6 +47,7 @@ class FeedbackServicePrepareForSaveTest : FunSpec({
         )
 
         prepared.feedbackJson shouldNotContain "\"definition\""
+        prepared.feedbackJson shouldNotContain "\"flow\""
         prepared.feedbackJson shouldNotContain "deduplicationKey"
         prepared.feedbackJson shouldContain "\"surveyType\":\"rating\""
         (prepared.deduplicationKeyHash?.isNotBlank()) shouldBe true

--- a/apps/lumi-api/src/test/kotlin/no/nav/lumi/service/SubmissionServiceTest.kt
+++ b/apps/lumi-api/src/test/kotlin/no/nav/lumi/service/SubmissionServiceTest.kt
@@ -114,6 +114,7 @@ class SubmissionServiceTest : FunSpec({
                 "app-a",
                 "survey-1",
                 "definition-hash-v2",
+                null,
                 "dedup-hash"
             )
         } returns saveResult

--- a/docs/adr/0006-teamavgrensede-analyseprodukter.md
+++ b/docs/adr/0006-teamavgrensede-analyseprodukter.md
@@ -45,13 +45,26 @@ sikkerhetstilbakekallinger. Brudd i kontrakten lager en ny major-versjon; en
 gammel major kan aldri bevare felt, dimensjoner eller retensjon som ikke lenger
 er tillatt.
 
-Releasen pinner også en separat `flow_hash`: normalisert `visibleIf`-graf,
-eventuell eldre `logic`, predicate-avhengigheter og evaluatorversjoner. Dagens
-strukturelle `definition_hash` inneholder ikke dette og kan ikke brukes til å
-rekonstruere historisk synlighet. Rader uten en registrert, ingest-matchet
-flytrevisjon får `flow_status=UNPINNED` og aldri en oppdiktet eksakt
-applicability. Eldre `logic` gir ikke eksakt applicability i V1 selv når
-flytrevisjonen kan identifiseres.
+Releasen pinner også separate `flow_hash`-verdier: normalisert
+`visibleIf`-flyt, predicate-avhengigheter, spørsmålsrekkefølge og
+evaluatorversjon. Dagens strukturelle `definition_hash` inneholder ikke dette
+og kan ikke brukes til å rekonstruere historisk synlighet. Rader uten en
+registrert, ingest-matchet flytrevisjon får `flow_status=UNPINNED` og aldri en
+oppdiktet eksakt applicability. Deprecated `logic` inngår ikke i den nye
+analysemodellen; surveys som fortsatt bruker den sender ingen flow-kontrakt og
+må migreres til `visibleIf` før nye rader kan pinnes.
+
+En release tillater bare ikke-null, serverberegnede flow-hasher. Historisk
+`UNPINNED` kan ekskluderes etter et nyere, pinnet cutover, men hvis siste
+observerte rad igjen er `UNPINNED`, blokkeres kilden. Flowregisteret er
+app-avgrenset, har maksimalt 50 revisjoner per kilde og definisjon, og lagrer
+predicate-strenger på maksimalt 2048 tegn. Hver normaliserte flow er begrenset
+til 64 KiB, og definition-/flow-registeret har et samlet 16 MiB-budsjett per
+team. Kvoteoverflow stopper ikke feedbackinnsamling; raden lagres `UNPINNED`.
+Immutable kontrakter slettes når siste refererende feedbackrad slettes, slik
+at predicate-konstanter følger kildens retention. `visible-if-v1` sin operator-, type-, null- og
+normaliseringssemantikk er normativt spesifisert i V1-datakontrakten; enhver
+endring krever ny evaluatorversjon.
 
 Lumi oppretter en lukket publiseringsflate, men gir aldri menneskelig
 lesetilgang. Personer og grupper søker om og får tilgang gjennom

--- a/docs/analyseprodukter/datakontrakt-v1.md
+++ b/docs/analyseprodukter/datakontrakt-v1.md
@@ -40,9 +40,8 @@ En release pinner kildekatalogrevisjonen og eksakt tillatt kombinasjon av:
 - `(team_slug, app, survey_id)`
 - `definition_status` og tillatte `definition_hash`-verdier, med eksplisitt
   legacy-regel for `NULL`
-- tillatte `flow_hash`-verdier med normalisert `visibleIf`, eventuell eldre
-  `logic`, eksplisitte avhengigheter og evaluatorversjoner; manglende historisk
-  flow må være eksplisitt tillatt som `UNPINNED`
+- tillatte ikke-null `flow_hash`-verdier med normalisert `visibleIf`,
+  eksplisitte avhengigheter og evaluatorversjon
 - `field_id`, `field_type`, ratingvariant/-skala og `max_selections`
 - tillatte `option_id`-er
 - godkjente metadatarevisjoner og dimensjoner
@@ -52,8 +51,12 @@ automatisk publisert eller droppet fra en ellers publisert innsending. Bare
 berørt produkt går til `Må vurderes`, fryser nye data ved siste trygge
 `data_cutoff_at` og fortsetter purge-only refresh for retensjon og
 kildesletting. Andre produkter fra samme source-snapshot fortsetter uavhengig.
-`UNPINNED` godtas bare når releasen eksplisitt har tillatt historiske rader med
-manglende flow; det er ikke det samme som å godta en ukjent hash.
+Historiske `UNPINNED`-rader kan ikke tillates av en release. De ekskluderes
+eksplisitt når en nyere, kjent flyt etablerer et trygt cutover. Hvis den sist
+observerte innsendingen igjen er `UNPINNED`, blokkeres ny release og et aktivt
+produkt fryser ved siste trygge cutoff. Dermed kan en rollback til gammel
+klient eller deprecated `logic` aldri stille starte en stadig voksende
+eksklusjon. En ukjent ikke-null hash blokkerer alltid.
 
 Kildeendringen tas inn gjennom et nytt utkast, ny preview og ny validert
 release. En ny flervalgsoption er kompatibel når releasen legger til en
@@ -66,9 +69,10 @@ reglene for godkjent metadata nedenfor.
 ## `responses_<app>_<survey>_wide_v1`
 
 Det publiseres én wide-view per valgt `(app, survey_id)`. Den har én rad per
-innsending og er fasit for total response-populasjon og applicability-baserte
-denominatorer. En
-innsending er med selv om ingen av de valgte svarfeltene ble besvart.
+release-tillatt, pinnet innsending og er fasit for den eksplisitt avgrensede
+response-populasjonen og applicability-baserte denominatorer. Historiske
+`UNPINNED`-rader er synlig rapportert som ekskludert i preview/release. En
+tillatt innsending er med selv om ingen av de valgte svarfeltene ble besvart.
 
 Viewnavn og dynamiske kolonnenavn avledes deterministisk fra stabil ID,
 kollisjonssikker slug og kort hash. Brukeren kan ikke skrive SQL-identifikatorer.
@@ -95,20 +99,64 @@ flow_status        STRING NOT NULL    -- PINNED | UNPINNED
 Lumi fabrikerer aldri en `definition_hash`. Legacy-rader uten registrert hash
 har `definition_hash=NULL` og `definition_status=LEGACY_DERIVED`.
 
-`flow_hash` er hash av hele den normaliserte flytdefinisjonen: `visibleIf`-
-grafen, eventuell eldre `logic`, dependency-identitetene og evaluatorenes
-semantikkversjoner. `PINNED` krever en ikke-null hash som ble registrert og
-matchet ved ingest; en klientoppgitt, ukjent hash er aldri tilstrekkelig. Samme
+`flow_hash` er hash av hele den normaliserte `visibleIf`-flyten:
+spørsmålsrekkefølge, predicate-avhengigheter og evaluatorens semantikkversjon.
+`PINNED` krever en ikke-null hash som API-et selv beregnet fra en validert,
+fullstendig flow-kontrakt og matchet ved ingest; en klientoppgitt hash er aldri
+tilstrekkelig. Samme
 `definition_hash` med endret flyt skal gi ulik `flow_hash`. Eksisterende rader
 uten en entydig historisk flytrevisjon får `flow_hash=NULL` og
 `flow_status=UNPINNED`; Lumi rekonstruerer dem aldri med dagens betingelser.
-V1 beregner bare eksakt applicability for den kanoniske `visibleIf`-modellen.
-Eldre `logic` som kan påvirke eksponering gir `NULL` og kvalitetsvarsel selv om
-flytrevisjonen kan identifiseres.
+En survey som bruker deprecated `logic`, sender ingen flow-kontrakt og blir
+`UNPINNED`. V1 lagrer, hasher eller evaluerer ikke `logic`; surveyen må
+migreres til `visibleIf` før nye rader kan få eksakt applicability.
+
+Flow-kontrakten registreres immutable og app-avgrenset på
+`(team, app, survey_id, definition_hash, flow_hash)` før feedbackraden lagres i
+samme transaksjon. Bare hashene lagres på feedbackraden. Definition og flow
+fjernes fra rå feedback-JSON, og kildekatalogen leser materialiserte
+kontraktobservasjoner i stedet for å skanne feedbacktabellen. Gamle klienter
+fortsetter å virke med `flow_hash=NULL`.
+
+En flow-kontrakt kan ha maksimalt 50 immutable revisjoner per
+`(team, app, survey_id, definition_hash)`. Predicate-nøkler er maksimalt 200
+tegn, predicate-strenger maksimalt 2048 tegn, og answer-predicates valideres
+mot felttype, ratingintervall og choice-domene. Normalisert flow er maksimalt
+64 KiB, og lagrede definition-/flow-kontrakter har et samlet budsjett på
+16 MiB per team. Budsjettet serialiseres bare når en ny revisjon registreres;
+kjente revisjoner deler eksisterende kontrakt. Når en revisjons- eller
+bytegrense nås, lagres selve svaret fortsatt, men med `flow_hash=NULL`; kilden
+blir dermed fail-closed `UNPINNED`. En kontrakt slettes automatisk når siste
+feedbackrad som refererer den slettes. Kontrakten kan derfor ikke leve lenger
+enn kildedataene den dokumenterer.
+
+### Normativ `visible-if-v1`-semantikk
+
+Alle conditions evalueres mot tilstanden ved innsending. En manglende verdi er
+`undefined`; `null`, objekter og frie JSON-verdier finnes ikke i kontrakten.
+
+| Operator | Normativ betydning |
+| --- | --- |
+| `EXISTS` | sann når input ikke er `undefined` |
+| `EQ` | streng likhet uten typekonvertering |
+| `NEQ` | negasjonen av streng likhet |
+| `GT` / `LT` | numerisk sammenligning av endelige tall |
+| `CONTAINS` på streng | case-insensitiv substring |
+| `CONTAINS` på flervalg | eksakt medlemskap i listen |
+
+`ALL` er sann når alle conditions er sanne; `ANY` er sann når minst én er
+sann. Conditions normaliseres til deterministisk rekkefølge før hashing, men
+rekkefølgen endrer ikke evaluatorresultatet. ANSWER kan bare referere et
+tidligere felt. Den lukkede `deviceType`-dimensjonen støtter `EXISTS`, `EQ`,
+`NEQ` og `CONTAINS`; likhetsverdier må være `desktop`, `mobile` eller
+`tablet`. Enhver endring i disse sannhetstabellene, null-/typesemantikken eller
+normaliseringen krever en ny evaluatorversjon og ny hashdomeneidentitet.
 
 `flow_status=PINNED` krever både `definition_status=REGISTERED` og ikke-null
 `flow_hash`. `flow_status=UNPINNED` krever `flow_hash=NULL`. Brudd på denne
-invarianten stopper produktpubliseringen.
+invarianten stopper produktpubliseringen. En `UNPINNED` kilderad er aldri en
+aktiv offentlig V1-rad; statusen brukes i privat validering og preview for å
+forklare blokkering eller eksplisitt historisk eksklusjon.
 
 ### Dynamiske kolonner
 
@@ -128,34 +176,31 @@ dimensjon:       dim_<key>_<hash> STRING|BOOL|FLOAT64
   evalueres deterministisk til sann.
 - `FALSE` betyr at en registrert, fullstendig definisjon beviser at feltet ikke
   fantes, eller at en pinnet og sikkert evaluerbar `visibleIf` var usann.
-- `NULL` betyr at feltet finnes, men relevans ikke kan fastslås, blant annet
-  ved `flow_status=UNPINNED`, `LEGACY_DERIVED` eller eldre `logic`.
+- `NULL` er bare gyldig når en tillatt, pinnet definisjon ikke kan uttrykke en
+  offentlig verdi for feltet; en `UNPINNED` kilderad ekskluderes før viewet.
 
-Prioriteten er normativ: strukturelt bevist fravær i en registrert definisjon
-gir `FALSE` selv om raden mangler flow. Når feltet finnes, gir `UNPINNED`
-derimot alltid `NULL`; dagens predicate kan aldri brukes. For
-`LEGACY_DERIVED` kan heller ikke strukturelt fravær bevises, og resultatet er
-`NULL`.
+Prioriteten er normativ: strukturelt bevist fravær i en release-tillatt,
+registrert definisjon gir `FALSE`. Dagens predicate brukes aldri på en annen
+historisk flytrevisjon. `UNPINNED` og `LEGACY_DERIVED` inngår ikke i den aktive
+V1-populasjonen.
 
 Alle answer- og metadataavhengigheter i en predicate må selv være eksplisitt
 valgt, klassifisert og offentlig i samme produkt før det betingede feltet kan
 inngå i en release. Preview viser avhengigheten og hvilken inferens både
 answer-tilstedeværelse og applicability røper. En bare allowlistet, men uvalgt
 avhengighet blokkerer releasen; det finnes ingen skjult «evaluation-only»-omvei
-i V1. `NULL` er en konservativ fallback for allerede publiserte historiske
-rader med unpinned/ukomplett flyt, ikke en måte å godkjenne et nytt ufullstendig
-scope på. En betinget gren kan aldri merkes `TRUE` bare fordi feltet finnes i
-definisjonen. `NULL` gir kvalitetsvarsel og utelates fra eksakte feltrater. Et
+i V1. Historiske rader med unpinned/ukomplett flyt ekskluderes med et synlig
+kvalitetsvarsel; `NULL` brukes ikke som en omvei til å publisere dem. En
+betinget gren kan aldri merkes `TRUE` bare fordi feltet finnes i definisjonen. Et
 ubesvart, men bevist tilgjengelig felt har derimot `applicable=TRUE` og `NULL` i
 svarverdien.
 
 En offentlig svarverdi kan bare finnes når feltets applicability er `TRUE`.
 `FALSE` eller `NULL` gir alltid `NULL` i alle wide-svarkolonner og ingen
-tilsvarende long-rad. For `UNPINNED` historikk undertrykkes en eventuell
-kildeverdi med `PASSED_WITH_WARNINGS`. Manifestet viser bare kvalitetsstatus;
-team-scope preview kan vise et personverntersklet antall uten verdiinnhold.
-Dette er en eksplisitt legacyregel og kan ikke aktiveres for en ukjent
-ikke-null flow-hash.
+tilsvarende long-rad. `UNPINNED` historikk ekskluderes fra både wide og long
+med `PASSED_WITH_WARNINGS`. Manifestet viser bare kvalitetsstatus; team-scope
+preview kan vise et personverntersklet antall uten verdiinnhold. Dette kan ikke
+aktiveres for en ukjent ikke-null flow-hash.
 
 Hvis applicability er `FALSE`, men kildekandidaten likevel har et svar, er det
 et kontraktsbrudd. Produktet fryser før aktivering og fortsetter bare
@@ -244,8 +289,8 @@ mens raden representerer ett verdiatom.
 Duplisert option-ID i en registrert definisjon eller duplisert valgt option i
 et registrert/pinnet svar er et kontraktsbrudd og fryser produktet. Wide sin
 `selection_count` og long sin N beregnes fra samme validerte option-sett og er
-dermed identiske. `LEGACY_DERIVED`/`UNPINNED` publiserer ingen svarverdier og
-har derfor ingen offentlig dedupliseringssemantikk.
+dermed identiske. `LEGACY_DERIVED`/`UNPINNED` publiseres ikke og har derfor
+ingen offentlig dedupliseringssemantikk.
 
 Ratingvariant, skala og min/max skal være innbyrdes konsistente med den
 release-pinnede kildedefinisjonen. NPS har intervallet `0..10`; verdien `0` er

--- a/docs/analyseprodukter/trusselmodell-v1.md
+++ b/docs/analyseprodukter/trusselmodell-v1.md
@@ -111,7 +111,10 @@ nøkkelversjon og eierskap skal være dokumentert før shadow.
 - [ ] `flow_hash` beregnes fra normalisert flyt, dependencies og
       evaluatorversjoner, registreres før ingest og inngår i release/effective
       spec. Ukjent klienthash avvises; manglende historikk blir `UNPINNED`, og
-      eldre `logic` brukes ikke til eksakt V1-applicability.
+      eldre `logic` lagres eller hashes ikke og brukes ikke til eksakt
+      V1-applicability. Siste observerte flow styrer cutoverstatus;
+      revisjonskvote, 64 KiB per flow, 16 MiB kontraktbudsjett per team,
+      verdi-/størrelsesgrenser og kontrakt-GC følger retention.
 - [ ] Team-scope avledes gjennom eksisterende autorisasjon på hvert endepunkt.
 - [ ] Preview bruker bare syntetiske rader og en versjonert terskelpolicy:
       1–4 distinkte innsendinger gir `BELOW_THRESHOLD`, 0 kan vises som 0, og
@@ -177,11 +180,11 @@ nøkkelversjon og eierskap skal være dokumentert før shadow.
       en ny release av det betingede feltet. Samme `definition_hash` med endret
       `visibleIf` får ny `flow_hash`, og historiske rader uten entydig flow får
       `NULL`/kvalitetsvarsel og evalueres aldri med dagens predicate.
-- [ ] `UNPINNED` felt som finnes får `applicable=NULL`, null wide-verdi og ingen
-      long-rad selv når kilden inneholder et svar. Manifestet viser bare
+- [ ] `UNPINNED` historikk ekskluderes fra wide og long med synlig
       kvalitetsvarsel; eventuelt count i team-preview følger terskelpolicy.
-      Strukturelt bevist fravær i en registrert definition gir fortsatt
-      `FALSE`.
+      En nyere `UNPINNED` rad etter cutover blokkerer ny release i stedet for å
+      øke eksklusjonen stille. Strukturelt bevist fravær i en tillatt,
+      registrert definition gir fortsatt `FALSE`.
 - [ ] Enhver `applicable=FALSE` kombinert med kildeverdi fryser produktet før
       aktivering for rating, enkeltvalg, flervalg og `EMPTY_SELECTION`, både ved
       strukturelt fravær og usann predicate. Ingen verdi blir en tilsynelatende

--- a/packages/lumi-survey/CHANGELOG.md
+++ b/packages/lumi-survey/CHANGELOG.md
@@ -6,6 +6,15 @@ This project follows SemVer.
 
 ## [Unreleased]
 
+### Added
+
+- Schema V2 submissions now include a versioned, canonical `visibleIf` flow
+  contract. Surveys that still use deprecated imperative `logic` remain
+  submission-compatible but deliberately omit the flow contract so analytics
+  treats those rows as unpinned. Legacy `visibleIf` shapes that cannot be
+  represented exactly by `visible-if-v1` likewise keep submitting without a
+  flow contract instead of failing or recording false provenance.
+
 ### Fixed
 
 - `validateSurveyDocumentV1` and `buildCanonicalSurvey` now reject `visibleIf`

--- a/packages/lumi-survey/src/contracts/lumiApi.ts
+++ b/packages/lumi-survey/src/contracts/lumiApi.ts
@@ -182,6 +182,27 @@ export interface SubmissionDefinition {
   fields: SubmissionFieldDefinition[];
 }
 
+export interface SubmissionFlowCondition {
+  source: "ANSWER" | "METADATA";
+  key: string;
+  operator: "EQ" | "NEQ" | "GT" | "LT" | "CONTAINS" | "EXISTS";
+  value?: string | number | boolean;
+}
+
+export interface SubmissionFlowField {
+  fieldId: string;
+  visibleIf?: {
+    combinator: "ALL" | "ANY";
+    conditions: SubmissionFlowCondition[];
+  };
+}
+
+export interface SubmissionFlowV1 {
+  schemaVersion: 1;
+  evaluatorVersion: "visible-if-v1";
+  fields: SubmissionFlowField[];
+}
+
 export interface FeedbackSubmissionV2 {
   schemaVersion: 2;
   surveyId: string;
@@ -191,6 +212,7 @@ export interface FeedbackSubmissionV2 {
   timeToCompleteMs?: number | null;
   deduplicationKey: string;
   definition: SubmissionDefinition;
+  flow?: SubmissionFlowV1;
   context?: SubmissionContextV1 | null;
   answers: Answer[];
 }

--- a/packages/lumi-survey/src/core/__tests__/transportPayloadV2.test.ts
+++ b/packages/lumi-survey/src/core/__tests__/transportPayloadV2.test.ts
@@ -1,5 +1,6 @@
 import { act, renderHook } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { buildFlowBlock } from "../flowBlock.js";
 import type {
   LumiSurveyQuestion,
   LumiSurveySubmission,
@@ -283,6 +284,188 @@ describe("v2 transport payload", () => {
     const payload = submitMock.mock.calls[0][0].transportPayload;
     expect(payload.surveyType).toBe("rating");
     expect(payload.surveyType).toBe(payload.definition.surveyType);
+  });
+
+  it("includes a canonical visibleIf-only flow contract", async () => {
+    const submitMock = vi.fn(async (_: LumiSurveySubmission) => {});
+    const transport: LumiSurveyTransport = { submit: submitMock };
+    const questions: LumiSurveyQuestion[] = [
+      {
+        id: "rating",
+        type: "rating",
+        prompt: "Rating",
+        variant: "nps",
+      },
+      {
+        id: "details",
+        type: "text",
+        prompt: "Details",
+        visibleIf: {
+          any: [
+            {
+              field: "METADATA",
+              key: "deviceType",
+              operator: "EQ",
+              value: "mobile",
+            },
+            { questionId: "rating", operator: "LT", value: 7 },
+          ],
+        },
+      },
+    ];
+
+    const { result } = renderHook(() =>
+      useLumiSurvey({ surveyId: SURVEY_ID, questions, transport }),
+    );
+    await act(() => result.current.setAnswer("rating", 5));
+    await act(() => result.current.setAnswer("details", "Could be better"));
+    await act(async () => result.current.submit());
+
+    expect(submitMock.mock.calls[0][0].transportPayload.flow).toEqual({
+      schemaVersion: 1,
+      evaluatorVersion: "visible-if-v1",
+      fields: [
+        { fieldId: "rating" },
+        {
+          fieldId: "details",
+          visibleIf: {
+            combinator: "ANY",
+            conditions: [
+              {
+                source: "ANSWER",
+                key: "rating",
+                operator: "LT",
+                value: 7,
+              },
+              {
+                source: "METADATA",
+                key: "deviceType",
+                operator: "EQ",
+                value: "mobile",
+              },
+            ],
+          },
+        },
+      ],
+    });
+  });
+
+  it("does not emit a flow contract for deprecated logic", async () => {
+    const submitMock = vi.fn(async (_: LumiSurveySubmission) => {});
+    const transport: LumiSurveyTransport = { submit: submitMock };
+    const questions: LumiSurveyQuestion[] = [
+      {
+        id: "rating",
+        type: "rating",
+        prompt: "Rating",
+        logic: [
+          {
+            condition: { operator: "LT", value: 3 },
+            action: { type: "SUBMIT" },
+          },
+        ],
+      },
+    ];
+
+    const { result } = renderHook(() =>
+      useLumiSurvey({ surveyId: SURVEY_ID, questions, transport }),
+    );
+    await act(() => result.current.setAnswer("rating", 5));
+    await act(async () => result.current.submit());
+
+    expect(submitMock.mock.calls[0][0].transportPayload.flow).toBeUndefined();
+  });
+
+  it("omits flow for legacy visibleIf shapes that the pinned evaluator cannot represent", () => {
+    const forwardReference: LumiSurveyQuestion[] = [
+      {
+        id: "details",
+        type: "text",
+        prompt: "Details",
+        visibleIf: { questionId: "rating", operator: "LT", value: 7 },
+      },
+      {
+        id: "rating",
+        type: "rating",
+        prompt: "Rating",
+        variant: "nps",
+      },
+    ];
+    const invalidRatingDomain: LumiSurveyQuestion[] = [
+      forwardReference[1],
+      {
+        ...forwardReference[0],
+        visibleIf: {
+          questionId: "rating",
+          operator: "LT",
+          value: "7",
+        },
+      } as LumiSurveyQuestion,
+    ];
+
+    expect(buildFlowBlock(forwardReference)).toBeUndefined();
+    expect(buildFlowBlock(invalidRatingDomain)).toBeUndefined();
+  });
+
+  it("fails flow capability checks closed without throwing for malformed runtime input", () => {
+    const rating: LumiSurveyQuestion = {
+      id: "rating",
+      type: "rating",
+      prompt: "Rating",
+      variant: "nps",
+    };
+    const malformedConditions: unknown[] = [
+      null,
+      { questionId: "details", operator: "EXISTS" },
+      { operator: "EXISTS" },
+      {
+        any: [{ questionId: "rating", operator: "EXISTS" }],
+        all: [{ questionId: "rating", operator: "EXISTS" }],
+      },
+      {
+        any: Array.from({ length: 51 }, () => ({
+          questionId: "rating",
+          operator: "EXISTS",
+        })),
+      },
+      { field: "METADATA", key: "x".repeat(201), operator: "EXISTS" },
+      { field: "METADATA", key: 42, operator: "EXISTS" },
+      { questionId: 42, operator: "EXISTS" },
+      {
+        field: "METADATA",
+        key: "segment",
+        operator: "EQ",
+        value: "x".repeat(2_049),
+      },
+      { questionId: "rating", operator: "LT", value: Number.POSITIVE_INFINITY },
+      { questionId: "rating", operator: "UNKNOWN", value: 7 },
+    ];
+
+    for (const visibleIf of malformedConditions) {
+      const questions = [
+        rating,
+        {
+          id: "details",
+          type: "text",
+          prompt: "Details",
+          visibleIf,
+        } as LumiSurveyQuestion,
+      ];
+      expect(() => buildFlowBlock(questions)).not.toThrow();
+      expect(buildFlowBlock(questions)).toBeUndefined();
+    }
+
+    const unknownQuestionType = [
+      rating,
+      {
+        id: "details",
+        type: "unknown",
+        prompt: "Details",
+        visibleIf: { questionId: "rating", operator: "EXISTS" },
+      },
+    ] as unknown as LumiSurveyQuestion[];
+    expect(() => buildFlowBlock(unknownQuestionType)).not.toThrow();
+    expect(buildFlowBlock(unknownQuestionType)).toBeUndefined();
   });
 
   it("definition includes correct field metadata for rating and choice types", async () => {

--- a/packages/lumi-survey/src/core/flowBlock.ts
+++ b/packages/lumi-survey/src/core/flowBlock.ts
@@ -1,0 +1,245 @@
+import {
+  allowedVisibleIfOperators,
+  getLeafConditions,
+  isConditionGroup,
+  isLeafCondition,
+} from "./conditionUtils.js";
+import type {
+  LogicLeafCondition,
+  LumiSurveyQuestion,
+  RatingQuestion,
+  TransportFlowCondition,
+  TransportFlowV1,
+} from "./types.js";
+import { RATING_SCALES } from "./types.js";
+
+export const FLOW_EVALUATOR_VERSION = "visible-if-v1" as const;
+const MAX_FLOW_KEY_LENGTH = 200;
+const MAX_FLOW_STRING_VALUE_LENGTH = 2_048;
+const MAX_FLOW_CONDITIONS_PER_FIELD = 50;
+const MAX_FLOW_FIELDS = 50;
+const SUPPORTED_QUESTION_TYPES = new Set([
+  "rating",
+  "singleChoice",
+  "multiChoice",
+  "text",
+]);
+
+/**
+ * Builds the canonical flow contract for structured visibility.
+ *
+ * Legacy imperative `logic` is intentionally a hard boundary: submissions
+ * continue to work, but no flow contract is emitted and analytics must treat
+ * the row as unpinned until the survey is migrated to `visibleIf`.
+ */
+export function buildFlowBlock(
+  questions: LumiSurveyQuestion[],
+): TransportFlowV1 | undefined {
+  if (
+    questions.length === 0 ||
+    questions.length > MAX_FLOW_FIELDS ||
+    questions.some(
+      (question) =>
+        question.logic !== undefined ||
+        typeof question.id !== "string" ||
+        question.id.trim().length === 0 ||
+        question.id.length > MAX_FLOW_KEY_LENGTH ||
+        !SUPPORTED_QUESTION_TYPES.has(question.type),
+    )
+  ) {
+    return undefined;
+  }
+
+  const previousQuestions = new Map<string, LumiSurveyQuestion>();
+  const fields: TransportFlowV1["fields"] = [];
+  for (const question of questions) {
+    if (question.visibleIf === undefined) {
+      fields.push({ fieldId: question.id });
+      previousQuestions.set(question.id, question);
+      continue;
+    }
+
+    if (
+      typeof question.visibleIf !== "object" ||
+      question.visibleIf === null ||
+      Array.isArray(question.visibleIf) ||
+      ("any" in question.visibleIf && "all" in question.visibleIf)
+    ) {
+      return undefined;
+    }
+
+    const leaves = getLeafConditions(question.visibleIf);
+    if (
+      leaves.length === 0 ||
+      leaves.length > MAX_FLOW_CONDITIONS_PER_FIELD ||
+      leaves.some((leaf) => !isLeafCondition(leaf))
+    ) {
+      return undefined;
+    }
+
+    const conditions = leaves.map((leaf) =>
+      normalizeCondition(leaf, previousQuestions),
+    );
+    if (conditions.some((condition) => condition === undefined)) {
+      return undefined;
+    }
+
+    fields.push({
+      fieldId: question.id,
+      visibleIf: {
+        combinator:
+          isConditionGroup(question.visibleIf) && "any" in question.visibleIf
+            ? "ANY"
+            : "ALL",
+        conditions: conditions
+          .filter(
+            (condition): condition is TransportFlowCondition =>
+              condition !== undefined,
+          )
+          .sort(compareConditions),
+      },
+    });
+    previousQuestions.set(question.id, question);
+  }
+
+  return {
+    schemaVersion: 1,
+    evaluatorVersion: FLOW_EVALUATOR_VERSION,
+    fields,
+  };
+}
+
+function normalizeCondition(
+  condition: LogicLeafCondition,
+  previousQuestions: Map<string, LumiSurveyQuestion>,
+): TransportFlowCondition | undefined {
+  if (
+    condition.field !== undefined &&
+    condition.field !== "ANSWER" &&
+    condition.field !== "METADATA"
+  ) {
+    return undefined;
+  }
+  const [source, key] =
+    condition.field === "METADATA"
+      ? (["METADATA", condition.key] as const)
+      : (["ANSWER", condition.questionId ?? ""] as const);
+  if (
+    typeof key !== "string" ||
+    key.trim().length === 0 ||
+    key.length > MAX_FLOW_KEY_LENGTH
+  ) {
+    return undefined;
+  }
+  if (!hasCanonicalValue(condition)) {
+    return undefined;
+  }
+  if (source === "METADATA") {
+    if (!isCompatibleWithMetadata(condition, key)) return undefined;
+  } else {
+    const referenced = previousQuestions.get(key);
+    if (!referenced || !isCompatibleWithQuestion(condition, referenced)) {
+      return undefined;
+    }
+  }
+
+  return {
+    source,
+    key,
+    operator: condition.operator,
+    ...(condition.value !== undefined ? { value: condition.value } : {}),
+  };
+}
+
+function hasCanonicalValue(condition: LogicLeafCondition): boolean {
+  if (condition.operator === "EXISTS") {
+    return condition.value === undefined;
+  }
+  if (condition.value === undefined) return false;
+  if (typeof condition.value === "number")
+    return Number.isFinite(condition.value);
+  if (typeof condition.value === "string") {
+    return condition.value.length <= MAX_FLOW_STRING_VALUE_LENGTH;
+  }
+  return typeof condition.value === "boolean";
+}
+
+function isCompatibleWithMetadata(
+  condition: LogicLeafCondition,
+  key: string,
+): boolean {
+  if (key !== "deviceType") return true;
+  if (!["EXISTS", "EQ", "NEQ", "CONTAINS"].includes(condition.operator)) {
+    return false;
+  }
+  if (condition.operator === "EXISTS") return true;
+  if (typeof condition.value !== "string") return false;
+  return (
+    condition.operator === "CONTAINS" ||
+    ["desktop", "mobile", "tablet"].includes(condition.value)
+  );
+}
+
+function isCompatibleWithQuestion(
+  condition: LogicLeafCondition,
+  question: LumiSurveyQuestion,
+): boolean {
+  if (!SUPPORTED_QUESTION_TYPES.has(question.type)) return false;
+  if (!allowedVisibleIfOperators(question.type).includes(condition.operator)) {
+    return false;
+  }
+  if (condition.operator === "EXISTS") return true;
+
+  switch (question.type) {
+    case "rating": {
+      if (
+        typeof condition.value !== "number" ||
+        !Number.isInteger(condition.value)
+      ) {
+        return false;
+      }
+      const variant = (question as RatingQuestion).variant ?? "emoji";
+      const minimum = variant === "nps" ? 0 : 1;
+      return (
+        condition.value >= minimum &&
+        condition.value <= RATING_SCALES[variant] - (variant === "nps" ? 1 : 0)
+      );
+    }
+    case "singleChoice":
+    case "multiChoice":
+      return (
+        typeof condition.value === "string" &&
+        question.options.some((option) => option.value === condition.value)
+      );
+    case "text":
+      return (
+        typeof condition.value === "string" && condition.value.trim().length > 0
+      );
+  }
+}
+
+function compareConditions(
+  left: TransportFlowCondition,
+  right: TransportFlowCondition,
+): number {
+  const leftParts = conditionSortParts(left);
+  const rightParts = conditionSortParts(right);
+  for (let index = 0; index < leftParts.length; index += 1) {
+    const leftPart = leftParts[index];
+    const rightPart = rightParts[index];
+    if (leftPart !== rightPart) return leftPart < rightPart ? -1 : 1;
+  }
+  return 0;
+}
+
+function conditionSortParts(
+  condition: TransportFlowCondition,
+): readonly string[] {
+  return [
+    condition.source,
+    condition.key,
+    condition.operator,
+    condition.value === undefined ? "undefined" : typeof condition.value,
+    condition.value === undefined ? "" : JSON.stringify(condition.value),
+  ];
+}

--- a/packages/lumi-survey/src/core/index.ts
+++ b/packages/lumi-survey/src/core/index.ts
@@ -7,6 +7,7 @@ export type {
   SubmissionCreatedResponse as LumiApiSubmissionCreatedResponse,
   SubmissionDefinition as LumiApiSubmissionDefinition,
   SubmissionFieldDefinition as LumiApiSubmissionFieldDefinition,
+  SubmissionFlowV1 as LumiApiSubmissionFlowV1,
 } from "../contracts/lumiApi";
 export { ErrorType as LumiApiErrorType } from "../contracts/lumiApi";
 

--- a/packages/lumi-survey/src/core/transportPayload.ts
+++ b/packages/lumi-survey/src/core/transportPayload.ts
@@ -1,4 +1,5 @@
 import { buildDefinitionBlock } from "./definitionBlock.js";
+import { buildFlowBlock } from "./flowBlock.js";
 import { assertSpecializedSurveyContract } from "./specializedSurveyContract.js";
 import type {
   ChoiceOption,
@@ -48,6 +49,7 @@ export function buildTransportPayload(
   });
 
   const definition = buildDefinitionBlock(questions, resolvedSurveyType);
+  const flow = buildFlowBlock(questions);
 
   const payload: LumiSurveyTransportPayload = {
     schemaVersion: 2,
@@ -57,6 +59,7 @@ export function buildTransportPayload(
     startedAt,
     deduplicationKey,
     definition,
+    ...(flow ? { flow } : {}),
     context,
     answers: [],
   };

--- a/packages/lumi-survey/src/core/types.ts
+++ b/packages/lumi-survey/src/core/types.ts
@@ -337,6 +337,35 @@ export interface TransportDefinition {
   fields: TransportFieldDefinition[];
 }
 
+export type TransportFlowConditionSource = "ANSWER" | "METADATA";
+
+export interface TransportFlowCondition {
+  source: TransportFlowConditionSource;
+  key: string;
+  operator: LogicOperator;
+  value?: string | number | boolean;
+}
+
+export interface TransportVisibleIf {
+  combinator: "ALL" | "ANY";
+  conditions: TransportFlowCondition[];
+}
+
+export interface TransportFlowField {
+  fieldId: string;
+  visibleIf?: TransportVisibleIf;
+}
+
+/**
+ * Canonical, visibleIf-only flow contract sent with schemaVersion 2.
+ * Deprecated imperative `logic` is deliberately not representable here.
+ */
+export interface TransportFlowV1 {
+  schemaVersion: 1;
+  evaluatorVersion: "visible-if-v1";
+  fields: TransportFlowField[];
+}
+
 /**
  * Canonical submission payload (schemaVersion=2).
  * Includes full definition of all fields and deduplication key.
@@ -350,6 +379,7 @@ export interface LumiSurveyTransportPayload {
   timeToCompleteMs?: number;
   deduplicationKey: string;
   definition: TransportDefinition;
+  flow?: TransportFlowV1;
   context?: LumiSurveyContext;
   answers: TransportAnswer[];
 }

--- a/packages/lumi-types/src/api.ts
+++ b/packages/lumi-types/src/api.ts
@@ -87,6 +87,27 @@ export interface SubmissionDefinition {
   fields: SubmissionFieldDefinition[];
 }
 
+export interface SubmissionFlowCondition {
+  source: "ANSWER" | "METADATA";
+  key: string;
+  operator: "EQ" | "NEQ" | "GT" | "LT" | "CONTAINS" | "EXISTS";
+  value?: string | number | boolean;
+}
+
+export interface SubmissionFlowField {
+  fieldId: string;
+  visibleIf?: {
+    combinator: "ALL" | "ANY";
+    conditions: SubmissionFlowCondition[];
+  };
+}
+
+export interface SubmissionFlowV1 {
+  schemaVersion: 1;
+  evaluatorVersion: "visible-if-v1";
+  fields: SubmissionFlowField[];
+}
+
 export interface FeedbackSubmissionV2 {
   schemaVersion: 2;
   surveyId: string;
@@ -96,6 +117,7 @@ export interface FeedbackSubmissionV2 {
   timeToCompleteMs?: number | null;
   deduplicationKey: string;
   definition: SubmissionDefinition;
+  flow?: SubmissionFlowV1;
   context?: SubmissionContextV1 | null;
   answers: Answer[];
 }

--- a/packages/lumi-types/src/schemas.test.mjs
+++ b/packages/lumi-types/src/schemas.test.mjs
@@ -1,7 +1,105 @@
 import assert from "node:assert/strict";
 import { test } from "node:test";
 
-import { FilterBootstrapResponseSchema } from "./schemas.ts";
+import {
+  FeedbackSubmissionV2Schema,
+  FilterBootstrapResponseSchema,
+} from "./schemas.ts";
+
+const v2Submission = {
+  schemaVersion: 2,
+  surveyId: "survey",
+  surveyType: "custom",
+  submittedAt: "2026-08-29T12:00:00Z",
+  deduplicationKey: "deduplication-key-123",
+  definition: {
+    surveyType: "custom",
+    fields: [
+      {
+        fieldId: "rating",
+        fieldType: "RATING",
+        ratingVariant: "nps",
+        ratingScale: 11,
+      },
+      { fieldId: "details", fieldType: "TEXT" },
+    ],
+  },
+  flow: {
+    schemaVersion: 1,
+    evaluatorVersion: "visible-if-v1",
+    fields: [
+      { fieldId: "rating" },
+      {
+        fieldId: "details",
+        visibleIf: {
+          combinator: "ALL",
+          conditions: [
+            { source: "ANSWER", key: "rating", operator: "LT", value: 7 },
+          ],
+        },
+      },
+    ],
+  },
+  answers: [
+    {
+      fieldId: "rating",
+      fieldType: "RATING",
+      question: { label: "Rating" },
+      value: {
+        type: "rating",
+        rating: 5,
+        ratingVariant: "nps",
+        ratingScale: 11,
+      },
+    },
+  ],
+};
+
+test("submission v2 accepts a complete visibleIf flow contract", () => {
+  assert.equal(
+    FeedbackSubmissionV2Schema.parse(v2Submission).flow?.evaluatorVersion,
+    "visible-if-v1",
+  );
+});
+
+test("submission v2 rejects flow fields that do not match the definition", () => {
+  assert.throws(() =>
+    FeedbackSubmissionV2Schema.parse({
+      ...v2Submission,
+      flow: {
+        ...v2Submission.flow,
+        fields: [...v2Submission.flow.fields].reverse(),
+      },
+    }),
+  );
+});
+
+test("submission v2 rejects flow values outside bounded field and metadata domains", () => {
+  const invalidRating = structuredClone(v2Submission);
+  invalidRating.flow.fields[1].visibleIf.conditions[0].value = "7";
+
+  const oversizedPredicate = structuredClone(v2Submission);
+  oversizedPredicate.flow.fields[1].visibleIf.conditions[0].value = "x".repeat(
+    2_049,
+  );
+
+  const invalidMetadata = structuredClone(v2Submission);
+  invalidMetadata.flow.fields[1].visibleIf.conditions[0] = {
+    source: "METADATA",
+    key: "deviceType",
+    operator: "GT",
+    value: 7,
+  };
+
+  assert.throws(() => FeedbackSubmissionV2Schema.parse(invalidRating));
+  assert.throws(() => FeedbackSubmissionV2Schema.parse(oversizedPredicate));
+  assert.throws(() => FeedbackSubmissionV2Schema.parse(invalidMetadata));
+
+  const blankMetadataKey = structuredClone(v2Submission);
+  blankMetadataKey.flow.fields[1].visibleIf.conditions[0].source = "METADATA";
+  blankMetadataKey.flow.fields[1].visibleIf.conditions[0].key = "   ";
+  assert.throws(() => FeedbackSubmissionV2Schema.parse(blankMetadataKey));
+});
 
 test("filter bootstrap preserves app-specific survey metadata", () => {
   const archivedAt = "2023-01-01T00:00:00Z";

--- a/packages/lumi-types/src/schemas.ts
+++ b/packages/lumi-types/src/schemas.ts
@@ -782,6 +782,164 @@ export const SubmissionDefinitionSchema = z
     }
   });
 
+const SubmissionFlowConditionSchema = z
+  .object({
+    source: z.enum(["ANSWER", "METADATA"]),
+    key: z
+      .string()
+      .min(1)
+      .max(200)
+      .refine(
+        (key) => key.trim().length > 0,
+        "flow condition key must be non-blank",
+      ),
+    operator: z.enum(["EQ", "NEQ", "GT", "LT", "CONTAINS", "EXISTS"]),
+    value: z
+      .union([z.string().max(2_048), z.number().finite(), z.boolean()])
+      .optional(),
+  })
+  .strict()
+  .superRefine((condition, ctx) => {
+    if (condition.operator === "EXISTS" && condition.value !== undefined) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: "EXISTS flow conditions must not include value",
+        path: ["value"],
+      });
+    }
+    if (condition.operator !== "EXISTS" && condition.value === undefined) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: `${condition.operator} flow conditions require value`,
+        path: ["value"],
+      });
+    }
+  });
+
+const SubmissionFlowFieldSchema = z
+  .object({
+    fieldId: z.string().min(1).max(200),
+    visibleIf: z
+      .object({
+        combinator: z.enum(["ALL", "ANY"]),
+        conditions: z.array(SubmissionFlowConditionSchema).min(1).max(50),
+      })
+      .strict()
+      .optional(),
+  })
+  .strict();
+
+export const SubmissionFlowV1Schema = z
+  .object({
+    schemaVersion: z.literal(1),
+    evaluatorVersion: z.literal("visible-if-v1"),
+    fields: z.array(SubmissionFlowFieldSchema).min(1).max(50),
+  })
+  .strict()
+  .superRefine((flow, ctx) => {
+    const seen = new Set<string>();
+    for (let i = 0; i < flow.fields.length; i += 1) {
+      const fieldId = flow.fields[i]?.fieldId;
+      if (!fieldId) continue;
+      if (seen.has(fieldId)) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          message: `flow.fields.fieldId must be unique (duplicate: ${fieldId})`,
+          path: ["fields", i, "fieldId"],
+        });
+      }
+      seen.add(fieldId);
+    }
+  });
+
+function validateFlowConditionAgainstField(
+  condition: z.infer<typeof SubmissionFlowConditionSchema>,
+  field: z.infer<typeof SubmissionFieldDefinitionSchema>,
+  path: Array<string | number>,
+  ctx: z.RefinementCtx,
+) {
+  const allowedByType = {
+    RATING: ["EXISTS", "EQ", "NEQ", "GT", "LT"],
+    SINGLE_CHOICE: ["EXISTS", "EQ", "NEQ", "CONTAINS"],
+    MULTI_CHOICE: ["EXISTS", "CONTAINS"],
+    TEXT: ["EXISTS", "EQ", "NEQ", "CONTAINS"],
+    DATE: ["EXISTS", "EQ", "NEQ", "CONTAINS"],
+  } as const;
+  if (
+    !(allowedByType[field.fieldType] as readonly string[]).includes(
+      condition.operator,
+    )
+  ) {
+    ctx.addIssue({
+      code: z.ZodIssueCode.custom,
+      message: `flow operator ${condition.operator} is not supported for ${field.fieldType}`,
+      path: [...path, "operator"],
+    });
+    return;
+  }
+  if (condition.operator === "EXISTS") return;
+
+  const value = condition.value;
+  let valid = true;
+  switch (field.fieldType) {
+    case "RATING": {
+      const minimum = field.ratingVariant === "nps" ? 0 : 1;
+      const maximum =
+        field.ratingScale - (field.ratingVariant === "nps" ? 1 : 0);
+      valid =
+        typeof value === "number" &&
+        Number.isInteger(value) &&
+        value >= minimum &&
+        value <= maximum;
+      break;
+    }
+    case "SINGLE_CHOICE":
+    case "MULTI_CHOICE":
+      valid = typeof value === "string" && field.optionIds.includes(value);
+      break;
+    case "TEXT":
+    case "DATE":
+      valid = typeof value === "string" && value.trim().length > 0;
+      break;
+  }
+  if (!valid) {
+    ctx.addIssue({
+      code: z.ZodIssueCode.custom,
+      message: `flow condition value is outside the domain for ${field.fieldType}`,
+      path: [...path, "value"],
+    });
+  }
+}
+
+function validateFlowMetadataCondition(
+  condition: z.infer<typeof SubmissionFlowConditionSchema>,
+  path: Array<string | number>,
+  ctx: z.RefinementCtx,
+) {
+  if (condition.key !== "deviceType") return;
+  if (!["EXISTS", "EQ", "NEQ", "CONTAINS"].includes(condition.operator)) {
+    ctx.addIssue({
+      code: z.ZodIssueCode.custom,
+      message: `flow operator ${condition.operator} is not supported for metadata deviceType`,
+      path: [...path, "operator"],
+    });
+    return;
+  }
+  if (condition.operator === "EXISTS") return;
+  if (
+    typeof condition.value !== "string" ||
+    (condition.operator !== "CONTAINS" &&
+      !["desktop", "mobile", "tablet"].includes(condition.value))
+  ) {
+    ctx.addIssue({
+      code: z.ZodIssueCode.custom,
+      message:
+        "flow condition value is outside the domain for metadata deviceType",
+      path: [...path, "value"],
+    });
+  }
+}
+
 const DeduplicationKeySchema = z
   .string()
   .min(16)
@@ -948,6 +1106,7 @@ export const FeedbackSubmissionV2Schema = z
     timeToCompleteMs: z.number().int().nonnegative().nullable().optional(),
     deduplicationKey: DeduplicationKeySchema,
     definition: SubmissionDefinitionSchema,
+    flow: SubmissionFlowV1Schema.optional(),
     context: SubmissionContextV1Schema.nullable().optional(),
     answers: z.array(SubmissionAnswerSchema).min(1),
   })
@@ -964,6 +1123,72 @@ export const FeedbackSubmissionV2Schema = z
     const fieldsById = new Map(
       submission.definition.fields.map((field) => [field.fieldId, field]),
     );
+    if (submission.flow) {
+      const definitionFieldIds = submission.definition.fields.map(
+        (field) => field.fieldId,
+      );
+      const flowFieldIds = submission.flow.fields.map((field) => field.fieldId);
+      if (
+        definitionFieldIds.length !== flowFieldIds.length ||
+        definitionFieldIds.some(
+          (fieldId, index) => fieldId !== flowFieldIds[index],
+        )
+      ) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          message: "flow.fields must match definition.fields in order",
+          path: ["flow", "fields"],
+        });
+      }
+
+      const priorFieldIds = new Set<string>();
+      submission.flow.fields.forEach((field, fieldIndex) => {
+        field.visibleIf?.conditions.forEach((condition, conditionIndex) => {
+          const conditionPath = [
+            "flow",
+            "fields",
+            fieldIndex,
+            "visibleIf",
+            "conditions",
+            conditionIndex,
+          ] as Array<string | number>;
+          if (
+            condition.source === "ANSWER" &&
+            !priorFieldIds.has(condition.key)
+          ) {
+            ctx.addIssue({
+              code: z.ZodIssueCode.custom,
+              message: "ANSWER flow conditions must reference an earlier field",
+              path: [
+                "flow",
+                "fields",
+                fieldIndex,
+                "visibleIf",
+                "conditions",
+                conditionIndex,
+                "key",
+              ],
+            });
+            return;
+          }
+          if (condition.source === "ANSWER") {
+            const referenced = fieldsById.get(condition.key);
+            if (referenced) {
+              validateFlowConditionAgainstField(
+                condition,
+                referenced,
+                conditionPath,
+                ctx,
+              );
+            }
+          } else {
+            validateFlowMetadataCondition(condition, conditionPath, ctx);
+          }
+        });
+        priorFieldIds.add(field.fieldId);
+      });
+    }
+
     for (let i = 0; i < submission.answers.length; i += 1) {
       const answer = submission.answers[i];
       if (!answer) continue;


### PR DESCRIPTION
Closes #573
Relates to #482

## Hvorfor

Analyseprodukter må vite hvilken betinget flyt som faktisk gjaldt da et svar ble sendt inn. Dagens definition-hash beskriver feltene, men ikke visibleIf. Uten en egen ingest-matchet flytrevisjon kan historisk applicability bli feil.

## Hva

- lumi-survey sender en kanonisk og versjonert visibleIf-kontrakt sammen med schema v2. Deprecated logic og legacy-shapes som ikke kan uttrykkes eksakt, fortsetter å sende svar uten flow og blir fail-closed unpinned.
- API validerer og hasher flyten server-side, registrerer en immutable app-avgrenset kontrakt i samme transaksjon og lagrer bare flow-hash på feedbackraden.
- Kildekatalog og compiler bruker siste observerte flow, varsler om legacy/ukjent historikk og blokkerer ved nyere unpinned eller ugyldige kontrakter.
- Rolling deploy er bakoverkompatibel. FK, låser og delete-trigger beskytter mot ukjente hasher, races og foreldreløse private predicate-konstanter.
- Registeret har maks 50 revisjoner per kilde/definition, 64 KiB per flow og 16 MiB samlet kontraktbudsjett per team. Overflow stopper ikke feedbackinnsamling; raden lagres unpinned.

## Verifisering

- pnpm run lint
- pnpm run typecheck
- pnpm test
- pnpm run verify:lumi-survey
- full API-test: ./gradlew cleanTest test
- spesialiserte reviews av klient/kontrakt, katalog/compiler og database/concurrency uten gjenværende blockers